### PR TITLE
Fix startup schema compatibility for EndpointDependencies legacy shapes

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -25,6 +25,13 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "StateTransitions",
         "ApplicationSettings"
     ];
+    private static readonly string[] RequiredEndpointDependencyColumns =
+    [
+        "EndpointDependencyId",
+        "EndpointId",
+        "DependsOnEndpointId",
+        "CreatedAtUtc"
+    ];
 
     private readonly IDbContextFactory<PingMonitorDbContext> _dbContextFactory;
     private readonly IStartupDatabaseConfigurationStore _configurationStore;
@@ -78,6 +85,14 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         {
             var status = new StartupSchemaStatus { State = StartupGateSchemaState.Missing };
             status.Diagnostics.Add($"Missing required tables: {string.Join(", ", missingTables)}.");
+            return status;
+        }
+
+        var missingEndpointDependencyColumns = await GetMissingEndpointDependencyColumnsAsync(connection, cancellationToken);
+        if (missingEndpointDependencyColumns.Length > 0)
+        {
+            var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
+            status.Diagnostics.Add($"EndpointDependencies table is missing required columns: {string.Join(", ", missingEndpointDependencyColumns)}.");
             return status;
         }
 
@@ -201,7 +216,202 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await dbContext.Database.ExecuteSqlRawAsync(createStateTransitionsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createApplicationSettingsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointDependenciesSql, cancellationToken);
+        await EnsureEndpointDependenciesColumnsAsync(dbContext, cancellationToken);
         await MigrateLegacyEndpointDependenciesAsync(dbContext, cancellationToken);
+    }
+
+    private static async Task<string[]> GetMissingEndpointDependencyColumnsAsync(MySqlConnection connection, CancellationToken cancellationToken)
+    {
+        var existingColumns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COLUMN_NAME
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'EndpointDependencies';
+            """;
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            existingColumns.Add(reader.GetString(0));
+        }
+
+        return RequiredEndpointDependencyColumns
+            .Where(column => !existingColumns.Contains(column))
+            .ToArray();
+    }
+
+    private static async Task EnsureEndpointDependenciesColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
+    {
+        await using var connection = dbContext.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        var hasDependsOnEndpointId = await HasEndpointDependencyColumnAsync(connection, "DependsOnEndpointId", cancellationToken);
+        var hasParentEndpointId = await HasEndpointDependencyColumnAsync(connection, "ParentEndpointId", cancellationToken);
+
+        if (!hasDependsOnEndpointId && hasParentEndpointId)
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `EndpointDependencies`
+                ADD COLUMN `DependsOnEndpointId` varchar(64) NULL;
+                """,
+                cancellationToken);
+
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                UPDATE `EndpointDependencies`
+                SET `DependsOnEndpointId` = `ParentEndpointId`
+                WHERE (`DependsOnEndpointId` IS NULL OR `DependsOnEndpointId` = '')
+                  AND `ParentEndpointId` IS NOT NULL
+                  AND `ParentEndpointId` <> '';
+                """,
+                cancellationToken);
+
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `EndpointDependencies`
+                MODIFY COLUMN `DependsOnEndpointId` varchar(64) NOT NULL;
+                """,
+                cancellationToken);
+        }
+
+        var hasEndpointDependencyId = await HasEndpointDependencyColumnAsync(connection, "EndpointDependencyId", cancellationToken);
+        if (!hasEndpointDependencyId)
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `EndpointDependencies`
+                ADD COLUMN `EndpointDependencyId` varchar(64) NULL;
+                """,
+                cancellationToken);
+
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                UPDATE `EndpointDependencies`
+                SET `EndpointDependencyId` = UUID()
+                WHERE `EndpointDependencyId` IS NULL OR `EndpointDependencyId` = '';
+                """,
+                cancellationToken);
+
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `EndpointDependencies`
+                MODIFY COLUMN `EndpointDependencyId` varchar(64) NOT NULL;
+                """,
+                cancellationToken);
+
+            if (await HasPrimaryKeyAsync(connection, "EndpointDependencies", cancellationToken))
+            {
+                await dbContext.Database.ExecuteSqlRawAsync(
+                    """
+                    ALTER TABLE `EndpointDependencies`
+                    DROP PRIMARY KEY;
+                    """,
+                    cancellationToken);
+            }
+
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `EndpointDependencies`
+                ADD PRIMARY KEY (`EndpointDependencyId`);
+                """,
+                cancellationToken);
+        }
+
+        var hasCreatedAtUtc = await HasEndpointDependencyColumnAsync(connection, "CreatedAtUtc", cancellationToken);
+        if (!hasCreatedAtUtc)
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `EndpointDependencies`
+                ADD COLUMN `CreatedAtUtc` datetime(6) NULL;
+                """,
+                cancellationToken);
+
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                UPDATE `EndpointDependencies`
+                SET `CreatedAtUtc` = UTC_TIMESTAMP(6)
+                WHERE `CreatedAtUtc` IS NULL;
+                """,
+                cancellationToken);
+
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `EndpointDependencies`
+                MODIFY COLUMN `CreatedAtUtc` datetime(6) NOT NULL;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasEndpointDependencyIndexAsync(connection, "UX_EndpointDependencies_EndpointId_DependsOnEndpointId", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                CREATE UNIQUE INDEX `UX_EndpointDependencies_EndpointId_DependsOnEndpointId`
+                ON `EndpointDependencies` (`EndpointId`, `DependsOnEndpointId`);
+                """,
+                cancellationToken);
+        }
+    }
+
+    private static async Task<bool> HasEndpointDependencyColumnAsync(System.Data.Common.DbConnection connection, string columnName, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'EndpointDependencies'
+              AND column_name = @columnName;
+            """;
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "@columnName";
+        parameter.Value = columnName;
+        command.Parameters.Add(parameter);
+
+        return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
+    }
+
+    private static async Task<bool> HasEndpointDependencyIndexAsync(System.Data.Common.DbConnection connection, string indexName, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM information_schema.statistics
+            WHERE table_schema = DATABASE()
+              AND table_name = 'EndpointDependencies'
+              AND index_name = @indexName;
+            """;
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "@indexName";
+        parameter.Value = indexName;
+        command.Parameters.Add(parameter);
+
+        return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
+    }
+
+    private static async Task<bool> HasPrimaryKeyAsync(System.Data.Common.DbConnection connection, string tableName, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM information_schema.table_constraints
+            WHERE table_schema = DATABASE()
+              AND table_name = @tableName
+              AND constraint_type = 'PRIMARY KEY';
+            """;
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "@tableName";
+        parameter.Value = tableName;
+        command.Parameters.Add(parameter);
+
+        return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
     }
 
     private static async Task MigrateLegacyEndpointDependenciesAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)


