### PR TITLE
Handle agent result submission 5xx without crashing

### DIFF
--- a/src/Agent/app/main.py
+++ b/src/Agent/app/main.py
@@ -5,6 +5,8 @@ import platform
 import time
 from datetime import UTC, datetime
 
+import httpx
+
 from app.api_client import AgentApiClient
 from app.checks import CheckRunner
 from app.config import load_config
@@ -59,13 +61,17 @@ def main() -> None:
             if now - last_result_batch >= result_batch_interval_seconds:
                 batch = queue.dequeue_batch(max_result_batch_size)
                 if batch:
-                    client.submit_results(
-                        ResultsRequest(
-                            sent_at_utc=_utc_now(),
-                            batch_id=f"results-{config.instance_id}-{int(now)}",
-                            results=batch,
+                    try:
+                        client.submit_results(
+                            ResultsRequest(
+                                sent_at_utc=_utc_now(),
+                                batch_id=f"results-{config.instance_id}-{int(now)}",
+                                results=batch,
+                            )
                         )
-                    )
+                    except httpx.HTTPError as ex:
+                        logging.error("Result submission failed and will be retried: %s", _format_http_error(ex))
+                        queue.requeue_front(batch)
                 last_result_batch = now
 
             if now - last_heartbeat >= heartbeat_interval_seconds:
@@ -94,6 +100,14 @@ def main() -> None:
 
 def _utc_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _format_http_error(error: httpx.HTTPError) -> str:
+    if isinstance(error, httpx.HTTPStatusError):
+        response_body = error.response.text.strip()
+        if response_body:
+            return f"{error}; response={response_body}"
+    return str(error)
 
 
 if __name__ == "__main__":

--- a/src/Agent/app/result_queue.py
+++ b/src/Agent/app/result_queue.py
@@ -23,5 +23,10 @@ class ResultQueue:
         for item in items:
             self.enqueue(item)
 
+    def requeue_front(self, items: Iterable[ResultItem]) -> None:
+        buffered = list(items)
+        for item in reversed(buffered):
+            self._items.appendleft(item)
+
     def __len__(self) -> int:
         return len(self._items)

--- a/src/Agent/tests/test_result_queue.py
+++ b/src/Agent/tests/test_result_queue.py
@@ -1,0 +1,33 @@
+import unittest
+
+from app.models import ResultItem
+from app.result_queue import ResultQueue
+
+
+def _result(assignment_id: str) -> ResultItem:
+    return ResultItem(
+        assignment_id=assignment_id,
+        endpoint_id=f"endpoint-{assignment_id}",
+        check_type="icmp",
+        checked_at_utc="2026-03-25T00:00:00Z",
+        success=False,
+        round_trip_ms=None,
+        error_code="ERR",
+        error_message="error",
+    )
+
+
+class ResultQueueTests(unittest.TestCase):
+    def test_requeue_front_preserves_original_order(self) -> None:
+        queue = ResultQueue()
+        queue.extend([_result("a"), _result("b"), _result("c")])
+
+        batch = queue.dequeue_batch(2)
+        queue.requeue_front(batch)
+
+        result_ids = [item.assignment_id for item in queue.dequeue_batch(3)]
+        self.assertEqual(["a", "b", "c"], result_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- The agent was exiting when the server returned HTTP 5xx during `/api/v1/agent/results`, which violates the platform constraint that agents must tolerate temporary server failures and remain running.
- Failed result batches must be retried rather than lost to preserve monitoring data integrity and avoid silent failure.
- Better logging of server error responses is needed to aid diagnosis of transient server-side failures.

### Description
- Catch `httpx.HTTPError` around the result submission in the agent loop and prevent the process from exiting by logging the failure and continuing the main loop (`src/Agent/app/main.py`).
- Add `_format_http_error` to include HTTP response body context for `HTTPStatusError` cases to improve log usefulness (`src/Agent/app/main.py`).
- Implement `ResultQueue.requeue_front(...)` to restore a failed batch to the front of the queue so it will be retried while preserving original ordering (`src/Agent/app/result_queue.py`).
- Add a unit test that verifies requeue-front preserves ordering (`src/Agent/tests/test_result_queue.py`).
- Fix is linked to an issue for traceability: `Fixes #54`.

### Testing
- Ran unit tests with `cd src/Agent && python -m unittest discover -s tests -v` and the new test passed (1 test, OK).
- Compiled the agent package with `cd src/Agent && python -m compileall app tests` which succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3a2cf2794832ab8e42932b768f504)