### PR TITLE
Fix startup gate schema apply using saved DB credentials

### DIFF
--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -21,19 +21,7 @@ builder.Services.Configure<AgentApiOptions>(builder.Configuration.GetSection(Age
 builder.Services.Configure<DevelopmentSeedAgentOptions>(builder.Configuration.GetSection(DevelopmentSeedAgentOptions.SectionName));
 builder.Services.Configure<StartupGateOptions>(builder.Configuration.GetSection(StartupGateOptions.SectionName));
 
-builder.Services.AddDbContextFactory<PingMonitorDbContext>((serviceProvider, options) =>
-{
-    var configurationStore = serviceProvider.GetRequiredService<IStartupDatabaseConfigurationStore>();
-    var startupGateOptions = serviceProvider.GetRequiredService<Microsoft.Extensions.Options.IOptions<StartupGateOptions>>().Value;
-    var configuration = configurationStore.LoadAsync(CancellationToken.None).GetAwaiter().GetResult();
-    var password = configuration is null ? null : configurationStore.LoadPasswordAsync(CancellationToken.None).GetAwaiter().GetResult();
-    var connectionString = configuration is not null && configuration.IsComplete && !string.IsNullOrWhiteSpace(password)
-        ? configurationStore.BuildConnectionString(configuration, password)
-        : $"Server=localhost;Port={startupGateOptions.DefaultMySqlPort};Database=pingmonitor_placeholder;User ID=placeholder;Password=placeholder;SslMode=Preferred;AllowPublicKeyRetrieval=True";
-
-    options.UseMySQL(connectionString);
-});
-
+builder.Services.AddSingleton<IDbContextFactory<PingMonitorDbContext>, DynamicPingMonitorDbContextFactory>();
 builder.Services.AddScoped(sp => sp.GetRequiredService<IDbContextFactory<PingMonitorDbContext>>().CreateDbContext());
 
 builder.Services

--- a/src/WebApp/PingMonitor.Web/Services/DynamicPingMonitorDbContextFactory.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DynamicPingMonitorDbContextFactory.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore;
+using MySql.EntityFrameworkCore.Extensions;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Options;
+using PingMonitor.Web.Services.StartupGate;
+
+namespace PingMonitor.Web.Services;
+
+internal sealed class DynamicPingMonitorDbContextFactory : IDbContextFactory<PingMonitorDbContext>
+{
+    private readonly IStartupDatabaseConfigurationStore _configurationStore;
+    private readonly StartupGateOptions _startupGateOptions;
+
+    public DynamicPingMonitorDbContextFactory(
+        IStartupDatabaseConfigurationStore configurationStore,
+        Microsoft.Extensions.Options.IOptions<StartupGateOptions> startupGateOptions)
+    {
+        _configurationStore = configurationStore;
+        _startupGateOptions = startupGateOptions.Value;
+    }
+
+    public PingMonitorDbContext CreateDbContext()
+    {
+        var configuration = _configurationStore.LoadAsync(CancellationToken.None).GetAwaiter().GetResult();
+        var password = configuration is null
+            ? null
+            : _configurationStore.LoadPasswordAsync(CancellationToken.None).GetAwaiter().GetResult();
+        var connectionString = configuration is not null && configuration.IsComplete && !string.IsNullOrWhiteSpace(password)
+            ? _configurationStore.BuildConnectionString(configuration, password)
+            : $"Server=localhost;Port={_startupGateOptions.DefaultMySqlPort};Database=pingmonitor_placeholder;User ID=placeholder;Password=placeholder;SslMode=Preferred;AllowPublicKeyRetrieval=True";
+
+        var optionsBuilder = new DbContextOptionsBuilder<PingMonitorDbContext>();
+        optionsBuilder.UseMySQL(connectionString);
+        return new PingMonitorDbContext(optionsBuilder.Options);
+    }
+
+    public Task<PingMonitorDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(CreateDbContext());
+    }
+}


### PR DESCRIPTION
### Motivation
- The startup gate captured a placeholder MySQL connection string at app startup causing subsequent schema apply attempts to authenticate with the `placeholder` user instead of the saved credentials, blocking first-run setup. 
- Schema apply and other startup-gate DB operations must always use the latest saved database configuration stored by the startup gate.

### Description
- Replace the static EF Core factory registration that locked in the startup connection string with a dynamic factory `DynamicPingMonitorDbContextFactory` that reloads saved startup-gate DB settings each time a context is created. 
- Update `Program.cs` to register the dynamic factory via `AddSingleton<IDbContextFactory<PingMonitorDbContext>, DynamicPingMonitorDbContextFactory>()` and keep the scoped context resolution unchanged. 
- Keep the existing placeholder MySQL fallback for pre-configuration behavior so the startup gate still functions safely before real DB settings are saved. 
- Fix is tracked and linked to the new issue created for traceability (`Fixes #27`).

### Testing
- Ran a solution build with `PATH=/root/.dotnet:$PATH dotnet build src/WebApp/PingMonitor.WebApp.slnx` and the build succeeded with zero errors. 
- Verified repository state and commit including changes to `src/WebApp/PingMonitor.Web/Program.cs` and the new `src/WebApp/PingMonitor.Web/Services/DynamicPingMonitorDbContextFactory.cs` were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1b20af2b8832abbfaaab102d489f3)