### PR DESCRIPTION
### Motivation
- Prevent runtime HTTP 500 on the landing/status pages after upgrading by ensuring the `EndpointDependencies` table shape matches the runtime model. 
- Detect and report incompatible `EndpointDependencies` schemas early in the startup-gate check so operators can safely apply schema reconciliation.
- Reconcile legacy column names/structures that could be left behind by prior versions (e.g. `ParentEndpointId`, missing `EndpointDependencyId`, missing `CreatedAtUtc`, missing unique index/PK).

### Description
- Add `RequiredEndpointDependencyColumns` and validate the `EndpointDependencies` column set in `GetStatusAsync`, returning `Incompatible` when required columns are missing. (`StartupSchemaService.cs`)
- Add `GetMissingEndpointDependencyColumnsAsync` to inspect existing columns for `EndpointDependencies`. (`StartupSchemaService.cs`)
- Add `EnsureEndpointDependenciesColumnsAsync` to reconcile legacy shapes by:
  - Renaming/moving values from `ParentEndpointId` → `DependsOnEndpointId` when present, and making `DependsOnEndpointId` NOT NULL.
  - Backfilling `EndpointDependencyId` (generating `UUID()` values), making it NOT NULL and setting it as the primary key, dropping an existing PK if needed.
  - Backfilling `CreatedAtUtc` with `UTC_TIMESTAMP(6)` and making it NOT NULL.
  - Creating the unique index `UX_EndpointDependencies_EndpointId_DependsOnEndpointId` if missing.
  All reconciliation runs during the startup schema apply flow before legacy migration from `Endpoints.DependsOnEndpointId`. (`StartupSchemaService.cs`)
- Add helper checks to detect existing columns, indexes and primary key in the `information_schema`. (`StartupSchemaService.cs`)
- Keep the previous legacy migration that copies per-endpoint `DependsOnEndpointId` values from the `Endpoints` table into the `EndpointDependencies` table; it now runs after shape reconciliation. (`StartupSchemaService.cs`)
- Reference and track the related issue: `Fixes #72`.

### Testing
- Ran `dotnet build src/WebApp/PingMonitor.WebApp.slnx -v minimal`; build succeeded. (success)
- Ran `dotnet test src/WebApp/PingMonitor.WebApp.slnx -v minimal`; tests completed (no failures reported). (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c444d8941c832a98946d8bf34d37b8)