### PR TITLE
Add Manage Agents page with enable/disable and credential rotation package flow

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.Agents;
 using PingMonitor.Web.ViewModels.Agents;
 
 namespace PingMonitor.Web.Controllers;
@@ -7,11 +8,46 @@ namespace PingMonitor.Web.Controllers;
 [Route("agents")]
 public sealed class AgentsController : Controller
 {
-    private readonly IAgentProvisioningService _agentProvisioningService;
+    private const string StatusMessageKey = "Agents.StatusMessage";
+    private const string ErrorMessageKey = "Agents.ErrorMessage";
 
-    public AgentsController(IAgentProvisioningService agentProvisioningService)
+    private readonly IAgentProvisioningService _agentProvisioningService;
+    private readonly IAgentManagementQueryService _agentManagementQueryService;
+
+    public AgentsController(
+        IAgentProvisioningService agentProvisioningService,
+        IAgentManagementQueryService agentManagementQueryService)
     {
         _agentProvisioningService = agentProvisioningService;
+        _agentManagementQueryService = agentManagementQueryService;
+    }
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index(CancellationToken cancellationToken)
+    {
+        var rows = await _agentManagementQueryService.ListAsync(cancellationToken);
+        var viewModel = new ManageAgentsPageViewModel
+        {
+            Agents = rows.Select(row => new ManageAgentRowViewModel
+            {
+                AgentId = row.AgentId,
+                Name = row.Name,
+                InstanceId = row.InstanceId,
+                Enabled = row.Enabled,
+                ApiKeyRevoked = row.ApiKeyRevoked,
+                LastSeenUtc = row.LastSeenUtc,
+                LastHeartbeatUtc = row.LastHeartbeatUtc,
+                AgentVersion = row.AgentVersion,
+                MachineName = row.MachineName,
+                Platform = row.Platform,
+                CreatedAtUtc = row.CreatedAtUtc,
+                AssignmentCount = row.AssignmentCount
+            }).ToList(),
+            StatusMessage = TempData[StatusMessageKey] as string,
+            ErrorMessage = TempData[ErrorMessageKey] as string
+        };
+
+        return View("Index", viewModel);
     }
 
     [HttpGet("deploy")]
@@ -39,5 +75,61 @@ public sealed class AgentsController : Controller
             model.ErrorMessage = ex.Message;
             return View("Deploy", model);
         }
