### PR TITLE
Document authenticated origin remote

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,7 @@ Correctness, safety, and predictability take priority over elegance.
 ### GitHub authentication and issue creation
 
 - This repository allows use of GitHub Personal Access Tokens (PATs)
+- The default origin remote points to https://github.com/ijyates1992/ping-monitor and requires authenticated access; when a command needs credentials, prompt the user for their GitHub username and personal access token
 - Codex should attempt to create issues automatically when required
 - If issue creation fails:
   - report the failure clearly


### PR DESCRIPTION
### Motivation
- Provide explicit repository guidance that the default `origin` remote points to `https://github.com/ijyates1992/ping-monitor` and that commands requiring credentials should prompt for the user's GitHub username and personal access token to ensure authenticated access is obvious and auditable.

### Description
- Insert a single line into `AGENTS.md` documenting the authenticated `origin` remote and add the local Git `origin` remote pointing to `https://github.com/ijyates1992/ping-monitor.git`, then commit the change (Fixes #1).

### Testing
- Verified the change and local repo state by running `git remote -v`, `git diff -- AGENTS.md`, `git add AGENTS.md && git commit -m "Document authenticated origin remote"`, and a GitHub API request to list open issues; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfeeeb7560832a90f59d2544ca9941)