### PR TITLE
Add server-rendered admin settings page with persistent app defaults

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -159,6 +159,28 @@ Defines what an agent monitors and how.
 
 ---
 
+### ApplicationSettings
+
+Represents singleton control-plane settings managed from the admin page.
+
+#### Purpose
+
+- provide explicit application-level defaults
+- avoid hidden environment-dependent behavior
+
+#### Key fields
+
+- `applicationSettingsId` (singleton id: 1)
+- `siteUrl` (used when generating agent `.env` `SERVER_URL`)
+- `defaultPingIntervalSeconds`
+- `defaultRetryIntervalSeconds`
+- `defaultTimeoutMs`
+- `defaultFailureThreshold`
+- `defaultRecoveryThreshold`
+- `updatedAtUtc`
+
+---
+
 ### CheckResult
 
 Represents a single raw check result.
@@ -338,6 +360,7 @@ These are scoped per agent:
 These are shared:
 
 - Endpoint  
+- ApplicationSettings  
 
 ### Important implication
 

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminController.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Services;
+using PingMonitor.Web.ViewModels.Admin;
+
+namespace PingMonitor.Web.Controllers;
+
+[Route("admin")]
+public sealed class AdminController : Controller
+{
+    private readonly IApplicationSettingsService _applicationSettingsService;
+
+    public AdminController(IApplicationSettingsService applicationSettingsService)
+    {
+        _applicationSettingsService = applicationSettingsService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Index(CancellationToken cancellationToken)
+    {
+        var settings = await _applicationSettingsService.GetCurrentAsync(cancellationToken);
+        return View("Index", ToViewModel(settings, saved: false));
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Index([FromForm] AdminSettingsPageViewModel model, CancellationToken cancellationToken)
+    {
+        ValidateAbsoluteSiteUrl(model);
+
+        if (!ModelState.IsValid)
+        {
+            return View("Index", model);
+        }
+
+        var updated = await _applicationSettingsService.UpdateAsync(
+            new UpdateApplicationSettingsCommand
+            {
+                SiteUrl = model.SiteUrl,
+                DefaultPingIntervalSeconds = model.DefaultPingIntervalSeconds,
+                DefaultRetryIntervalSeconds = model.DefaultRetryIntervalSeconds,
+                DefaultTimeoutMs = model.DefaultTimeoutMs,
+                DefaultFailureThreshold = model.DefaultFailureThreshold,
+                DefaultRecoveryThreshold = model.DefaultRecoveryThreshold
+            },
+            cancellationToken);
+
+        return View("Index", ToViewModel(updated, saved: true));
+    }
+
+    private void ValidateAbsoluteSiteUrl(AdminSettingsPageViewModel model)
+    {
+        if (!Uri.TryCreate(model.SiteUrl?.Trim(), UriKind.Absolute, out _))
+        {
+            ModelState.AddModelError(nameof(AdminSettingsPageViewModel.SiteUrl), "Site URL must be a valid absolute URL.");
+        }
+    }
+
+    private static AdminSettingsPageViewModel ToViewModel(ApplicationSettingsDto settings, bool saved)
+    {
+        return new AdminSettingsPageViewModel
+        {
+            SiteUrl = settings.SiteUrl,
+            DefaultPingIntervalSeconds = settings.DefaultPingIntervalSeconds,
+            DefaultRetryIntervalSeconds = settings.DefaultRetryIntervalSeconds,
+            DefaultTimeoutMs = settings.DefaultTimeoutMs,
+            DefaultFailureThreshold = settings.DefaultFailureThreshold,
+            DefaultRecoveryThreshold = settings.DefaultRecoveryThreshold,
+            UpdatedAtUtc = settings.UpdatedAtUtc,
+            Saved = saved
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.Endpoints;
 using PingMonitor.Web.ViewModels.Endpoints;
 
@@ -9,19 +10,30 @@ public sealed class EndpointsController : Controller
 {
     private readonly IEndpointCreationQueryService _endpointCreationQueryService;
     private readonly IEndpointManagementService _endpointManagementService;
+    private readonly IApplicationSettingsService _applicationSettingsService;
 
     public EndpointsController(
         IEndpointCreationQueryService endpointCreationQueryService,
-        IEndpointManagementService endpointManagementService)
+        IEndpointManagementService endpointManagementService,
+        IApplicationSettingsService applicationSettingsService)
     {
         _endpointCreationQueryService = endpointCreationQueryService;
         _endpointManagementService = endpointManagementService;
+        _applicationSettingsService = applicationSettingsService;
     }
 
     [HttpGet("new")]
     public async Task<IActionResult> New(CancellationToken cancellationToken)
     {
-        var model = new CreateEndpointPageViewModel();
+        var defaults = await _applicationSettingsService.GetCurrentAsync(cancellationToken);
+        var model = new CreateEndpointPageViewModel
+        {
+            PingIntervalSeconds = defaults.DefaultPingIntervalSeconds,
+            RetryIntervalSeconds = defaults.DefaultRetryIntervalSeconds,
+            TimeoutMs = defaults.DefaultTimeoutMs,
+            FailureThreshold = defaults.DefaultFailureThreshold,
+            RecoveryThreshold = defaults.DefaultRecoveryThreshold
+        };
         await PopulateOptionsAsync(model, cancellationToken);
         return View("New", model);
     }

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -24,6 +24,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
     public DbSet<EndpointState> EndpointStates => Set<EndpointState>();
     public DbSet<StateTransition> StateTransitions => Set<StateTransition>();
     public DbSet<AppSchemaInfo> AppSchemaInfos => Set<AppSchemaInfo>();
+    public DbSet<ApplicationSettings> ApplicationSettings => Set<ApplicationSettings>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -134,5 +135,17 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         stateTransition.Property(x => x.ReasonCode).HasMaxLength(64);
         stateTransition.Property(x => x.DependencyEndpointId).HasMaxLength(64);
         stateTransition.HasIndex(x => new { x.AssignmentId, x.TransitionAtUtc });
+
+        var appSettings = modelBuilder.Entity<ApplicationSettings>();
+        appSettings.ToTable("ApplicationSettings");
+        appSettings.HasKey(x => x.ApplicationSettingsId);
+        appSettings.Property(x => x.ApplicationSettingsId).ValueGeneratedNever();
+        appSettings.Property(x => x.SiteUrl).HasMaxLength(2048).IsRequired();
+        appSettings.Property(x => x.DefaultPingIntervalSeconds).IsRequired();
+        appSettings.Property(x => x.DefaultRetryIntervalSeconds).IsRequired();
+        appSettings.Property(x => x.DefaultTimeoutMs).IsRequired();
+        appSettings.Property(x => x.DefaultFailureThreshold).IsRequired();
+        appSettings.Property(x => x.DefaultRecoveryThreshold).IsRequired();
+        appSettings.Property(x => x.UpdatedAtUtc).IsRequired();
     }
 }

--- a/src/WebApp/PingMonitor.Web/Models/ApplicationSettings.cs
+++ b/src/WebApp/PingMonitor.Web/Models/ApplicationSettings.cs
@@ -1,0 +1,22 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class ApplicationSettings
+{
+    public const int SingletonId = 1;
+
+    public int ApplicationSettingsId { get; set; } = SingletonId;
+
+    public string SiteUrl { get; set; } = string.Empty;
+
+    public int DefaultPingIntervalSeconds { get; set; } = 60;
+
+    public int DefaultRetryIntervalSeconds { get; set; } = 5;
+
+    public int DefaultTimeoutMs { get; set; } = 1000;
+
+    public int DefaultFailureThreshold { get; set; } = 3;
+
+    public int DefaultRecoveryThreshold { get; set; } = 2;
+
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
@@ -5,6 +5,6 @@ public sealed class StartupGateOptions
     public const string SectionName = "StartupGate";
 
     public string StorageDirectory { get; set; } = "App_Data/StartupGate";
-    public int RequiredSchemaVersion { get; set; } = 2;
+    public int RequiredSchemaVersion { get; set; } = 3;
     public int DefaultMySqlPort { get; set; } = 3306;
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -92,6 +92,7 @@ builder.Services.AddScoped<IStartupAdminBootstrapService, StartupAdminBootstrapS
 builder.Services.AddScoped<DevelopmentAgentSeeder>();
 builder.Services.AddScoped<IAgentPackageBuilder, AgentPackageBuilder>();
 builder.Services.AddScoped<IAgentProvisioningService, AgentProvisioningService>();
+builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsService>();
 builder.Services.AddScoped<IEndpointCreationQueryService, EndpointCreationQueryService>();
 builder.Services.AddScoped<IEndpointManagementService, EndpointManagementService>();
 

--- a/src/WebApp/PingMonitor.Web/README.md
+++ b/src/WebApp/PingMonitor.Web/README.md
@@ -59,3 +59,12 @@ In normal startup mode, the first operational status page is available at `GET /
 The default landing page at `GET /` routes to the same `StatusController.Index` page so the control plane has an operational landing route immediately after startup-gate completion.
 
 It shows the current server-derived state for each `MonitorAssignment`, including endpoint, target, agent instance, state, counters, dependency parent, suppression source, check type, and enabled flags. The page is assignment-scoped, so the same endpoint can appear more than once for different agents. `SUPPRESSED` is derived on the server from dependency evaluation and is never agent-supplied.
+
+## Admin settings page
+
+In normal startup mode, `GET /admin` provides a server-rendered settings page for:
+
+- `SiteUrl` used by generated agent `.env` files as `SERVER_URL`
+- default endpoint timing/threshold values used to prefill `GET /endpoints/new`
+
+These values are persisted in the `ApplicationSettings` table and can be updated from `POST /admin`.

--- a/src/WebApp/PingMonitor.Web/Services/AgentProvisioningService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentProvisioningService.cs
@@ -1,10 +1,8 @@
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Options;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
-using PingMonitor.Web.Options;
 
 namespace PingMonitor.Web.Services;
 
@@ -13,20 +11,20 @@ internal sealed class AgentProvisioningService : IAgentProvisioningService
     private readonly PingMonitorDbContext _dbContext;
     private readonly IAgentApiKeyHasher _apiKeyHasher;
     private readonly IAgentPackageBuilder _agentPackageBuilder;
-    private readonly AgentProvisioningOptions _options;
+    private readonly IApplicationSettingsService _applicationSettingsService;
     private readonly ILogger<AgentProvisioningService> _logger;
 
     public AgentProvisioningService(
         PingMonitorDbContext dbContext,
         IAgentApiKeyHasher apiKeyHasher,
         IAgentPackageBuilder agentPackageBuilder,
-        IOptions<AgentProvisioningOptions> options,
+        IApplicationSettingsService applicationSettingsService,
         ILogger<AgentProvisioningService> logger)
     {
         _dbContext = dbContext;
         _apiKeyHasher = apiKeyHasher;
         _agentPackageBuilder = agentPackageBuilder;
-        _options = options.Value;
+        _applicationSettingsService = applicationSettingsService;
         _logger = logger;
     }
 
@@ -38,7 +36,8 @@ internal sealed class AgentProvisioningService : IAgentProvisioningService
             throw new ArgumentException("Agent name is required.", nameof(agentName));
         }
 
-        var serverUrl = ValidateServerUrl(_options.ServerUrl);
+        var settings = await _applicationSettingsService.GetCurrentAsync(cancellationToken);
+        var serverUrl = ValidateServerUrl(settings.SiteUrl);
         var now = DateTimeOffset.UtcNow;
         var instanceId = await GenerateUniqueInstanceIdAsync(normalizedName, cancellationToken);
 
@@ -94,18 +93,18 @@ internal sealed class AgentProvisioningService : IAgentProvisioningService
     {
         if (string.IsNullOrWhiteSpace(configuredServerUrl))
         {
-            throw new InvalidOperationException("Agent provisioning is not configured. Set AgentProvisioning:ServerUrl.");
+            throw new InvalidOperationException("Agent provisioning Site URL is not configured. Set it on /admin.");
         }
 
         var value = configuredServerUrl.Trim();
         if (!Uri.TryCreate(value, UriKind.Absolute, out var uri))
         {
-            throw new InvalidOperationException("AgentProvisioning:ServerUrl must be an absolute URL.");
+            throw new InvalidOperationException("Admin Site URL must be an absolute URL.");
         }
 
         if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
         {
-            throw new InvalidOperationException("AgentProvisioning:ServerUrl must use HTTPS.");
+            throw new InvalidOperationException("Admin Site URL must use HTTPS.");
         }
 
         return uri.ToString().TrimEnd('/');

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationSettingsDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationSettingsDto.cs
@@ -1,0 +1,12 @@
+namespace PingMonitor.Web.Services;
+
+public sealed class ApplicationSettingsDto
+{
+    public string SiteUrl { get; init; } = string.Empty;
+    public int DefaultPingIntervalSeconds { get; init; }
+    public int DefaultRetryIntervalSeconds { get; init; }
+    public int DefaultTimeoutMs { get; init; }
+    public int DefaultFailureThreshold { get; init; }
+    public int DefaultRecoveryThreshold { get; init; }
+    public DateTimeOffset UpdatedAtUtc { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationSettingsService.cs
@@ -1,0 +1,95 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Options;
+
+namespace PingMonitor.Web.Services;
+
+internal sealed class ApplicationSettingsService : IApplicationSettingsService
+{
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly AgentProvisioningOptions _provisioningOptions;
+
+    public ApplicationSettingsService(PingMonitorDbContext dbContext, IOptions<AgentProvisioningOptions> provisioningOptions)
+    {
+        _dbContext = dbContext;
+        _provisioningOptions = provisioningOptions.Value;
+    }
+
+    public async Task<ApplicationSettingsDto> GetCurrentAsync(CancellationToken cancellationToken)
+    {
+        var settings = await GetOrCreateEntityAsync(cancellationToken);
+        return ToDto(settings);
+    }
+
+    public async Task<ApplicationSettingsDto> UpdateAsync(UpdateApplicationSettingsCommand command, CancellationToken cancellationToken)
+    {
+        var settings = await GetOrCreateEntityAsync(cancellationToken);
+
+        settings.SiteUrl = command.SiteUrl.Trim();
+        settings.DefaultPingIntervalSeconds = command.DefaultPingIntervalSeconds;
+        settings.DefaultRetryIntervalSeconds = command.DefaultRetryIntervalSeconds;
+        settings.DefaultTimeoutMs = command.DefaultTimeoutMs;
+        settings.DefaultFailureThreshold = command.DefaultFailureThreshold;
+        settings.DefaultRecoveryThreshold = command.DefaultRecoveryThreshold;
+        settings.UpdatedAtUtc = DateTimeOffset.UtcNow;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return ToDto(settings);
+    }
+
+    private async Task<ApplicationSettings> GetOrCreateEntityAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _dbContext.ApplicationSettings
+            .SingleOrDefaultAsync(x => x.ApplicationSettingsId == ApplicationSettings.SingletonId, cancellationToken);
+
+        if (settings is not null)
+        {
+            return settings;
+        }
+
+        settings = new ApplicationSettings
+        {
+            ApplicationSettingsId = ApplicationSettings.SingletonId,
+            SiteUrl = BuildInitialSiteUrl(),
+            DefaultPingIntervalSeconds = 60,
+            DefaultRetryIntervalSeconds = 5,
+            DefaultTimeoutMs = 1000,
+            DefaultFailureThreshold = 3,
+            DefaultRecoveryThreshold = 2,
+            UpdatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        _dbContext.ApplicationSettings.Add(settings);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return settings;
+    }
+
+    private string BuildInitialSiteUrl()
+    {
+        var configuredUrl = _provisioningOptions.ServerUrl?.Trim();
+        if (string.IsNullOrWhiteSpace(configuredUrl))
+        {
+            return string.Empty;
+        }
+
+        return Uri.TryCreate(configuredUrl, UriKind.Absolute, out var uri)
+            ? uri.ToString().TrimEnd('/')
+            : string.Empty;
+    }
+
+    private static ApplicationSettingsDto ToDto(ApplicationSettings settings)
+    {
+        return new ApplicationSettingsDto
+        {
+            SiteUrl = settings.SiteUrl,
+            DefaultPingIntervalSeconds = settings.DefaultPingIntervalSeconds,
+            DefaultRetryIntervalSeconds = settings.DefaultRetryIntervalSeconds,
+            DefaultTimeoutMs = settings.DefaultTimeoutMs,
+            DefaultFailureThreshold = settings.DefaultFailureThreshold,
+            DefaultRecoveryThreshold = settings.DefaultRecoveryThreshold,
+            UpdatedAtUtc = settings.UpdatedAtUtc
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/IApplicationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IApplicationSettingsService.cs
@@ -1,0 +1,8 @@
+namespace PingMonitor.Web.Services;
+
+public interface IApplicationSettingsService
+{
+    Task<ApplicationSettingsDto> GetCurrentAsync(CancellationToken cancellationToken);
+
+    Task<ApplicationSettingsDto> UpdateAsync(UpdateApplicationSettingsCommand command, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -21,7 +21,8 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "CheckResults",
         "ResultBatches",
         "EndpointStates",
-        "StateTransitions"
+        "StateTransitions",
+        "ApplicationSettings"
     ];
 
     private readonly IDbContextFactory<PingMonitorDbContext> _dbContextFactory;
@@ -114,7 +115,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
 
         await using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
         await dbContext.Database.EnsureCreatedAsync(cancellationToken);
-        await EnsureStateEngineTablesAsync(dbContext, cancellationToken);
+        await EnsureAdditionalTablesAsync(dbContext, cancellationToken);
 
         var schemaInfo = await dbContext.AppSchemaInfos.OrderByDescending(x => x.AppSchemaInfoId).FirstOrDefaultAsync(cancellationToken);
         if (schemaInfo is null)
@@ -138,7 +139,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         return await GetStatusAsync(cancellationToken);
     }
 
-    private static async Task EnsureStateEngineTablesAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
+    private static async Task EnsureAdditionalTablesAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
     {
         const string createEndpointStatesSql = """
             CREATE TABLE IF NOT EXISTS `EndpointStates` (
@@ -170,7 +171,22 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             );
             """;
 
+        const string createApplicationSettingsSql = """
+            CREATE TABLE IF NOT EXISTS `ApplicationSettings` (
+                `ApplicationSettingsId` int NOT NULL,
+                `SiteUrl` varchar(2048) NOT NULL,
+                `DefaultPingIntervalSeconds` int NOT NULL,
+                `DefaultRetryIntervalSeconds` int NOT NULL,
+                `DefaultTimeoutMs` int NOT NULL,
+                `DefaultFailureThreshold` int NOT NULL,
+                `DefaultRecoveryThreshold` int NOT NULL,
+                `UpdatedAtUtc` datetime(6) NOT NULL,
+                PRIMARY KEY (`ApplicationSettingsId`)
+            );
+            """;
+
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointStatesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createStateTransitionsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createApplicationSettingsSql, cancellationToken);
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/UpdateApplicationSettingsCommand.cs
+++ b/src/WebApp/PingMonitor.Web/Services/UpdateApplicationSettingsCommand.cs
@@ -1,0 +1,11 @@
+namespace PingMonitor.Web.Services;
+
+public sealed class UpdateApplicationSettingsCommand
+{
+    public string SiteUrl { get; init; } = string.Empty;
+    public int DefaultPingIntervalSeconds { get; init; }
+    public int DefaultRetryIntervalSeconds { get; init; }
+    public int DefaultTimeoutMs { get; init; }
+    public int DefaultFailureThreshold { get; init; }
+    public int DefaultRecoveryThreshold { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/AdminSettingsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/AdminSettingsPageViewModel.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PingMonitor.Web.ViewModels.Admin;
+
+public sealed class AdminSettingsPageViewModel
+{
+    [Required(ErrorMessage = "Site URL is required.")]
+    [Url(ErrorMessage = "Site URL must be a valid absolute URL.")]
+    [Display(Name = "Site URL")]
+    public string SiteUrl { get; set; } = string.Empty;
+
+    [Range(1, int.MaxValue, ErrorMessage = "Default ping interval must be at least 1 second.")]
+    [Display(Name = "Default ping interval (seconds)")]
+    public int DefaultPingIntervalSeconds { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Default retry interval must be at least 1 second.")]
+    [Display(Name = "Default retry interval (seconds)")]
+    public int DefaultRetryIntervalSeconds { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Default timeout must be at least 1 millisecond.")]
+    [Display(Name = "Default timeout (ms)")]
+    public int DefaultTimeoutMs { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Default failure threshold must be at least 1.")]
+    [Display(Name = "Default failure threshold")]
+    public int DefaultFailureThreshold { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Default recovery threshold must be at least 1.")]
+    [Display(Name = "Default recovery threshold")]
+    public int DefaultRecoveryThreshold { get; set; }
+
+    public bool Saved { get; set; }
+
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
@@ -1,0 +1,116 @@
+@model PingMonitor.Web.ViewModels.Admin.AdminSettingsPageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin settings</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #f3f6f8;
+            --card: #ffffff;
+            --text: #102a43;
+            --muted: #52606d;
+            --border: #d9e2ec;
+            --accent: #0f62fe;
+            --success: #137333;
+            --error-bg: #fee4e2;
+            --error-text: #b42318;
+        }
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 760px; margin: 0 auto; padding: 1rem; }
+        .stack { display: grid; gap: 1rem; }
+        .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
+        .field-grid { display: grid; gap: .85rem; }
+        label { display: block; font-weight: 600; margin-bottom: .35rem; }
+        input { width: 100%; min-height: 48px; padding: .8rem; border: 1px solid var(--border); border-radius: 10px; font-size: 1rem; }
+        .button-row { display: flex; gap: .75rem; flex-wrap: wrap; }
+        .button, .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 48px; padding: .8rem 1rem; border-radius: 10px; font-weight: 600; text-decoration: none; }
+        .button { border: 0; background: var(--accent); color: white; }
+        .button-secondary { border: 1px solid var(--border); color: var(--text); background: white; }
+        .field-error { color: var(--error-text); font-size: .9rem; margin-top: .25rem; }
+        .errors { border: 1px solid #fda29b; background: var(--error-bg); color: var(--error-text); border-radius: 10px; padding: .8rem; }
+        .saved { border: 1px solid #c2f0c2; background: #ebffee; color: var(--success); border-radius: 10px; padding: .8rem; }
+        .muted { color: var(--muted); }
+        @@media (min-width: 720px) {
+            .field-grid.two-col { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        }
+    </style>
+</head>
+<body>
+<main>
+    <div class="stack">
+        <section class="card">
+            <h1>Admin settings</h1>
+            <p class="muted">Configure application-level settings used by agent provisioning and new endpoint defaults.</p>
+            <div class="button-row">
+                <a class="button-secondary" href="/status">Back to status</a>
+            </div>
+        </section>
+
+        <form method="post" action="/admin" class="stack">
+            @Html.AntiForgeryToken()
+
+            @if (Model.Saved)
+            {
+                <div class="saved" role="status">Settings saved successfully.</div>
+            }
+
+            @if (!ViewData.ModelState.IsValid)
+            {
+                <div class="errors" asp-validation-summary="ModelOnly"></div>
+            }
+
+            <section class="card">
+                <h2>Agent provisioning</h2>
+                <div class="field-grid">
+                    <div>
+                        <label asp-for="SiteUrl"></label>
+                        <input asp-for="SiteUrl" />
+                        <div class="field-error"><span asp-validation-for="SiteUrl"></span></div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="card">
+                <h2>Default endpoint values</h2>
+                <div class="field-grid two-col">
+                    <div>
+                        <label asp-for="DefaultPingIntervalSeconds"></label>
+                        <input asp-for="DefaultPingIntervalSeconds" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="DefaultPingIntervalSeconds"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="DefaultRetryIntervalSeconds"></label>
+                        <input asp-for="DefaultRetryIntervalSeconds" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="DefaultRetryIntervalSeconds"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="DefaultTimeoutMs"></label>
+                        <input asp-for="DefaultTimeoutMs" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="DefaultTimeoutMs"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="DefaultFailureThreshold"></label>
+                        <input asp-for="DefaultFailureThreshold" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="DefaultFailureThreshold"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="DefaultRecoveryThreshold"></label>
+                        <input asp-for="DefaultRecoveryThreshold" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="DefaultRecoveryThreshold"></span></div>
+                    </div>
+                </div>
+                <p class="muted">Last updated: @Model.UpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</p>
+            </section>
+
+            <div class="button-row">
+                <button class="button" type="submit">Save settings</button>
+            </div>
+        </form>
+    </div>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -86,6 +86,7 @@
             <div class="button-row">
                 <a class="button" href="/agents/deploy">Deploy new agent</a>
                 <a class="button-secondary" href="/endpoints/new">Add new endpoint</a>
+                <a class="button-secondary" href="/admin">Admin settings</a>
             </div>
         </section>
 

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 2,
+    "RequiredSchemaVersion": 3,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 2,
+    "RequiredSchemaVersion": 3,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
### Motivation

- Provide an explicit, persistent place to manage the `SiteUrl` used for agent provisioning and the default endpoint timing/threshold values so provisioning and new endpoint flows are deterministic and operationally simple. 
- Keep implementation minimal and explicit (singleton settings record) to avoid introducing a generic key/value subsystem. 
- Follow platform constraints and data-model guidance by making settings auditable, startup-gate aware, and safe to change.

### Description

- Add a singleton `ApplicationSettings` model and EF mapping to persist `SiteUrl`, `DefaultPingIntervalSeconds`, `DefaultRetryIntervalSeconds`, `DefaultTimeoutMs`, `DefaultFailureThreshold`, `DefaultRecoveryThreshold`, and `UpdatedAtUtc`, and wire it into `PingMonitorDbContext` and the startup-gate SQL apply step; bump schema version to `3` so the startup-gate knows to apply the new table. (Fixes #60)
- Implement `IApplicationSettingsService` and `ApplicationSettingsService` that load the current settings, create a default record if missing, and update settings; defaults are derived from existing provisioning option where appropriate.
- Add server-rendered Admin page (`GET /admin`, `POST /admin`) with `AdminSettingsPageViewModel`, explicit validation (required absolute `SiteUrl`, numeric minimums ≥ 1 for timing/threshold fields), and a simple mobile-friendly Razor view to view and save settings.
- Wire flows to use persisted settings: `AgentProvisioningService` now reads persisted `SiteUrl` (used for generated agent `.env` `SERVER_URL`) and fails with clear messages if missing/invalid; `EndpointsController` `GET /endpoints/new` pre-populates monitoring fields from persisted defaults; register the settings service in DI and add a simple `/admin` link from the status page; update docs (`docs/data-model.md`, webapp README) to mention the new `ApplicationSettings` and admin behaviors.

### Testing

- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully with `Build succeeded.`
- No automated end-to-end database/UI tests were run in this environment because startup-gate/MySQL schema apply and runtime UI interaction require a configured MySQL instance and startup-gate completion; those runtime persistence and browser-save/load flows should be validated in an environment with MySQL and the startup gate applied.
- Repository-level schema wiring was exercised by adding the `CREATE TABLE IF NOT EXISTS` SQL for `ApplicationSettings` in the startup-gate apply step, but `ApplySchemaAsync` was not executed here (requires live DB).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3cf301bbc832a945df8356ec1219b)