+    }
+
+    [HttpPost("{id}/enable")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Enable([FromRoute] string id, CancellationToken cancellationToken)
+    {
+        return await SetEnabledAsync(id, true, cancellationToken);
+    }
+
+    [HttpPost("{id}/disable")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Disable([FromRoute] string id, CancellationToken cancellationToken)
+    {
+        return await SetEnabledAsync(id, false, cancellationToken);
+    }
+
+    [HttpPost("{id}/rotate-package")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RotatePackage([FromRoute] string id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _agentProvisioningService.RotatePackageAsync(id, cancellationToken);
+            return File(result.PackageBytes, "application/zip", result.PackageFileName);
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData[ErrorMessageKey] = ex.Message;
+            return RedirectToAction(nameof(Index));
+        }
+    }
+
+    private async Task<IActionResult> SetEnabledAsync(string agentId, bool enabled, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var changed = await _agentProvisioningService.SetEnabledAsync(agentId, enabled, cancellationToken);
+            if (changed)
+            {
+                TempData[StatusMessageKey] = enabled
+                    ? "Agent enabled. Future authenticated requests are allowed."
+                    : "Agent disabled. Future authenticated requests are blocked.";
+            }
+            else
+            {
+                TempData[StatusMessageKey] = enabled
+                    ? "Agent was already enabled."
+                    : "Agent was already disabled.";
+            }
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData[ErrorMessageKey] = ex.Message;
+        }
+
+        return RedirectToAction(nameof(Index));
     }
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -7,6 +7,7 @@ using PingMonitor.Web.Data;
 using PingMonitor.Web.Models.Identity;
 using PingMonitor.Web.Options;
 using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.Agents;
 using PingMonitor.Web.Services.Endpoints;
 using PingMonitor.Web.Services.StartupGate;
 using PingMonitor.Web.Services.Status;
@@ -95,6 +96,7 @@ builder.Services.AddScoped<IAgentProvisioningService, AgentProvisioningService>(
 builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsService>();
 builder.Services.AddScoped<IEndpointCreationQueryService, EndpointCreationQueryService>();
 builder.Services.AddScoped<IEndpointManagementService, EndpointManagementService>();
+builder.Services.AddScoped<IAgentManagementQueryService, AgentManagementQueryService>();
 
 var app = builder.Build();
 

--- a/src/WebApp/PingMonitor.Web/README.md
+++ b/src/WebApp/PingMonitor.Web/README.md
@@ -68,3 +68,15 @@ In normal startup mode, `GET /admin` provides a server-rendered settings page fo
 - default endpoint timing/threshold values used to prefill `GET /endpoints/new`
 
 These values are persisted in the `ApplicationSettings` table and can be updated from `POST /admin`.
+
+## Manage agents page
+
+In normal startup mode, `GET /agents` provides a server-rendered operational page for registered agents.
+
+Per-agent actions include:
+
+- `POST /agents/{id}/enable` to allow future authenticated agent use
+- `POST /agents/{id}/disable` to block future authenticated agent use without deleting assignments or history
+- `POST /agents/{id}/rotate-package` to rotate the agent API credential and download a fresh package
+
+Credential rotation replaces the stored API key hash and returns a ZIP with a new `.env` file. The new package must be redeployed to the agent host for continued connectivity.

--- a/src/WebApp/PingMonitor.Web/Services/AgentProvisioningService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentProvisioningService.cs
@@ -36,10 +36,11 @@ internal sealed class AgentProvisioningService : IAgentProvisioningService
             throw new ArgumentException("Agent name is required.", nameof(agentName));
         }
 
+        var now = DateTimeOffset.UtcNow;
         var settings = await _applicationSettingsService.GetCurrentAsync(cancellationToken);
         var serverUrl = ValidateServerUrl(settings.SiteUrl);
-        var now = DateTimeOffset.UtcNow;
         var instanceId = await GenerateUniqueInstanceIdAsync(normalizedName, cancellationToken);
+        var plainTextApiKey = GenerateApiKey();
 
         var agent = new Agent
         {
@@ -56,10 +57,10 @@ internal sealed class AgentProvisioningService : IAgentProvisioningService
             Platform = null,
             MachineName = null,
             CreatedAtUtc = now,
-            ApiKeyCreatedAtUtc = now
+            ApiKeyCreatedAtUtc = now,
+            ApiKeyHash = string.Empty
         };
 
-        var plainTextApiKey = GenerateApiKey();
         agent.ApiKeyHash = _apiKeyHasher.Hash(agent, plainTextApiKey);
 
         await using var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
@@ -73,20 +74,93 @@ internal sealed class AgentProvisioningService : IAgentProvisioningService
             await transaction.CommitAsync(cancellationToken);
             _logger.LogInformation("Provisioned agent {AgentId} with instance {InstanceId}", agent.AgentId, agent.InstanceId);
 
-            return new AgentProvisioningResult
-            {
-                AgentId = agent.AgentId,
-                InstanceId = agent.InstanceId,
-                AgentName = normalizedName,
-                PackageFileName = BuildFileName(instanceId),
-                PackageBytes = packageBytes
-            };
+            return BuildResult(agent.AgentId, agent.InstanceId, normalizedName, packageBytes);
         }
         catch
         {
             await transaction.RollbackAsync(cancellationToken);
             throw;
         }
