### PR TITLE
docs: support multi-parent endpoint dependencies and clarify suppression semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Defines:
 
 ### Dependency
 
-Defines parent/child relationships between endpoints.
+Defines direct parent/child relationships between endpoints (an endpoint may have multiple direct parents).
 
 Used to suppress alerts when a root device fails.
 
@@ -145,7 +145,8 @@ Each endpoint (per agent) has a state:
 
 - Dependencies form a **directed graph (no cycles)**
 - Suppression is evaluated per-agent
-- Child endpoints never alert if a parent is down
+- Child endpoints are eligible for suppression when at least one direct parent is `DOWN` in the same agent scope
+- Only direct parents in `DOWN` suppress; `SUPPRESSED` does not cascade
 - Suppression is a **real state**, not just UI logic
 
 ---

--- a/docs/PLATFORM_CONSTRAINTS.md
+++ b/docs/PLATFORM_CONSTRAINTS.md
@@ -174,7 +174,7 @@ The implementation must follow it exactly.
 ## Dependency constraints
 
 - Dependencies must form a **directed acyclic graph (no cycles)**
-- Only direct parent in `DOWN` state suppresses child
+- Only direct parent dependencies in `DOWN` state may suppress a child (at least one `DOWN` direct parent is sufficient)
 - Suppression must be evaluated server-side only
 
 ---

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -295,7 +295,7 @@ No request body.
       "timeoutMs": 1000,
       "failureThreshold": 3,
       "recoveryThreshold": 2,
-      "dependsOnEndpointId": null,
+      "dependsOnEndpointIds": [],
       "tags": [
         "core",
         "switch"
@@ -313,7 +313,9 @@ No request body.
       "timeoutMs": 1000,
       "failureThreshold": 2,
       "recoveryThreshold": 2,
-      "dependsOnEndpointId": "f5b72b2d-3d4d-4736-91dd-530b4a88c501",
+      "dependsOnEndpointIds": [
+        "f5b72b2d-3d4d-4736-91dd-530b4a88c501"
+      ],
       "tags": [
         "printer"
       ]
@@ -345,7 +347,7 @@ No request body.
 | `timeoutMs` | integer | yes | timeout per check attempt |
 | `failureThreshold` | integer | yes | consecutive failures required |
 | `recoveryThreshold` | integer | yes | consecutive recoveries required |
-| `dependsOnEndpointId` | string or null | yes | dependency reference |
+| `dependsOnEndpointIds` | array of string | yes | direct parent endpoint IDs; empty array means no dependencies |
 | `tags` | array of string | yes | optional descriptive tags |
 
 ### Validation rules
@@ -366,7 +368,7 @@ No request body.
 - the agent must replace or reconcile cached assignments using this response
 - the agent must not invent assignments locally
 - the agent must not apply dependency suppression locally
-- `dependsOnEndpointId` is informational/config metadata only in v1
+- `dependsOnEndpointIds` is informational/config metadata only in v1
 
 ## Refresh rules
 
@@ -693,7 +695,7 @@ The retry interval is an execution hint only. The agent still submits raw result
 
 ## Dependency semantics
 
-Assignments may include `dependsOnEndpointId`.
+Assignments may include `dependsOnEndpointIds`.
 
 In v1:
 

--- a/docs/agent-hello-local.md
+++ b/docs/agent-hello-local.md
@@ -70,7 +70,7 @@ curl -i \
       "timeoutMs": 1000,
       "failureThreshold": 3,
       "recoveryThreshold": 2,
-      "dependsOnEndpointId": null,
+      "dependsOnEndpointIds": [],
       "tags": ["dev", "gateway"]
     },
     {
@@ -85,7 +85,7 @@ curl -i \
       "timeoutMs": 1000,
       "failureThreshold": 2,
       "recoveryThreshold": 2,
-      "dependsOnEndpointId": "endpoint-dev-gateway",
+      "dependsOnEndpointIds": ["endpoint-dev-gateway"],
       "tags": ["dev", "printer"]
     }
   ]

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -105,7 +105,7 @@ Represents a logical target to monitor.
 
 #### Relationships
 
-- `dependsOnEndpointId` (nullable)
+- dependencies are stored in `EndpointDependency` (0..many rows per endpoint)
 
 #### Metadata
 
@@ -150,6 +150,31 @@ Defines what an agent monitors and how.
 
 - `createdAtUtc`
 - `updatedAtUtc`
+
+---
+
+### EndpointDependency
+
+Represents one explicit direct dependency edge between two endpoints.
+
+#### Purpose
+
+- model endpoint dependency relationships explicitly
+- allow multiple direct parent dependencies per endpoint
+- keep dependency traversal relational and auditable
+
+#### Key fields
+
+- `endpointDependencyId`
+- `endpointId`
+- `dependsOnEndpointId`
+- `createdAtUtc`
+
+#### Constraints
+
+- (`endpointId`, `dependsOnEndpointId`) must be unique
+- self-reference is not allowed (`endpointId != dependsOnEndpointId`)
+- dependency graph must remain acyclic
 
 ---
 
@@ -321,7 +346,8 @@ Represents an alert lifecycle.
 
 - Agent 1 → many MonitorAssignments  
 - Endpoint 1 → many MonitorAssignments  
-- Endpoint 1 → optional parent Endpoint  
+- Endpoint 1 → many EndpointDependency (as child)  
+- Endpoint 1 → many EndpointDependency (as parent)  
 
 - MonitorAssignment 1 → many CheckResults  
 - MonitorAssignment 1 → 1 EndpointState  
@@ -335,7 +361,7 @@ Represents an alert lifecycle.
 Agent
   └── MonitorAssignment
         ├── Endpoint
