### PR TITLE
Add operational endpoint status page

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/StatusController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/StatusController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Services.Status;
+
+namespace PingMonitor.Web.Controllers;
+
+[Route("status")]
+public sealed class StatusController : Controller
+{
+    private readonly IEndpointStatusQueryService _endpointStatusQueryService;
+
+    public StatusController(IEndpointStatusQueryService endpointStatusQueryService)
+    {
+        _endpointStatusQueryService = endpointStatusQueryService;
+    }
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index([FromQuery] string? state, [FromQuery] string? agent, [FromQuery] string? search, CancellationToken cancellationToken)
+    {
+        var viewModel = await _endpointStatusQueryService.GetStatusPageAsync(state, agent, search, cancellationToken);
+        return View("Index", viewModel);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -7,6 +7,7 @@ using PingMonitor.Web.Models.Identity;
 using PingMonitor.Web.Options;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.StartupGate;
+using PingMonitor.Web.Services.Status;
 using PingMonitor.Web.Support;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -82,6 +83,7 @@ builder.Services.AddScoped<IAgentConfigurationService, AgentConfigurationService
 builder.Services.AddScoped<IResultIngestionService, ResultIngestionService>();
 builder.Services.AddScoped<IHeartbeatService, AgentHeartbeatService>();
 builder.Services.AddScoped<IStateEvaluationService, StateEvaluationService>();
+builder.Services.AddScoped<IEndpointStatusQueryService, EndpointStatusQueryService>();
 builder.Services.AddScoped<IStartupGateService, StartupGateService>();
 builder.Services.AddSingleton<IStartupDatabaseConfigurationStore, FileStartupDatabaseConfigurationStore>();
 builder.Services.AddSingleton<ILocalRequestEvaluator, LocalRequestEvaluator>();

--- a/src/WebApp/PingMonitor.Web/README.md
+++ b/src/WebApp/PingMonitor.Web/README.md
@@ -52,3 +52,9 @@ In development, inspect current assignment state and transition history at:
 
 - `GET /internal/dev/state/assignments/assignment-dev-gateway`
 - `GET /internal/dev/state/assignments/assignment-dev-printer`
+
+## Operational status page
+
+In normal startup mode, the first operational status page is available at `GET /status`.
+
+It shows the current server-derived state for each `MonitorAssignment`, including endpoint, target, agent instance, state, counters, dependency parent, suppression source, check type, and enabled flags. The page is assignment-scoped, so the same endpoint can appear more than once for different agents. `SUPPRESSED` is derived on the server from dependency evaluation and is never agent-supplied.

--- a/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
@@ -1,0 +1,127 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.ViewModels.Status;
+
+namespace PingMonitor.Web.Services.Status;
+
+internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
+{
+    private readonly PingMonitorDbContext _dbContext;
+
+    public EndpointStatusQueryService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<EndpointStatusPageViewModel> GetStatusPageAsync(
+        string? state,
+        string? agent,
+        string? search,
+        CancellationToken cancellationToken)
+    {
+        var normalizedState = Normalize(state);
+        var normalizedAgent = Normalize(agent);
+        var normalizedSearch = Normalize(search);
+        var parsedState = TryParseState(normalizedState);
+
+        var baseQuery =
+            from assignment in _dbContext.MonitorAssignments.AsNoTracking()
+            join endpoint in _dbContext.Endpoints.AsNoTracking() on assignment.EndpointId equals endpoint.EndpointId
+            join assignmentAgent in _dbContext.Agents.AsNoTracking() on assignment.AgentId equals assignmentAgent.AgentId
+            join endpointState in _dbContext.EndpointStates.AsNoTracking() on assignment.AssignmentId equals endpointState.AssignmentId into endpointStateJoin
+            from endpointState in endpointStateJoin.DefaultIfEmpty()
+            join parentEndpoint in _dbContext.Endpoints.AsNoTracking() on endpoint.DependsOnEndpointId equals parentEndpoint.EndpointId into parentEndpointJoin
+            from parentEndpoint in parentEndpointJoin.DefaultIfEmpty()
+            join suppressedByEndpoint in _dbContext.Endpoints.AsNoTracking() on endpointState!.SuppressedByEndpointId equals suppressedByEndpoint.EndpointId into suppressedByEndpointJoin
+            from suppressedByEndpoint in suppressedByEndpointJoin.DefaultIfEmpty()
+            select new EndpointStatusRowViewModel
+            {
+                AssignmentId = assignment.AssignmentId,
+                EndpointId = endpoint.EndpointId,
+                EndpointName = endpoint.Name,
+                Target = endpoint.Target,
+                AgentId = assignmentAgent.AgentId,
+                AgentInstanceId = assignmentAgent.InstanceId,
+                AgentName = assignmentAgent.Name ?? assignmentAgent.InstanceId,
+                CurrentState = endpointState != null ? endpointState.CurrentState : EndpointStateKind.Unknown,
+                LastCheckUtc = endpointState != null ? endpointState.LastCheckUtc : null,
+                LastStateChangeUtc = endpointState != null ? endpointState.LastStateChangeUtc : null,
+                ConsecutiveFailureCount = endpointState != null ? endpointState.ConsecutiveFailureCount : 0,
+                ConsecutiveSuccessCount = endpointState != null ? endpointState.ConsecutiveSuccessCount : 0,
+                CheckType = assignment.CheckType.ToString(),
+                AssignmentEnabled = assignment.Enabled,
+                EndpointEnabled = endpoint.Enabled,
+                ParentEndpointId = endpoint.DependsOnEndpointId,
+                ParentEndpointName = parentEndpoint != null ? parentEndpoint.Name : null,
+                SuppressedByEndpointId = endpointState != null ? endpointState.SuppressedByEndpointId : null,
+                SuppressedByEndpointName = suppressedByEndpoint != null ? suppressedByEndpoint.Name : null
+            };
+
+        if (parsedState.HasValue)
+        {
+            baseQuery = baseQuery.Where(row => row.CurrentState == parsedState.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(normalizedAgent))
+        {
+            baseQuery = baseQuery.Where(row => row.AgentInstanceId == normalizedAgent);
+        }
+
+        if (!string.IsNullOrWhiteSpace(normalizedSearch))
+        {
+            baseQuery = baseQuery.Where(row =>
+                EF.Functions.Like(row.EndpointName, $"%{normalizedSearch}%") ||
+                EF.Functions.Like(row.Target, $"%{normalizedSearch}%"));
+        }
+
+        var availableAgents = await _dbContext.Agents.AsNoTracking()
+            .OrderBy(x => x.InstanceId)
+            .Select(x => x.InstanceId)
+            .ToArrayAsync(cancellationToken);
+
+        var rows = await baseQuery
+            .OrderBy(row => row.CurrentState)
+            .ThenBy(row => row.EndpointName)
+            .ThenBy(row => row.AgentInstanceId)
+            .ToArrayAsync(cancellationToken);
+
+        return new EndpointStatusPageViewModel
+        {
+            Summary = new EndpointStatusSummaryViewModel
+            {
+                TotalAssignments = rows.Length,
+                UnknownCount = rows.Count(row => row.CurrentState == EndpointStateKind.Unknown),
+                UpCount = rows.Count(row => row.CurrentState == EndpointStateKind.Up),
+                DegradedCount = rows.Count(row => row.CurrentState == EndpointStateKind.Degraded),
+                DownCount = rows.Count(row => row.CurrentState == EndpointStateKind.Down),
+                SuppressedCount = rows.Count(row => row.CurrentState == EndpointStateKind.Suppressed)
+            },
+            Filters = new EndpointStatusFiltersViewModel
+            {
+                State = normalizedState,
+                Agent = normalizedAgent,
+                Search = normalizedSearch,
+                AvailableAgents = availableAgents
+            },
+            Rows = rows
+        };
+    }
+
+    private static string? Normalize(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private static EndpointStateKind? TryParseState(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return Enum.TryParse<EndpointStateKind>(value, ignoreCase: true, out var parsedValue)
+            ? parsedValue
+            : null;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Status/IEndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/IEndpointStatusQueryService.cs
@@ -1,0 +1,8 @@
+using PingMonitor.Web.ViewModels.Status;
+
+namespace PingMonitor.Web.Services.Status;
+
+public interface IEndpointStatusQueryService
+{
+    Task<EndpointStatusPageViewModel> GetStatusPageAsync(string? state, string? agent, string? search, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/Status/EndpointStatusPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Status/EndpointStatusPageViewModel.cs
@@ -1,0 +1,59 @@
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.ViewModels.Status;
+
+public sealed class EndpointStatusPageViewModel
+{
+    public EndpointStatusSummaryViewModel Summary { get; init; } = new();
+    public EndpointStatusFiltersViewModel Filters { get; init; } = new();
+    public IReadOnlyList<EndpointStatusRowViewModel> Rows { get; init; } = [];
+}
+
+public sealed class EndpointStatusSummaryViewModel
+{
+    public int TotalAssignments { get; init; }
+    public int UnknownCount { get; init; }
+    public int UpCount { get; init; }
+    public int DegradedCount { get; init; }
+    public int DownCount { get; init; }
+    public int SuppressedCount { get; init; }
+}
+
+public sealed class EndpointStatusFiltersViewModel
+{
+    public string? State { get; init; }
+    public string? Agent { get; init; }
+    public string? Search { get; init; }
+    public IReadOnlyList<string> AvailableAgents { get; init; } = [];
+    public IReadOnlyList<EndpointStateKind> AvailableStates { get; init; } =
+    [
+        EndpointStateKind.Unknown,
+        EndpointStateKind.Up,
+        EndpointStateKind.Degraded,
+        EndpointStateKind.Down,
+        EndpointStateKind.Suppressed
+    ];
+}
+
+public sealed class EndpointStatusRowViewModel
+{
+    public string AssignmentId { get; init; } = string.Empty;
+    public string EndpointId { get; init; } = string.Empty;
+    public string EndpointName { get; init; } = string.Empty;
+    public string Target { get; init; } = string.Empty;
+    public string AgentId { get; init; } = string.Empty;
+    public string AgentInstanceId { get; init; } = string.Empty;
+    public string AgentName { get; init; } = string.Empty;
+    public EndpointStateKind CurrentState { get; init; } = EndpointStateKind.Unknown;
+    public DateTimeOffset? LastCheckUtc { get; init; }
+    public DateTimeOffset? LastStateChangeUtc { get; init; }
+    public int ConsecutiveFailureCount { get; init; }
+    public int ConsecutiveSuccessCount { get; init; }
+    public string CheckType { get; init; } = string.Empty;
+    public bool AssignmentEnabled { get; init; }
+    public bool EndpointEnabled { get; init; }
+    public string? ParentEndpointId { get; init; }
+    public string? ParentEndpointName { get; init; }
+    public string? SuppressedByEndpointId { get; init; }
+    public string? SuppressedByEndpointName { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -1,0 +1,181 @@
+@model PingMonitor.Web.ViewModels.Status.EndpointStatusPageViewModel
+@using PingMonitor.Web.Models
+@{
+    static string FormatDate(DateTimeOffset? value) => value.HasValue ? value.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") : "No checks yet";
+    static string FormatDependency(string? endpointId, string? endpointName, string emptyText) => string.IsNullOrWhiteSpace(endpointId)
+        ? emptyText
+        : string.IsNullOrWhiteSpace(endpointName)
+            ? $"{endpointId} (name unavailable)"
+            : endpointName;
+    static string StateClass(EndpointStateKind state) => state switch
+    {
+        EndpointStateKind.Up => "state-up",
+        EndpointStateKind.Down => "state-down",
+        EndpointStateKind.Suppressed => "state-suppressed",
+        EndpointStateKind.Degraded => "state-degraded",
+        _ => "state-unknown"
+    };
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Endpoint status</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #f3f6f8;
+            --card: #ffffff;
+            --text: #102a43;
+            --muted: #52606d;
+            --border: #d9e2ec;
+            --up: #137333;
+            --down: #b42318;
+            --suppressed: #7a2e0e;
+            --unknown: #475467;
+            --degraded: #b54708;
+            --accent: #0f62fe;
+        }
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 1180px; margin: 0 auto; padding: 1rem; }
+        .stack { display: grid; gap: 1rem; }
+        .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
+        .summary-grid, .filter-grid, .row-meta { display: grid; gap: .75rem; }
+        .summary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        .summary-item { border: 1px solid var(--border); border-radius: 12px; padding: .85rem; }
+        .summary-item strong { display: block; font-size: 1.4rem; margin-top: .25rem; }
+        .filter-grid { grid-template-columns: 1fr; }
+        label { display: block; font-weight: 600; margin-bottom: .35rem; }
+        input, select { width: 100%; padding: .85rem; border: 1px solid var(--border); border-radius: 10px; font-size: 1rem; }
+        .button-row { display: flex; gap: .75rem; flex-wrap: wrap; }
+        .button, .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 48px; padding: .8rem 1rem; border-radius: 10px; font-weight: 600; text-decoration: none; }
+        .button { border: 0; background: var(--accent); color: white; }
+        .button-secondary { border: 1px solid var(--border); color: var(--text); background: white; }
+        .badge { display: inline-flex; align-items: center; justify-content: center; min-height: 32px; padding: .3rem .65rem; border-radius: 999px; font-size: .9rem; font-weight: 700; letter-spacing: .02em; }
+        .state-up { color: var(--up); background: #e7f6ec; }
+        .state-down { color: var(--down); background: #fee4e2; }
+        .state-suppressed { color: var(--suppressed); background: #fff1eb; }
+        .state-unknown { color: var(--unknown); background: #eaecf0; }
+        .state-degraded { color: var(--degraded); background: #fff7e6; }
+        .muted { color: var(--muted); }
+        .row-list { display: grid; gap: .9rem; }
+        .status-row { border: 1px solid var(--border); border-radius: 12px; padding: 1rem; }
+        .status-row h2 { margin: 0; font-size: 1.1rem; }
+        .row-header { display: flex; flex-direction: column; gap: .75rem; margin-bottom: .85rem; }
+        .row-meta { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        .meta-item { min-width: 0; }
+        .meta-item span { display: block; font-size: .85rem; color: var(--muted); margin-bottom: .2rem; }
+        .empty { text-align: center; padding: 1rem; border: 1px dashed var(--border); border-radius: 12px; }
+        .nowrap { white-space: nowrap; }
+        @@media (min-width: 720px) {
+            .summary-grid { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+            .filter-grid { grid-template-columns: 1fr 220px 220px; align-items: end; }
+            .row-header { flex-direction: row; justify-content: space-between; align-items: start; }
+            .row-meta { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+        }
+    </style>
+</head>
+<body>
+<main>
+    <div class="stack">
+        <section class="card">
+            <h1>Operational endpoint status</h1>
+            <p class="muted">Current assignment-scoped status derived by the server state engine. Missing state rows are shown as <strong>UNKNOWN</strong> until trusted server-side state exists.</p>
+        </section>
+
+        <section class="card">
+            <h2>Summary</h2>
+            <div class="summary-grid">
+                <div class="summary-item"><div class="muted">Total assignments</div><strong>@Model.Summary.TotalAssignments</strong></div>
+                <div class="summary-item"><div class="muted">UP</div><strong>@Model.Summary.UpCount</strong></div>
+                <div class="summary-item"><div class="muted">DOWN</div><strong>@Model.Summary.DownCount</strong></div>
+                <div class="summary-item"><div class="muted">SUPPRESSED</div><strong>@Model.Summary.SuppressedCount</strong></div>
+                <div class="summary-item"><div class="muted">UNKNOWN</div><strong>@Model.Summary.UnknownCount</strong></div>
+                <div class="summary-item"><div class="muted">DEGRADED</div><strong>@Model.Summary.DegradedCount</strong></div>
+            </div>
+        </section>
+
+        <section class="card">
+            <h2>Filters</h2>
+            <form method="get" action="/status" class="stack">
+                <div class="filter-grid">
+                    <div>
+                        <label for="search">Search endpoint or target</label>
+                        <input id="search" name="search" value="@Model.Filters.Search" placeholder="Endpoint name or IP / hostname" />
+                    </div>
+                    <div>
+                        <label for="state">State</label>
+                        <select id="state" name="state">
+                            <option value="">All states</option>
+                            @foreach (var state in Model.Filters.AvailableStates)
+                            {
+                                <option value="@state" selected="@(string.Equals(Model.Filters.State, state.ToString(), StringComparison.OrdinalIgnoreCase))">@state</option>
+                            }
+                        </select>
+                    </div>
+                    <div>
+                        <label for="agent">Agent</label>
+                        <select id="agent" name="agent">
+                            <option value="">All agents</option>
+                            @foreach (var availableAgent in Model.Filters.AvailableAgents)
+                            {
+                                <option value="@availableAgent" selected="@(string.Equals(Model.Filters.Agent, availableAgent, StringComparison.Ordinal))">@availableAgent</option>
+                            }
+                        </select>
+                    </div>
+                </div>
+                <div class="button-row">
+                    <button class="button" type="submit">Apply filters</button>
+                    <a class="button-secondary" href="/status">Clear filters</a>
+                </div>
+            </form>
+        </section>
+
+        <section class="card">
+            <h2>Assignments</h2>
+            @if (Model.Rows.Count == 0)
+            {
+                <div class="empty">
+                    <p><strong>No assignments match the current view.</strong></p>
+                    <p class="muted">If assignments have not been created yet, they will appear here once the server has configuration records. Assignments with no current state snapshot are still shown as UNKNOWN when present.</p>
+                </div>
+            }
+            else
+            {
+                <div class="row-list">
+                    @foreach (var row in Model.Rows)
+                    {
+                        <article class="status-row">
+                            <div class="row-header">
+                                <div>
+                                    <h2>@row.EndpointName</h2>
+                                    <div class="muted">@row.Target</div>
+                                </div>
+                                <div class="badge @StateClass(row.CurrentState)">@row.CurrentState</div>
+                            </div>
+
+                            <div class="row-meta">
+                                <div class="meta-item"><span>Agent / instance</span><div>@row.AgentName <span class="muted">(@row.AgentInstanceId)</span></div></div>
+                                <div class="meta-item"><span>Check type</span><div>@row.CheckType</div></div>
+                                <div class="meta-item"><span>Last check</span><div class="nowrap">@FormatDate(row.LastCheckUtc)</div></div>
+                                <div class="meta-item"><span>Last state change</span><div class="nowrap">@FormatDate(row.LastStateChangeUtc)</div></div>
+                                <div class="meta-item"><span>Consecutive failures</span><div>@row.ConsecutiveFailureCount</div></div>
+                                <div class="meta-item"><span>Consecutive successes</span><div>@row.ConsecutiveSuccessCount</div></div>
+                                <div class="meta-item"><span>Dependency parent</span><div>@FormatDependency(row.ParentEndpointId, row.ParentEndpointName, "None")</div></div>
+                                <div class="meta-item"><span>Suppressed by</span><div>@FormatDependency(row.SuppressedByEndpointId, row.SuppressedByEndpointName, "Not suppressed")</div></div>
+                                <div class="meta-item"><span>Assignment enabled</span><div>@(row.AssignmentEnabled ? "Enabled" : "Disabled")</div></div>
+                                <div class="meta-item"><span>Endpoint enabled</span><div>@(row.EndpointEnabled ? "Enabled" : "Disabled")</div></div>
+                                <div class="meta-item"><span>Assignment ID</span><div>@row.AssignmentId</div></div>
+                                <div class="meta-item"><span>Endpoint ID</span><div>@row.EndpointId</div></div>
+                            </div>
+                        </article>
+                    }
+                </div>
+            }
+        </section>
+    </div>
+</main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide the first operational, server-rendered status page that shows current assignment-scoped endpoint state derived by the server-side state engine and obeys platform constraints.
- Keep the UI simple, read-only, mobile-friendly and avoid adding alerting, history, or agent-side semantics while preserving startup-gate behaviour.
- Expose useful operational fields (agent, target, state, counters, dependency/suppression) to operators without changing any state or semantics.

### Description
- Add a read-only query service (`IEndpointStatusQueryService` / `EndpointStatusQueryService`) that joins `MonitorAssignment`, `Endpoint`, `Agent`, and optional `EndpointState` and resolves parent and suppressed-by endpoint names, defaulting missing state to `UNKNOWN` (src/WebApp/PingMonitor.Web/Services/Status).
- Add view models for the page (`EndpointStatusPageViewModel` and row/summary/filter models) and a thin `StatusController` mapped at `GET /status` which loads the view model and returns the Razor view (src/WebApp/PingMonitor.Web/ViewModels/Status and Controllers/StatusController.cs).
- Add a server-rendered Razor view `Views/Status/Index.cshtml` that shows a summary strip, simple server-side filters (`state`, `agent`, `search`), and assignment cards with endpoint name, target, agent/instance, current state, last check, last state change, consecutive failure/success counters, dependency parent, suppressed-by endpoint, check type, and enabled flags.
- Register the service in DI (`Program.cs`) and add a short README note describing the route and that state is per-assignment and `SUPPRESSED` is server-derived; no write actions or alerting were added.
- This change is linked to the tracking issue and includes the standard issue reference: Fixes #19.

### Testing
- `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` succeeded with 0 errors and 0 warnings.
- `dotnet run --project src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` started the app successfully and served the new route in normal mode.
- Verified with an automated HTTP check that `GET /status` is available in normal mode and that, while the startup gate is active in this environment, `GET /status` redirects to `/startup-gate` as designed (startup-gate blocking behaviour preserved).
- No UI screenshots were captured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1880b81a4832a9e71cd27d45e0552)