### PR TITLE
Fix startup gate required schema version status

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupGateService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupGateService.cs
@@ -42,7 +42,8 @@ internal sealed class StartupGateService : IStartupGateService
             ApplicationVersion = applicationVersion,
             DatabaseConfiguration = configuration,
             IsLocalRequest = isLocalRequest,
-            CanPerformWriteActions = isLocalRequest
+            CanPerformWriteActions = isLocalRequest,
+            RequiredSchemaVersion = _requiredSchemaVersion
         };
 
         if (configuration is null || !configuration.IsComplete)
@@ -110,7 +111,6 @@ internal sealed class StartupGateService : IStartupGateService
 
         status.SchemaState = schemaStatus.State;
         status.CurrentSchemaVersion = schemaStatus.CurrentSchemaVersion;
-        status.RequiredSchemaVersion = _requiredSchemaVersion;
         status.Diagnostics.AddRange(schemaStatus.Diagnostics);
         if (schemaStatus.State != StartupGateSchemaState.Compatible)
         {


### PR DESCRIPTION
### Motivation
- Ensure the startup-gate diagnostics page shows the configured `RequiredSchemaVersion` even when MySQL configuration is missing so first-run diagnostics remain accurate and informative.

### Description
- Populate `RequiredSchemaVersion` on the `StartupGateStatus` model early in `EvaluateAsync` to avoid early-return paths omitting the value. 
- Change applied in `src/WebApp/PingMonitor.Web/Services/StartupGate/StartupGateService.cs`. 
- Verified the local setup flow (DB config, schema apply, initial admin) completes and the app transitions out of the startup gate to the normal landing page. 
- Fixes #35

### Testing
- Installed runtime dependencies (`dotnet-sdk-10.0`, `powershell`, `mysql-server`, `socat`) and the installation completed successfully. 
- Built the web app with `dotnet restore` and `dotnet build`, and the build succeeded. 
- Ran the app locally and exercised the startup-gate flow by posting DB settings (`/startup-gate/database`), running schema apply (`/startup-gate/schema/apply`), and creating the initial admin (`/startup-gate/admin`), all of which succeeded. 
- Automated verification via a small Python HTTP script confirmed the landing page (`/`) returned HTTP 200 and the endpoint status page loaded after setup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1d00d46b0832aa5fe1b698fc7b4a0)