+    }
+
+    public async Task<bool> SetEnabledAsync(string agentId, bool enabled, CancellationToken cancellationToken)
+    {
+        var normalizedAgentId = NormalizeAgentId(agentId);
+        var agent = await _dbContext.Agents.SingleOrDefaultAsync(x => x.AgentId == normalizedAgentId, cancellationToken);
+        if (agent is null)
+        {
+            throw new InvalidOperationException("Agent not found.");
+        }
+
+        if (agent.Enabled == enabled)
+        {
+            return false;
+        }
+
+        agent.Enabled = enabled;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("Set enabled={Enabled} for agent {AgentId}", enabled, agent.AgentId);
+        return true;
+    }
+
+    public async Task<AgentProvisioningResult> RotatePackageAsync(string agentId, CancellationToken cancellationToken)
+    {
+        var normalizedAgentId = NormalizeAgentId(agentId);
+        var agent = await _dbContext.Agents.SingleOrDefaultAsync(x => x.AgentId == normalizedAgentId, cancellationToken);
+        if (agent is null)
+        {
+            throw new InvalidOperationException("Agent not found.");
+        }
+
+        var settings = await _applicationSettingsService.GetCurrentAsync(cancellationToken);
+        var serverUrl = ValidateServerUrl(settings.SiteUrl);
+        var now = DateTimeOffset.UtcNow;
+        var plainTextApiKey = GenerateApiKey();
+        var apiKeyHash = _apiKeyHasher.Hash(agent, plainTextApiKey);
+
+        await using var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            agent.ApiKeyHash = apiKeyHash;
+            agent.ApiKeyCreatedAtUtc = now;
+            agent.ApiKeyRevoked = false;
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+            var packageBytes = await _agentPackageBuilder.BuildAsync(serverUrl, agent.InstanceId, plainTextApiKey, cancellationToken);
+
+            await transaction.CommitAsync(cancellationToken);
+            _logger.LogInformation("Rotated API key and package for agent {AgentId} ({InstanceId})", agent.AgentId, agent.InstanceId);
+
+            return BuildResult(agent.AgentId, agent.InstanceId, agent.Name ?? agent.InstanceId, packageBytes);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            throw;
+        }
+    }
+
+    private static string NormalizeAgentId(string agentId)
+    {
+        var normalizedAgentId = agentId.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedAgentId))
+        {
+            throw new InvalidOperationException("Agent ID is required.");
+        }
+
+        return normalizedAgentId;
+    }
+
+    private static AgentProvisioningResult BuildResult(string agentId, string instanceId, string agentName, byte[] packageBytes)
+    {
+        return new AgentProvisioningResult
+        {
+            AgentId = agentId,
+            InstanceId = instanceId,
+            AgentName = agentName,
+            PackageFileName = BuildFileName(instanceId),
+            PackageBytes = packageBytes
+        };
     }
 
     private static string ValidateServerUrl(string? configuredServerUrl)

