### PR TITLE
Add Windows run-agent.cmd helper to bootstrap and run the Python agent

### DIFF
--- a/src/Agent/README.md
+++ b/src/Agent/README.md
@@ -16,3 +16,19 @@ This directory contains the phase 1 outbound-only Python agent skeleton.
 - persistent queue storage
 - retry/backoff implementation
 - agent-side state, suppression, or alert logic
+
+## Windows startup helper
+
+Use `run-agent.cmd` for local Windows development or manual testing:
+
+1. Open `src/Agent`
+2. Run `run-agent.cmd` (double-click or from `cmd.exe`)
+
+The script will:
+
+- detect `py` first, then fall back to `python`
+- create `src/Agent/.venv` if needed and reuse it on later runs
+- upgrade `pip` and install `requirements.txt`
+- start the agent in the foreground via `python app/main.py`
+
+`SERVER_URL`, `INSTANCE_ID`, and `API_KEY` still need to be configured (for example via `.env`) before startup.

--- a/src/Agent/run-agent.cmd
+++ b/src/Agent/run-agent.cmd
@@ -1,0 +1,82 @@
+@echo off
+setlocal
+
+rem Run the PingMonitor Python agent on Windows.
+rem - Creates src/Agent/.venv if it does not exist
+rem - Upgrades pip and installs requirements.txt
+rem - Starts the existing agent entry point in the foreground
+
+set "SCRIPT_DIR=%~dp0"
+cd /d "%SCRIPT_DIR%"
+if errorlevel 1 (
+  echo [ERROR] Unable to switch to agent directory: %SCRIPT_DIR%
+  goto :fail
+)
+
+echo [INFO] Agent directory: %CD%
+
+set "PYTHON_CMD="
+py --version >nul 2>&1
+if not errorlevel 1 (
+  set "PYTHON_CMD=py"
+)
+
+if not defined PYTHON_CMD (
+  python --version >nul 2>&1
+  if not errorlevel 1 (
+    set "PYTHON_CMD=python"
+  )
+)
+
+if not defined PYTHON_CMD (
+  echo [ERROR] Python was not found. Install Python 3 and ensure ^"py^" or ^"python^" is on PATH.
+  goto :fail
+)
+
+echo [INFO] Using Python launcher: %PYTHON_CMD%
+
+if not exist ".venv\Scripts\python.exe" (
+  echo [INFO] Creating virtual environment at %CD%\.venv
+  %PYTHON_CMD% -m venv .venv
+  if errorlevel 1 (
+    echo [ERROR] Failed to create virtual environment.
+    goto :fail
+  )
+) else (
+  echo [INFO] Reusing existing virtual environment at %CD%\.venv
+)
+
+call ".venv\Scripts\activate.bat"
+if errorlevel 1 (
+  echo [ERROR] Failed to activate virtual environment.
+  goto :fail
+)
+
+echo [INFO] Upgrading pip
+python -m pip install --upgrade pip
+if errorlevel 1 (
+  echo [ERROR] Failed to upgrade pip.
+  goto :fail
+)
+
+echo [INFO] Installing dependencies from requirements.txt
+python -m pip install -r requirements.txt
+if errorlevel 1 (
+  echo [ERROR] Failed to install dependencies.
+  goto :fail
+)
+
+echo [INFO] Starting agent (app/main.py)
+python app/main.py
+if errorlevel 1 (
+  echo [ERROR] Agent exited with an error.
+  goto :fail
+)
+
+echo [INFO] Agent exited successfully.
+exit /b 0
+
+:fail
+echo [ERROR] run-agent.cmd failed.
+pause
+exit /b 1


### PR DESCRIPTION
### Motivation

- Provide a simple, explicit Windows-friendly startup helper so developers can create/reuse a venv, install deps, and run the agent without manual venv activation.
- Keep the change tooling-only and low-risk by using the existing Python agent entry point and requirements without altering runtime behaviour.
- Meet repository rules requiring an issue be created and linked for any change to agent tooling.

### Description

- Add `src/Agent/run-agent.cmd` which detects Python (`py` then `python`), creates or reuses `src/Agent/.venv`, activates it, upgrades `pip`, installs from `requirements.txt`, and launches the agent with `python app/main.py` in the foreground.
- Update `src/Agent/README.md` with concise usage notes describing how to run the script, where the venv is created, and that `SERVER_URL`, `INSTANCE_ID`, and `API_KEY` must still be configured (for example via `.env`).
- Created GitHub issue #37 to track this work and linked the change (PR references `Fixes #37`).

### Testing

- Verified the new script and README were added and reference the real paths using repository inspections (`rg`, `cat`, `nl`) and file-existence checks, which succeeded.
- Created and committed the changes to the repository (`git commit`), which succeeded.
- Attempted to run the `.cmd` in this Linux environment using `cmd.exe`, which failed as expected because `cmd.exe` is not available here, so full Windows end-to-end execution was not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c2d45974832aaf6ab3910c4b7313)