### PR TITLE
Keep Python agent running for recurring checks and heartbeats

### DIFF
--- a/src/Agent/app/main.py
+++ b/src/Agent/app/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import platform
+import time
 from datetime import UTC, datetime
 
 from app.api_client import AgentApiClient
@@ -34,31 +35,61 @@ def main() -> None:
     current_config = client.fetch_config()
     logging.info("Agent %s connected with config version %s", hello_response.agent_id, current_config.config_version)
 
-    results = scheduler.run_once(current_config.assignments)
-    queue.extend(results)
+    config_refresh_seconds = max(1, hello_response.config_refresh_seconds)
+    heartbeat_interval_seconds = max(1, hello_response.heartbeat_interval_seconds)
+    result_batch_interval_seconds = max(1, hello_response.result_batch_interval_seconds)
+    max_result_batch_size = max(1, hello_response.max_result_batch_size)
 
-    batch = queue.dequeue_batch(hello_response.max_result_batch_size)
-    if batch:
-        client.submit_results(
-            ResultsRequest(
-                sent_at_utc=_utc_now(),
-                batch_id=f"bootstrap-{config.instance_id}",
-                results=batch,
-            )
-        )
+    last_config_refresh = 0.0
+    last_heartbeat = 0.0
+    last_result_batch = 0.0
 
-    client.send_heartbeat(
-        HeartbeatRequest(
-            agent_version="0.1.0",
-            sent_at_utc=_utc_now(),
-            config_version=current_config.config_version,
-            active_assignments=len([assignment for assignment in current_config.assignments if assignment.enabled]),
-            queued_result_count=len(queue),
-            status="online",
-        )
-    )
+    try:
+        while True:
+            now = time.monotonic()
 
-    client.close()
+            if now - last_config_refresh >= config_refresh_seconds:
+                current_config = client.fetch_config()
+                logging.info("Fetched config version %s with %d assignments", current_config.config_version, len(current_config.assignments))
+                last_config_refresh = now
+
+            results = scheduler.run_once(current_config.assignments)
+            queue.extend(results)
+
+            if now - last_result_batch >= result_batch_interval_seconds:
+                batch = queue.dequeue_batch(max_result_batch_size)
+                if batch:
+                    client.submit_results(
+                        ResultsRequest(
+                            sent_at_utc=_utc_now(),
+                            batch_id=f"results-{config.instance_id}-{int(now)}",
+                            results=batch,
+                        )
+                    )
+                last_result_batch = now
+
+            if now - last_heartbeat >= heartbeat_interval_seconds:
+                heartbeat_response = client.send_heartbeat(
+                    HeartbeatRequest(
+                        agent_version="0.1.0",
+                        sent_at_utc=_utc_now(),
+                        config_version=current_config.config_version,
+                        active_assignments=len([assignment for assignment in current_config.assignments if assignment.enabled]),
+                        queued_result_count=len(queue),
+                        status="online",
+                    )
+                )
+                last_heartbeat = now
+                if heartbeat_response.config_changed:
+                    current_config = client.fetch_config()
+                    logging.info("Server reported config change. Updated to version %s", current_config.config_version)
+                    last_config_refresh = now
+
+            time.sleep(1)
+    except KeyboardInterrupt:
+        logging.info("Agent shutdown requested. Exiting.")
+    finally:
+        client.close()
 
 
 def _utc_now() -> str:

--- a/src/Agent/app/scheduler.py
+++ b/src/Agent/app/scheduler.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import time
+
 from app.checks import CheckRunner
 from app.models import AssignmentModel, ResultItem
 
@@ -7,13 +9,19 @@ from app.models import AssignmentModel, ResultItem
 class AssignmentScheduler:
     def __init__(self, check_runner: CheckRunner) -> None:
         self._check_runner = check_runner
+        self._next_run_at_by_assignment_id: dict[str, float] = {}
 
     def run_once(self, assignments: list[AssignmentModel]) -> list[ResultItem]:
+        now = time.monotonic()
         results: list[ResultItem] = []
         for assignment in assignments:
             if not assignment.enabled:
                 continue
             if assignment.check_type != "icmp":
                 continue
+            next_run_at = self._next_run_at_by_assignment_id.get(assignment.assignment_id, 0.0)
+            if now < next_run_at:
+                continue
             results.append(self._check_runner.run_icmp_check(assignment))
+            self._next_run_at_by_assignment_id[assignment.assignment_id] = now + max(1, assignment.ping_interval_seconds)
         return results


### PR DESCRIPTION
### Motivation
- The agent exited immediately after the initial hello/config/heartbeat sequence which prevented ongoing check execution, batching and heartbeats.  The change ensures the agent continues running to perform its execution-plane responsibilities. 
- Behaviour was implemented to respect server-provided intervals and assignment scheduling so the agent remains a simple executor that only initiates outbound actions, in line with platform constraints.

### Description
- Replace one-shot bootstrap logic in `app.main` with a long-running loop that refreshes config, runs due assignments, submits result batches and sends heartbeats using server-provided intervals and sensible minimums. 
- Add handling of `heartbeat` responses so a `config_changed` flag causes an immediate config refetch. 
- Implement per-assignment scheduling bookkeeping in `app.scheduler` so checks run only when `ping_interval_seconds` elapses rather than every loop iteration. 
- Ensure graceful shutdown and client cleanup by closing the HTTP client in a `finally` block and exiting on `KeyboardInterrupt`.

### Testing
- Ran `python -m compileall src/Agent/app` and compilation completed successfully. 
- No repository unit test suite was present or executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d771a3c4832a83f2fc5491115c90)