### PR TITLE
Make agent startup resilient to transient /agent/config failures and support dependency ID list

### DIFF
--- a/src/Agent/app/api_client.py
+++ b/src/Agent/app/api_client.py
@@ -62,7 +62,12 @@ class AgentApiClient:
 def _assignment_from_dict(payload: dict[str, Any]):
     from app.models import AssignmentModel
 
-    return AssignmentModel(**_to_snake_kwargs(payload))
+    snake_payload = _to_snake_kwargs(payload)
+    if "depends_on_endpoint_ids" not in snake_payload:
+        singular_dependency = snake_payload.pop("depends_on_endpoint_id", None)
+        if singular_dependency:
+            snake_payload["depends_on_endpoint_ids"] = [singular_dependency]
+    return AssignmentModel(**snake_payload)
 
 
 def _to_snake_kwargs(payload: dict[str, Any]) -> dict[str, Any]:

--- a/src/Agent/app/main.py
+++ b/src/Agent/app/main.py
@@ -14,6 +14,8 @@ from app.models import ConfigResponse, HeartbeatRequest, HelloRequest, ResultsRe
 from app.result_queue import ResultQueue
 from app.scheduler import AssignmentScheduler
 
+BOOTSTRAP_CONFIG_VERSION = "bootstrap-pending"
+
 
 def main() -> None:
     config = load_config()
@@ -35,7 +37,7 @@ def main() -> None:
         )
     )
 
-    current_config = client.fetch_config()
+    current_config = _initialize_config(client, hello_response.config_version)
     logging.info(
         "Agent %s connected with config version %s containing %d assignments",
         hello_response.agent_id,
@@ -167,6 +169,15 @@ def _try_refresh_config(client: AgentApiClient, current_config: ConfigResponse, 
             _format_http_error(ex),
         )
         return current_config
+
+
+def _initialize_config(client: AgentApiClient, hello_config_version: str) -> ConfigResponse:
+    bootstrap_config = ConfigResponse(
+        config_version=hello_config_version or BOOTSTRAP_CONFIG_VERSION,
+        generated_at_utc=_utc_now(),
+        assignments=[],
+    )
+    return _try_refresh_config(client, bootstrap_config, "startup")
 
 
 if __name__ == "__main__":

--- a/src/Agent/app/models.py
+++ b/src/Agent/app/models.py
@@ -37,7 +37,7 @@ class AssignmentModel:
     timeout_ms: int
     failure_threshold: int
     recovery_threshold: int
-    depends_on_endpoint_id: Optional[str]
+    depends_on_endpoint_ids: list[str] = field(default_factory=list)
     tags: list[str] = field(default_factory=list)
 
 

--- a/src/Agent/tests/test_api_client.py
+++ b/src/Agent/tests/test_api_client.py
@@ -1,0 +1,51 @@
+import unittest
+
+from app.api_client import _assignment_from_dict
+
+
+class AgentApiClientTests(unittest.TestCase):
+    def test_assignment_parsing_reads_dependency_id_list(self) -> None:
+        payload = {
+            "assignmentId": "a1",
+            "endpointId": "e1",
+            "name": "endpoint-1",
+            "target": "8.8.8.8",
+            "checkType": "icmp",
+            "enabled": True,
+            "pingIntervalSeconds": 30,
+            "retryIntervalSeconds": 5,
+            "timeoutMs": 1000,
+            "failureThreshold": 3,
+            "recoveryThreshold": 2,
+            "dependsOnEndpointIds": ["e-parent-1", "e-parent-2"],
+            "tags": ["prod"],
+        }
+
+        assignment = _assignment_from_dict(payload)
+
+        self.assertEqual(["e-parent-1", "e-parent-2"], assignment.depends_on_endpoint_ids)
+
+    def test_assignment_parsing_keeps_legacy_single_dependency_compatibility(self) -> None:
+        payload = {
+            "assignmentId": "a1",
+            "endpointId": "e1",
+            "name": "endpoint-1",
+            "target": "8.8.8.8",
+            "checkType": "icmp",
+            "enabled": True,
+            "pingIntervalSeconds": 30,
+            "retryIntervalSeconds": 5,
+            "timeoutMs": 1000,
+            "failureThreshold": 3,
+            "recoveryThreshold": 2,
+            "dependsOnEndpointId": "e-parent-1",
+            "tags": [],
+        }
+
+        assignment = _assignment_from_dict(payload)
+
+        self.assertEqual(["e-parent-1"], assignment.depends_on_endpoint_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- The agent currently exits if the initial `/api/v1/agent/config` call fails, which reduces resilience during transient control-plane errors. 
- The server contract sends assignment dependencies as `dependsOnEndpointIds` (a list) while the agent model and parser still expected a singular `depends_on_endpoint_id`, risking parse failures.

### Description
- Initialize the agent with a small bootstrap `ConfigResponse` and reuse the existing config-refresh error handling so the agent keeps running and heartbeating if the first config fetch fails (`src/Agent/app/main.py`).
- Parse assignment dependency IDs from the server-provided list `dependsOnEndpointIds` and preserve backward compatibility for the legacy singular `dependsOnEndpointId` field in the API client (`src/Agent/app/api_client.py`).
- Change the agent assignment model to store dependencies as a list `depends_on_endpoint_ids` to match the API shape (`src/Agent/app/models.py`).
- Add unit tests validating both payload formats for dependency fields (`src/Agent/tests/test_api_client.py`).
- Fix is linked to the related issue: Fixes #76

### Testing
- Ran the agent unit test suite for the Agent package with `cd src/Agent && python -m unittest discover -s tests -v` and all tests passed (3 tests, OK).
- Existing `test_result_queue` remained green and the new `test_api_client` tests passed verifying both dependency formats.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c44e99d3b8832aa6147baf1a1a6c02)