### PR TITLE
Fix HTTP 500 in agent /results ingestion on MySQL

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
@@ -46,9 +46,13 @@ internal sealed class ResultIngestionService : IResultIngestionService
             .Distinct(StringComparer.Ordinal)
             .ToArray();
 
-        var assignments = await _dbContext.MonitorAssignments
-            .Where(x => x.AgentId == agent.AgentId && normalizedAssignmentIds.Contains(x.AssignmentId))
-            .ToDictionaryAsync(x => x.AssignmentId, StringComparer.Ordinal, cancellationToken);
+        var assignmentsForAgent = await _dbContext.MonitorAssignments
+            .Where(x => x.AgentId == agent.AgentId)
+            .ToListAsync(cancellationToken);
+
+        var assignments = assignmentsForAgent
+            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId, StringComparer.Ordinal))
+            .ToDictionary(x => x.AssignmentId, StringComparer.Ordinal);
 
         for (var index = 0; index < request.Results.Count; index++)
         {


### PR DESCRIPTION
### Motivation
- Prevent `POST /api/v1/agent/results` from returning HTTP 500 for valid agent batches by fixing an EF Core/MySQL translation error in the assignment ownership lookup that threw before validation and persistence completed.

### Description
- Replaced the provider-translated `Contains` query with a safe two-step lookup: load `MonitorAssignment` rows scoped to the authenticated agent then filter requested assignment IDs in-memory, implemented in `ResultIngestionService` (`src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs`).
- Kept behavior unchanged for idempotency and validation paths and made no schema or state-machine changes; this PR links and fixes the created issue `Fixes #56`.

### Testing
- Built the web app with `dotnet build` and ran it in Development; the change compiled successfully and the app started. 
- End-to-end validations performed against a local MySQL instance included: a valid results batch returned `200` and persisted `CheckResult`/`ResultBatch`, a duplicate submission returned `200` with `duplicate=true` and did not duplicate rows, an invalid result payload returned `400`, and a results payload referencing an assignment not owned by the agent returned `400`; all automated requests succeeded as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3b01de260832aad8843f3fe20daec)