### PR TITLE
Implement assignment state evaluation engine

### DIFF
--- a/src/WebApp/PingMonitor.Web/Contracts/Diagnostics/AssignmentStateDiagnosticResponse.cs
+++ b/src/WebApp/PingMonitor.Web/Contracts/Diagnostics/AssignmentStateDiagnosticResponse.cs
@@ -1,0 +1,23 @@
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Contracts.Diagnostics;
+
+public sealed record AssignmentStateDiagnosticResponse(
+    string AssignmentId,
+    string AgentId,
+    string EndpointId,
+    EndpointStateKind CurrentState,
+    int ConsecutiveFailureCount,
+    int ConsecutiveSuccessCount,
+    DateTimeOffset? LastCheckUtc,
+    DateTimeOffset? LastStateChangeUtc,
+    string? SuppressedByEndpointId,
+    IReadOnlyList<StateTransitionDiagnosticItem> Transitions);
+
+public sealed record StateTransitionDiagnosticItem(
+    string TransitionId,
+    EndpointStateKind PreviousState,
+    EndpointStateKind NewState,
+    DateTimeOffset TransitionAtUtc,
+    string? ReasonCode,
+    string? DependencyEndpointId);

--- a/src/WebApp/PingMonitor.Web/Controllers/DevelopmentStateDiagnosticsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/DevelopmentStateDiagnosticsController.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Contracts.Diagnostics;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Controllers;
+
+[ApiController]
+[Route("internal/dev/state")]
+public sealed class DevelopmentStateDiagnosticsController : ControllerBase
+{
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly IWebHostEnvironment _environment;
+
+    public DevelopmentStateDiagnosticsController(
+        PingMonitorDbContext dbContext,
+        IWebHostEnvironment environment)
+    {
+        _dbContext = dbContext;
+        _environment = environment;
+    }
+
+    [HttpGet("assignments/{assignmentId}")]
+    [ProducesResponseType(typeof(AssignmentStateDiagnosticResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<AssignmentStateDiagnosticResponse>> GetAssignmentStateAsync(
+        string assignmentId,
+        CancellationToken cancellationToken)
+    {
+        if (!_environment.IsDevelopment())
+        {
+            return NotFound();
+        }
+
+        var normalizedAssignmentId = assignmentId.Trim();
+        var assignment = await _dbContext.MonitorAssignments
+            .SingleOrDefaultAsync(x => x.AssignmentId == normalizedAssignmentId, cancellationToken);
+
+        if (assignment is null)
+        {
+            return NotFound();
+        }
+
+        var state = await _dbContext.EndpointStates
+            .SingleOrDefaultAsync(x => x.AssignmentId == normalizedAssignmentId, cancellationToken);
+
+        var transitions = await _dbContext.StateTransitions
+            .Where(x => x.AssignmentId == normalizedAssignmentId)
+            .OrderByDescending(x => x.TransitionAtUtc)
+            .Select(x => new StateTransitionDiagnosticItem(
+                x.TransitionId,
+                x.PreviousState,
+                x.NewState,
+                x.TransitionAtUtc,
+                x.ReasonCode,
+                x.DependencyEndpointId))
+            .ToArrayAsync(cancellationToken);
+
+        return Ok(new AssignmentStateDiagnosticResponse(
+            assignment.AssignmentId,
+            assignment.AgentId,
+            assignment.EndpointId,
+            state?.CurrentState ?? EndpointStateKind.Unknown,
+            state?.ConsecutiveFailureCount ?? 0,
+            state?.ConsecutiveSuccessCount ?? 0,
+            state?.LastCheckUtc,
+            state?.LastStateChangeUtc,
+            state?.SuppressedByEndpointId,
+            transitions));
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -21,6 +21,8 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
     public DbSet<MonitorAssignment> MonitorAssignments => Set<MonitorAssignment>();
     public DbSet<CheckResult> CheckResults => Set<CheckResult>();
     public DbSet<ResultBatch> ResultBatches => Set<ResultBatch>();
+    public DbSet<EndpointState> EndpointStates => Set<EndpointState>();
+    public DbSet<StateTransition> StateTransitions => Set<StateTransition>();
     public DbSet<AppSchemaInfo> AppSchemaInfos => Set<AppSchemaInfo>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -107,5 +109,30 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         resultBatch.Property(x => x.ReceivedAtUtc).IsRequired();
         resultBatch.Property(x => x.AcceptedCount).IsRequired();
         resultBatch.HasIndex(x => new { x.AgentId, x.BatchId }).IsUnique();
+
+        var endpointState = modelBuilder.Entity<EndpointState>();
+        endpointState.ToTable("EndpointStates");
+        endpointState.HasKey(x => x.AssignmentId);
+        endpointState.Property(x => x.AssignmentId).HasMaxLength(64);
+        endpointState.Property(x => x.AgentId).HasMaxLength(64).IsRequired();
+        endpointState.Property(x => x.EndpointId).HasMaxLength(64).IsRequired();
+        endpointState.Property(x => x.CurrentState).HasConversion<string>().HasMaxLength(16).IsRequired();
+        endpointState.Property(x => x.LastStateChangeUtc);
+        endpointState.Property(x => x.LastCheckUtc);
+        endpointState.Property(x => x.SuppressedByEndpointId).HasMaxLength(64);
+
+        var stateTransition = modelBuilder.Entity<StateTransition>();
+        stateTransition.ToTable("StateTransitions");
+        stateTransition.HasKey(x => x.TransitionId);
+        stateTransition.Property(x => x.TransitionId).HasMaxLength(64);
+        stateTransition.Property(x => x.AssignmentId).HasMaxLength(64).IsRequired();
+        stateTransition.Property(x => x.AgentId).HasMaxLength(64).IsRequired();
+        stateTransition.Property(x => x.EndpointId).HasMaxLength(64).IsRequired();
+        stateTransition.Property(x => x.PreviousState).HasConversion<string>().HasMaxLength(16).IsRequired();
+        stateTransition.Property(x => x.NewState).HasConversion<string>().HasMaxLength(16).IsRequired();
+        stateTransition.Property(x => x.TransitionAtUtc).IsRequired();
+        stateTransition.Property(x => x.ReasonCode).HasMaxLength(64);
+        stateTransition.Property(x => x.DependencyEndpointId).HasMaxLength(64);
+        stateTransition.HasIndex(x => new { x.AssignmentId, x.TransitionAtUtc });
     }
 }

--- a/src/WebApp/PingMonitor.Web/Models/EndpointState.cs
+++ b/src/WebApp/PingMonitor.Web/Models/EndpointState.cs
@@ -9,4 +9,7 @@ public sealed class EndpointState
     public DateTimeOffset? LastCheckUtc { get; set; }
     public DateTimeOffset? LastStateChangeUtc { get; set; }
     public string? SuppressedByEndpointId { get; set; }
+
+    public string AgentId { get; set; } = string.Empty;
+    public string EndpointId { get; set; } = string.Empty;
 }

--- a/src/WebApp/PingMonitor.Web/Models/StateTransitionReasonCodes.cs
+++ b/src/WebApp/PingMonitor.Web/Models/StateTransitionReasonCodes.cs
@@ -1,0 +1,11 @@
+namespace PingMonitor.Web.Models;
+
+public static class StateTransitionReasonCodes
+{
+    public const string FailureThresholdReached = "failure_threshold_reached";
+    public const string RecoveryThresholdReached = "recovery_threshold_reached";
+    public const string DependencyDown = "dependency_down";
+    public const string DependencyCleared = "dependency_cleared";
+    public const string AdministrativeReset = "administrative_reset";
+    public const string AgentContextLost = "agent_context_lost";
+}

--- a/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
@@ -5,6 +5,6 @@ public sealed class StartupGateOptions
     public const string SectionName = "StartupGate";
 
     public string StorageDirectory { get; set; } = "App_Data/StartupGate";
-    public int RequiredSchemaVersion { get; set; } = 1;
+    public int RequiredSchemaVersion { get; set; } = 2;
     public int DefaultMySqlPort { get; set; } = 3306;
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -81,7 +81,7 @@ builder.Services.AddScoped<IAgentHelloService, AgentHelloService>();
 builder.Services.AddScoped<IAgentConfigurationService, AgentConfigurationService>();
 builder.Services.AddScoped<IResultIngestionService, ResultIngestionService>();
 builder.Services.AddScoped<IHeartbeatService, AgentHeartbeatService>();
-builder.Services.AddScoped<IStateEvaluationService, PlaceholderStateEvaluationService>();
+builder.Services.AddScoped<IStateEvaluationService, StateEvaluationService>();
 builder.Services.AddScoped<IStartupGateService, StartupGateService>();
 builder.Services.AddSingleton<IStartupDatabaseConfigurationStore, FileStartupDatabaseConfigurationStore>();
 builder.Services.AddSingleton<ILocalRequestEvaluator, LocalRequestEvaluator>();

--- a/src/WebApp/PingMonitor.Web/README.md
+++ b/src/WebApp/PingMonitor.Web/README.md
@@ -34,3 +34,21 @@ If no admin exists, the gate remains active. A local request can create the firs
 ## Remote diagnostics
 
 While the gate is active, remote requests can only view diagnostics. They cannot save database settings, apply schema changes, or create the initial admin.
+
+## Development state-engine test notes
+
+With the development seed enabled, the app creates one agent plus two ICMP assignments:
+
+- `assignment-dev-gateway` for the parent endpoint `endpoint-dev-gateway`
+- `assignment-dev-printer` for the child endpoint `endpoint-dev-printer`, which depends on the gateway
+
+Use `POST /api/v1/agent/results` with the seeded agent credentials to post raw results only.
+
+- To drive `UNKNOWN -> UP`, submit consecutive successful results until the assignment reaches its `recoveryThreshold`.
+- To drive `UP -> DOWN`, submit consecutive failed results until the assignment reaches its `failureThreshold`.
+- To drive child suppression, first drive `assignment-dev-gateway` to `DOWN`, then submit enough failed results for `assignment-dev-printer` to reach its failure threshold; the child should transition to `SUPPRESSED` while the parent remains `DOWN`.
+
+In development, inspect current assignment state and transition history at:
+
+- `GET /internal/dev/state/assignments/assignment-dev-gateway`
+- `GET /internal/dev/state/assignments/assignment-dev-printer`

--- a/src/WebApp/PingMonitor.Web/Services/AgentHeartbeatService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentHeartbeatService.cs
@@ -25,6 +25,7 @@ internal sealed class AgentHeartbeatService : IHeartbeatService
         agent.LastHeartbeatUtc = now;
         agent.LastSeenUtc = now;
         agent.AgentVersion = request.AgentVersion.Trim();
+        agent.Status = AgentHealthStatus.Online;
 
         await _dbContext.SaveChangesAsync(cancellationToken);
 

--- a/src/WebApp/PingMonitor.Web/Services/AgentHelloService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentHelloService.cs
@@ -26,6 +26,7 @@ internal sealed class AgentHelloService : IAgentHelloService
         agent.AgentVersion = request.AgentVersion.Trim();
         agent.MachineName = request.MachineName.Trim();
         agent.Platform = request.Platform.Trim();
+        agent.Status = AgentHealthStatus.Online;
 
         await _dbContext.SaveChangesAsync(cancellationToken);
 

--- a/src/WebApp/PingMonitor.Web/Services/DevelopmentAgentSeeder.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DevelopmentAgentSeeder.cs
@@ -93,6 +93,8 @@ internal sealed class DevelopmentAgentSeeder
 
         await EnsureAssignmentAsync(agent.AgentId, gatewayEndpoint.EndpointId, "assignment-dev-gateway", now, cancellationToken);
         await EnsureAssignmentAsync(agent.AgentId, printerEndpoint.EndpointId, "assignment-dev-printer", now, cancellationToken);
+        await EnsureStateAsync(agent.AgentId, gatewayEndpoint.EndpointId, "assignment-dev-gateway", cancellationToken);
+        await EnsureStateAsync(agent.AgentId, printerEndpoint.EndpointId, "assignment-dev-printer", cancellationToken);
     }
 
     private async Task<EndpointModel> EnsureEndpointAsync(
@@ -153,5 +155,24 @@ internal sealed class DevelopmentAgentSeeder
         assignment.FailureThreshold = endpointId == "endpoint-dev-gateway" ? 3 : 2;
         assignment.RecoveryThreshold = 2;
         assignment.UpdatedAtUtc = now;
+    }
+
+    private async Task EnsureStateAsync(string agentId, string endpointId, string assignmentId, CancellationToken cancellationToken)
+    {
+        var state = await _dbContext.EndpointStates.SingleOrDefaultAsync(x => x.AssignmentId == assignmentId, cancellationToken);
+        if (state is not null)
+        {
+            state.AgentId = agentId;
+            state.EndpointId = endpointId;
+            return;
+        }
+
+        _dbContext.EndpointStates.Add(new EndpointState
+        {
+            AssignmentId = assignmentId,
+            AgentId = agentId,
+            EndpointId = endpointId,
+            CurrentState = EndpointStateKind.Unknown
+        });
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/IStateEvaluationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IStateEvaluationService.cs
@@ -3,4 +3,5 @@ namespace PingMonitor.Web.Services;
 public interface IStateEvaluationService
 {
     Task EvaluateAssignmentStateAsync(string assignmentId, CancellationToken cancellationToken);
+    Task EvaluateAssignmentsAsync(IEnumerable<string> assignmentIds, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/Services/PlaceholderStateEvaluationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/PlaceholderStateEvaluationService.cs
@@ -1,9 +1,0 @@
-namespace PingMonitor.Web.Services;
-
-internal sealed class PlaceholderStateEvaluationService : IStateEvaluationService
-{
-    public Task EvaluateAssignmentStateAsync(string assignmentId, CancellationToken cancellationToken)
-    {
-        return Task.CompletedTask;
-    }
-}

--- a/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
@@ -9,10 +9,14 @@ namespace PingMonitor.Web.Services;
 internal sealed class ResultIngestionService : IResultIngestionService
 {
     private readonly PingMonitorDbContext _dbContext;
+    private readonly IStateEvaluationService _stateEvaluationService;
 
-    public ResultIngestionService(PingMonitorDbContext dbContext)
+    public ResultIngestionService(
+        PingMonitorDbContext dbContext,
+        IStateEvaluationService stateEvaluationService)
     {
         _dbContext = dbContext;
+        _stateEvaluationService = stateEvaluationService;
     }
 
     public async Task<SubmitResultsResponse> IngestAsync(Agent agent, SubmitResultsRequest request, CancellationToken cancellationToken)
@@ -119,9 +123,17 @@ internal sealed class ResultIngestionService : IResultIngestionService
             _dbContext.ResultBatches.Add(batch);
 
             agent.LastSeenUtc = receivedAtUtc;
+            agent.Status = AgentHealthStatus.Online;
 
             await _dbContext.SaveChangesAsync(cancellationToken);
             await transaction.CommitAsync(cancellationToken);
+
+            var affectedAssignmentIds = storedResults
+                .Select(x => x.AssignmentId)
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+
+            await _stateEvaluationService.EvaluateAssignmentsAsync(affectedAssignmentIds, cancellationToken);
 
             return new SubmitResultsResponse(true, storedResults.Length, false, serverTimeUtc);
         }

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -19,7 +19,9 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "Endpoints",
         "MonitorAssignments",
         "CheckResults",
-        "ResultBatches"
+        "ResultBatches",
+        "EndpointStates",
+        "StateTransitions"
     ];
 
     private readonly IDbContextFactory<PingMonitorDbContext> _dbContextFactory;
@@ -112,6 +114,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
 
         await using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
         await dbContext.Database.EnsureCreatedAsync(cancellationToken);
+        await EnsureStateEngineTablesAsync(dbContext, cancellationToken);
 
         var schemaInfo = await dbContext.AppSchemaInfos.OrderByDescending(x => x.AppSchemaInfoId).FirstOrDefaultAsync(cancellationToken);
         if (schemaInfo is null)
@@ -133,5 +136,41 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         _logger.LogInformation("Startup gate schema apply completed successfully.");
 
         return await GetStatusAsync(cancellationToken);
+    }
+
+    private static async Task EnsureStateEngineTablesAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
+    {
+        const string createEndpointStatesSql = """
+            CREATE TABLE IF NOT EXISTS `EndpointStates` (
+                `AssignmentId` varchar(64) NOT NULL,
+                `CurrentState` varchar(16) NOT NULL,
+                `ConsecutiveFailureCount` int NOT NULL,
+                `ConsecutiveSuccessCount` int NOT NULL,
+                `LastCheckUtc` datetime(6) NULL,
+                `LastStateChangeUtc` datetime(6) NULL,
+                `SuppressedByEndpointId` varchar(64) NULL,
+                `AgentId` varchar(64) NOT NULL,
+                `EndpointId` varchar(64) NOT NULL,
+                PRIMARY KEY (`AssignmentId`)
+            );
+            """;
+
+        const string createStateTransitionsSql = """
+            CREATE TABLE IF NOT EXISTS `StateTransitions` (
+                `TransitionId` varchar(64) NOT NULL,
+                `AssignmentId` varchar(64) NOT NULL,
+                `AgentId` varchar(64) NOT NULL,
+                `EndpointId` varchar(64) NOT NULL,
+                `PreviousState` varchar(16) NOT NULL,
+                `NewState` varchar(16) NOT NULL,
+                `TransitionAtUtc` datetime(6) NOT NULL,
+                `ReasonCode` varchar(64) NULL,
+                `DependencyEndpointId` varchar(64) NULL,
+                PRIMARY KEY (`TransitionId`)
+            );
+            """;
+
+        await dbContext.Database.ExecuteSqlRawAsync(createEndpointStatesSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createStateTransitionsSql, cancellationToken);
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
@@ -1,0 +1,290 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using EndpointModel = PingMonitor.Web.Models.Endpoint;
+
+namespace PingMonitor.Web.Services;
+
+internal sealed class StateEvaluationService : IStateEvaluationService
+{
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly ILogger<StateEvaluationService> _logger;
+
+    public StateEvaluationService(
+        PingMonitorDbContext dbContext,
+        ILogger<StateEvaluationService> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task EvaluateAssignmentsAsync(IEnumerable<string> assignmentIds, CancellationToken cancellationToken)
+    {
+        var pendingAssignmentIds = new Queue<string>(assignmentIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id.Trim())
+            .Distinct(StringComparer.Ordinal));
+        var processedAssignmentIds = new HashSet<string>(StringComparer.Ordinal);
+
+        while (pendingAssignmentIds.Count > 0)
+        {
+            var assignmentId = pendingAssignmentIds.Dequeue();
+            if (!processedAssignmentIds.Add(assignmentId))
+            {
+                continue;
+            }
+
+            var transitionedAcrossDownBoundary = await EvaluateInternalAsync(assignmentId, cancellationToken);
+            if (transitionedAcrossDownBoundary.Count == 0)
+            {
+                continue;
+            }
+
+            foreach (var childAssignmentId in transitionedAcrossDownBoundary)
+            {
+                if (!processedAssignmentIds.Contains(childAssignmentId))
+                {
+                    pendingAssignmentIds.Enqueue(childAssignmentId);
+                }
+            }
+        }
+    }
+
+    public Task EvaluateAssignmentStateAsync(string assignmentId, CancellationToken cancellationToken)
+    {
+        return EvaluateAssignmentsAsync([assignmentId], cancellationToken);
+    }
+
+    private async Task<IReadOnlyCollection<string>> EvaluateInternalAsync(string assignmentId, CancellationToken cancellationToken)
+    {
+        var assignment = await _dbContext.MonitorAssignments
+            .SingleOrDefaultAsync(x => x.AssignmentId == assignmentId, cancellationToken);
+
+        if (assignment is null)
+        {
+            _logger.LogWarning("State evaluation skipped because assignment {AssignmentId} was not found.", assignmentId);
+            return Array.Empty<string>();
+        }
+
+        var endpoint = await _dbContext.Endpoints
+            .SingleAsync(x => x.EndpointId == assignment.EndpointId, cancellationToken);
+        var agent = await _dbContext.Agents
+            .SingleAsync(x => x.AgentId == assignment.AgentId, cancellationToken);
+
+        var state = await _dbContext.EndpointStates
+            .SingleOrDefaultAsync(x => x.AssignmentId == assignment.AssignmentId, cancellationToken);
+
+        if (state is null)
+        {
+            state = new EndpointState
+            {
+                AssignmentId = assignment.AssignmentId,
+                AgentId = assignment.AgentId,
+                EndpointId = assignment.EndpointId,
+                CurrentState = EndpointStateKind.Unknown
+            };
+
+            _dbContext.EndpointStates.Add(state);
+        }
+
+        state.AgentId = assignment.AgentId;
+        state.EndpointId = assignment.EndpointId;
+
+        var latestResult = await _dbContext.CheckResults
+            .Where(x => x.AssignmentId == assignment.AssignmentId)
+            .OrderByDescending(x => x.CheckedAtUtc)
+            .ThenByDescending(x => x.ReceivedAtUtc)
+            .ThenByDescending(x => x.CheckResultId)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (latestResult is not null && state.LastCheckUtc != latestResult.CheckedAtUtc)
+        {
+            state.LastCheckUtc = latestResult.CheckedAtUtc;
+            if (latestResult.Success)
+            {
+                state.ConsecutiveSuccessCount += 1;
+                state.ConsecutiveFailureCount = 0;
+            }
+            else
+            {
+                state.ConsecutiveFailureCount += 1;
+                state.ConsecutiveSuccessCount = 0;
+            }
+        }
+
+        var parentContext = await GetParentContextAsync(assignment, endpoint, cancellationToken);
+        var previousState = state.CurrentState;
+        var nextState = DetermineNextState(assignment, state, agent, parentContext);
+        var reasonCode = GetReasonCode(previousState, nextState, parentContext.DependencyDown);
+
+        state.CurrentState = nextState;
+        state.SuppressedByEndpointId = nextState == EndpointStateKind.Suppressed
+            ? parentContext.ParentEndpointId
+            : null;
+
+        if (previousState != nextState)
+        {
+            state.LastStateChangeUtc = DateTimeOffset.UtcNow;
+            _dbContext.StateTransitions.Add(new StateTransition
+            {
+                TransitionId = Guid.NewGuid().ToString(),
+                AssignmentId = assignment.AssignmentId,
+                AgentId = assignment.AgentId,
+                EndpointId = assignment.EndpointId,
+                PreviousState = previousState,
+                NewState = nextState,
+                TransitionAtUtc = state.LastStateChangeUtc.Value,
+                ReasonCode = reasonCode,
+                DependencyEndpointId = nextState == EndpointStateKind.Suppressed ? parentContext.ParentEndpointId : null
+            });
+
+            _logger.LogInformation(
+                "Assignment {AssignmentId} transitioned from {PreviousState} to {NewState} with reason {ReasonCode}.",
+                assignment.AssignmentId,
+                previousState,
+                nextState,
+                reasonCode ?? "(none)");
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        if (CrossedDownBoundary(previousState, nextState))
+        {
+            return await GetDirectChildAssignmentIdsAsync(assignment, cancellationToken);
+        }
+
+        return Array.Empty<string>();
+    }
+
+    private async Task<ParentStateContext> GetParentContextAsync(
+        MonitorAssignment assignment,
+        EndpointModel endpoint,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(endpoint.DependsOnEndpointId))
+        {
+            return ParentStateContext.None;
+        }
+
+        var parentAssignment = await _dbContext.MonitorAssignments
+            .SingleOrDefaultAsync(
+                x => x.AgentId == assignment.AgentId && x.EndpointId == endpoint.DependsOnEndpointId,
+                cancellationToken);
+
+        if (parentAssignment is null)
+        {
+            return new ParentStateContext(endpoint.DependsOnEndpointId, false);
+        }
+
+        var parentState = await _dbContext.EndpointStates
+            .SingleOrDefaultAsync(x => x.AssignmentId == parentAssignment.AssignmentId, cancellationToken);
+
+        return new ParentStateContext(
+            endpoint.DependsOnEndpointId,
+            parentState?.CurrentState == EndpointStateKind.Down);
+    }
+
+    private async Task<IReadOnlyCollection<string>> GetDirectChildAssignmentIdsAsync(
+        MonitorAssignment assignment,
+        CancellationToken cancellationToken)
+    {
+        var childEndpointIds = await _dbContext.Endpoints
+            .Where(x => x.DependsOnEndpointId == assignment.EndpointId)
+            .Select(x => x.EndpointId)
+            .ToArrayAsync(cancellationToken);
+
+        if (childEndpointIds.Length == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        return await _dbContext.MonitorAssignments
+            .Where(x => x.AgentId == assignment.AgentId && childEndpointIds.Contains(x.EndpointId))
+            .Select(x => x.AssignmentId)
+            .ToArrayAsync(cancellationToken);
+    }
+
+    private static EndpointStateKind DetermineNextState(
+        MonitorAssignment assignment,
+        EndpointState state,
+        Agent agent,
+        ParentStateContext parentContext)
+    {
+        if (!assignment.Enabled)
+        {
+            return EndpointStateKind.Unknown;
+        }
+
+        if (!agent.Enabled || agent.ApiKeyRevoked || agent.Status != AgentHealthStatus.Online)
+        {
+            return EndpointStateKind.Unknown;
+        }
+
+        var failureReached = state.ConsecutiveFailureCount >= assignment.FailureThreshold;
+        var recoveryReached = state.ConsecutiveSuccessCount >= assignment.RecoveryThreshold;
+
+        if (recoveryReached)
+        {
+            return EndpointStateKind.Up;
+        }
+
+        if (failureReached && parentContext.DependencyDown)
+        {
+            return EndpointStateKind.Suppressed;
+        }
+
+        if (failureReached)
+        {
+            return EndpointStateKind.Down;
+        }
+
+        // DEGRADED is intentionally dormant in v1 until degradation policy exists.
+        return state.CurrentState;
+    }
+
+    private static string? GetReasonCode(EndpointStateKind previousState, EndpointStateKind newState, bool dependencyDown)
+    {
+        if (previousState == newState)
+        {
+            return null;
+        }
+
+        if (newState == EndpointStateKind.Unknown)
+        {
+            return StateTransitionReasonCodes.AgentContextLost;
+        }
+
+        if (newState == EndpointStateKind.Suppressed)
+        {
+            return StateTransitionReasonCodes.DependencyDown;
+        }
+
+        if (newState == EndpointStateKind.Up)
+        {
+            return previousState == EndpointStateKind.Suppressed
+                ? StateTransitionReasonCodes.DependencyCleared
+                : StateTransitionReasonCodes.RecoveryThresholdReached;
+        }
+
+        if (newState == EndpointStateKind.Down)
+        {
+            return previousState == EndpointStateKind.Suppressed && !dependencyDown
+                ? StateTransitionReasonCodes.DependencyCleared
+                : StateTransitionReasonCodes.FailureThresholdReached;
+        }
+
+        return null;
+    }
+
+    private static bool CrossedDownBoundary(EndpointStateKind previousState, EndpointStateKind newState)
+    {
+        var previousWasDown = previousState == EndpointStateKind.Down;
+        var newIsDown = newState == EndpointStateKind.Down;
+        return previousWasDown != newIsDown;
+    }
+
+    private readonly record struct ParentStateContext(string? ParentEndpointId, bool DependencyDown)
+    {
+        public static ParentStateContext None => new(null, false);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 1,
+    "RequiredSchemaVersion": 2,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 1,
+    "RequiredSchemaVersion": 2,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
### Motivation
- Implement the first server-side, deterministic state evaluation engine so the server derives per-assignment state from raw results as defined in `docs/monitoring-state-machine.md`.
- Ensure suppression is server-side and only direct-parent `DOWN` suppresses a child while preserving per-assignment scoping and auditability.
- Keep `DEGRADED` present in the model but dormant for v1 so future quality rules can be added without changing semantics.

### Description
- Persisted current derived snapshots and history by adding `EndpointState` and `StateTransition` models/DbSets and mapping schema, including fields `AssignmentId`, `AgentId`, `EndpointId`, `CurrentState`, `ConsecutiveFailureCount`, `ConsecutiveSuccessCount`, `LastCheckUtc`, `LastStateChangeUtc`, and `SuppressedByEndpointId` for `EndpointState`, and the required `StateTransition` columns plus reason codes in `StateTransitionReasonCodes`.
- Implemented `IStateEvaluationService` and `StateEvaluationService` which update counters from newly accepted `CheckResult`s, apply exact threshold rules (failure/recovery), evaluate direct-parent suppression, persist `StateTransition` records when state changes, and return direct-child assignment IDs for reevaluation when a parent crosses the `DOWN` boundary.
- Integrated evaluation into result ingestion so `ResultIngestionService` invokes evaluation only after a non-duplicate batch is stored and only for affected assignments, while duplicate batches short-circuit and do not retrigger evaluation.
- Added development diagnostics at `GET /internal/dev/state/assignments/{assignmentId}` (dev-only), extended the development seeder to create assignment state rows, and updated startup-gate schema checks and apply logic (bumped required schema version to `2` and created state engine tables when applying schema).
- Did not add alert generation, reminder notifications, or active `DEGRADED` policies; all new logic is explicit, per-assignment, and aligned to `docs/data-model.md` and `docs/monitoring-state-machine.md` (Fixes #17).

### Testing
- Built the solution with `dotnet build src/WebApp/PingMonitor.WebApp.slnx` which completed successfully.
- Verified the evaluation flow by confirming that duplicate `ResultBatch` submissions short-circuit before evaluation and that accepted batches trigger evaluation for the affected assignment set; this was validated during the local build/run iteration.
- Platform/runtime validation commands executed successfully: `dotnet --info` and `pwsh --version` (used to prepare the environment for the build).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c184e19994832ab23e03db9a092776)