### PR TITLE
Fix startup gate nested form binding

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs
@@ -41,7 +41,7 @@ public sealed class StartupGateController : Controller
 
     [HttpPost("database")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> SaveDatabaseConfiguration([FromForm] StartupDatabaseConfigurationForm form, CancellationToken cancellationToken)
+    public async Task<IActionResult> SaveDatabaseConfiguration([FromForm(Name = "DatabaseForm")] StartupDatabaseConfigurationForm form, CancellationToken cancellationToken)
     {
         var status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
         if (!status.CanPerformWriteActions)
@@ -105,7 +105,7 @@ public sealed class StartupGateController : Controller
 
     [HttpPost("admin")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> CreateInitialAdmin([FromForm] StartupAdminBootstrapForm form, CancellationToken cancellationToken)
+    public async Task<IActionResult> CreateInitialAdmin([FromForm(Name = "AdminForm")] StartupAdminBootstrapForm form, CancellationToken cancellationToken)
     {
         var status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
         if (!status.CanPerformWriteActions)


### PR DESCRIPTION
### Motivation
- The startup gate Razor view submits nested field names like `DatabaseForm.Host` and `AdminForm.Username`, but the controller actions were binding directly to the nested form types without the matching prefix, causing ASP.NET Core model binding to mark required fields as missing and preventing MySQL configuration and initial admin creation from being saved.

### Description
- Update `StartupGateController` POST actions to bind the nested forms by name by adding `[FromForm(Name = "DatabaseForm")]` to the database action and `[FromForm(Name = "AdminForm")]` to the admin action.  
- This aligns controller binding with the Razor view field prefixes so submitted values are recognized and validated correctly.  
- No behavioural changes beyond correcting model binding and preserving existing validation and logging.  
- Fixes #25.

### Testing
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the build succeeded with `0 Warning(s)` and `0 Error(s)`.  
- Verified the project restores and compiles against the required .NET 10 SDK (`10.0.104`) after installing the SDK used during testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c19881bc3c832ab67205e84165cc90)