### PR TITLE
Add server-rendered endpoint creation page with initial MonitorAssignment

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -439,3 +439,14 @@ This data model enforces:
 - full auditability  
 
 **Raw data is stored. State is derived. Alerts follow state.**
+
+---
+
+## Endpoint creation flow note (control-plane UI)
+
+- Creating a new endpoint in the web UI creates both:
+  - one `Endpoint` record
+  - one initial `MonitorAssignment` record
+- The assignment is always agent-specific and requires selecting a target agent.
+- Dependency selection is optional (`dependsOnEndpointId` may be null).
+- Dependency cycles are not allowed; creation must be blocked if a cycle would be introduced.

--- a/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
@@ -1,0 +1,90 @@
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Services.Endpoints;
+using PingMonitor.Web.ViewModels.Endpoints;
+
+namespace PingMonitor.Web.Controllers;
+
+[Route("endpoints")]
+public sealed class EndpointsController : Controller
+{
+    private readonly IEndpointCreationQueryService _endpointCreationQueryService;
+    private readonly IEndpointManagementService _endpointManagementService;
+
+    public EndpointsController(
+        IEndpointCreationQueryService endpointCreationQueryService,
+        IEndpointManagementService endpointManagementService)
+    {
+        _endpointCreationQueryService = endpointCreationQueryService;
+        _endpointManagementService = endpointManagementService;
+    }
+
+    [HttpGet("new")]
+    public async Task<IActionResult> New(CancellationToken cancellationToken)
+    {
+        var model = new CreateEndpointPageViewModel();
+        await PopulateOptionsAsync(model, cancellationToken);
+        return View("New", model);
+    }
+
+    [HttpPost("new")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> New([FromForm] CreateEndpointPageViewModel model, CancellationToken cancellationToken)
+    {
+        await PopulateOptionsAsync(model, cancellationToken);
+
+        if (!ModelState.IsValid)
+        {
+            return View("New", model);
+        }
+
+        var result = await _endpointManagementService.CreateEndpointWithAssignmentAsync(
+            new CreateEndpointCommand
+            {
+                EndpointName = model.EndpointName,
+                Target = model.Target,
+                AgentId = model.AgentId,
+                DependsOnEndpointId = model.DependsOnEndpointId,
+                PingIntervalSeconds = model.PingIntervalSeconds,
+                RetryIntervalSeconds = model.RetryIntervalSeconds,
+                TimeoutMs = model.TimeoutMs,
+                FailureThreshold = model.FailureThreshold,
+                RecoveryThreshold = model.RecoveryThreshold,
+                EndpointEnabled = model.EndpointEnabled,
+                AssignmentEnabled = model.AssignmentEnabled
+            },
+            cancellationToken);
+
+        if (!result.Success)
+        {
+            foreach (var validationError in result.ValidationErrors)
+            {
+                var modelKey = validationError.Field switch
+                {
+                    nameof(CreateEndpointCommand.EndpointName) => nameof(CreateEndpointPageViewModel.EndpointName),
+                    nameof(CreateEndpointCommand.Target) => nameof(CreateEndpointPageViewModel.Target),
+                    nameof(CreateEndpointCommand.AgentId) => nameof(CreateEndpointPageViewModel.AgentId),
+                    nameof(CreateEndpointCommand.DependsOnEndpointId) => nameof(CreateEndpointPageViewModel.DependsOnEndpointId),
+                    nameof(CreateEndpointCommand.PingIntervalSeconds) => nameof(CreateEndpointPageViewModel.PingIntervalSeconds),
+                    nameof(CreateEndpointCommand.RetryIntervalSeconds) => nameof(CreateEndpointPageViewModel.RetryIntervalSeconds),
+                    nameof(CreateEndpointCommand.TimeoutMs) => nameof(CreateEndpointPageViewModel.TimeoutMs),
+                    nameof(CreateEndpointCommand.FailureThreshold) => nameof(CreateEndpointPageViewModel.FailureThreshold),
+                    nameof(CreateEndpointCommand.RecoveryThreshold) => nameof(CreateEndpointPageViewModel.RecoveryThreshold),
+                    _ => string.Empty
+                };
+
+                ModelState.AddModelError(modelKey, validationError.Message);
+            }
+
+            return View("New", model);
+        }
+
+        return Redirect("/status");
+    }
+
+    private async Task PopulateOptionsAsync(CreateEndpointPageViewModel model, CancellationToken cancellationToken)
+    {
+        var options = await _endpointCreationQueryService.GetOptionsAsync(cancellationToken);
+        model.AvailableAgents = options.Agents;
+        model.AvailableDependencyEndpoints = options.DependencyEndpoints;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -7,6 +7,7 @@ using PingMonitor.Web.Data;
 using PingMonitor.Web.Models.Identity;
 using PingMonitor.Web.Options;
 using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.Endpoints;
 using PingMonitor.Web.Services.StartupGate;
 using PingMonitor.Web.Services.Status;
 using PingMonitor.Web.Support;
@@ -91,6 +92,8 @@ builder.Services.AddScoped<IStartupAdminBootstrapService, StartupAdminBootstrapS
 builder.Services.AddScoped<DevelopmentAgentSeeder>();
 builder.Services.AddScoped<IAgentPackageBuilder, AgentPackageBuilder>();
 builder.Services.AddScoped<IAgentProvisioningService, AgentProvisioningService>();
+builder.Services.AddScoped<IEndpointCreationQueryService, EndpointCreationQueryService>();
+builder.Services.AddScoped<IEndpointManagementService, EndpointManagementService>();
 
 var app = builder.Build();
 

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointCreationQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointCreationQueryService.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.ViewModels.Endpoints;
+
+namespace PingMonitor.Web.Services.Endpoints;
+
+internal sealed class EndpointCreationQueryService : IEndpointCreationQueryService
+{
+    private readonly PingMonitorDbContext _dbContext;
+
+    public EndpointCreationQueryService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<CreateEndpointPageOptions> GetOptionsAsync(CancellationToken cancellationToken)
+    {
+        var agentOptions = await _dbContext.Agents.AsNoTracking()
+            .Where(x => x.Enabled && !x.ApiKeyRevoked)
+            .OrderBy(x => x.InstanceId)
+            .Select(x => new CreateEndpointAgentOptionViewModel
+            {
+                AgentId = x.AgentId,
+                DisplayName = string.IsNullOrWhiteSpace(x.Name)
+                    ? x.InstanceId
+                    : $"{x.Name} ({x.InstanceId})"
+            })
+            .ToArrayAsync(cancellationToken);
+
+        var endpointOptions = await _dbContext.Endpoints.AsNoTracking()
+            .OrderBy(x => x.Name)
+            .Select(x => new CreateEndpointDependencyOptionViewModel
+            {
+                EndpointId = x.EndpointId,
+                EndpointName = x.Name
+            })
+            .ToArrayAsync(cancellationToken);
+
+        return new CreateEndpointPageOptions
+        {
+            Agents = agentOptions,
+            DependencyEndpoints = endpointOptions
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementService.cs
@@ -1,0 +1,173 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using EndpointModel = PingMonitor.Web.Models.Endpoint;
+
+namespace PingMonitor.Web.Services.Endpoints;
+
+internal sealed class EndpointManagementService : IEndpointManagementService
+{
+    private readonly PingMonitorDbContext _dbContext;
+
+    public EndpointManagementService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<CreateEndpointResult> CreateEndpointWithAssignmentAsync(CreateEndpointCommand command, CancellationToken cancellationToken)
+    {
+        var validationErrors = await ValidateAsync(command, cancellationToken);
+        if (validationErrors.Count > 0)
+        {
+            return CreateEndpointResult.Failed(validationErrors.ToArray());
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var endpointId = Guid.NewGuid().ToString();
+        var assignmentId = Guid.NewGuid().ToString();
+        var dependencyId = NormalizeDependency(command.DependsOnEndpointId);
+
+        if (string.Equals(dependencyId, endpointId, StringComparison.Ordinal))
+        {
+            return CreateEndpointResult.Failed(
+                new CreateEndpointValidationError(nameof(CreateEndpointCommand.DependsOnEndpointId), "Dependency cannot reference the new endpoint itself."));
+        }
+
+        var endpoint = new EndpointModel
+        {
+            EndpointId = endpointId,
+            Name = command.EndpointName.Trim(),
+            Target = command.Target.Trim(),
+            Enabled = command.EndpointEnabled,
+            DependsOnEndpointId = dependencyId,
+            CreatedAtUtc = now,
+            Tags = []
+        };
+
+        var assignment = new MonitorAssignment
+        {
+            AssignmentId = assignmentId,
+            AgentId = command.AgentId.Trim(),
+            EndpointId = endpointId,
+            CheckType = CheckType.Icmp,
+            Enabled = command.AssignmentEnabled,
+            PingIntervalSeconds = command.PingIntervalSeconds,
+            RetryIntervalSeconds = command.RetryIntervalSeconds,
+            TimeoutMs = command.TimeoutMs,
+            FailureThreshold = command.FailureThreshold,
+            RecoveryThreshold = command.RecoveryThreshold,
+            CreatedAtUtc = now,
+            UpdatedAtUtc = now
+        };
+
+        _dbContext.Endpoints.Add(endpoint);
+        _dbContext.MonitorAssignments.Add(assignment);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return CreateEndpointResult.Succeeded(endpointId, assignmentId);
+    }
+
+    private async Task<List<CreateEndpointValidationError>> ValidateAsync(CreateEndpointCommand command, CancellationToken cancellationToken)
+    {
+        var errors = new List<CreateEndpointValidationError>();
+
+        if (string.IsNullOrWhiteSpace(command.EndpointName))
+        {
+            errors.Add(new CreateEndpointValidationError(nameof(CreateEndpointCommand.EndpointName), "Endpoint name is required."));
+        }
+
+        if (string.IsNullOrWhiteSpace(command.Target))
+        {
+            errors.Add(new CreateEndpointValidationError(nameof(CreateEndpointCommand.Target), "Target is required."));
+        }
+
+        if (string.IsNullOrWhiteSpace(command.AgentId))
+        {
+            errors.Add(new CreateEndpointValidationError(nameof(CreateEndpointCommand.AgentId), "Agent is required."));
+        }
+
+        ValidatePositive(nameof(CreateEndpointCommand.PingIntervalSeconds), command.PingIntervalSeconds, "Ping interval must be at least 1 second.", errors);
+        ValidatePositive(nameof(CreateEndpointCommand.RetryIntervalSeconds), command.RetryIntervalSeconds, "Retry interval must be at least 1 second.", errors);
+        ValidatePositive(nameof(CreateEndpointCommand.TimeoutMs), command.TimeoutMs, "Timeout must be at least 1 millisecond.", errors);
+        ValidatePositive(nameof(CreateEndpointCommand.FailureThreshold), command.FailureThreshold, "Failure threshold must be at least 1.", errors);
+        ValidatePositive(nameof(CreateEndpointCommand.RecoveryThreshold), command.RecoveryThreshold, "Recovery threshold must be at least 1.", errors);
+
+        if (errors.Count > 0)
+        {
+            return errors;
+        }
+
+        var normalizedAgentId = command.AgentId.Trim();
+        var agentExists = await _dbContext.Agents.AsNoTracking()
+            .AnyAsync(x => x.AgentId == normalizedAgentId && x.Enabled && !x.ApiKeyRevoked, cancellationToken);
+        if (!agentExists)
+        {
+            errors.Add(new CreateEndpointValidationError(nameof(CreateEndpointCommand.AgentId), "Selected agent is not available."));
+        }
+
+        var dependencyId = NormalizeDependency(command.DependsOnEndpointId);
+        if (dependencyId is not null)
+        {
+            var dependencyExists = await _dbContext.Endpoints.AsNoTracking()
+                .AnyAsync(x => x.EndpointId == dependencyId, cancellationToken);
+
+            if (!dependencyExists)
+            {
+                errors.Add(new CreateEndpointValidationError(nameof(CreateEndpointCommand.DependsOnEndpointId), "Selected dependency endpoint does not exist."));
+            }
+            else
+            {
+                var hasCycle = await WouldCreateCycleAsync(dependencyId, cancellationToken);
+                if (hasCycle)
+                {
+                    errors.Add(new CreateEndpointValidationError(nameof(CreateEndpointCommand.DependsOnEndpointId), "Selected dependency creates a circular dependency."));
+                }
+            }
+        }
+
+        var normalizedEndpointName = command.EndpointName.Trim();
+        var endpointNameExists = await _dbContext.Endpoints.AsNoTracking()
+            .AnyAsync(x => x.Name == normalizedEndpointName, cancellationToken);
+
+        if (endpointNameExists)
+        {
+            errors.Add(new CreateEndpointValidationError(nameof(CreateEndpointCommand.EndpointName), "An endpoint with this name already exists."));
+        }
+
+        return errors;
+    }
+
+    private async Task<bool> WouldCreateCycleAsync(string dependencyEndpointId, CancellationToken cancellationToken)
+    {
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var currentId = dependencyEndpointId;
+
+        while (!string.IsNullOrWhiteSpace(currentId))
+        {
+            if (!visited.Add(currentId))
+            {
+                return true;
+            }
+
+            currentId = await _dbContext.Endpoints.AsNoTracking()
+                .Where(x => x.EndpointId == currentId)
+                .Select(x => x.DependsOnEndpointId)
+                .SingleOrDefaultAsync(cancellationToken);
+        }
+
+        return false;
+    }
+
+    private static string? NormalizeDependency(string? dependencyId)
+    {
+        return string.IsNullOrWhiteSpace(dependencyId) ? null : dependencyId.Trim();
+    }
+
+    private static void ValidatePositive(string field, int value, string message, ICollection<CreateEndpointValidationError> errors)
+    {
+        if (value < 1)
+        {
+            errors.Add(new CreateEndpointValidationError(field, message));
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointCreationQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointCreationQueryService.cs
@@ -1,0 +1,14 @@
+using PingMonitor.Web.ViewModels.Endpoints;
+
+namespace PingMonitor.Web.Services.Endpoints;
+
+public interface IEndpointCreationQueryService
+{
+    Task<CreateEndpointPageOptions> GetOptionsAsync(CancellationToken cancellationToken);
+}
+
+public sealed class CreateEndpointPageOptions
+{
+    public IReadOnlyList<CreateEndpointAgentOptionViewModel> Agents { get; init; } = [];
+    public IReadOnlyList<CreateEndpointDependencyOptionViewModel> DependencyEndpoints { get; init; } = [];
+}

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointManagementService.cs
@@ -1,0 +1,60 @@
+namespace PingMonitor.Web.Services.Endpoints;
+
+public interface IEndpointManagementService
+{
+    Task<CreateEndpointResult> CreateEndpointWithAssignmentAsync(CreateEndpointCommand command, CancellationToken cancellationToken);
+}
+
+public sealed class CreateEndpointCommand
+{
+    public string EndpointName { get; init; } = string.Empty;
+    public string Target { get; init; } = string.Empty;
+    public string AgentId { get; init; } = string.Empty;
+    public string? DependsOnEndpointId { get; init; }
+    public int PingIntervalSeconds { get; init; }
+    public int RetryIntervalSeconds { get; init; }
+    public int TimeoutMs { get; init; }
+    public int FailureThreshold { get; init; }
+    public int RecoveryThreshold { get; init; }
+    public bool EndpointEnabled { get; init; }
+    public bool AssignmentEnabled { get; init; }
+}
+
+public sealed class CreateEndpointResult
+{
+    public bool Success { get; init; }
+    public string? EndpointId { get; init; }
+    public string? AssignmentId { get; init; }
+    public IReadOnlyList<CreateEndpointValidationError> ValidationErrors { get; init; } = [];
+
+    public static CreateEndpointResult Succeeded(string endpointId, string assignmentId)
+    {
+        return new CreateEndpointResult
+        {
+            Success = true,
+            EndpointId = endpointId,
+            AssignmentId = assignmentId
+        };
+    }
+
+    public static CreateEndpointResult Failed(params CreateEndpointValidationError[] errors)
+    {
+        return new CreateEndpointResult
+        {
+            Success = false,
+            ValidationErrors = errors
+        };
+    }
+}
+
+public sealed class CreateEndpointValidationError
+{
+    public CreateEndpointValidationError(string field, string message)
+    {
+        Field = field;
+        Message = message;
+    }
+
+    public string Field { get; }
+    public string Message { get; }
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/CreateEndpointPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/CreateEndpointPageViewModel.cs
@@ -1,0 +1,63 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PingMonitor.Web.ViewModels.Endpoints;
+
+public sealed class CreateEndpointPageViewModel
+{
+    [Required(ErrorMessage = "Endpoint name is required.")]
+    [Display(Name = "Endpoint name")]
+    public string EndpointName { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Target is required.")]
+    [Display(Name = "Target")]
+    public string Target { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Agent selection is required.")]
+    [Display(Name = "Agent")]
+    public string AgentId { get; set; } = string.Empty;
+
+    [Display(Name = "Depends on endpoint")]
+    public string? DependsOnEndpointId { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Ping interval must be at least 1 second.")]
+    [Display(Name = "Ping interval (seconds)")]
+    public int PingIntervalSeconds { get; set; } = 60;
+
+    [Range(1, int.MaxValue, ErrorMessage = "Retry interval must be at least 1 second.")]
+    [Display(Name = "Retry interval (seconds)")]
+    public int RetryIntervalSeconds { get; set; } = 5;
+
+    [Range(1, int.MaxValue, ErrorMessage = "Timeout must be at least 1 millisecond.")]
+    [Display(Name = "Timeout (ms)")]
+    public int TimeoutMs { get; set; } = 1000;
+
+    [Range(1, int.MaxValue, ErrorMessage = "Failure threshold must be at least 1.")]
+    [Display(Name = "Failure threshold")]
+    public int FailureThreshold { get; set; } = 3;
+
+    [Range(1, int.MaxValue, ErrorMessage = "Recovery threshold must be at least 1.")]
+    [Display(Name = "Recovery threshold")]
+    public int RecoveryThreshold { get; set; } = 2;
+
+    [Display(Name = "Endpoint enabled")]
+    public bool EndpointEnabled { get; set; } = true;
+
+    [Display(Name = "Assignment enabled")]
+    public bool AssignmentEnabled { get; set; } = true;
+
+    public IReadOnlyList<CreateEndpointAgentOptionViewModel> AvailableAgents { get; set; } = [];
+
+    public IReadOnlyList<CreateEndpointDependencyOptionViewModel> AvailableDependencyEndpoints { get; set; } = [];
+}
+
+public sealed class CreateEndpointAgentOptionViewModel
+{
+    public string AgentId { get; init; } = string.Empty;
+    public string DisplayName { get; init; } = string.Empty;
+}
+
+public sealed class CreateEndpointDependencyOptionViewModel
+{
+    public string EndpointId { get; init; } = string.Empty;
+    public string EndpointName { get; init; } = string.Empty;
+}

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/New.cshtml
@@ -1,0 +1,149 @@
+@model PingMonitor.Web.ViewModels.Endpoints.CreateEndpointPageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Add new endpoint</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #f3f6f8;
+            --card: #ffffff;
+            --text: #102a43;
+            --muted: #52606d;
+            --border: #d9e2ec;
+            --accent: #0f62fe;
+            --danger: #b42318;
+        }
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 760px; margin: 0 auto; padding: 1rem; }
+        .stack { display: grid; gap: 1rem; }
+        .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
+        .section-title { margin-top: 0; margin-bottom: .65rem; }
+        .field-grid { display: grid; gap: .85rem; }
+        label { display: block; font-weight: 600; margin-bottom: .35rem; }
+        input, select { width: 100%; min-height: 48px; padding: .8rem; border: 1px solid var(--border); border-radius: 10px; font-size: 1rem; }
+        .checkbox { display: flex; align-items: center; gap: .55rem; }
+        .checkbox input { width: 22px; min-height: 22px; margin: 0; }
+        .checkbox label { margin: 0; }
+        .errors { border: 1px solid #fecdca; background: #fef3f2; border-radius: 10px; padding: .8rem; color: var(--danger); }
+        .field-error { color: var(--danger); font-size: .9rem; margin-top: .25rem; }
+        .actions { display: flex; gap: .75rem; flex-wrap: wrap; }
+        .button, .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 48px; padding: .8rem 1rem; border-radius: 10px; font-weight: 600; text-decoration: none; }
+        .button { border: 0; background: var(--accent); color: white; }
+        .button-secondary { border: 1px solid var(--border); color: var(--text); background: white; }
+        .muted { color: var(--muted); }
+        @@media (min-width: 720px) {
+            .field-grid.two-col { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        }
+    </style>
+</head>
+<body>
+<main>
+    <div class="stack">
+        <section class="card">
+            <h1>Add new endpoint</h1>
+            <p class="muted">Create one endpoint and one initial monitor assignment for a selected agent.</p>
+        </section>
+
+        <form method="post" action="/endpoints/new" class="stack">
+            @Html.AntiForgeryToken()
+            @if (!ViewData.ModelState.IsValid)
+            {
+                <div class="errors" asp-validation-summary="ModelOnly"></div>
+            }
+
+            <section class="card">
+                <h2 class="section-title">Endpoint details</h2>
+                <div class="field-grid">
+                    <div>
+                        <label asp-for="EndpointName"></label>
+                        <input asp-for="EndpointName" />
+                        <div class="field-error"><span asp-validation-for="EndpointName"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="Target"></label>
+                        <input asp-for="Target" />
+                        <div class="field-error"><span asp-validation-for="Target"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="AgentId"></label>
+                        <select asp-for="AgentId">
+                            <option value="">Select an agent</option>
+                            @foreach (var agent in Model.AvailableAgents)
+                            {
+                                <option value="@agent.AgentId">@agent.DisplayName</option>
+                            }
+                        </select>
+                        <div class="field-error"><span asp-validation-for="AgentId"></span></div>
+                    </div>
+                    <div class="checkbox">
+                        <input asp-for="EndpointEnabled" />
+                        <label asp-for="EndpointEnabled"></label>
+                    </div>
+                </div>
+            </section>
+
+            <section class="card">
+                <h2 class="section-title">Dependency</h2>
+                <div class="field-grid">
+                    <div>
+                        <label asp-for="DependsOnEndpointId"></label>
+                        <select asp-for="DependsOnEndpointId">
+                            <option value="">None</option>
+                            @foreach (var endpoint in Model.AvailableDependencyEndpoints)
+                            {
+                                <option value="@endpoint.EndpointId">@endpoint.EndpointName</option>
+                            }
+                        </select>
+                        <div class="field-error"><span asp-validation-for="DependsOnEndpointId"></span></div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="card">
+                <h2 class="section-title">Monitoring settings</h2>
+                <div class="field-grid two-col">
+                    <div>
+                        <label asp-for="PingIntervalSeconds"></label>
+                        <input asp-for="PingIntervalSeconds" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="PingIntervalSeconds"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="RetryIntervalSeconds"></label>
+                        <input asp-for="RetryIntervalSeconds" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="RetryIntervalSeconds"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="TimeoutMs"></label>
+                        <input asp-for="TimeoutMs" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="TimeoutMs"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="FailureThreshold"></label>
+                        <input asp-for="FailureThreshold" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="FailureThreshold"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="RecoveryThreshold"></label>
+                        <input asp-for="RecoveryThreshold" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="RecoveryThreshold"></span></div>
+                    </div>
+                    <div class="checkbox">
+                        <input asp-for="AssignmentEnabled" />
+                        <label asp-for="AssignmentEnabled"></label>
+                    </div>
+                </div>
+            </section>
+
+            <div class="actions">
+                <button class="button" type="submit">Create endpoint</button>
+                <a class="button-secondary" href="/status">Cancel</a>
+            </div>
+        </form>
+    </div>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -85,6 +85,7 @@
             <p class="muted">Current assignment-scoped status derived by the server state engine. Missing state rows are shown as <strong>UNKNOWN</strong> until trusted server-side state exists.</p>
             <div class="button-row">
                 <a class="button" href="/agents/deploy">Deploy new agent</a>
+                <a class="button-secondary" href="/endpoints/new">Add new endpoint</a>
             </div>
         </section>
 


### PR DESCRIPTION
### Motivation

- Provide a simple, server-rendered UI to add a new Endpoint and its initial MonitorAssignment in a single operational flow. 
- Ensure the user explicitly selects an agent and configures timing/thresholds so assignment-scoped state and scheduling remain agent-owned. 
- Follow platform constraints and data model rules (agent-specific assignments, dependency optional, no cycles) and document the behavior.

### Description

- Add `GET /endpoints/new` and `POST /endpoints/new` handled by a new `EndpointsController` that renders a server-side form and submits a create command, redirecting to `/status` on success. (Files: `Controllers/EndpointsController.cs`, `Views/Endpoints/New.cshtml`)
- Add a dedicated form view model with sensible v1 defaults and fields for endpoint details, optional dependency, and monitoring settings (`CreateEndpointPageViewModel`). (File: `ViewModels/Endpoints/CreateEndpointPageViewModel.cs`)
- Add a read/query service `IEndpointCreationQueryService` / `EndpointCreationQueryService` to populate available agents and existing endpoints for the dependency dropdown, and an explicit management service `IEndpointManagementService` / `EndpointManagementService` that validates input, prevents dependency cycles, creates the `Endpoint` first then the `MonitorAssignment` (with `checkType = icmp`) and saves both together. (Files: `Services/Endpoints/*`)
- Implement validation rules including required fields, positive numeric checks, agent existence, dependency existence, self-dependency protection, and simple cycle detection via parent-chain traversal; map validation errors back to the form. (`EndpointManagementService`)
- Wire services into DI, add a navigation link from the status page to the new endpoint page, and add a short doc note explaining that creating an endpoint creates both an `Endpoint` and an initial `MonitorAssignment`. (`Program.cs`, `Views/Status/Index.cshtml`, `docs/data-model.md`).
- Keep the change limited to control-plane configuration creation only; no state-machine, alerting, or agent-side execution logic was added or modified.

### Testing

- Installed .NET 10 SDK as required by `global.json` and verified the runtime with `dotnet --version` reporting the expected SDK, and then built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which completed successfully with 0 errors.
- No automated unit tests were present/modified for this change; the compilation build is the primary automated verification performed and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2db8f4504832aa0fb61b791a7afb7)