### PR TITLE
Add Manage Endpoints list and edit pages

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -473,3 +473,10 @@ This data model enforces:
 - The assignment is always agent-specific and requires selecting a target agent.
 - Dependency selection is optional (`dependsOnEndpointId` may be null).
 - Dependency cycles are not allowed; creation must be blocked if a cycle would be introduced.
+
+## Endpoint management note (control-plane UI)
+
+- Manage Endpoints (`/endpoints`) edits both shared `Endpoint` fields and assignment-scoped `MonitorAssignment` fields.
+- Assignment state remains per `MonitorAssignment`; endpoint edits do not change this scoping rule.
+- Dependency updates block self-reference and cycle creation to preserve a directed acyclic dependency graph.
+- Reassignment updates the existing `MonitorAssignment.agentId` explicitly; this flow does not create duplicate assignments.

--- a/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
@@ -9,17 +9,27 @@ namespace PingMonitor.Web.Controllers;
 public sealed class EndpointsController : Controller
 {
     private readonly IEndpointCreationQueryService _endpointCreationQueryService;
+    private readonly IEndpointManagementQueryService _endpointManagementQueryService;
     private readonly IEndpointManagementService _endpointManagementService;
     private readonly IApplicationSettingsService _applicationSettingsService;
 
     public EndpointsController(
         IEndpointCreationQueryService endpointCreationQueryService,
+        IEndpointManagementQueryService endpointManagementQueryService,
         IEndpointManagementService endpointManagementService,
         IApplicationSettingsService applicationSettingsService)
     {
         _endpointCreationQueryService = endpointCreationQueryService;
+        _endpointManagementQueryService = endpointManagementQueryService;
         _endpointManagementService = endpointManagementService;
         _applicationSettingsService = applicationSettingsService;
+    }
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index(CancellationToken cancellationToken)
+    {
+        var model = await _endpointManagementQueryService.GetManagePageAsync(cancellationToken);
+        return View("Index", model);
     }
 
     [HttpGet("new")]
@@ -68,29 +78,81 @@ public sealed class EndpointsController : Controller
 
         if (!result.Success)
         {
-            foreach (var validationError in result.ValidationErrors)
-            {
-                var modelKey = validationError.Field switch
-                {
-                    nameof(CreateEndpointCommand.EndpointName) => nameof(CreateEndpointPageViewModel.EndpointName),
-                    nameof(CreateEndpointCommand.Target) => nameof(CreateEndpointPageViewModel.Target),
-                    nameof(CreateEndpointCommand.AgentId) => nameof(CreateEndpointPageViewModel.AgentId),
-                    nameof(CreateEndpointCommand.DependsOnEndpointId) => nameof(CreateEndpointPageViewModel.DependsOnEndpointId),
-                    nameof(CreateEndpointCommand.PingIntervalSeconds) => nameof(CreateEndpointPageViewModel.PingIntervalSeconds),
-                    nameof(CreateEndpointCommand.RetryIntervalSeconds) => nameof(CreateEndpointPageViewModel.RetryIntervalSeconds),
-                    nameof(CreateEndpointCommand.TimeoutMs) => nameof(CreateEndpointPageViewModel.TimeoutMs),
-                    nameof(CreateEndpointCommand.FailureThreshold) => nameof(CreateEndpointPageViewModel.FailureThreshold),
-                    nameof(CreateEndpointCommand.RecoveryThreshold) => nameof(CreateEndpointPageViewModel.RecoveryThreshold),
-                    _ => string.Empty
-                };
-
-                ModelState.AddModelError(modelKey, validationError.Message);
-            }
-
+            AddValidationErrorsToModelState(result.ValidationErrors);
             return View("New", model);
         }
 
-        return Redirect("/status");
+        return Redirect("/endpoints");
+    }
+
+    [HttpGet("{assignmentId}/edit")]
+    public async Task<IActionResult> Edit([FromRoute] string assignmentId, CancellationToken cancellationToken)
+    {
+        var editModel = await _endpointManagementService.GetEditModelAsync(assignmentId, cancellationToken);
+        if (editModel is null)
+        {
+            return NotFound();
+        }
+
+        var model = new EditEndpointPageViewModel
+        {
+            AssignmentId = editModel.AssignmentId,
+            EndpointId = editModel.EndpointId,
+            EndpointName = editModel.EndpointName,
+            Target = editModel.Target,
+            AgentId = editModel.AgentId,
+            DependsOnEndpointId = editModel.DependsOnEndpointId,
+            EndpointEnabled = editModel.EndpointEnabled,
+            AssignmentEnabled = editModel.AssignmentEnabled,
+            PingIntervalSeconds = editModel.PingIntervalSeconds,
+            RetryIntervalSeconds = editModel.RetryIntervalSeconds,
+            TimeoutMs = editModel.TimeoutMs,
+            FailureThreshold = editModel.FailureThreshold,
+            RecoveryThreshold = editModel.RecoveryThreshold
+        };
+
+        await PopulateEditOptionsAsync(model, cancellationToken);
+        return View("Edit", model);
+    }
+
+    [HttpPost("{assignmentId}/edit")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Edit([FromRoute] string assignmentId, [FromForm] EditEndpointPageViewModel model, CancellationToken cancellationToken)
+    {
+        model.AssignmentId = assignmentId;
+        await PopulateEditOptionsAsync(model, cancellationToken);
+
+        if (!ModelState.IsValid)
+        {
+            return View("Edit", model);
+        }
+
+        var result = await _endpointManagementService.UpdateEndpointWithAssignmentAsync(
+            new UpdateEndpointCommand
+            {
+                AssignmentId = model.AssignmentId,
+                EndpointId = model.EndpointId,
+                EndpointName = model.EndpointName,
+                Target = model.Target,
+                AgentId = model.AgentId,
+                DependsOnEndpointId = model.DependsOnEndpointId,
+                EndpointEnabled = model.EndpointEnabled,
+                AssignmentEnabled = model.AssignmentEnabled,
+                PingIntervalSeconds = model.PingIntervalSeconds,
+                RetryIntervalSeconds = model.RetryIntervalSeconds,
+                TimeoutMs = model.TimeoutMs,
+                FailureThreshold = model.FailureThreshold,
+                RecoveryThreshold = model.RecoveryThreshold
+            },
+            cancellationToken);
+
+        if (!result.Success)
+        {
+            AddValidationErrorsToModelState(result.ValidationErrors);
+            return View("Edit", model);
+        }
+
+        return Redirect("/endpoints");
     }
 
     private async Task PopulateOptionsAsync(CreateEndpointPageViewModel model, CancellationToken cancellationToken)
@@ -98,5 +160,21 @@ public sealed class EndpointsController : Controller
         var options = await _endpointCreationQueryService.GetOptionsAsync(cancellationToken);
         model.AvailableAgents = options.Agents;
         model.AvailableDependencyEndpoints = options.DependencyEndpoints;
+    }
+
+    private async Task PopulateEditOptionsAsync(EditEndpointPageViewModel model, CancellationToken cancellationToken)
+    {
+        var options = await _endpointManagementQueryService.GetEditOptionsAsync(model.AssignmentId, cancellationToken);
+        model.AvailableAgents = options.Agents;
+        model.AvailableDependencies = options.Dependencies;
+    }
+
+    private void AddValidationErrorsToModelState(IReadOnlyList<EndpointValidationError> validationErrors)
+    {
+        foreach (var validationError in validationErrors)
+        {
+            var modelKey = validationError.Field;
+            ModelState.AddModelError(modelKey, validationError.Message);
+        }
     }
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -95,6 +95,7 @@ builder.Services.AddScoped<IAgentPackageBuilder, AgentPackageBuilder>();
 builder.Services.AddScoped<IAgentProvisioningService, AgentProvisioningService>();
 builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsService>();
 builder.Services.AddScoped<IEndpointCreationQueryService, EndpointCreationQueryService>();
