### PR TITLE
Short-circuit dependency lookup when no endpoint IDs are present

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
@@ -85,13 +85,15 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
         var endpointIds = rows.Select(x => x.EndpointId).Distinct(StringComparer.Ordinal).ToArray();
         var endpointNames = await _dbContext.Endpoints.AsNoTracking()
             .ToDictionaryAsync(x => x.EndpointId, x => x.Name, cancellationToken);
-        var dependencyLookup = await _dbContext.EndpointDependencies.AsNoTracking()
-            .Where(x => endpointIds.Contains(x.EndpointId))
-            .GroupBy(x => x.EndpointId)
-            .ToDictionaryAsync(
-                group => group.Key,
-                group => (IReadOnlyList<string>)group.Select(x => x.DependsOnEndpointId).OrderBy(x => x).ToArray(),
-                cancellationToken);
+        var dependencyLookup = endpointIds.Length == 0
+            ? new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+            : await _dbContext.EndpointDependencies.AsNoTracking()
+                .Where(x => endpointIds.Contains(x.EndpointId))
+                .GroupBy(x => x.EndpointId)
+                .ToDictionaryAsync(
+                    group => group.Key,
+                    group => (IReadOnlyList<string>)group.Select(x => x.DependsOnEndpointId).OrderBy(x => x).ToArray(),
+                    cancellationToken);
 
         var projectedRows = rows.Select(row =>
         {


### PR DESCRIPTION
### Motivation
- Avoid executing a database query for endpoint dependencies when there are no endpoint IDs to look up, preventing unnecessary work and potential EF translation issues while ensuring the lookup uses an ordinal comparer.

### Description
- Add a guard that returns an empty `Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)` when `endpointIds.Length == 0`, otherwise perform the existing EF Core query and grouping to build `dependencyLookup`.

### Testing
- Ran automated tests via `dotnet test` covering unit and integration suites; all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c447e98500832a9fc8d085ab6a6c6a)