### PR TITLE
Process forwarded proxy headers before HTTPS redirect (fix landing page timeout)

### DIFF
--- a/docs/iis-build-and-setup.md
+++ b/docs/iis-build-and-setup.md
@@ -225,6 +225,23 @@ Keep these deployment details in mind:
 - Confirm the **.NET 10 Hosting Bundle** is installed on the server.
 - If IIS was installed after the Hosting Bundle, repair/re-run the Hosting Bundle installer.
 
+### Landing page times out after startup gate is complete
+
+If startup-gate setup succeeds locally but the public landing page at `https://your-hostname/` hangs or times out after that, verify that the deployed application is running a build that processes forwarded proxy headers before HTTPS redirection.
+
+Why this matters:
+
+- the application is expected to run behind IIS with HTTPS exposed to users
+- without forwarded header processing, an app behind a proxy can misread the original request scheme/host
+- that can cause incorrect HTTPS redirect behavior after startup-gate completion, which may appear in browser diagnostics as a timeout or an unsafe attempt to reload the deployed URL from `chrome-error://chromewebdata/`
+
+Practical checks:
+
+- confirm IIS is serving the latest published output, not an older publish folder
+- recycle the IIS application pool after deploying the updated publish output
+- verify the site binding and certificate are correct for the public hostname
+- if another reverse proxy sits in front of IIS, make sure it preserves standard forwarded headers
+
 ### Site keeps landing on `/startup-gate`
 
 That means one or more startup checks still fail. Review the diagnostics shown by the gate and verify:

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using MySql.EntityFrameworkCore.Extensions;
 using PingMonitor.Web.Data;
@@ -63,6 +64,15 @@ builder.Services.Configure<ApiBehaviorOptions>(options =>
 });
 
 builder.Services.AddHealthChecks();
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders =
+        ForwardedHeaders.XForwardedFor |
+        ForwardedHeaders.XForwardedProto |
+        ForwardedHeaders.XForwardedHost;
+    options.KnownIPNetworks.Clear();
+    options.KnownProxies.Clear();
+});
 
 builder.Services.AddScoped<IAgentApiKeyHasher, AgentApiKeyHasher>();
 builder.Services.AddScoped<IAgentAuthenticationService, AgentAuthenticationService>();
@@ -81,6 +91,7 @@ builder.Services.AddScoped<DevelopmentAgentSeeder>();
 
 var app = builder.Build();
 
+app.UseForwardedHeaders();
 app.UseHttpsRedirection();
 app.UseAuthorization();
 app.UseStaticFiles();


### PR DESCRIPTION
### Motivation

- After completing the startup-gate and initial admin setup some deployments behind IIS/reverse proxies experienced the landing page hanging or timing out due to incorrect scheme/host handling.  
- Requests proxied through HTTPS can be misinterpreted by the app if forwarded headers are not processed before `UseHttpsRedirection()`, causing redirect/timeouts in browsers.  
- The change is a minimal, explicit platform-safe fix to preserve original request metadata when running behind standard HTTPS-terminating proxies.

### Description

- Configure `ForwardedHeadersOptions` to accept `X-Forwarded-For`, `X-Forwarded-Proto`, and `X-Forwarded-Host` and clear `KnownIPNetworks`/`KnownProxies` in `Program.cs`.  
- Call `app.UseForwardedHeaders()` before `app.UseHttpsRedirection()` so the original scheme/host are available when the app performs HTTPS redirects.  
- Add a troubleshooting section to `docs/iis-build-and-setup.md` describing the landing-page timeout symptom and practical deployment checks.  
- Fixes #31.

### Testing

- Built the web project with `dotnet build ./src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj --configuration Release` and the build completed successfully.  
- Verified runtime/tooling information with `dotnet --info` and PowerShell via `pwsh -NoLogo -Command '$PSVersionTable.PSVersion.ToString()'`.  
- Confirmed the project compiles with the forwarded-header changes and no build errors remained after replacing deprecated API usage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1ba4adeb4832a90c3863b12495421)