+builder.Services.AddScoped<IEndpointManagementQueryService, EndpointManagementQueryService>();
 builder.Services.AddScoped<IEndpointManagementService, EndpointManagementService>();
 builder.Services.AddScoped<IAgentManagementQueryService, AgentManagementQueryService>();
 

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
@@ -1,0 +1,95 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.ViewModels.Endpoints;
+
+namespace PingMonitor.Web.Services.Endpoints;
+
+internal sealed class EndpointManagementQueryService : IEndpointManagementQueryService
+{
+    private readonly PingMonitorDbContext _dbContext;
+
+    public EndpointManagementQueryService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<ManageEndpointsPageViewModel> GetManagePageAsync(CancellationToken cancellationToken)
+    {
+        var rows = await (
+            from assignment in _dbContext.MonitorAssignments.AsNoTracking()
+            join endpoint in _dbContext.Endpoints.AsNoTracking() on assignment.EndpointId equals endpoint.EndpointId
+            join agent in _dbContext.Agents.AsNoTracking() on assignment.AgentId equals agent.AgentId
+            join state in _dbContext.EndpointStates.AsNoTracking() on assignment.AssignmentId equals state.AssignmentId into stateJoin
+            from state in stateJoin.DefaultIfEmpty()
+            join parent in _dbContext.Endpoints.AsNoTracking() on endpoint.DependsOnEndpointId equals parent.EndpointId into parentJoin
+            from parent in parentJoin.DefaultIfEmpty()
+            orderby endpoint.Name, agent.InstanceId
+            select new ManageEndpointRowViewModel
+            {
+                AssignmentId = assignment.AssignmentId,
+                EndpointName = endpoint.Name,
+                Target = endpoint.Target,
+                AgentDisplay = string.IsNullOrWhiteSpace(agent.Name)
+                    ? agent.InstanceId
+                    : $"{agent.Name} ({agent.InstanceId})",
+                ParentEndpointName = parent != null ? parent.Name : null,
+                EndpointEnabled = endpoint.Enabled,
+                AssignmentEnabled = assignment.Enabled,
+                PingIntervalSeconds = assignment.PingIntervalSeconds,
+                RetryIntervalSeconds = assignment.RetryIntervalSeconds,
+                TimeoutMs = assignment.TimeoutMs,
+                FailureThreshold = assignment.FailureThreshold,
+                RecoveryThreshold = assignment.RecoveryThreshold,
+                CurrentState = state != null ? state.CurrentState : EndpointStateKind.Unknown
+            }).ToArrayAsync(cancellationToken);
+
+        return new ManageEndpointsPageViewModel
+        {
+            Rows = rows
+        };
+    }
+
+    public async Task<EditEndpointOptionsViewModel> GetEditOptionsAsync(string assignmentId, CancellationToken cancellationToken)
+    {
+        var normalizedAssignmentId = assignmentId.Trim();
+
+        var endpointId = await _dbContext.MonitorAssignments.AsNoTracking()
+            .Where(x => x.AssignmentId == normalizedAssignmentId)
+            .Select(x => x.EndpointId)
+            .SingleOrDefaultAsync(cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(endpointId))
+        {
+            return new EditEndpointOptionsViewModel();
+        }
+
+        var agents = await _dbContext.Agents.AsNoTracking()
+            .Where(x => x.Enabled && !x.ApiKeyRevoked)
+            .OrderBy(x => x.InstanceId)
+            .Select(x => new EndpointAgentOptionViewModel
+            {
+                AgentId = x.AgentId,
+                DisplayName = string.IsNullOrWhiteSpace(x.Name)
+                    ? x.InstanceId
+                    : $"{x.Name} ({x.InstanceId})"
+            })
+            .ToArrayAsync(cancellationToken);
+
+        var dependencies = await _dbContext.Endpoints.AsNoTracking()
+            .Where(x => x.EndpointId != endpointId)
+            .OrderBy(x => x.Name)
+            .Select(x => new EndpointDependencyOptionViewModel
+            {
+                EndpointId = x.EndpointId,
+                EndpointName = x.Name
+            })
+            .ToArrayAsync(cancellationToken);
+
+        return new EditEndpointOptionsViewModel
+        {
+            Agents = agents,
+            Dependencies = dependencies
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementService.cs
@@ -16,7 +16,7 @@ internal sealed class EndpointManagementService : IEndpointManagementService
 
     public async Task<CreateEndpointResult> CreateEndpointWithAssignmentAsync(CreateEndpointCommand command, CancellationToken cancellationToken)
     {
-        var validationErrors = await ValidateAsync(command, cancellationToken);
+        var validationErrors = await ValidateCreateAsync(command, cancellationToken);
         if (validationErrors.Count > 0)
         {
             return CreateEndpointResult.Failed(validationErrors.ToArray());
@@ -25,13 +25,6 @@ internal sealed class EndpointManagementService : IEndpointManagementService
         var now = DateTimeOffset.UtcNow;
         var endpointId = Guid.NewGuid().ToString();
         var assignmentId = Guid.NewGuid().ToString();
-        var dependencyId = NormalizeDependency(command.DependsOnEndpointId);
-
-        if (string.Equals(dependencyId, endpointId, StringComparison.Ordinal))
-        {
-            return CreateEndpointResult.Failed(
-                new CreateEndpointValidationError(nameof(CreateEndpointCommand.DependsOnEndpointId), "Dependency cannot reference the new endpoint itself."));
-        }
 
         var endpoint = new EndpointModel
         {
@@ -39,7 +32,7 @@ internal sealed class EndpointManagementService : IEndpointManagementService
             Name = command.EndpointName.Trim(),
             Target = command.Target.Trim(),
             Enabled = command.EndpointEnabled,
-            DependsOnEndpointId = dependencyId,
+            DependsOnEndpointId = NormalizeDependency(command.DependsOnEndpointId),
             CreatedAtUtc = now,
             Tags = []
         };
@@ -67,63 +60,89 @@ internal sealed class EndpointManagementService : IEndpointManagementService
         return CreateEndpointResult.Succeeded(endpointId, assignmentId);
     }
 
-    private async Task<List<CreateEndpointValidationError>> ValidateAsync(CreateEndpointCommand command, CancellationToken cancellationToken)
+    public async Task<EditEndpointModel?> GetEditModelAsync(string assignmentId, CancellationToken cancellationToken)
     {
-        var errors = new List<CreateEndpointValidationError>();
-
-        if (string.IsNullOrWhiteSpace(command.EndpointName))
+        var normalizedAssignmentId = NormalizeRequired(assignmentId);
+        if (normalizedAssignmentId is null)
         {
-            errors.Add(new CreateEndpointValidationError(nameof(CreateEndpointCommand.EndpointName), "Endpoint name is required."));
+            return null;
         }
 
-        if (string.IsNullOrWhiteSpace(command.Target))
+        return await (
+            from assignment in _dbContext.MonitorAssignments.AsNoTracking()
+            join endpoint in _dbContext.Endpoints.AsNoTracking() on assignment.EndpointId equals endpoint.EndpointId
+            where assignment.AssignmentId == normalizedAssignmentId
+            select new EditEndpointModel
+            {
+                AssignmentId = assignment.AssignmentId,
+                EndpointId = endpoint.EndpointId,
+                EndpointName = endpoint.Name,
+                Target = endpoint.Target,
+                AgentId = assignment.AgentId,
+                DependsOnEndpointId = endpoint.DependsOnEndpointId,
+                EndpointEnabled = endpoint.Enabled,
+                AssignmentEnabled = assignment.Enabled,
+                PingIntervalSeconds = assignment.PingIntervalSeconds,
+                RetryIntervalSeconds = assignment.RetryIntervalSeconds,
+                TimeoutMs = assignment.TimeoutMs,
+                FailureThreshold = assignment.FailureThreshold,
+                RecoveryThreshold = assignment.RecoveryThreshold
+            }).SingleOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<UpdateEndpointResult> UpdateEndpointWithAssignmentAsync(UpdateEndpointCommand command, CancellationToken cancellationToken)
+    {
+        var validationErrors = await ValidateUpdateAsync(command, cancellationToken);
+        if (validationErrors.Count > 0)
         {
-            errors.Add(new CreateEndpointValidationError(nameof(CreateEndpointCommand.Target), "Target is required."));
+            return UpdateEndpointResult.Failed(validationErrors.ToArray());
         }
 
-        if (string.IsNullOrWhiteSpace(command.AgentId))
-        {
-            errors.Add(new CreateEndpointValidationError(nameof(CreateEndpointCommand.AgentId), "Agent is required."));
-        }
+        var assignment = await _dbContext.MonitorAssignments
+            .SingleAsync(x => x.AssignmentId == command.AssignmentId.Trim(), cancellationToken);
+        var endpoint = await _dbContext.Endpoints
+            .SingleAsync(x => x.EndpointId == command.EndpointId.Trim(), cancellationToken);
 
-        ValidatePositive(nameof(CreateEndpointCommand.PingIntervalSeconds), command.PingIntervalSeconds, "Ping interval must be at least 1 second.", errors);
-        ValidatePositive(nameof(CreateEndpointCommand.RetryIntervalSeconds), command.RetryIntervalSeconds, "Retry interval must be at least 1 second.", errors);
-        ValidatePositive(nameof(CreateEndpointCommand.TimeoutMs), command.TimeoutMs, "Timeout must be at least 1 millisecond.", errors);
-        ValidatePositive(nameof(CreateEndpointCommand.FailureThreshold), command.FailureThreshold, "Failure threshold must be at least 1.", errors);
-        ValidatePositive(nameof(CreateEndpointCommand.RecoveryThreshold), command.RecoveryThreshold, "Recovery threshold must be at least 1.", errors);
+        endpoint.Name = command.EndpointName.Trim();
+        endpoint.Target = command.Target.Trim();
+        endpoint.Enabled = command.EndpointEnabled;
+        endpoint.DependsOnEndpointId = NormalizeDependency(command.DependsOnEndpointId);
+
+        assignment.AgentId = command.AgentId.Trim();
+        assignment.Enabled = command.AssignmentEnabled;
+        assignment.PingIntervalSeconds = command.PingIntervalSeconds;
+        assignment.RetryIntervalSeconds = command.RetryIntervalSeconds;
+        assignment.TimeoutMs = command.TimeoutMs;
+        assignment.FailureThreshold = command.FailureThreshold;
+        assignment.RecoveryThreshold = command.RecoveryThreshold;
+        assignment.UpdatedAtUtc = DateTimeOffset.UtcNow;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return UpdateEndpointResult.Succeeded();
+    }
+
+    private async Task<List<EndpointValidationError>> ValidateCreateAsync(CreateEndpointCommand command, CancellationToken cancellationToken)
+    {
+        var errors = new List<EndpointValidationError>();
+
+        ValidateCommon(
+            command.EndpointName,
+            command.Target,
+            command.AgentId,
+            command.PingIntervalSeconds,
+            command.RetryIntervalSeconds,
+            command.TimeoutMs,
+            command.FailureThreshold,
+            command.RecoveryThreshold,
+            errors);
 
         if (errors.Count > 0)
         {
             return errors;
         }
 
-        var normalizedAgentId = command.AgentId.Trim();
-        var agentExists = await _dbContext.Agents.AsNoTracking()
-            .AnyAsync(x => x.AgentId == normalizedAgentId && x.Enabled && !x.ApiKeyRevoked, cancellationToken);
-        if (!agentExists)
-        {
-            errors.Add(new CreateEndpointValidationError(nameof(CreateEndpointCommand.AgentId), "Selected agent is not available."));
-        }
-
-        var dependencyId = NormalizeDependency(command.DependsOnEndpointId);
-        if (dependencyId is not null)
-        {
-            var dependencyExists = await _dbContext.Endpoints.AsNoTracking()
-                .AnyAsync(x => x.EndpointId == dependencyId, cancellationToken);
-
-            if (!dependencyExists)
-            {
-                errors.Add(new CreateEndpointValidationError(nameof(CreateEndpointCommand.DependsOnEndpointId), "Selected dependency endpoint does not exist."));
-            }
-            else
-            {
-                var hasCycle = await WouldCreateCycleAsync(dependencyId, cancellationToken);
-                if (hasCycle)
-                {
-                    errors.Add(new CreateEndpointValidationError(nameof(CreateEndpointCommand.DependsOnEndpointId), "Selected dependency creates a circular dependency."));
-                }
-            }
-        }
+        await ValidateAgentAndDependencyAsync(command.AgentId, command.DependsOnEndpointId, null, errors, cancellationToken);
 
         var normalizedEndpointName = command.EndpointName.Trim();
         var endpointNameExists = await _dbContext.Endpoints.AsNoTracking()
@@ -131,19 +150,150 @@ internal sealed class EndpointManagementService : IEndpointManagementService
 
         if (endpointNameExists)
         {
-            errors.Add(new CreateEndpointValidationError(nameof(CreateEndpointCommand.EndpointName), "An endpoint with this name already exists."));
+            errors.Add(new EndpointValidationError(nameof(CreateEndpointCommand.EndpointName), "An endpoint with this name already exists."));
         }
 
         return errors;
     }
 
-    private async Task<bool> WouldCreateCycleAsync(string dependencyEndpointId, CancellationToken cancellationToken)
+    private async Task<List<EndpointValidationError>> ValidateUpdateAsync(UpdateEndpointCommand command, CancellationToken cancellationToken)
+    {
+        var errors = new List<EndpointValidationError>();
+
+        var normalizedAssignmentId = NormalizeRequired(command.AssignmentId);
+        var normalizedEndpointId = NormalizeRequired(command.EndpointId);
+
+        if (normalizedAssignmentId is null)
+        {
+            errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.AssignmentId), "Assignment ID is required."));
+        }
+
+        if (normalizedEndpointId is null)
+        {
+            errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.EndpointId), "Endpoint ID is required."));
+        }
+
+        ValidateCommon(
+            command.EndpointName,
+            command.Target,
+            command.AgentId,
+            command.PingIntervalSeconds,
+            command.RetryIntervalSeconds,
+            command.TimeoutMs,
+            command.FailureThreshold,
+            command.RecoveryThreshold,
+            errors);
+
+        if (errors.Count > 0)
+        {
+            return errors;
+        }
+
+        var assignment = await _dbContext.MonitorAssignments.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.AssignmentId == normalizedAssignmentId, cancellationToken);
+
+        if (assignment is null)
+        {
+            errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.AssignmentId), "Assignment was not found."));
+            return errors;
+        }
+
+        if (!string.Equals(assignment.EndpointId, normalizedEndpointId, StringComparison.Ordinal))
+        {
+            errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.EndpointId), "Endpoint does not match assignment."));
+            return errors;
+        }
+
+        var endpointExists = await _dbContext.Endpoints.AsNoTracking()
+            .AnyAsync(x => x.EndpointId == normalizedEndpointId, cancellationToken);
+
+        if (!endpointExists)
+        {
+            errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.EndpointId), "Endpoint was not found."));
+            return errors;
+        }
+
+        await ValidateAgentAndDependencyAsync(command.AgentId, command.DependsOnEndpointId, normalizedEndpointId, errors, cancellationToken);
+
+        var normalizedEndpointName = command.EndpointName.Trim();
+        var duplicateNameExists = await _dbContext.Endpoints.AsNoTracking()
+            .AnyAsync(x => x.Name == normalizedEndpointName && x.EndpointId != normalizedEndpointId, cancellationToken);
+
+        if (duplicateNameExists)
+        {
+            errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.EndpointName), "An endpoint with this name already exists."));
+        }
+
+        var duplicateAssignmentExists = await _dbContext.MonitorAssignments.AsNoTracking()
+            .AnyAsync(x => x.AssignmentId != normalizedAssignmentId && x.AgentId == command.AgentId.Trim() && x.EndpointId == normalizedEndpointId, cancellationToken);
+
+        if (duplicateAssignmentExists)
+        {
+            errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.AgentId), "This agent is already assigned to the endpoint."));
+        }
+
+        return errors;
+    }
+
+    private async Task ValidateAgentAndDependencyAsync(
+        string agentId,
+        string? dependsOnEndpointId,
+        string? currentEndpointId,
+        ICollection<EndpointValidationError> errors,
+        CancellationToken cancellationToken)
+    {
+        var normalizedAgentId = agentId.Trim();
+        var agentExists = await _dbContext.Agents.AsNoTracking()
+            .AnyAsync(x => x.AgentId == normalizedAgentId && x.Enabled && !x.ApiKeyRevoked, cancellationToken);
+
+        if (!agentExists)
+        {
+            errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.AgentId), "Selected agent is not available."));
+        }
+
+        var dependencyId = NormalizeDependency(dependsOnEndpointId);
+        if (dependencyId is null)
+        {
+            return;
+        }
+
+        var dependencyExists = await _dbContext.Endpoints.AsNoTracking()
+            .AnyAsync(x => x.EndpointId == dependencyId, cancellationToken);
+
+        if (!dependencyExists)
+        {
+            errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.DependsOnEndpointId), "Selected dependency endpoint does not exist."));
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(currentEndpointId) && string.Equals(dependencyId, currentEndpointId, StringComparison.Ordinal))
+        {
+            errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.DependsOnEndpointId), "Dependency cannot reference the endpoint itself."));
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(currentEndpointId))
+        {
+            var hasCycle = await WouldCreateCycleAsync(currentEndpointId, dependencyId, cancellationToken);
+            if (hasCycle)
+            {
+                errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.DependsOnEndpointId), "Selected dependency creates a circular dependency."));
+            }
+        }
+    }
+
+    private async Task<bool> WouldCreateCycleAsync(string endpointId, string dependencyEndpointId, CancellationToken cancellationToken)
     {
         var visited = new HashSet<string>(StringComparer.Ordinal);
         var currentId = dependencyEndpointId;
 
         while (!string.IsNullOrWhiteSpace(currentId))
         {
+            if (string.Equals(currentId, endpointId, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
             if (!visited.Add(currentId))
             {
                 return true;
@@ -158,16 +308,54 @@ internal sealed class EndpointManagementService : IEndpointManagementService
         return false;
     }
 
+    private static void ValidateCommon(
+        string endpointName,
+        string target,
+        string agentId,
+        int pingIntervalSeconds,
+        int retryIntervalSeconds,
+        int timeoutMs,
+        int failureThreshold,
+        int recoveryThreshold,
+        ICollection<EndpointValidationError> errors)
+    {
+        if (string.IsNullOrWhiteSpace(endpointName))
+        {
+            errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.EndpointName), "Endpoint name is required."));
+        }
+
+        if (string.IsNullOrWhiteSpace(target))
+        {
+            errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.Target), "Target is required."));
+        }
+
+        if (string.IsNullOrWhiteSpace(agentId))
+        {
+            errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.AgentId), "Agent is required."));
+        }
+
+        ValidatePositive(nameof(UpdateEndpointCommand.PingIntervalSeconds), pingIntervalSeconds, "Ping interval must be at least 1 second.", errors);
+        ValidatePositive(nameof(UpdateEndpointCommand.RetryIntervalSeconds), retryIntervalSeconds, "Retry interval must be at least 1 second.", errors);
+        ValidatePositive(nameof(UpdateEndpointCommand.TimeoutMs), timeoutMs, "Timeout must be at least 1 millisecond.", errors);
+        ValidatePositive(nameof(UpdateEndpointCommand.FailureThreshold), failureThreshold, "Failure threshold must be at least 1.", errors);
+        ValidatePositive(nameof(UpdateEndpointCommand.RecoveryThreshold), recoveryThreshold, "Recovery threshold must be at least 1.", errors);
+    }
+
     private static string? NormalizeDependency(string? dependencyId)
     {
         return string.IsNullOrWhiteSpace(dependencyId) ? null : dependencyId.Trim();
     }
 
