### PR TITLE
Fix Windows agent launcher package import resolution

### DIFF
--- a/src/Agent/README.md
+++ b/src/Agent/README.md
@@ -29,6 +29,6 @@ The script will:
 - detect `py` first, then fall back to `python`
 - create `src/Agent/.venv` if needed and reuse it on later runs
 - upgrade `pip` and install `requirements.txt`
-- start the agent in the foreground via `python app/main.py`
+- start the agent in the foreground via `python -m app.main`
 
 `SERVER_URL`, `INSTANCE_ID`, and `API_KEY` still need to be configured (for example via `.env`) before startup.

--- a/src/Agent/run-agent.cmd
+++ b/src/Agent/run-agent.cmd
@@ -66,8 +66,8 @@ if errorlevel 1 (
   goto :fail
 )
 
-echo [INFO] Starting agent (app/main.py)
-python app/main.py
+echo [INFO] Starting agent module (python -m app.main)
+python -m app.main
 if errorlevel 1 (
   echo [ERROR] Agent exited with an error.
   goto :fail


### PR DESCRIPTION
### Motivation
- The Windows launcher started the agent by running `python app/main.py`, which sets `sys.path` to `src/Agent/app` and caused absolute imports like `from app.api_client import AgentApiClient` to fail with `ModuleNotFoundError: No module named 'app'`.

### Description
- Start the agent as a module using `python -m app.main` in `src/Agent/run-agent.cmd` so package imports resolve correctly.
- Update `src/Agent/README.md` to document the startup command as `python -m app.main` to match the launcher behavior.
- This change addresses the tracking issue and is linked with `Fixes #39`.

### Testing
- Ran the automated validation `cd src/Agent && python -c "import app.main; print('import-ok')"`, which printed `import-ok` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c81feae0832a9a438fd3577d2604)