### PR TITLE
Implement real ICMP ping execution for agent checks

### DIFF
--- a/src/Agent/README.md
+++ b/src/Agent/README.md
@@ -8,11 +8,12 @@ This directory contains the phase 1 outbound-only Python agent skeleton.
 - prepares authenticated HTTPS calls to the web application
 - fetches hello/config/heartbeat/results using the documented v1 API paths
 - keeps result handling as raw fact submission only
-- leaves ICMP execution and scheduling behaviour intentionally minimal
+- executes real ICMP checks using the system `ping` command
+- uses each assignment's configured `target` and `timeoutMs` when running ICMP
+- keeps scheduling behaviour intentionally minimal
 
 ## Out of scope in phase 1
 
-- real ICMP probing
 - persistent queue storage
 - retry/backoff implementation
 - agent-side state, suppression, or alert logic

--- a/src/Agent/app/checks.py
+++ b/src/Agent/app/checks.py
@@ -1,20 +1,162 @@
 from __future__ import annotations
 
+import logging
+import platform
+import re
+import subprocess
+import time
 from datetime import UTC, datetime
 
 from app.models import AssignmentModel, ResultItem
 
 
 class CheckRunner:
+    _WINDOWS_TIME_RE = re.compile(r"time[=<]\s*(\d+)\s*ms", re.IGNORECASE)
+    _UNIX_TIME_RE = re.compile(r"time[=<]?\s*(\d+(?:\.\d+)?)\s*ms", re.IGNORECASE)
+
     def run_icmp_check(self, assignment: AssignmentModel) -> ResultItem:
-        # TODO: Implement ICMP execution and return raw facts only.
-        return ResultItem(
-            assignment_id=assignment.assignment_id,
-            endpoint_id=assignment.endpoint_id,
-            check_type=assignment.check_type,
-            checked_at_utc=datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
-            success=False,
-            round_trip_ms=None,
-            error_code="NOT_IMPLEMENTED",
-            error_message="ICMP check execution is not implemented in the phase 1 skeleton.",
+        checked_at_utc = _utc_now()
+        timeout_ms = max(1, assignment.timeout_ms)
+        ping_command = _build_ping_command(assignment.target, timeout_ms)
+        timeout_seconds = max(1.0, timeout_ms / 1000.0 + 1.0)
+
+        logging.info(
+            "Running ICMP check assignment=%s target=%s timeoutMs=%d",
+            assignment.assignment_id,
+            assignment.target,
+            timeout_ms,
         )
+
+        started = time.monotonic()
+        try:
+            completed = subprocess.run(  # noqa: S603
+                ping_command,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            elapsed_ms = int((time.monotonic() - started) * 1000)
+            logging.warning(
+                "ICMP timeout assignment=%s target=%s elapsedMs=%d",
+                assignment.assignment_id,
+                assignment.target,
+                elapsed_ms,
+            )
+            return _failure_result(
+                assignment,
+                checked_at_utc,
+                "PING_TIMEOUT",
+                f"Ping command timed out after approximately {timeout_ms} ms.",
+            )
+        except OSError as ex:
+            logging.error(
+                "ICMP execution error assignment=%s target=%s error=%s",
+                assignment.assignment_id,
+                assignment.target,
+                ex,
+            )
+            return _failure_result(
+                assignment,
+                checked_at_utc,
+                "PING_EXECUTION_ERROR",
+                f"Failed to execute ping command: {ex}",
+            )
+
+        output = "\n".join(part for part in [completed.stdout.strip(), completed.stderr.strip()] if part).strip()
+        elapsed_ms = int((time.monotonic() - started) * 1000)
+
+        if completed.returncode == 0:
+            round_trip_ms = self._parse_round_trip_ms(output)
+            logging.info(
+                "ICMP success assignment=%s target=%s elapsedMs=%d roundTripMs=%s",
+                assignment.assignment_id,
+                assignment.target,
+                elapsed_ms,
+                round_trip_ms,
+            )
+            return ResultItem(
+                assignment_id=assignment.assignment_id,
+                endpoint_id=assignment.endpoint_id,
+                check_type=assignment.check_type,
+                checked_at_utc=checked_at_utc,
+                success=True,
+                round_trip_ms=round_trip_ms,
+                error_code=None,
+                error_message=None,
+            )
+
+        error_code, error_message = _classify_ping_failure(output)
+        logging.warning(
+            "ICMP failure assignment=%s target=%s returnCode=%d errorCode=%s message=%s",
+            assignment.assignment_id,
+            assignment.target,
+            completed.returncode,
+            error_code,
+            error_message,
+        )
+        return _failure_result(assignment, checked_at_utc, error_code, error_message)
+
+    def _parse_round_trip_ms(self, output: str) -> int | None:
+        windows_match = self._WINDOWS_TIME_RE.search(output)
+        if windows_match:
+            return int(windows_match.group(1))
+
+        unix_match = self._UNIX_TIME_RE.search(output)
+        if unix_match:
+            return int(round(float(unix_match.group(1))))
+
+        return None
+
+
+def _build_ping_command(target: str, timeout_ms: int) -> list[str]:
+    if platform.system().lower() == "windows":
+        return ["ping", "-n", "1", "-w", str(timeout_ms), target]
+
+    timeout_seconds = max(1, int(round(timeout_ms / 1000.0)))
+    return ["ping", "-n", "-c", "1", "-W", str(timeout_seconds), target]
+
+
+def _classify_ping_failure(output: str) -> tuple[str, str]:
+    lowered = output.lower()
+
+    if "request timed out" in lowered or "100% packet loss" in lowered or "100.0% packet loss" in lowered:
+        return "PING_TIMEOUT", "Ping request timed out."
+
+    if "destination host unreachable" in lowered or "general failure" in lowered:
+        return "HOST_UNREACHABLE", "Host is unreachable."
+
+    if (
+        "could not find host" in lowered
+        or "name or service not known" in lowered
+        or "temporary failure in name resolution" in lowered
+        or "unknown host" in lowered
+    ):
+        return "HOST_UNREACHABLE", "Host could not be resolved."
+
+    if "unreachable" in lowered:
+        return "HOST_UNREACHABLE", "Host is unreachable."
+
+    trimmed = output.strip()
+    if trimmed:
+        return "PING_FAILED", trimmed.splitlines()[0]
+
+    return "PING_FAILED", "Ping command failed."
+
+
+def _failure_result(assignment: AssignmentModel, checked_at_utc: str, error_code: str, error_message: str) -> ResultItem:
+    return ResultItem(
+        assignment_id=assignment.assignment_id,
+        endpoint_id=assignment.endpoint_id,
+        check_type=assignment.check_type,
+        checked_at_utc=checked_at_utc,
+        success=False,
+        round_trip_ms=None,
+        error_code=error_code,
+        error_message=error_message,
+    )
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")


### PR DESCRIPTION
### Motivation
- Replace the placeholder ICMP runner with a real, outbound-only ping implementation so the agent submits accurate raw facts for ICMP checks per the v1 contract. 
- Keep the change minimal and compliant with platform constraints (Python agent, outbound-only, no agent-side state/suppression/alerting). 

### Description
- Replaced the stub in `src/Agent/app/checks.py` with a real system `ping` execution that uses each assignment's `target` and `timeoutMs` and preserves the raw result contract (`assignmentId`, `endpointId`, `checkType`, `checkedAtUtc`, `success`, `roundTripMs`, `errorCode`, `errorMessage`). (Fixes #58)
- Implemented Windows-friendly and Unix fallback command builders: Windows uses `ping -n 1 -w <ms>`, Unix uses `ping -c 1 -W <seconds>` with a documented approximation between `timeoutMs` and seconds.
- Added parsing of round-trip time from typical ping output (`time=...ms`) and deterministic failure mapping (`PING_TIMEOUT`, `HOST_UNREACHABLE`, `PING_FAILED`, `PING_EXECUTION_ERROR`).
- Added concise logging around ICMP execution (target, timeout, elapsed, RTT when available, and failure reason) while avoiding any sensitive data logging.
- Updated `src/Agent/README.md` to note the agent now performs real ICMP checks using assignment `target` + `timeoutMs`.

### Testing
- Compiled the package with `python -m compileall src/Agent/app` and compilation succeeded.
- Ran unit tests with `PYTHONPATH=src/Agent pytest -q src/Agent/tests` and all tests passed (`1 passed`).
- Performed manual smoke checks using `CheckRunner` against a reachable host (`127.0.0.1`) and an unreachable host (`203.0.113.1`) to validate success and failure payload shapes; the result payload shape matches `app.models.ResultItem` and round-trip parsing / failure codes behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3ca669b24832a87dc61d1d915e40b)