### PR TITLE
Fix agent package build crash during /agents/deploy

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/AgentPackageBuilder.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentPackageBuilder.cs
@@ -63,7 +63,6 @@ internal sealed class AgentPackageBuilder : IAgentPackageBuilder
         await writer.WriteAsync(envContents.AsMemory(), cancellationToken);
         await writer.FlushAsync(cancellationToken);
 
-        archive.Dispose();
         _logger.LogInformation("Built agent package for instance {InstanceId} from template {TemplatePath}", instanceId, agentRoot);
         return output.ToArray();
     }


### PR DESCRIPTION
### Motivation
- Deploying an agent via `/agents/deploy` threw `System.NotSupportedException` while flushing the `.env` entry into the ZIP because the `ZipArchive` was being disposed too early, breaking package generation.

### Description
- Removed the premature manual `archive.Dispose()` call in `AgentPackageBuilder.BuildAsync` so entry streams (the `.env` writer) can complete before the archive is closed, preventing write/flush errors in `ZipArchiveEntry`; change made in `src/WebApp/PingMonitor.Web/Services/AgentPackageBuilder.cs` and links this PR to the tracking issue with `Fixes #46`.

### Testing
- Built the web app with the .NET 10 SDK using `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d1126ac4832a968c57bd7ec416fd)