-        │     └── (dependsOn → Endpoint)
+        │     └── EndpointDependency (Endpoint → DependsOnEndpoint)
         ├── CheckResult (many)
         ├── EndpointState (1)
         ├── StateTransition (many)
@@ -379,8 +405,10 @@ depending on the agent.
 - dependencies are defined at the Endpoint level  
 - evaluation occurs at assignment level  
 - dependency lookup must use:
+  - all direct parent endpoints from `EndpointDependency`
   - same agent scope  
-  - corresponding assignment  
+  - corresponding parent assignments  
+- if no parent assignment exists in the same agent scope, that parent does not suppress in that scope
 
 ---
 
@@ -445,7 +473,6 @@ The model must support:
 
 ## Non-goals (v1)
 
-- multi-parent dependencies  
 - cross-agent correlation  
 - distributed consensus  
 - automatic topology discovery  
@@ -471,7 +498,7 @@ This data model enforces:
   - one `Endpoint` record
   - one initial `MonitorAssignment` record
 - The assignment is always agent-specific and requires selecting a target agent.
-- Dependency selection is optional (`dependsOnEndpointId` may be null).
+- Dependency selection is optional (zero `EndpointDependency` rows is valid).
 - Dependency cycles are not allowed; creation must be blocked if a cycle would be introduced.
 
 ## Endpoint management note (control-plane UI)
@@ -479,4 +506,5 @@ This data model enforces:
 - Manage Endpoints (`/endpoints`) edits both shared `Endpoint` fields and assignment-scoped `MonitorAssignment` fields.
 - Assignment state remains per `MonitorAssignment`; endpoint edits do not change this scoping rule.
 - Dependency updates block self-reference and cycle creation to preserve a directed acyclic dependency graph.
+- Dependency updates may add or remove multiple direct parents for the same endpoint.
 - Reassignment updates the existing `MonitorAssignment.agentId` explicitly; this flow does not create duplicate assignments.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -24,7 +24,7 @@ Agent startup flow, cached configuration handling, and explicit heartbeat/config
 Raw check-result persistence, batch idempotency, and auditable ingestion outcomes are in place.
 
 ## Phase 5: State engine
-Implement server-side assignment-scoped state calculation and suppression rules from the monitoring state machine.
+Implement server-side assignment-scoped state calculation and suppression rules from the monitoring state machine, including multi-dependency evaluation using direct parent `DOWN` status only.
 
 ## Phase 6: Alerting
 Add server-side alert lifecycle handling driven by state transitions.

--- a/docs/monitoring-state-machine.md
+++ b/docs/monitoring-state-machine.md
@@ -240,12 +240,12 @@ else if agent not trustworthy:
 else:
     failureReached = consecutiveFailure >= failureThreshold
     recoveryReached = consecutiveSuccess >= recoveryThreshold
-    dependencyDown = parent exists and parent state == DOWN
+    directParentDown = any(direct parent state == DOWN in same agent scope)
 
     if recoveryReached:
         state = UP
 
-    else if failureReached and dependencyDown:
+    else if failureReached and directParentDown:
         state = SUPPRESSED
 
     else if failureReached:
@@ -261,8 +261,13 @@ else:
 
 ### Rule (v1)
 
-- only **direct parent in DOWN** causes suppression  
-- suppressed parents do NOT cascade suppression  
+- an endpoint may have zero, one, or many direct parent dependencies
+- endpoint is eligible for `SUPPRESSED` only when:
+  - failure threshold is reached, and
+  - at least one direct parent is currently `DOWN` in the same agent scope
+- only direct parents in `DOWN` cause suppression
+- direct parents in `SUPPRESSED` do **not** cascade suppression
+- suppression is derived by the server only (never by the agent)
 
 ---
 


### PR DESCRIPTION
### Motivation

- Move from a single `dependsOnEndpointId` field to an explicit, relational multi-dependency model so endpoints can have multiple direct parents. 
- Keep suppression simple, deterministic, and server-side only, avoiding cascading `SUPPRESSED` behavior. 
- Make the agent contract and control-plane docs explicit about dependency metadata being informational and not used by agents for suppression.

### Description

- Introduced an `EndpointDependency` relationship in `docs/data-model.md` with fields `endpointDependencyId`, `endpointId`, `dependsOnEndpointId`, and `createdAtUtc`, plus uniqueness, no-self-reference, and acyclic constraints. 
- Updated the state machine in `docs/monitoring-state-machine.md` to evaluate suppression using `any(direct parent state == DOWN in same agent scope)` and documented that at least one direct parent `DOWN` is required for `SUPPRESSED`, with no cascade from `SUPPRESSED` parents. 
- Changed the agent config contract in `docs/agent-api.md` (and `docs/agent-hello-local.md`) from `dependsOnEndpointId` to `dependsOnEndpointIds` (array of strings) and clarified it is informational in v1. 
- Aligned related docs (`README.md`, `docs/PLATFORM_CONSTRAINTS.md`, `docs/implementation-plan.md`) to reflect multi-dependency wording and to call out that evaluation is per-assignment/agent scope.

### Testing

- Created Issue #68 via the GitHub API to track this work (issue creation succeeded). 
- Ran repository searches (`rg`) to find and update all occurrences of single-dependency wording and verified examples were updated to use `dependsOnEndpointIds`. 
- Verified only documentation files were modified by checking changed paths and confirmed a commit containing the docs changes succeeded. 
- No unit or runtime code tests were required because this is a documentation-only change; the above automated checks all succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c43c4bb0b0832a9c182fcab4c9a6b7)