### PR TITLE
docs: align architecture docs with MySQL-only setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Network Monitoring Web App
 
-A lightweight, agent-based network monitoring platform built with .NET.
+A lightweight, agent-based network monitoring platform with a .NET 10 control plane and Python execution agents.
 
 This system focuses on **reliable uptime monitoring**, **clean alerting**, and **predictable behaviour**, without the complexity of a full NMS.
 
@@ -38,7 +38,7 @@ The design prioritises:
 
 ### Execution Plane (Agents)
 
-- Lightweight .NET worker services
+- Lightweight Python agents
 - Run on remote networks/sites
 - Execute checks locally (ICMP ping in v1)
 - Report raw results to the server
@@ -189,12 +189,12 @@ Each endpoint (per agent) has a state:
 
 ---
 
-## Tech Stack (Planned)
+## Tech Stack
 
-- .NET (ASP.NET Core + Worker Services)
+- .NET 10 (ASP.NET Core web application)
+- Python agents
 - REST API (agent communication)
-- MySQL or PostgreSQL (production)
-- SQLite (optional for development)
+- MySQL (used in all environments)
 - Razor / Blazor (UI)
 
 ---
@@ -208,9 +208,9 @@ Each endpoint (per agent) has a state:
 
 ---
 
-## Getting Started (Planned)
+## Getting Started
 
-> Initial setup instructions will be added as the project structure is created.
+> Initial setup instructions are still being expanded as the platform foundation is completed.
 
 Expected flow:
 
@@ -235,9 +235,9 @@ Expected flow:
 
 ## Status
 
-🚧 Early development / design phase
+🚧 Foundational implementation in progress
 
-Core architecture is being defined before implementation begins.
+Startup gate and agent API endpoints are in place, with MySQL used in all environments. The core control-plane and execution-plane foundation exists, while the server-side state engine and alert lifecycle remain to be completed.
 
 ---
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -31,6 +31,14 @@ This model is **authoritative** and must align with:
 
 ---
 
+## Storage baseline
+
+- MySQL is the only supported database engine in all environments
+- The data model does not define a SQLite or alternate relational database path
+- Startup-gate schema validation must align with this model before the main application becomes available
+
+---
+
 ## Core entities
 
 ### Agent

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,16 +1,27 @@
 # Implementation plan
 
-## Phase 1: Skeleton
-Create the repository structure, .NET 10 web API shell, Python outbound agent shell, and minimal configuration/docs alignment.
+## Current status
+
+The platform foundation is in place:
+
+- startup gate exists for MySQL-backed application startup
+- authenticated agent API endpoints exist for hello/config/heartbeat/results
+- result ingestion and core control-plane/execution-plane wiring exist
+- server-side state engine and alert lifecycle are still pending
+
+---
+
+## Phase 1: Foundation
+Repository structure, .NET 10 web application shell, Python outbound agent shell, and core configuration/docs alignment are in place.
 
 ## Phase 2: Auth/config endpoints
-Implement authenticated agent hello/config/heartbeat/results handling with persisted agent records and configuration delivery.
+Authenticated agent hello/config/heartbeat/results handling with persisted agent records and configuration delivery is in place.
 
 ## Phase 3: Agent hello/config flow
-Add agent startup flow, cached configuration handling, and explicit heartbeat/config refresh behaviour.
+Agent startup flow, cached configuration handling, and explicit heartbeat/config refresh behaviour are in place.
 
 ## Phase 4: Result ingestion
-Persist raw check results, batch idempotency, and auditable ingestion outcomes.
+Raw check-result persistence, batch idempotency, and auditable ingestion outcomes are in place.
 
 ## Phase 5: State engine
 Implement server-side assignment-scoped state calculation and suppression rules from the monitoring state machine.
@@ -19,4 +30,4 @@ Implement server-side assignment-scoped state calculation and suppression rules 
 Add server-side alert lifecycle handling driven by state transitions.
 
 ## Phase 7: UI
-Add the .NET web application control-plane UI without moving monitoring interpretation into the agent.
+Continue the .NET web application control-plane UI without moving monitoring interpretation into the agent.


### PR DESCRIPTION
### Motivation

- Ensure documentation accurately reflects the current MySQL-only architecture and the implemented platform foundation while keeping changes documentation-only and minimal. 
- Clarify project status to show the startup gate and agent API foundation exist while server-side state engine and alert lifecycle remain pending. 

### Description

- Updated `README.md` to reflect the control plane as a .NET 10 web application and the execution plane as Python agents, replaced multi-DB/dev DB wording with MySQL-only wording, and adjusted the status text to note foundational components are in place. (file: `README.md`) 
- Added a short `Storage baseline` section to `docs/data-model.md` explicitly stating MySQL is the only supported engine and that the startup-gate/schema validation must align with this model. (file: `docs/data-model.md`) 
- Updated `docs/implementation-plan.md` to present current status and to mark the startup gate, authenticated agent API endpoints, and result ingestion as in place while noting the server-side state engine and alert lifecycle are pending. (file: `docs/implementation-plan.md`) 
- Did not modify code or runtime behaviour; only documentation files were changed. 
- This PR links and fixes the documentation issue created for this work: `Fixes #15`. 

### Testing

- Verified open-issue state and created issue `#15` when none matched the task requirements, which completed successfully. 
- Performed targeted searches (`rg`) across README and docs to find and replace stale references to PostgreSQL/SQLite and confirm MySQL-only wording; all searches returned expected results. 
- Ran `git` checks to confirm only documentation files were staged and committed, and no code files were modified; commit succeeded. 
- Generated and reviewed diffs (`git diff`) to validate the exact changes to `README.md`, `docs/data-model.md`, and `docs/implementation-plan.md`; results matched the intended edits. 

All automated checks and validation commands run during the change process completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c182ec4014832a808f8167bcff5fbb)