--- a/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementQueryService.cs
@@ -1,0 +1,64 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+
+namespace PingMonitor.Web.Services.Agents;
+
+internal sealed class AgentManagementQueryService : IAgentManagementQueryService
+{
+    private readonly PingMonitorDbContext _dbContext;
+
+    public AgentManagementQueryService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<AgentManagementRow>> ListAsync(CancellationToken cancellationToken)
+    {
+        var assignmentCounts = await _dbContext.MonitorAssignments
+            .AsNoTracking()
+            .GroupBy(assignment => assignment.AgentId)
+            .Select(group => new
+            {
+                AgentId = group.Key,
+                Count = group.Count()
+            })
+            .ToDictionaryAsync(x => x.AgentId, x => x.Count, cancellationToken);
+
+        var agents = await _dbContext.Agents
+            .AsNoTracking()
+            .OrderBy(agent => agent.Name ?? agent.InstanceId)
+            .ThenBy(agent => agent.InstanceId)
+            .Select(agent => new
+            {
+                agent.AgentId,
+                agent.Name,
+                agent.InstanceId,
+                agent.Enabled,
+                agent.ApiKeyRevoked,
+                agent.LastSeenUtc,
+                agent.LastHeartbeatUtc,
+                agent.AgentVersion,
+                agent.MachineName,
+                agent.Platform,
+                agent.CreatedAtUtc
+            })
+            .ToListAsync(cancellationToken);
+
+        return agents.Select(agent => new AgentManagementRow
+            {
+                AgentId = agent.AgentId,
+                Name = string.IsNullOrWhiteSpace(agent.Name) ? "(unnamed agent)" : agent.Name!,
+                InstanceId = agent.InstanceId,
+                Enabled = agent.Enabled,
+                ApiKeyRevoked = agent.ApiKeyRevoked,
+                LastSeenUtc = agent.LastSeenUtc,
+                LastHeartbeatUtc = agent.LastHeartbeatUtc,
+                AgentVersion = agent.AgentVersion ?? "Unknown",
+                MachineName = agent.MachineName ?? "Unknown",
+                Platform = agent.Platform ?? "Unknown",
+                CreatedAtUtc = agent.CreatedAtUtc,
+                AssignmentCount = assignmentCounts.GetValueOrDefault(agent.AgentId, 0)
+            })
+            .ToList();
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementRow.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementRow.cs
@@ -1,0 +1,17 @@
+namespace PingMonitor.Web.Services.Agents;
+
+public sealed class AgentManagementRow
+{
+    public required string AgentId { get; init; }
+    public required string Name { get; init; }
+    public required string InstanceId { get; init; }
+    public required bool Enabled { get; init; }
+    public required bool ApiKeyRevoked { get; init; }
+    public required DateTimeOffset? LastSeenUtc { get; init; }
+    public required DateTimeOffset? LastHeartbeatUtc { get; init; }
+    public required string AgentVersion { get; init; }
+    public required string MachineName { get; init; }
+    public required string Platform { get; init; }
+    public required DateTimeOffset CreatedAtUtc { get; init; }
+    public required int AssignmentCount { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Agents/IAgentManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Agents/IAgentManagementQueryService.cs
@@ -1,0 +1,6 @@
+namespace PingMonitor.Web.Services.Agents;
+
+public interface IAgentManagementQueryService
+{
+    Task<IReadOnlyList<AgentManagementRow>> ListAsync(CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/IAgentProvisioningService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IAgentProvisioningService.cs
@@ -3,4 +3,6 @@ namespace PingMonitor.Web.Services;
 public interface IAgentProvisioningService
 {
     Task<AgentProvisioningResult> ProvisionAsync(string agentName, CancellationToken cancellationToken);
+    Task<bool> SetEnabledAsync(string agentId, bool enabled, CancellationToken cancellationToken);
+    Task<AgentProvisioningResult> RotatePackageAsync(string agentId, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Agents/ManageAgentsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Agents/ManageAgentsPageViewModel.cs
@@ -1,0 +1,24 @@
+namespace PingMonitor.Web.ViewModels.Agents;
+
+public sealed class ManageAgentsPageViewModel
+{
+    public required IReadOnlyList<ManageAgentRowViewModel> Agents { get; init; }
+    public string? StatusMessage { get; init; }
+    public string? ErrorMessage { get; init; }
+}
+
+public sealed class ManageAgentRowViewModel
+{
+    public required string AgentId { get; init; }
+    public required string Name { get; init; }
+    public required string InstanceId { get; init; }
+    public required bool Enabled { get; init; }
+    public required bool ApiKeyRevoked { get; init; }
+    public required DateTimeOffset? LastSeenUtc { get; init; }
+    public required DateTimeOffset? LastHeartbeatUtc { get; init; }
+    public required string AgentVersion { get; init; }
+    public required string MachineName { get; init; }
+    public required string Platform { get; init; }
+    public required DateTimeOffset CreatedAtUtc { get; init; }
+    public required int AssignmentCount { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
@@ -1,0 +1,145 @@
+@model PingMonitor.Web.ViewModels.Agents.ManageAgentsPageViewModel
+@{
+    static string FormatDate(DateTimeOffset? value) => value.HasValue ? value.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") : "Never";
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Manage agents</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #f3f6f8;
+            --card: #ffffff;
+            --text: #102a43;
+            --muted: #52606d;
+            --border: #d9e2ec;
+            --accent: #0f62fe;
+            --warn: #b54708;
+            --success: #137333;
+            --error-bg: #fee4e2;
+            --error-text: #b42318;
+        }
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 1120px; margin: 0 auto; padding: 1rem; }
+        .stack { display: grid; gap: 1rem; }
+        .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
+        .muted { color: var(--muted); }
+        .button-row, .action-row { display: flex; flex-wrap: wrap; gap: .65rem; }
+        .button, .button-secondary, .button-warning { display: inline-flex; align-items: center; justify-content: center; min-height: 46px; padding: .72rem .95rem; border-radius: 10px; font-weight: 600; text-decoration: none; border: 0; font-size: .95rem; }
+        .button { background: var(--accent); color: #fff; }
+        .button-secondary { border: 1px solid var(--border); color: var(--text); background: #fff; }
+        .button-warning { background: var(--warn); color: #fff; }
+        .row-list { display: grid; gap: .85rem; }
+        .agent-row { border: 1px solid var(--border); border-radius: 12px; padding: 1rem; }
+        .row-header { display: flex; flex-direction: column; gap: .6rem; margin-bottom: .85rem; }
+        .row-meta { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .7rem; }
+        .meta-item span { display: block; font-size: .85rem; color: var(--muted); margin-bottom: .15rem; }
+        .badge { display: inline-flex; min-height: 28px; padding: .25rem .55rem; border-radius: 999px; font-weight: 700; font-size: .83rem; }
+        .enabled { background: #e7f6ec; color: var(--success); }
+        .disabled { background: #fee4e2; color: var(--error-text); }
+        .revoked { background: #fff1eb; color: var(--warn); }
+        .ok { background: #e7f6ec; color: var(--success); }
+        .notice, .error { border-radius: 10px; padding: .75rem; }
+        .notice { border: 1px solid #b7e4c7; background: #ebffee; color: var(--success); }
+        .error { border: 1px solid #fda29b; background: var(--error-bg); color: var(--error-text); }
+        .empty { text-align: center; padding: 1rem; border: 1px dashed var(--border); border-radius: 12px; }
+        form { margin: 0; }
+        @@media (min-width: 760px) {
+            .row-header { flex-direction: row; justify-content: space-between; align-items: start; }
+            .row-meta { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+        }
+    </style>
+</head>
+<body>
+<main>
+    <div class="stack">
+        <section class="card">
+            <h1>Manage agents</h1>
+            <p class="muted">Operational control for registered agents. Actions here do not delete history or assignments.</p>
+            <div class="button-row">
+                <a class="button-secondary" href="/status">Back to status</a>
+                <a class="button" href="/agents/deploy">Deploy new agent</a>
+            </div>
+        </section>
+
+        @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
+        {
+            <div class="notice" role="status">@Model.StatusMessage</div>
+        }
+
+        @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
+        {
+            <div class="error" role="alert">@Model.ErrorMessage</div>
+        }
+
+        <section class="card">
+            <h2>Registered agents</h2>
+            @if (Model.Agents.Count == 0)
+            {
+                <div class="empty">
+                    <p><strong>No agents are registered yet.</strong></p>
+                    <p class="muted">Use Deploy new agent to create an agent identity and package.</p>
+                </div>
+            }
+            else
+            {
+                <div class="row-list">
+                    @foreach (var agent in Model.Agents)
+                    {
+                        <article class="agent-row">
+                            <div class="row-header">
+                                <div>
+                                    <strong>@agent.Name</strong>
+                                    <div class="muted">Instance: @agent.InstanceId</div>
+                                    <div class="muted">Agent ID: @agent.AgentId</div>
+                                </div>
+                                <div class="action-row">
+                                    <span class="badge @(agent.Enabled ? "enabled" : "disabled")">@(agent.Enabled ? "Enabled" : "Disabled")</span>
+                                    <span class="badge @(agent.ApiKeyRevoked ? "revoked" : "ok")">@(agent.ApiKeyRevoked ? "API key revoked" : "API key active")</span>
+                                </div>
+                            </div>
+
+                            <div class="row-meta">
+                                <div class="meta-item"><span>Assignments</span><div>@agent.AssignmentCount</div></div>
+                                <div class="meta-item"><span>Created</span><div>@FormatDate(agent.CreatedAtUtc)</div></div>
+                                <div class="meta-item"><span>Last seen</span><div>@FormatDate(agent.LastSeenUtc)</div></div>
+                                <div class="meta-item"><span>Last heartbeat</span><div>@FormatDate(agent.LastHeartbeatUtc)</div></div>
+                                <div class="meta-item"><span>Agent version</span><div>@agent.AgentVersion</div></div>
+                                <div class="meta-item"><span>Machine name</span><div>@agent.MachineName</div></div>
+                                <div class="meta-item"><span>Platform</span><div>@agent.Platform</div></div>
+                            </div>
+
+                            <div class="action-row" style="margin-top:.9rem;">
+                                @if (agent.Enabled)
+                                {
+                                    <form method="post" action="/agents/@agent.AgentId/disable">
+                                        @Html.AntiForgeryToken()
+                                        <button class="button-warning" type="submit">Disable agent</button>
+                                    </form>
+                                }
+                                else
+                                {
+                                    <form method="post" action="/agents/@agent.AgentId/enable">
+                                        @Html.AntiForgeryToken()
+                                        <button class="button" type="submit">Enable agent</button>
+                                    </form>
+                                }
+
+                                <form method="post" action="/agents/@agent.AgentId/rotate-package">
+                                    @Html.AntiForgeryToken()
+                                    <button class="button-secondary" type="submit">Rotate credentials + download package</button>
+                                </form>
+                            </div>
+                        </article>
+                    }
+                </div>
+            }
+        </section>
+    </div>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -84,7 +84,8 @@
             <h1>Operational endpoint status</h1>
             <p class="muted">Current assignment-scoped status derived by the server state engine. Missing state rows are shown as <strong>UNKNOWN</strong> until trusted server-side state exists.</p>
             <div class="button-row">
-                <a class="button" href="/agents/deploy">Deploy new agent</a>
+                <a class="button" href="/agents">Manage agents</a>
+                <a class="button-secondary" href="/agents/deploy">Deploy new agent</a>
                 <a class="button-secondary" href="/endpoints/new">Add new endpoint</a>
                 <a class="button-secondary" href="/admin">Admin settings</a>
             </div>


### PR DESCRIPTION
### Motivation

- Provide a simple, operational control-plane page to list agents and perform safe operational actions without modifying history or assignments. 
- Keep agent actions explicit and auditable while reusing existing provisioning/package builder logic and following platform constraints and the data model.

### Description

- Add a server-rendered Manage Agents page at `GET /agents` that lists agents with metadata: `AgentId`, `Name`, `InstanceId`, `Enabled`, `ApiKeyRevoked`, `LastSeenUtc`, `LastHeartbeatUtc`, `AgentVersion`, `MachineName`, `Platform`, `CreatedAtUtc`, and assignment count (`AssignmentCount`).
- Implement idempotent operational actions: `POST /agents/{id}/enable` and `POST /agents/{id}/disable` which toggle `Agent.Enabled` only and return clear feedback via TempData; these actions do not delete history or assignments.
- Implement `POST /agents/{id}/rotate-package` which generates a new secure API key, stores only its hash and timestamps on the existing Agent record, clears the revoked flag, and returns a fresh ZIP package built with the existing `AgentPackageBuilder` (plaintext API key is present only inside the generated package `.env`).
- Reuse and extend the existing provisioning flow by adding `SetEnabledAsync` and `RotatePackageAsync` to `IAgentProvisioningService` and implementing them in `AgentProvisioningService` instead of duplicating package logic.
- Add a read-only `IAgentManagementQueryService` and `AgentManagementQueryService` to fetch agent rows and assignment counts; register the query service in DI and wire the controller and views.
- Add a mobile-first `Views/Agents/Index.cshtml` page and a navigation link to Manage Agents from the status page; add a short README note explaining disable/rotation semantics.
- Work is tracked in GitHub Issue #62 and the change links/Closes that issue.

### Testing

- Ran `export PATH=/tmp/dotnet10:$PATH; dotnet build src/WebApp/PingMonitor.WebApp.slnx`, which completed successfully with a successful build. 
- Ran `export PATH=/tmp/dotnet10:$PATH; dotnet test src/WebApp/PingMonitor.WebApp.slnx --no-build`; there were no failing tests (no test assemblies executed in this workspace run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3d53665ec832a9ea691186e4fd0a3)