### PR TITLE
Route root (`/`) to StatusController.Index to restore landing page

### DIFF
--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -114,6 +114,8 @@ app.Use(async (context, next) =>
 });
 
 app.MapControllers();
-app.MapDefaultControllerRoute();
+app.MapControllerRoute(
+    name: "default",
+    pattern: "{controller=Status}/{action=Index}/{id?}");
 
 app.Run();

--- a/src/WebApp/PingMonitor.Web/README.md
+++ b/src/WebApp/PingMonitor.Web/README.md
@@ -56,5 +56,6 @@ In development, inspect current assignment state and transition history at:
 ## Operational status page
 
 In normal startup mode, the first operational status page is available at `GET /status`.
+The default landing page at `GET /` routes to the same `StatusController.Index` page so the control plane has an operational landing route immediately after startup-gate completion.
 
 It shows the current server-derived state for each `MonitorAssignment`, including endpoint, target, agent instance, state, counters, dependency parent, suppression source, check type, and enabled flags. The page is assignment-scoped, so the same endpoint can appear more than once for different agents. `SUPPRESSED` is derived on the server from dependency evaluation and is never agent-supplied.


### PR DESCRIPTION
### Motivation
- After completing schema creation and initial admin bootstrap the site remained unreachable at `/` because the default MVC route still targeted a non-operational `Home/Index` while the app exposes the operational page at `/status`.
- Provide an always-available control-plane landing route after the startup gate clears without changing startup-gate semantics or behavior.

### Description
- Change the default MVC route in `src/WebApp/PingMonitor.Web/Program.cs` to `"{controller=Status}/{action=Index}/{id?}"` so `GET /` resolves to `StatusController.Index` instead of `Home/Index`.
- Update `src/WebApp/PingMonitor.Web/README.md` to document that `GET /` and `GET /status` now lead to the same operational status page.
- This PR fixes the routing regression and preserves existing startup-gate middleware behavior; Fixes #29.

### Testing
- Installed the pinned .NET 10 SDK from `global.json` and validated the web project builds with `PATH=/root/.dotnet:$PATH dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which succeeded.
- Attempted `dotnet test` but there is no repository-level test project or solution so automated tests could not be run; `dotnet test` was not applicable in this repo layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1b6dffac0832a8957b7e7498734ad)