### PR TITLE
Fix control-plane root landing route

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/StatusController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/StatusController.cs
@@ -14,6 +14,7 @@ public sealed class StatusController : Controller
     }
 
     [HttpGet("")]
+    [HttpGet("/")]
     public async Task<IActionResult> Index([FromQuery] string? state, [FromQuery] string? agent, [FromQuery] string? search, CancellationToken cancellationToken)
     {
         var viewModel = await _endpointStatusQueryService.GetStatusPageAsync(state, agent, search, cancellationToken);


### PR DESCRIPTION
### Motivation
- The application documentation requires that `GET /` serve the operational status page after the startup-gate completes, but a 404 was observed for `/` following a successful local setup. 
- Ensure the control-plane landing route is explicit and reliable so users reach the same status page as `GET /status` once startup tasks (DB config, schema, admin) are complete.

### Description
- Add an explicit root route attribute to `StatusController.Index` by adding `[HttpGet("/")]` so `GET /` resolves to the same status page as `GET /status` (file: `src/WebApp/PingMonitor.Web/Controllers/StatusController.cs`).
- Verified the full startup-gate flow locally against a MySQL instance and confirmed the landing page loads as expected after setup.
- Link to tracking issue: Fixes #33.

### Testing
- Installed runtime dependencies (`dotnet-sdk-10.0`, `powershell`, `mysql-server`) and verified with `dotnet --info`, `pwsh -v`, and `mysql --version`, all succeeded. 
- Ran the repository build script with `pwsh -File ./scripts/build.ps1 -Configuration Release` and `dotnet build ./src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj --configuration Release`, which completed successfully and included Python syntax checks for the agent. 
- Launched the web app locally and exercised the startup-gate flow by posting the CSRF token-backed form data to `/startup-gate/database`, `/startup-gate/schema/apply`, and `/startup-gate/admin`, with schema apply and admin creation reported as successful. 
- Verified `GET /` returned `HTTP 200` and served the operational endpoint status page after setup (previously returned `404`), confirming the fix worked as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1c99e2f00832aa705846dd488e49f)