-    private static void ValidatePositive(string field, int value, string message, ICollection<CreateEndpointValidationError> errors)
+    private static string? NormalizeRequired(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private static void ValidatePositive(string field, int value, string message, ICollection<EndpointValidationError> errors)
     {
         if (value < 1)
         {
-            errors.Add(new CreateEndpointValidationError(field, message));
+            errors.Add(new EndpointValidationError(field, message));
         }
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointManagementQueryService.cs
@@ -1,0 +1,9 @@
+using PingMonitor.Web.ViewModels.Endpoints;
+
+namespace PingMonitor.Web.Services.Endpoints;
+
+public interface IEndpointManagementQueryService
+{
+    Task<ManageEndpointsPageViewModel> GetManagePageAsync(CancellationToken cancellationToken);
+    Task<EditEndpointOptionsViewModel> GetEditOptionsAsync(string assignmentId, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointManagementService.cs
@@ -3,6 +3,8 @@ namespace PingMonitor.Web.Services.Endpoints;
 public interface IEndpointManagementService
 {
     Task<CreateEndpointResult> CreateEndpointWithAssignmentAsync(CreateEndpointCommand command, CancellationToken cancellationToken);
+    Task<EditEndpointModel?> GetEditModelAsync(string assignmentId, CancellationToken cancellationToken);
+    Task<UpdateEndpointResult> UpdateEndpointWithAssignmentAsync(UpdateEndpointCommand command, CancellationToken cancellationToken);
 }
 
 public sealed class CreateEndpointCommand
@@ -20,12 +22,46 @@ public sealed class CreateEndpointCommand
     public bool AssignmentEnabled { get; init; }
 }
 
+public sealed class UpdateEndpointCommand
+{
+    public string AssignmentId { get; init; } = string.Empty;
+    public string EndpointId { get; init; } = string.Empty;
+    public string EndpointName { get; init; } = string.Empty;
+    public string Target { get; init; } = string.Empty;
+    public string AgentId { get; init; } = string.Empty;
+    public string? DependsOnEndpointId { get; init; }
+    public bool EndpointEnabled { get; init; }
+    public bool AssignmentEnabled { get; init; }
+    public int PingIntervalSeconds { get; init; }
+    public int RetryIntervalSeconds { get; init; }
+    public int TimeoutMs { get; init; }
+    public int FailureThreshold { get; init; }
+    public int RecoveryThreshold { get; init; }
+}
+
+public sealed class EditEndpointModel
+{
+    public string AssignmentId { get; init; } = string.Empty;
+    public string EndpointId { get; init; } = string.Empty;
+    public string EndpointName { get; init; } = string.Empty;
+    public string Target { get; init; } = string.Empty;
+    public string AgentId { get; init; } = string.Empty;
+    public string? DependsOnEndpointId { get; init; }
+    public bool EndpointEnabled { get; init; }
+    public bool AssignmentEnabled { get; init; }
+    public int PingIntervalSeconds { get; init; }
+    public int RetryIntervalSeconds { get; init; }
+    public int TimeoutMs { get; init; }
+    public int FailureThreshold { get; init; }
+    public int RecoveryThreshold { get; init; }
+}
+
 public sealed class CreateEndpointResult
 {
     public bool Success { get; init; }
     public string? EndpointId { get; init; }
     public string? AssignmentId { get; init; }
-    public IReadOnlyList<CreateEndpointValidationError> ValidationErrors { get; init; } = [];
+    public IReadOnlyList<EndpointValidationError> ValidationErrors { get; init; } = [];
 
     public static CreateEndpointResult Succeeded(string endpointId, string assignmentId)
     {
@@ -37,7 +73,7 @@ public sealed class CreateEndpointResult
         };
     }
 
-    public static CreateEndpointResult Failed(params CreateEndpointValidationError[] errors)
+    public static CreateEndpointResult Failed(params EndpointValidationError[] errors)
     {
         return new CreateEndpointResult
         {
@@ -47,9 +83,26 @@ public sealed class CreateEndpointResult
     }
 }
 
-public sealed class CreateEndpointValidationError
+public sealed class UpdateEndpointResult
 {
-    public CreateEndpointValidationError(string field, string message)
+    public bool Success { get; init; }
+    public IReadOnlyList<EndpointValidationError> ValidationErrors { get; init; } = [];
+
+    public static UpdateEndpointResult Succeeded() => new() { Success = true };
+
+    public static UpdateEndpointResult Failed(params EndpointValidationError[] errors)
+    {
+        return new UpdateEndpointResult
+        {
+            Success = false,
+            ValidationErrors = errors
+        };
+    }
+}
+
+public sealed class EndpointValidationError
+{
+    public EndpointValidationError(string field, string message)
     {
         Field = field;
         Message = message;

--- a/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/ManageEndpointsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/ManageEndpointsPageViewModel.cs
@@ -1,0 +1,97 @@
+using System.ComponentModel.DataAnnotations;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.ViewModels.Endpoints;
+
+public sealed class ManageEndpointsPageViewModel
+{
+    public IReadOnlyList<ManageEndpointRowViewModel> Rows { get; init; } = [];
+}
+
+public sealed class ManageEndpointRowViewModel
+{
+    public string AssignmentId { get; init; } = string.Empty;
+    public string EndpointName { get; init; } = string.Empty;
+    public string Target { get; init; } = string.Empty;
+    public string AgentDisplay { get; init; } = string.Empty;
+    public string? ParentEndpointName { get; init; }
+    public bool EndpointEnabled { get; init; }
+    public bool AssignmentEnabled { get; init; }
+    public int PingIntervalSeconds { get; init; }
+    public int RetryIntervalSeconds { get; init; }
+    public int TimeoutMs { get; init; }
+    public int FailureThreshold { get; init; }
+    public int RecoveryThreshold { get; init; }
+    public EndpointStateKind CurrentState { get; init; } = EndpointStateKind.Unknown;
+}
+
+public sealed class EditEndpointPageViewModel
+{
+    [Required]
+    public string AssignmentId { get; set; } = string.Empty;
+
+    [Required]
+    public string EndpointId { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Endpoint name is required.")]
+    [Display(Name = "Endpoint name")]
+    public string EndpointName { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Target is required.")]
+    [Display(Name = "Target")]
+    public string Target { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Agent selection is required.")]
+    [Display(Name = "Agent")]
+    public string AgentId { get; set; } = string.Empty;
+
+    [Display(Name = "Depends on endpoint")]
+    public string? DependsOnEndpointId { get; set; }
+
+    [Display(Name = "Endpoint enabled")]
+    public bool EndpointEnabled { get; set; }
+
+    [Display(Name = "Assignment enabled")]
+    public bool AssignmentEnabled { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Ping interval must be at least 1 second.")]
+    [Display(Name = "Ping interval (seconds)")]
+    public int PingIntervalSeconds { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Retry interval must be at least 1 second.")]
+    [Display(Name = "Retry interval (seconds)")]
+    public int RetryIntervalSeconds { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Timeout must be at least 1 millisecond.")]
+    [Display(Name = "Timeout (ms)")]
+    public int TimeoutMs { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Failure threshold must be at least 1.")]
+    [Display(Name = "Failure threshold")]
+    public int FailureThreshold { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Recovery threshold must be at least 1.")]
+    [Display(Name = "Recovery threshold")]
+    public int RecoveryThreshold { get; set; }
+
+    public IReadOnlyList<EndpointAgentOptionViewModel> AvailableAgents { get; set; } = [];
+    public IReadOnlyList<EndpointDependencyOptionViewModel> AvailableDependencies { get; set; } = [];
+}
+
+public sealed class EndpointAgentOptionViewModel
+{
+    public string AgentId { get; init; } = string.Empty;
+    public string DisplayName { get; init; } = string.Empty;
+}
+
+public sealed class EndpointDependencyOptionViewModel
+{
+    public string EndpointId { get; init; } = string.Empty;
+    public string EndpointName { get; init; } = string.Empty;
+}
+
+public sealed class EditEndpointOptionsViewModel
+{
+    public IReadOnlyList<EndpointAgentOptionViewModel> Agents { get; init; } = [];
+    public IReadOnlyList<EndpointDependencyOptionViewModel> Dependencies { get; init; } = [];
+}

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Edit.cshtml
@@ -1,0 +1,134 @@
+@model PingMonitor.Web.ViewModels.Endpoints.EditEndpointPageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Edit endpoint assignment</title>
+    <style>
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; --danger:#b42318; }
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 760px; margin: 0 auto; padding: 1rem; }
+        .stack { display: grid; gap: 1rem; }
+        .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
+        .field-grid { display:grid; gap:.85rem; }
+        label { display:block; font-weight:600; margin-bottom:.35rem; }
+        input, select { width:100%; min-height:48px; padding:.8rem; border:1px solid var(--border); border-radius:10px; font-size:1rem; }
+        .checkbox { display:flex; align-items:center; gap:.55rem; }
+        .checkbox input { width:22px; min-height:22px; margin:0; }
+        .checkbox label { margin:0; }
+        .errors { border:1px solid #fecdca; background:#fef3f2; border-radius:10px; padding:.8rem; color:var(--danger); }
+        .field-error { color:var(--danger); font-size:.9rem; margin-top:.25rem; }
+        .actions { display:flex; gap:.75rem; flex-wrap:wrap; }
+        .button,.button-secondary { display:inline-flex; align-items:center; justify-content:center; min-height:48px; padding:.8rem 1rem; border-radius:10px; font-weight:600; text-decoration:none; }
+        .button { border:0; background:var(--accent); color:white; }
+        .button-secondary { border:1px solid var(--border); color:var(--text); background:white; }
+        .muted { color: var(--muted); }
+        @@media (min-width: 720px) { .field-grid.two-col { grid-template-columns: repeat(2,minmax(0,1fr)); } }
+    </style>
+</head>
+<body>
+<main>
+    <div class="stack">
+        <section class="card">
+            <h1>Edit endpoint assignment</h1>
+            <p class="muted">Assignment ID: @Model.AssignmentId</p>
+        </section>
+
+        <form method="post" action="/endpoints/@Model.AssignmentId/edit" class="stack">
+            @Html.AntiForgeryToken()
+            <input type="hidden" asp-for="AssignmentId" />
+            <input type="hidden" asp-for="EndpointId" />
+
+            @if (!ViewData.ModelState.IsValid)
+            {
+                <div class="errors" asp-validation-summary="ModelOnly"></div>
+            }
+
+            <section class="card">
+                <h2>Endpoint details</h2>
+                <div class="field-grid">
+                    <div>
+                        <label asp-for="EndpointName"></label>
+                        <input asp-for="EndpointName" />
+                        <div class="field-error"><span asp-validation-for="EndpointName"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="Target"></label>
+                        <input asp-for="Target" />
+                        <div class="field-error"><span asp-validation-for="Target"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="AgentId"></label>
+                        <select asp-for="AgentId">
+                            <option value="">Select an agent</option>
+                            @foreach (var agent in Model.AvailableAgents)
+                            {
+                                <option value="@agent.AgentId">@agent.DisplayName</option>
+                            }
+                        </select>
+                        <div class="field-error"><span asp-validation-for="AgentId"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="DependsOnEndpointId"></label>
+                        <select asp-for="DependsOnEndpointId">
+                            <option value="">None</option>
+                            @foreach (var endpoint in Model.AvailableDependencies)
+                            {
+                                <option value="@endpoint.EndpointId">@endpoint.EndpointName</option>
+                            }
+                        </select>
+                        <div class="field-error"><span asp-validation-for="DependsOnEndpointId"></span></div>
+                    </div>
+                    <div class="checkbox">
+                        <input asp-for="EndpointEnabled" />
+                        <label asp-for="EndpointEnabled"></label>
+                    </div>
+                    <div class="checkbox">
+                        <input asp-for="AssignmentEnabled" />
+                        <label asp-for="AssignmentEnabled"></label>
+                    </div>
+                </div>
+            </section>
+
+            <section class="card">
+                <h2>Monitoring settings</h2>
+                <div class="field-grid two-col">
+                    <div>
+                        <label asp-for="PingIntervalSeconds"></label>
+                        <input asp-for="PingIntervalSeconds" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="PingIntervalSeconds"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="RetryIntervalSeconds"></label>
+                        <input asp-for="RetryIntervalSeconds" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="RetryIntervalSeconds"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="TimeoutMs"></label>
+                        <input asp-for="TimeoutMs" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="TimeoutMs"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="FailureThreshold"></label>
+                        <input asp-for="FailureThreshold" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="FailureThreshold"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="RecoveryThreshold"></label>
+                        <input asp-for="RecoveryThreshold" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="RecoveryThreshold"></span></div>
+                    </div>
+                </div>
+            </section>
+
+            <div class="actions">
+                <button class="button" type="submit">Save changes</button>
+                <a class="button-secondary" href="/endpoints">Cancel</a>
+            </div>
+        </form>
+    </div>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
@@ -1,0 +1,102 @@
+@model PingMonitor.Web.ViewModels.Endpoints.ManageEndpointsPageViewModel
+@using PingMonitor.Web.Models
+@{
+    static string StateClass(EndpointStateKind state) => state switch
+    {
+        EndpointStateKind.Up => "state-up",
+        EndpointStateKind.Down => "state-down",
+        EndpointStateKind.Suppressed => "state-suppressed",
+        EndpointStateKind.Degraded => "state-degraded",
+        _ => "state-unknown"
+    };
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Manage endpoints</title>
+    <style>
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; --up:#137333; --down:#b42318; --suppressed:#7a2e0e; --unknown:#475467; --degraded:#b54708; }
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 1180px; margin: 0 auto; padding: 1rem; }
+        .stack { display: grid; gap: 1rem; }
+        .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
+        .row-list { display: grid; gap: .9rem; }
+        .row { border: 1px solid var(--border); border-radius: 12px; padding: 1rem; }
+        .row-header { display:flex; flex-direction:column; gap:.75rem; margin-bottom:.8rem; }
+        .row-meta { display:grid; gap:.75rem; grid-template-columns: repeat(2, minmax(0,1fr)); }
+        .meta-item span { display:block; font-size:.85rem; color:var(--muted); margin-bottom:.2rem; }
+        .button-row { display:flex; gap:.75rem; flex-wrap:wrap; }
+        .button,.button-secondary { display:inline-flex; align-items:center; justify-content:center; min-height:48px; padding:.8rem 1rem; border-radius:10px; font-weight:600; text-decoration:none; }
+        .button { border:0; background:var(--accent); color:#fff; }
+        .button-secondary { border:1px solid var(--border); color:var(--text); background:#fff; }
+        .badge { display:inline-flex; align-items:center; justify-content:center; min-height:32px; padding:.3rem .65rem; border-radius:999px; font-size:.9rem; font-weight:700; letter-spacing:.02em; }
+        .state-up { color: var(--up); background: #e7f6ec; }
+        .state-down { color: var(--down); background: #fee4e2; }
+        .state-suppressed { color: var(--suppressed); background: #fff1eb; }
+        .state-unknown { color: var(--unknown); background: #eaecf0; }
+        .state-degraded { color: var(--degraded); background: #fff7e6; }
+        .muted { color: var(--muted); }
+        @@media (min-width: 720px) {
+            .row-header { flex-direction: row; justify-content: space-between; align-items: start; }
+            .row-meta { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+        }
+    </style>
+</head>
+<body>
+<main>
+    <div class="stack">
+        <section class="card">
+            <h1>Manage endpoints</h1>
+            <p class="muted">Edit endpoint and assignment records without changing assignment-scoped state behavior.</p>
+            <div class="button-row">
+                <a class="button" href="/endpoints/new">Add new endpoint</a>
+                <a class="button-secondary" href="/status">View status</a>
+            </div>
+        </section>
+
+        <section class="card">
+            <h2>Assignments</h2>
+            @if (Model.Rows.Count == 0)
+            {
+                <p class="muted">No endpoint assignments are available.</p>
+            }
+            else
+            {
+                <div class="row-list">
+                    @foreach (var row in Model.Rows)
+                    {
+                        <article class="row">
+                            <div class="row-header">
+                                <div>
+                                    <div><strong>@row.EndpointName</strong></div>
+                                    <div class="muted">@row.Target</div>
+                                </div>
+                                <div class="badge @StateClass(row.CurrentState)">@row.CurrentState</div>
+                            </div>
+                            <div class="row-meta">
+                                <div class="meta-item"><span>Assignment ID</span><div>@row.AssignmentId</div></div>
+                                <div class="meta-item"><span>Agent / instance</span><div>@row.AgentDisplay</div></div>
+                                <div class="meta-item"><span>Dependency parent</span><div>@(string.IsNullOrWhiteSpace(row.ParentEndpointName) ? "None" : row.ParentEndpointName)</div></div>
+                                <div class="meta-item"><span>Endpoint enabled</span><div>@(row.EndpointEnabled ? "Enabled" : "Disabled")</div></div>
+                                <div class="meta-item"><span>Assignment enabled</span><div>@(row.AssignmentEnabled ? "Enabled" : "Disabled")</div></div>
+                                <div class="meta-item"><span>Ping interval</span><div>@row.PingIntervalSeconds s</div></div>
+                                <div class="meta-item"><span>Retry interval</span><div>@row.RetryIntervalSeconds s</div></div>
+                                <div class="meta-item"><span>Timeout</span><div>@row.TimeoutMs ms</div></div>
+                                <div class="meta-item"><span>Failure threshold</span><div>@row.FailureThreshold</div></div>
+                                <div class="meta-item"><span>Recovery threshold</span><div>@row.RecoveryThreshold</div></div>
+                            </div>
+                            <div class="button-row" style="margin-top:.85rem;">
+                                <a class="button-secondary" href="/endpoints/@row.AssignmentId/edit">Edit assignment</a>
+                            </div>
+                        </article>
+                    }
+                </div>
+            }
+        </section>
+    </div>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -86,6 +86,7 @@
             <div class="button-row">
                 <a class="button" href="/agents">Manage agents</a>
                 <a class="button-secondary" href="/agents/deploy">Deploy new agent</a>
+                <a class="button-secondary" href="/endpoints">Manage endpoints</a>
                 <a class="button-secondary" href="/endpoints/new">Add new endpoint</a>
                 <a class="button-secondary" href="/admin">Admin settings</a>
             </div>


### PR DESCRIPTION
### Motivation

- Provide an operational, server-rendered Manage Endpoints UI to view and edit existing endpoint + assignment records while preserving the assignment-scoped truth model.
- Keep the feature simple and explicit: edits modify shared `Endpoint` fields and the per-agent `MonitorAssignment` in one operation without introducing alerting or state-evaluation logic.
- Align implementation with platform constraints and data-model rules (per-assignment state, dependency DAG, TLS/agent identity rules) and ensure changes are auditable and reversible.

### Description

- Add server-rendered routes and pages: `GET /endpoints` (list), `GET /endpoints/{assignmentId}/edit` (edit form) and `POST /endpoints/{assignmentId}/edit` (update handler) and wire them in `EndpointsController`.
- Introduce a read/query service `IEndpointManagementQueryService` / `EndpointManagementQueryService` that returns assignment-centric rows and edit dropdown options (available agents and dependency endpoints) for the UI.
- Extend the endpoint management surface with `IEndpointManagementService` / `EndpointManagementService` to load edit models and perform updates that atomically persist `Endpoint` and `MonitorAssignment` changes, support explicit reassignment by updating `MonitorAssignment.AgentId`, and validate common rules.
- Add view models and views for Manage and Edit pages (mobile-first, readable): show AssignmentId, Endpoint name, Target, Agent/instance, Dependency parent, Endpoint/Assignment enabled flags, Ping/Retry/Timeout, Failure/Recovery thresholds and current state, and add a concise docs note about management semantics and cycle blocking.

### Testing

- Created and linked issue on GitHub for this work (`#64`) prior to implementation (PR references `Fixes #64`).
- Performed a full project build with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which completed successfully.
- Ran `dotnet test src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj --no-build` (no test failures reported) and verified no state-evaluation/alerting logic was added to the new endpoint services by grep checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3d9305918832a8803bd0f4cd96b0a)