### PR TITLE
Bundle agent template into published web build for agent deployment

### DIFF
--- a/src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj
+++ b/src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj
@@ -13,4 +13,20 @@
     <PackageReference Include="MySqlConnector" Version="2.5.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\..\Agent\README.md;..\..\Agent\requirements.txt;..\..\Agent\run-agent.cmd">
+      <Link>Agent\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\..\Agent\app\**\*.py">
+      <Link>Agent\app\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/src/WebApp/PingMonitor.Web/Services/AgentPackageBuilder.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentPackageBuilder.cs
@@ -70,6 +70,12 @@ internal sealed class AgentPackageBuilder : IAgentPackageBuilder
 
     private string ResolveAgentRootPath()
     {
+        var bundledTemplatePath = Path.Combine(_environment.ContentRootPath, "Agent");
+        if (Directory.Exists(bundledTemplatePath))
+        {
+            return bundledTemplatePath;
+        }
+
         return Path.GetFullPath(Path.Combine(_environment.ContentRootPath, "..", "..", "Agent"));
     }
 


### PR DESCRIPTION
### Motivation
- Deploys were failing with `Agent template directory was not found at 'C:\Agent'.` because the agent template was only referenced via a source-tree relative path and not included in published output.  
- The web app must be able to build agent deployment packages from the published site without depending on the repository checkout layout.  
- The change is intended to make agent provisioning work reliably in published IIS/production deployments while preserving local development behavior.

### Description
- Add explicit content entries to `PingMonitor.Web.csproj` to include agent template files in build and publish output under the `Agent/` folder (`README.md`, `requirements.txt`, `run-agent.cmd`, and `app/**/*.py`) with `CopyToPublishDirectory=PreserveNewest`.  
- Update `AgentPackageBuilder.ResolveAgentRootPath()` to prefer the bundled path at `<ContentRoot>/Agent` and fall back to the previous source-tree relative path for local development.  
- Linkage: this change closes the related issue with `Fixes #44` for traceability.

### Testing
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -c Release` and the build succeeded.  
- Ran `dotnet publish src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -c Release -o /tmp/ping-publish` and verified the published output contains `Agent/run-agent.cmd`, `Agent/README.md`, `Agent/requirements.txt`, and `Agent/app/*.py`.  
- Verified that the web app can now locate the bundled `Agent` template directory in the publish output; publishing and packaging steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2cf0b4f18832a91547cc613dd0077)