### PR TITLE
Fix MySQL /endpoints dependency lookup query translation error

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
@@ -43,15 +43,18 @@ internal sealed class EndpointManagementQueryService : IEndpointManagementQueryS
             }).ToArrayAsync(cancellationToken);
 
         var endpointIds = rows.Select(x => x.EndpointId).Distinct(StringComparer.Ordinal).ToArray();
+        var endpointIdSet = endpointIds.ToHashSet(StringComparer.Ordinal);
         var endpointNames = await _dbContext.Endpoints.AsNoTracking()
             .ToDictionaryAsync(x => x.EndpointId, x => x.Name, cancellationToken);
-        var dependencyLookup = await _dbContext.EndpointDependencies.AsNoTracking()
-            .Where(x => endpointIds.Contains(x.EndpointId))
-            .GroupBy(x => x.EndpointId)
-            .ToDictionaryAsync(
+        var dependencies = await _dbContext.EndpointDependencies.AsNoTracking()
+            .ToArrayAsync(cancellationToken);
+        var dependencyLookup = dependencies
+            .Where(x => endpointIdSet.Contains(x.EndpointId))
+            .GroupBy(x => x.EndpointId, StringComparer.Ordinal)
+            .ToDictionary(
                 group => group.Key,
                 group => (IReadOnlyList<string>)group.Select(x => x.DependsOnEndpointId).ToArray(),
-                cancellationToken);
+                StringComparer.Ordinal);
 
         return new ManageEndpointsPageViewModel
         {


### PR DESCRIPTION
### Motivation
- The `/endpoints` management page was throwing a provider-specific EF Core translation error: `Expression '@endpointIds' in the SQL tree does not have a type mapping assigned.`
- The failure was caused by using `Contains` over an in-memory endpoint ID array which the MySQL provider could not translate to SQL.

### Description
- Replace the LINQ path that used `Where(endpointIds.Contains(...))` with a safe approach that materializes `EndpointDependencies` and filters/groupings in-memory using an ordinal `HashSet`/dictionary to avoid provider translation issues.
- Preserve the existing output semantics and endpoint-name fallback behavior while performing the dependency grouping in memory in `src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs`.
- Link the change to the created issue for traceability: `Fixes #78`.

### Testing
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -c Release` which succeeded.
- Ran project-level tests with `dotnet test src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which succeeded.
- Attempting `dotnet test` from the repository root failed because no solution/project file exists at the root, which is an environment invocation issue and not related to the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c507fe4930832a837d3809de3a3367)