### PR TITLE
Implement authenticated agent /api/v1/agent/hello with persisted Agent auth

### DIFF
--- a/docs/PLATFORM_CONSTRAINTS.md
+++ b/docs/PLATFORM_CONSTRAINTS.md
@@ -20,6 +20,20 @@ No implementation may violate these constraints unless:
 
 ---
 
+## Runtime constraints
+
+### Web application
+
+- The control-plane web application must target **.NET 10**
+- Changes to the web application runtime require an explicit issue and an update to this document
+
+### Agent
+
+- The execution-plane agent must be implemented in **Python**
+- Changes to the agent runtime require an explicit issue and an update to this document
+
+---
+
 ## Network model
 
 ### Inbound connectivity

--- a/docs/agent-hello-local.md
+++ b/docs/agent-hello-local.md
@@ -1,0 +1,44 @@
+# Local `/api/v1/agent/hello` example
+
+`docs/agent-api.md` remains the source of truth for the contract. This note shows the minimal local development flow.
+
+## Development seed agent
+
+In Development, the web app can seed a single agent record when both of these are true:
+
+- `DevelopmentSeedAgent:Enabled` is `true`
+- `DevelopmentSeedAgent__ApiKey` is supplied as an environment variable
+
+Default seeded instance ID:
+
+```text
+dev-agent-01
+```
+
+The plaintext development API key is never stored in configuration. Startup hashes the supplied `DevelopmentSeedAgent__ApiKey` value before saving it.
+
+## Example request
+
+```bash
+curl -i   -X POST https://localhost:5001/api/v1/agent/hello   -H 'Content-Type: application/json'   -H 'Accept: application/json'   -H 'X-Instance-Id: dev-agent-01'   -H "Authorization: Bearer ${DevelopmentSeedAgent__ApiKey}"   -d '{
+    "agentVersion": "0.1.0",
+    "machineName": "DEV-WORKSTATION",
+    "platform": "windows",
+    "capabilities": ["icmp"],
+    "startedAtUtc": "2026-03-21T21:30:00Z"
+  }'
+```
+
+## Example success response
+
+```json
+{
+  "agentId": "5e51c7cf-9f7d-4c6b-a83e-8c55bf1f9f77",
+  "serverTimeUtc": "2026-03-21T21:30:00Z",
+  "configRefreshSeconds": 300,
+  "heartbeatIntervalSeconds": 60,
+  "resultBatchIntervalSeconds": 10,
+  "maxResultBatchSize": 500,
+  "configVersion": "cfg_dev_v1"
+}
+```

--- a/src/WebApp/PingMonitor.Web/Contracts/Hello/AgentHelloRequest.cs
+++ b/src/WebApp/PingMonitor.Web/Contracts/Hello/AgentHelloRequest.cs
@@ -1,8 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace PingMonitor.Web.Contracts.Hello;
 
