### PR TITLE
Fix empty archive in Deploy new agent package download

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/AgentPackageBuilder.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentPackageBuilder.cs
@@ -31,37 +31,38 @@ internal sealed class AgentPackageBuilder : IAgentPackageBuilder
         }
 
         await using var output = new MemoryStream();
-        using var archive = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true);
-
-        foreach (var fileName in RootFiles)
+        using (var archive = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true))
         {
-            var fullPath = Path.Combine(agentRoot, fileName);
-            if (!File.Exists(fullPath))
+            foreach (var fileName in RootFiles)
             {
-                throw new InvalidOperationException($"Required agent template file '{fileName}' was not found.");
+                var fullPath = Path.Combine(agentRoot, fileName);
+                if (!File.Exists(fullPath))
+                {
+                    throw new InvalidOperationException($"Required agent template file '{fileName}' was not found.");
+                }
+
+                await AddFileAsync(archive, fullPath, fileName, cancellationToken);
             }
 
-            await AddFileAsync(archive, fullPath, fileName, cancellationToken);
-        }
+            var appDirectory = Path.Combine(agentRoot, "app");
+            if (!Directory.Exists(appDirectory))
+            {
+                throw new InvalidOperationException("Required agent app directory was not found.");
+            }
 
-        var appDirectory = Path.Combine(agentRoot, "app");
-        if (!Directory.Exists(appDirectory))
-        {
-            throw new InvalidOperationException("Required agent app directory was not found.");
-        }
+            foreach (var filePath in Directory.EnumerateFiles(appDirectory, "*.py", SearchOption.AllDirectories).OrderBy(path => path, StringComparer.Ordinal))
+            {
+                var relativePath = Path.GetRelativePath(agentRoot, filePath).Replace('\\', '/');
+                await AddFileAsync(archive, filePath, relativePath, cancellationToken);
+            }
 
-        foreach (var filePath in Directory.EnumerateFiles(appDirectory, "*.py", SearchOption.AllDirectories).OrderBy(path => path, StringComparer.Ordinal))
-        {
-            var relativePath = Path.GetRelativePath(agentRoot, filePath).Replace('\\', '/');
-            await AddFileAsync(archive, filePath, relativePath, cancellationToken);
+            var envContents = BuildEnvContents(serverUrl, instanceId, apiKey);
+            var envEntry = archive.CreateEntry(".env");
+            await using var envStream = envEntry.Open();
+            await using var writer = new StreamWriter(envStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            await writer.WriteAsync(envContents.AsMemory(), cancellationToken);
+            await writer.FlushAsync(cancellationToken);
         }
-
-        var envContents = BuildEnvContents(serverUrl, instanceId, apiKey);
-        var envEntry = archive.CreateEntry(".env");
-        await using var envStream = envEntry.Open();
-        await using var writer = new StreamWriter(envStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-        await writer.WriteAsync(envContents.AsMemory(), cancellationToken);
-        await writer.FlushAsync(cancellationToken);
 
         _logger.LogInformation("Built agent package for instance {InstanceId} from template {TemplatePath}", instanceId, agentRoot);
         return output.ToArray();


### PR DESCRIPTION
### Motivation
- The Deploy new agent flow produced ZIPs that appeared empty because the ZIP central directory was not written before reading the underlying `MemoryStream`.

### Description
- Wrap the `ZipArchive` in an explicit `using` block so the archive is disposed (and finalized) before returning `output.ToArray()`, while keeping `leaveOpen: true` and preserving packaging of root files, `app/*.py`, and the generated `.env`; Fixes #48.

### Testing
- Ran `dotnet test src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which restored the project and completed with no failing tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d2f5e7ec832a9681eb7af6df47d4)