-public sealed record AgentHelloRequest(
-    string AgentVersion,
-    string MachineName,
-    string Platform,
-    IReadOnlyList<string> Capabilities,
-    DateTimeOffset StartedAtUtc);
+public sealed class AgentHelloRequest
+{
+    [Required]
+    [StringLength(50, MinimumLength = 1)]
+    public string AgentVersion { get; init; } = string.Empty;
+
+    [Required]
+    [StringLength(255, MinimumLength = 1)]
+    public string MachineName { get; init; } = string.Empty;
+
+    [Required]
+    [StringLength(50, MinimumLength = 1)]
+    public string Platform { get; init; } = string.Empty;
+
+    [Required]
+    [MinLength(1)]
+    public IReadOnlyList<string> Capabilities { get; init; } = Array.Empty<string>();
+
+    [Required]
+    public DateTimeOffset StartedAtUtc { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentConfigController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentConfigController.cs
@@ -23,16 +23,13 @@ public sealed class AgentConfigController : ControllerBase
     [ProducesResponseType(typeof(AgentConfigResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<AgentConfigResponse>> GetAsync(CancellationToken cancellationToken)
     {
-        var instanceId = Request.Headers["X-Instance-Id"].ToString();
-
-        // TODO: Enforce authenticated agent access before returning assignments.
-        var isAuthenticated = await _authenticationService.ValidateAsync(instanceId, Request.Headers.Authorization, cancellationToken);
-        if (!isAuthenticated)
+        var authenticationResult = await _authenticationService.AuthenticateAsync(Request, cancellationToken);
+        if (!authenticationResult.Succeeded)
         {
-            return Unauthorized();
+            return authenticationResult.ToActionResult(HttpContext);
         }
 
-        var response = await _configurationService.GetConfigurationAsync(instanceId, cancellationToken);
+        var response = await _configurationService.GetConfigurationAsync(authenticationResult.Agent!, cancellationToken);
         return Ok(response);
     }
 }

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentHeartbeatController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentHeartbeatController.cs
@@ -23,16 +23,13 @@ public sealed class AgentHeartbeatController : ControllerBase
     [ProducesResponseType(typeof(AgentHeartbeatResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<AgentHeartbeatResponse>> PostAsync([FromBody] AgentHeartbeatRequest request, CancellationToken cancellationToken)
     {
-        var instanceId = Request.Headers["X-Instance-Id"].ToString();
-
-        // TODO: Enforce authenticated agent access and persist heartbeat metadata.
-        var isAuthenticated = await _authenticationService.ValidateAsync(instanceId, Request.Headers.Authorization, cancellationToken);
-        if (!isAuthenticated)
+        var authenticationResult = await _authenticationService.AuthenticateAsync(Request, cancellationToken);
+        if (!authenticationResult.Succeeded)
         {
-            return Unauthorized();
+            return authenticationResult.ToActionResult(HttpContext);
         }
 
-        var response = await _heartbeatService.ProcessHeartbeatAsync(instanceId, request, cancellationToken);
+        var response = await _heartbeatService.ProcessHeartbeatAsync(authenticationResult.Agent!, request, cancellationToken);
         return Ok(response);
     }
 }

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentHelloController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentHelloController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Contracts.Hello;
 using PingMonitor.Web.Services;
+using PingMonitor.Web.Support;
 
 namespace PingMonitor.Web.Controllers;
 
@@ -8,31 +9,71 @@ namespace PingMonitor.Web.Controllers;
 [Route("api/v1/agent/hello")]
 public sealed class AgentHelloController : ControllerBase
 {
+    private static readonly HashSet<string> SupportedCapabilities = ["icmp"];
+
     private readonly IAgentAuthenticationService _authenticationService;
-    private readonly IAgentConfigurationService _configurationService;
+    private readonly IAgentHelloService _helloService;
 
     public AgentHelloController(
         IAgentAuthenticationService authenticationService,
-        IAgentConfigurationService configurationService)
+        IAgentHelloService helloService)
     {
         _authenticationService = authenticationService;
-        _configurationService = configurationService;
+        _helloService = helloService;
     }
 
     [HttpPost]
     [ProducesResponseType(typeof(AgentHelloResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<AgentHelloResponse>> PostAsync([FromBody] AgentHelloRequest request, CancellationToken cancellationToken)
     {
-        var instanceId = Request.Headers["X-Instance-Id"].ToString();
-
-        // TODO: Replace placeholder validation with server-side agent credential verification.
-        var isAuthenticated = await _authenticationService.ValidateAsync(instanceId, Request.Headers.Authorization, cancellationToken);
-        if (!isAuthenticated)
+        var authenticationResult = await _authenticationService.AuthenticateAsync(Request, cancellationToken);
+        if (!authenticationResult.Succeeded)
         {
-            return Unauthorized();
+            return authenticationResult.ToActionResult(HttpContext);
         }
 
-        var response = await _configurationService.BuildHelloResponseAsync(instanceId, request, cancellationToken);
+        var validationErrors = ValidateRequest(request);
+        if (validationErrors.Count > 0)
+        {
+            return ApiErrorResponses.BadRequest(HttpContext, "invalid_request", "One or more fields are invalid.", validationErrors);
+        }
+
+        var response = await _helloService.ProcessHelloAsync(authenticationResult.Agent!, request, cancellationToken);
         return Ok(response);
+    }
+
+    private static List<ApiErrorDetail> ValidateRequest(AgentHelloRequest request)
+    {
+        var errors = new List<ApiErrorDetail>();
+
+        if (!IsUtc(request.StartedAtUtc))
+        {
+            errors.Add(new ApiErrorDetail("startedAtUtc", "Value must be a valid UTC ISO-8601 timestamp."));
+        }
+
+        for (var index = 0; index < request.Capabilities.Count; index++)
+        {
+            var capability = request.Capabilities[index];
+            if (string.IsNullOrWhiteSpace(capability))
+            {
+                errors.Add(new ApiErrorDetail($"capabilities[{index}]", "Capability must not be blank."));
+                continue;
+            }
+
+            if (!SupportedCapabilities.Contains(capability.Trim()))
+            {
+                errors.Add(new ApiErrorDetail($"capabilities[{index}]", $"Capability '{capability}' is not supported."));
+            }
+        }
+
+        return errors;
+    }
+
+    private static bool IsUtc(DateTimeOffset value)
+    {
+        return value.Offset == TimeSpan.Zero;
     }
 }

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentResultsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentResultsController.cs
@@ -23,16 +23,13 @@ public sealed class AgentResultsController : ControllerBase
     [ProducesResponseType(typeof(SubmitResultsResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<SubmitResultsResponse>> PostAsync([FromBody] SubmitResultsRequest request, CancellationToken cancellationToken)
     {
-        var instanceId = Request.Headers["X-Instance-Id"].ToString();
-
-        // TODO: Enforce authenticated agent access and hand off raw results for storage and later state evaluation.
-        var isAuthenticated = await _authenticationService.ValidateAsync(instanceId, Request.Headers.Authorization, cancellationToken);
-        if (!isAuthenticated)
+        var authenticationResult = await _authenticationService.AuthenticateAsync(Request, cancellationToken);
+        if (!authenticationResult.Succeeded)
         {
-            return Unauthorized();
+            return authenticationResult.ToActionResult(HttpContext);
         }
 
-        var response = await _resultIngestionService.IngestAsync(instanceId, request, cancellationToken);
+        var response = await _resultIngestionService.IngestAsync(authenticationResult.Agent!, request, cancellationToken);
         return Ok(response);
     }
 }

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Data;
+
+public sealed class PingMonitorDbContext : DbContext
+{
+    public PingMonitorDbContext(DbContextOptions<PingMonitorDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<Agent> Agents => Set<Agent>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        var agent = modelBuilder.Entity<Agent>();
+
+        agent.ToTable("Agents");
+        agent.HasKey(x => x.AgentId);
+        agent.Property(x => x.AgentId).HasMaxLength(64);
+        agent.Property(x => x.InstanceId).HasMaxLength(255).IsRequired();
+        agent.Property(x => x.Name).HasMaxLength(255);
+        agent.Property(x => x.Site).HasMaxLength(255);
+        agent.Property(x => x.ApiKeyHash).IsRequired();
+        agent.Property(x => x.AgentVersion).HasMaxLength(50);
+        agent.Property(x => x.Platform).HasMaxLength(50);
+        agent.Property(x => x.MachineName).HasMaxLength(255);
+        agent.Property(x => x.CreatedAtUtc).IsRequired();
+        agent.Property(x => x.ApiKeyCreatedAtUtc).IsRequired();
+        agent.Property(x => x.Enabled).HasDefaultValue(true);
+        agent.Property(x => x.ApiKeyRevoked).HasDefaultValue(false);
+        agent.Property(x => x.Status).HasConversion<string>().HasMaxLength(16);
+
+        agent.HasIndex(x => x.InstanceId).IsUnique();
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Data/README.md
+++ b/src/WebApp/PingMonitor.Web/Data/README.md
@@ -1,3 +1,9 @@
 # Data
 
-This folder is reserved for persistence-related code. Persistence is intentionally not implemented in the phase 1 skeleton.
+This folder contains the minimal persistence implementation needed for authenticated agent `/hello` handling.
+
+## Current scope
+
+- EF Core `DbContext` for the `Agent` entity only
+- SQLite provider for local development and initial end-to-end wiring
+- no result ingestion, state engine, or alerting persistence yet

--- a/src/WebApp/PingMonitor.Web/Options/AgentApiOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/AgentApiOptions.cs
@@ -1,0 +1,12 @@
+namespace PingMonitor.Web.Options;
+
+public sealed class AgentApiOptions
+{
+    public const string SectionName = "AgentApi";
+
+    public int ConfigRefreshSeconds { get; set; } = 300;
+    public int HeartbeatIntervalSeconds { get; set; } = 60;
+    public int ResultBatchIntervalSeconds { get; set; } = 10;
+    public int MaxResultBatchSize { get; set; } = 500;
+    public string ConfigVersion { get; set; } = "cfg_v1_initial";
+}

--- a/src/WebApp/PingMonitor.Web/Options/DevelopmentSeedAgentOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/DevelopmentSeedAgentOptions.cs
@@ -1,0 +1,12 @@
+namespace PingMonitor.Web.Options;
+
+public sealed class DevelopmentSeedAgentOptions
+{
+    public const string SectionName = "DevelopmentSeedAgent";
+
+    public bool Enabled { get; set; }
+    public string InstanceId { get; set; } = "dev-agent-01";
+    public string? ApiKey { get; set; }
+    public string Name { get; set; } = "Local Development Agent";
+    public string? Site { get; set; } = "Local";
+}

--- a/src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj
+++ b/src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj
@@ -6,4 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -1,4 +1,9 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Options;
 using PingMonitor.Web.Services;
+using PingMonitor.Web.Support;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -7,20 +12,62 @@ builder.Configuration
     .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true)
     .AddEnvironmentVariables();
 
-builder.Services.AddControllers();
+builder.Services.Configure<AgentApiOptions>(builder.Configuration.GetSection(AgentApiOptions.SectionName));
+builder.Services.Configure<DevelopmentSeedAgentOptions>(builder.Configuration.GetSection(DevelopmentSeedAgentOptions.SectionName));
+
+builder.Services.AddDbContext<PingMonitorDbContext>(options =>
+    options.UseSqlite(builder.Configuration.GetConnectionString("MonitoringDatabase")));
+
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new UtcDateTimeOffsetJsonConverter());
+    });
+builder.Services.Configure<ApiBehaviorOptions>(options =>
+{
+    options.InvalidModelStateResponseFactory = context =>
+    {
+        var details = context.ModelState
+            .Where(entry => entry.Value?.Errors.Count > 0)
+            .SelectMany(entry => entry.Value!.Errors.Select(error => new ApiErrorDetail(
+                ModelStateFieldNameFormatter.ToCamelCase(entry.Key),
+                string.IsNullOrWhiteSpace(error.ErrorMessage) ? "The value is invalid." : error.ErrorMessage)))
+            .ToArray();
+
+        return ApiErrorResponses.BadRequest(
+            context.HttpContext,
+            "invalid_request",
+            "One or more fields are invalid.",
+            details);
+    };
+});
+
 builder.Services.AddHealthChecks();
 
-builder.Services.AddSingleton<IAgentAuthenticationService, PlaceholderAgentAuthenticationService>();
-builder.Services.AddSingleton<IAgentConfigurationService, PlaceholderAgentConfigurationService>();
-builder.Services.AddSingleton<IResultIngestionService, PlaceholderResultIngestionService>();
-builder.Services.AddSingleton<IHeartbeatService, PlaceholderHeartbeatService>();
-builder.Services.AddSingleton<IStateEvaluationService, PlaceholderStateEvaluationService>();
+builder.Services.AddScoped<IAgentApiKeyHasher, AgentApiKeyHasher>();
+builder.Services.AddScoped<IAgentAuthenticationService, AgentAuthenticationService>();
+builder.Services.AddScoped<IAgentHelloService, AgentHelloService>();
+builder.Services.AddScoped<IAgentConfigurationService, PlaceholderAgentConfigurationService>();
+builder.Services.AddScoped<IResultIngestionService, PlaceholderResultIngestionService>();
+builder.Services.AddScoped<IHeartbeatService, PlaceholderHeartbeatService>();
+builder.Services.AddScoped<IStateEvaluationService, PlaceholderStateEvaluationService>();
+builder.Services.AddScoped<DevelopmentAgentSeeder>();
 
 var app = builder.Build();
 
-app.UseHttpsRedirection();
+using (var scope = app.Services.CreateScope())
+{
+    var dbContext = scope.ServiceProvider.GetRequiredService<PingMonitorDbContext>();
+    await dbContext.Database.EnsureCreatedAsync();
 
-// TODO: Add agent authentication middleware once server-side credential validation is implemented.
+    if (app.Environment.IsDevelopment())
+    {
+        var seeder = scope.ServiceProvider.GetRequiredService<DevelopmentAgentSeeder>();
+        await seeder.SeedAsync();
+    }
+}
+
+app.UseHttpsRedirection();
 app.UseAuthorization();
 
 app.MapHealthChecks("/health");

--- a/src/WebApp/PingMonitor.Web/Services/AgentApiKeyHasher.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentApiKeyHasher.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Identity;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services;
+
+internal sealed class AgentApiKeyHasher : IAgentApiKeyHasher
+{
+    private readonly PasswordHasher<Agent> _passwordHasher = new();
+
+    public string Hash(Agent agent, string apiKey)
+    {
+        return _passwordHasher.HashPassword(agent, apiKey);
+    }
+
+    public bool Verify(Agent agent, string apiKey)
+    {
+        var result = _passwordHasher.VerifyHashedPassword(agent, agent.ApiKeyHash, apiKey);
+        return result is PasswordVerificationResult.Success or PasswordVerificationResult.SuccessRehashNeeded;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/AgentAuthenticationResult.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentAuthenticationResult.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Support;
+
+namespace PingMonitor.Web.Services;
+
+public sealed class AgentAuthenticationResult
+{
+    private AgentAuthenticationResult(bool succeeded, Agent? agent, int statusCode, string errorCode, string message)
+    {
+        Succeeded = succeeded;
+        Agent = agent;
+        StatusCode = statusCode;
+        ErrorCode = errorCode;
+        Message = message;
+    }
+
+    public bool Succeeded { get; }
+    public Agent? Agent { get; }
+    public int StatusCode { get; }
+    public string ErrorCode { get; }
+    public string Message { get; }
+
+    public static AgentAuthenticationResult Success(Agent agent) => new(true, agent, StatusCodes.Status200OK, string.Empty, string.Empty);
+
+    public static AgentAuthenticationResult Unauthorized(string message) =>
+        new(false, null, StatusCodes.Status401Unauthorized, "unauthorized", message);
+
+    public static AgentAuthenticationResult Forbidden(string message) =>
+        new(false, null, StatusCodes.Status403Forbidden, "forbidden", message);
+
+    public ActionResult ToActionResult(HttpContext httpContext)
+    {
+        return StatusCode switch
+        {
+            StatusCodes.Status403Forbidden => ApiErrorResponses.Forbidden(httpContext, ErrorCode, Message),
+            _ => ApiErrorResponses.Unauthorized(httpContext, ErrorCode, Message)
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/AgentAuthenticationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentAuthenticationService.cs
@@ -1,0 +1,79 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+
+namespace PingMonitor.Web.Services;
+
+internal sealed class AgentAuthenticationService : IAgentAuthenticationService
+{
+    private const string InstanceIdHeaderName = "X-Instance-Id";
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly IAgentApiKeyHasher _apiKeyHasher;
+
+    public AgentAuthenticationService(PingMonitorDbContext dbContext, IAgentApiKeyHasher apiKeyHasher)
+    {
+        _dbContext = dbContext;
+        _apiKeyHasher = apiKeyHasher;
+    }
+
+    public async Task<AgentAuthenticationResult> AuthenticateAsync(HttpRequest request, CancellationToken cancellationToken)
+    {
+        var instanceId = request.Headers[InstanceIdHeaderName].ToString().Trim();
+        if (string.IsNullOrWhiteSpace(instanceId))
+        {
+            return AgentAuthenticationResult.Unauthorized($"Missing required header '{InstanceIdHeaderName}'.");
+        }
+
+        var authorizationHeader = request.Headers.Authorization.ToString();
+        if (!TryReadBearerToken(authorizationHeader, out var apiKey))
+        {
+            return AgentAuthenticationResult.Unauthorized("Missing or invalid bearer token.");
+        }
+
+        var agent = await _dbContext.Agents.SingleOrDefaultAsync(x => x.InstanceId == instanceId, cancellationToken);
+        if (agent is null)
+        {
+            return AgentAuthenticationResult.Unauthorized("The supplied agent credentials are invalid.");
+        }
+
+        if (!agent.Enabled)
+        {
+            return AgentAuthenticationResult.Forbidden("The agent is disabled.");
+        }
+
+        if (agent.ApiKeyRevoked)
+        {
+            return AgentAuthenticationResult.Forbidden("The agent API key has been revoked.");
+        }
+
+        if (string.IsNullOrWhiteSpace(agent.ApiKeyHash) || !_apiKeyHasher.Verify(agent, apiKey!))
+        {
+            return AgentAuthenticationResult.Unauthorized("The supplied agent credentials are invalid.");
+        }
+
+        return AgentAuthenticationResult.Success(agent);
+    }
+
+    private static bool TryReadBearerToken(string? authorizationHeader, out string? apiKey)
+    {
+        apiKey = null;
+        if (string.IsNullOrWhiteSpace(authorizationHeader))
+        {
+            return false;
+        }
+
+        const string prefix = "Bearer ";
+        if (!authorizationHeader.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var token = authorizationHeader[prefix.Length..].Trim();
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        apiKey = token;
+        return true;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/AgentHelloService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentHelloService.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Options;
+using PingMonitor.Web.Contracts.Hello;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Options;
+
+namespace PingMonitor.Web.Services;
+
+internal sealed class AgentHelloService : IAgentHelloService
+{
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly AgentApiOptions _options;
+
+    public AgentHelloService(PingMonitorDbContext dbContext, IOptions<AgentApiOptions> options)
+    {
+        _dbContext = dbContext;
+        _options = options.Value;
+    }
+
+    public async Task<AgentHelloResponse> ProcessHelloAsync(Agent agent, AgentHelloRequest request, CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        agent.LastSeenUtc = now;
+        agent.LastHeartbeatUtc = now;
+        agent.AgentVersion = request.AgentVersion.Trim();
+        agent.MachineName = request.MachineName.Trim();
+        agent.Platform = request.Platform.Trim();
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return new AgentHelloResponse(
+            AgentId: agent.AgentId,
+            ServerTimeUtc: now,
+            ConfigRefreshSeconds: _options.ConfigRefreshSeconds,
+            HeartbeatIntervalSeconds: _options.HeartbeatIntervalSeconds,
+            ResultBatchIntervalSeconds: _options.ResultBatchIntervalSeconds,
+            MaxResultBatchSize: _options.MaxResultBatchSize,
+            ConfigVersion: _options.ConfigVersion);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/DevelopmentAgentSeeder.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DevelopmentAgentSeeder.cs
@@ -1,0 +1,76 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Options;
+
+namespace PingMonitor.Web.Services;
+
+internal sealed class DevelopmentAgentSeeder
+{
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly DevelopmentSeedAgentOptions _options;
+    private readonly IAgentApiKeyHasher _apiKeyHasher;
+    private readonly ILogger<DevelopmentAgentSeeder> _logger;
+
+    public DevelopmentAgentSeeder(
+        PingMonitorDbContext dbContext,
+        IOptions<DevelopmentSeedAgentOptions> options,
+        IAgentApiKeyHasher apiKeyHasher,
+        ILogger<DevelopmentAgentSeeder> logger)
+    {
+        _dbContext = dbContext;
+        _options = options.Value;
+        _apiKeyHasher = apiKeyHasher;
+        _logger = logger;
+    }
+
+    public async Task SeedAsync()
+    {
+        if (!_options.Enabled)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.ApiKey))
+        {
+            _logger.LogWarning("Development agent seeding is enabled, but no API key was supplied. Set DevelopmentSeedAgent__ApiKey before calling /api/v1/agent/hello.");
+            return;
+        }
+
+        var existingAgent = await _dbContext.Agents.SingleOrDefaultAsync(x => x.InstanceId == _options.InstanceId);
+        if (existingAgent is not null)
+        {
+            existingAgent.Name = _options.Name;
+            existingAgent.Site = _options.Site;
+            existingAgent.Enabled = true;
+            existingAgent.ApiKeyRevoked = false;
+            existingAgent.ApiKeyCreatedAtUtc = DateTimeOffset.UtcNow;
+            existingAgent.ApiKeyHash = _apiKeyHasher.Hash(existingAgent, _options.ApiKey);
+            await _dbContext.SaveChangesAsync();
+
+            _logger.LogInformation("Updated development seed agent {InstanceId}.", _options.InstanceId);
+            return;
+        }
+
+        var agent = new Agent
+        {
+            AgentId = Guid.NewGuid().ToString(),
+            InstanceId = _options.InstanceId,
+            Name = _options.Name,
+            Site = _options.Site,
+            Enabled = true,
+            ApiKeyRevoked = false,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            ApiKeyCreatedAtUtc = DateTimeOffset.UtcNow,
+            Status = AgentHealthStatus.Offline
+        };
+
+        agent.ApiKeyHash = _apiKeyHasher.Hash(agent, _options.ApiKey);
+
+        _dbContext.Agents.Add(agent);
+        await _dbContext.SaveChangesAsync();
+
+        _logger.LogInformation("Seeded development agent {InstanceId}.", _options.InstanceId);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/IAgentApiKeyHasher.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IAgentApiKeyHasher.cs
@@ -1,0 +1,9 @@
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services;
+
+public interface IAgentApiKeyHasher
+{
+    string Hash(Agent agent, string apiKey);
+    bool Verify(Agent agent, string apiKey);
+}

--- a/src/WebApp/PingMonitor.Web/Services/IAgentAuthenticationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IAgentAuthenticationService.cs
@@ -1,6 +1,8 @@
+using Microsoft.AspNetCore.Http;
+
 namespace PingMonitor.Web.Services;
 
 public interface IAgentAuthenticationService
 {
-    Task<bool> ValidateAsync(string instanceId, string? authorizationHeader, CancellationToken cancellationToken);
+    Task<AgentAuthenticationResult> AuthenticateAsync(HttpRequest request, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/Services/IAgentConfigurationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IAgentConfigurationService.cs
@@ -1,10 +1,9 @@
 using PingMonitor.Web.Contracts.Config;
-using PingMonitor.Web.Contracts.Hello;
+using PingMonitor.Web.Models;
 
 namespace PingMonitor.Web.Services;
 
 public interface IAgentConfigurationService
 {
-    Task<AgentHelloResponse> BuildHelloResponseAsync(string instanceId, AgentHelloRequest request, CancellationToken cancellationToken);
-    Task<AgentConfigResponse> GetConfigurationAsync(string instanceId, CancellationToken cancellationToken);
+    Task<AgentConfigResponse> GetConfigurationAsync(Agent agent, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/Services/IAgentHelloService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IAgentHelloService.cs
@@ -1,0 +1,9 @@
+using PingMonitor.Web.Contracts.Hello;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services;
+
+public interface IAgentHelloService
+{
+    Task<AgentHelloResponse> ProcessHelloAsync(Agent agent, AgentHelloRequest request, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/IHeartbeatService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IHeartbeatService.cs
@@ -1,8 +1,9 @@
 using PingMonitor.Web.Contracts.Heartbeat;
+using PingMonitor.Web.Models;
 
 namespace PingMonitor.Web.Services;
 
 public interface IHeartbeatService
 {
-    Task<AgentHeartbeatResponse> ProcessHeartbeatAsync(string instanceId, AgentHeartbeatRequest request, CancellationToken cancellationToken);
+    Task<AgentHeartbeatResponse> ProcessHeartbeatAsync(Agent agent, AgentHeartbeatRequest request, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/Services/IResultIngestionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IResultIngestionService.cs
@@ -1,8 +1,9 @@
 using PingMonitor.Web.Contracts.Results;
+using PingMonitor.Web.Models;
 
 namespace PingMonitor.Web.Services;
 
 public interface IResultIngestionService
 {
-    Task<SubmitResultsResponse> IngestAsync(string instanceId, SubmitResultsRequest request, CancellationToken cancellationToken);
+    Task<SubmitResultsResponse> IngestAsync(Agent agent, SubmitResultsRequest request, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/Services/PlaceholderAgentAuthenticationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/PlaceholderAgentAuthenticationService.cs
@@ -1,9 +1,0 @@
-namespace PingMonitor.Web.Services;
-
-internal sealed class PlaceholderAgentAuthenticationService : IAgentAuthenticationService
-{
-    public Task<bool> ValidateAsync(string instanceId, string? authorizationHeader, CancellationToken cancellationToken)
-    {
-        return Task.FromResult(!string.IsNullOrWhiteSpace(instanceId));
-    }
-}

--- a/src/WebApp/PingMonitor.Web/Services/PlaceholderAgentConfigurationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/PlaceholderAgentConfigurationService.cs
@@ -1,26 +1,11 @@
 using PingMonitor.Web.Contracts.Config;
-using PingMonitor.Web.Contracts.Hello;
+using PingMonitor.Web.Models;
 
 namespace PingMonitor.Web.Services;
 
 internal sealed class PlaceholderAgentConfigurationService : IAgentConfigurationService
 {
-    public Task<AgentHelloResponse> BuildHelloResponseAsync(string instanceId, AgentHelloRequest request, CancellationToken cancellationToken)
-    {
-        var now = DateTimeOffset.UtcNow;
-        var response = new AgentHelloResponse(
-            AgentId: instanceId,
-            ServerTimeUtc: now,
-            ConfigRefreshSeconds: 300,
-            HeartbeatIntervalSeconds: 60,
-            ResultBatchIntervalSeconds: 10,
-            MaxResultBatchSize: 500,
-            ConfigVersion: "cfg_placeholder_v1");
-
-        return Task.FromResult(response);
-    }
-
-    public Task<AgentConfigResponse> GetConfigurationAsync(string instanceId, CancellationToken cancellationToken)
+    public Task<AgentConfigResponse> GetConfigurationAsync(Agent agent, CancellationToken cancellationToken)
     {
         var response = new AgentConfigResponse(
             ConfigVersion: "cfg_placeholder_v1",

--- a/src/WebApp/PingMonitor.Web/Services/PlaceholderHeartbeatService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/PlaceholderHeartbeatService.cs
@@ -1,10 +1,11 @@
 using PingMonitor.Web.Contracts.Heartbeat;
+using PingMonitor.Web.Models;
 
 namespace PingMonitor.Web.Services;
 
 internal sealed class PlaceholderHeartbeatService : IHeartbeatService
 {
-    public Task<AgentHeartbeatResponse> ProcessHeartbeatAsync(string instanceId, AgentHeartbeatRequest request, CancellationToken cancellationToken)
+    public Task<AgentHeartbeatResponse> ProcessHeartbeatAsync(Agent agent, AgentHeartbeatRequest request, CancellationToken cancellationToken)
     {
         var response = new AgentHeartbeatResponse(
             Ok: true,

--- a/src/WebApp/PingMonitor.Web/Services/PlaceholderResultIngestionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/PlaceholderResultIngestionService.cs
@@ -1,10 +1,11 @@
 using PingMonitor.Web.Contracts.Results;
+using PingMonitor.Web.Models;
 
 namespace PingMonitor.Web.Services;
 
 internal sealed class PlaceholderResultIngestionService : IResultIngestionService
 {
-    public Task<SubmitResultsResponse> IngestAsync(string instanceId, SubmitResultsRequest request, CancellationToken cancellationToken)
+    public Task<SubmitResultsResponse> IngestAsync(Agent agent, SubmitResultsRequest request, CancellationToken cancellationToken)
     {
         var response = new SubmitResultsResponse(
             Accepted: true,

--- a/src/WebApp/PingMonitor.Web/Support/ApiErrorResponse.cs
+++ b/src/WebApp/PingMonitor.Web/Support/ApiErrorResponse.cs
@@ -1,0 +1,11 @@
+namespace PingMonitor.Web.Support;
+
+public sealed record ApiErrorResponse(ApiErrorBody Error);
+
+public sealed record ApiErrorBody(
+    string Code,
+    string Message,
+    IReadOnlyList<ApiErrorDetail>? Details,
+    string? TraceId);
+
+public sealed record ApiErrorDetail(string Field, string Message);

--- a/src/WebApp/PingMonitor.Web/Support/ApiErrorResponses.cs
+++ b/src/WebApp/PingMonitor.Web/Support/ApiErrorResponses.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace PingMonitor.Web.Support;
+
+public static class ApiErrorResponses
+{
+    public static ObjectResult BadRequest(HttpContext httpContext, string code, string message, IReadOnlyList<ApiErrorDetail>? details = null)
+    {
+        return Create(httpContext, StatusCodes.Status400BadRequest, code, message, details);
+    }
+
+    public static ObjectResult Unauthorized(HttpContext httpContext, string code, string message, IReadOnlyList<ApiErrorDetail>? details = null)
+    {
+        return Create(httpContext, StatusCodes.Status401Unauthorized, code, message, details);
+    }
+
+    public static ObjectResult Forbidden(HttpContext httpContext, string code, string message, IReadOnlyList<ApiErrorDetail>? details = null)
+    {
+        return Create(httpContext, StatusCodes.Status403Forbidden, code, message, details);
+    }
+
+    private static ObjectResult Create(HttpContext httpContext, int statusCode, string code, string message, IReadOnlyList<ApiErrorDetail>? details)
+    {
+        var response = new ApiErrorResponse(new ApiErrorBody(
+            Code: code,
+            Message: message,
+            Details: details is { Count: > 0 } ? details : null,
+            TraceId: httpContext.TraceIdentifier));
+
+        return new ObjectResult(response)
+        {
+            StatusCode = statusCode
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Support/ModelStateFieldNameFormatter.cs
+++ b/src/WebApp/PingMonitor.Web/Support/ModelStateFieldNameFormatter.cs
@@ -1,0 +1,28 @@
+namespace PingMonitor.Web.Support;
+
+public static class ModelStateFieldNameFormatter
+{
+    public static string ToCamelCase(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return key;
+        }
+
+        var bracketIndex = key.IndexOf('[');
+        var dotIndex = key.IndexOf('.');
+        var stopIndex = new[] { bracketIndex, dotIndex }
+            .Where(index => index >= 0)
+            .DefaultIfEmpty(key.Length)
+            .Min();
+
+        var firstSegment = key[..stopIndex];
+        if (string.IsNullOrEmpty(firstSegment))
+        {
+            return key;
+        }
+
+        var camelFirstSegment = char.ToLowerInvariant(firstSegment[0]) + firstSegment[1..];
+        return camelFirstSegment + key[stopIndex..];
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Support/UtcDateTimeOffsetJsonConverter.cs
+++ b/src/WebApp/PingMonitor.Web/Support/UtcDateTimeOffsetJsonConverter.cs
@@ -1,0 +1,24 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace PingMonitor.Web.Support;
+
+public sealed class UtcDateTimeOffsetJsonConverter : JsonConverter<DateTimeOffset>
+{
+    public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new JsonException("A timestamp value is required.");
+        }
+
+        return DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.UtcDateTime.ToString("O", CultureInfo.InvariantCulture));
+    }
+}

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -1,10 +1,23 @@
 {
   "ConnectionStrings": {
-    "MonitoringDatabase": "Host=localhost;Database=pingmonitor_dev;Username=pingmonitor;Password=change-me"
+    "MonitoringDatabase": "Data Source=pingmonitor.development.db"
   },
   "Api": {
     "RequireHttps": true,
     "BasePath": "/api/v1"
+  },
+  "AgentApi": {
+    "ConfigRefreshSeconds": 300,
+    "HeartbeatIntervalSeconds": 60,
+    "ResultBatchIntervalSeconds": 10,
+    "MaxResultBatchSize": 500,
+    "ConfigVersion": "cfg_dev_v1"
+  },
+  "DevelopmentSeedAgent": {
+    "Enabled": true,
+    "InstanceId": "dev-agent-01",
+    "Name": "Local Development Agent",
+    "Site": "Local"
   },
   "Logging": {
     "LogLevel": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -1,10 +1,23 @@
 {
   "ConnectionStrings": {
-    "MonitoringDatabase": "Host=localhost;Database=pingmonitor;Username=pingmonitor;Password=change-me"
+    "MonitoringDatabase": "Data Source=pingmonitor.db"
   },
   "Api": {
     "RequireHttps": true,
     "BasePath": "/api/v1"
+  },
+  "AgentApi": {
+    "ConfigRefreshSeconds": 300,
+    "HeartbeatIntervalSeconds": 60,
+    "ResultBatchIntervalSeconds": 10,
+    "MaxResultBatchSize": 500,
+    "ConfigVersion": "cfg_v1_initial"
+  },
+  "DevelopmentSeedAgent": {
+    "Enabled": false,
+    "InstanceId": "dev-agent-01",
+    "Name": "Local Development Agent",
+    "Site": "Local"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
### Motivation

- Provide a minimal, explicit, and documented end-to-end implementation of `POST /api/v1/agent/hello` that authenticates agents and returns server timing guidance while preserving the platform constraints and API contract.
- Add the smallest persistence and plumbing needed to support agent authentication and metadata updates without implementing config, results ingestion, state engine, or alerting logic.

### Description

- Add EF Core + SQLite-backed persistence for the `Agent` entity via `PingMonitorDbContext` and wire `EnsureCreated` on startup, keeping the model limited to fields needed for `/hello` (identity, api key hash, enabled/revoked, last seen/heartbeat, metadata). (Fixes #6)
- Implement a robust authentication path that reads `X-Instance-Id` and `Authorization: Bearer <API_KEY>`, looks up the agent by `InstanceId`, checks `Enabled` and `ApiKeyRevoked`, and verifies the API key against a stored hash using ASP.NET Core `PasswordHasher`.
- Implement `IAgentHelloService` and `AgentHelloService` to validate the request shape (UTC `startedAtUtc`, capabilities), update agent metadata (`LastSeenUtc`, `LastHeartbeatUtc`, `AgentVersion`, `MachineName`, `Platform`), and return a structurally correct `AgentHelloResponse` populated from bound `AgentApi` options.
- Wire authentication into the v1 agent controllers so `/hello`, `/config`, `/heartbeat`, and `/results` all use the same authentication result, keep `/config`, `/heartbeat`, and `/results` behavior as placeholders, and add a development-only seeder that inserts/updates a single dev agent when enabled and hashes the supplied dev API key at startup.
- Add small API support pieces: `AgentApiOptions` config section with hello timing defaults, consistent JSON error envelope and helper `ApiErrorResponses`, a UTC `DateTimeOffset` JSON converter, and a short local dev note `docs/agent-hello-local.md`; also update `docs/PLATFORM_CONSTRAINTS.md` to explicitly require .NET 10 for the web app.

### Testing

- `dotnet build` of the solution completed successfully and the project compiled without errors. (succeeded)
- Ran the web app in `Development` with `DevelopmentSeedAgent__ApiKey` set and the development seeder created the dev agent and the app started and listened as expected. (succeeded)
- Exercised `/api/v1/agent/hello` via `curl` using the seeded `dev-agent-01` and the supplied dev API key and received a `200 OK` with a valid `AgentHelloResponse`. (succeeded)
- Verified error handling by calling `/hello` without `X-Instance-Id` and with a wrong API key and observed `401 Unauthorized` JSON envelopes, and verified non-UTC timestamps produce `400 Bad Request` JSON envelopes. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c00d367a18832a92060f36b70e2e29)