### PR TITLE
Fix MySQL status-page dependency lookup crash

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
@@ -85,15 +85,16 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
         var endpointIds = rows.Select(x => x.EndpointId).Distinct(StringComparer.Ordinal).ToArray();
         var endpointNames = await _dbContext.Endpoints.AsNoTracking()
             .ToDictionaryAsync(x => x.EndpointId, x => x.Name, cancellationToken);
-        var dependencyLookup = endpointIds.Length == 0
+        var endpointIdSet = endpointIds.ToHashSet(StringComparer.Ordinal);
+        var dependencyLookup = endpointIdSet.Count == 0
             ? new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
-            : await _dbContext.EndpointDependencies.AsNoTracking()
-                .Where(x => endpointIds.Contains(x.EndpointId))
+            : (await _dbContext.EndpointDependencies.AsNoTracking().ToArrayAsync(cancellationToken))
+                .Where(x => endpointIdSet.Contains(x.EndpointId))
                 .GroupBy(x => x.EndpointId)
-                .ToDictionaryAsync(
+                .ToDictionary(
                     group => group.Key,
                     group => (IReadOnlyList<string>)group.Select(x => x.DependsOnEndpointId).OrderBy(x => x).ToArray(),
-                    cancellationToken);
+                    StringComparer.Ordinal);
 
         var projectedRows = rows.Select(row =>
         {


### PR DESCRIPTION
### Motivation
- The status page was throwing `System.InvalidOperationException: Expression '@endpointIds' in the SQL tree does not have a type mapping assigned.` when using EF Core + MySQL to translate a `Contains`/`IN` predicate over runtime endpoint IDs. 
- Per platform constraints the change must preserve existing status-page semantics and avoid introducing unsafe DB behavior.

### Description
- Replace the DB-side `Where(x => endpointIds.Contains(x.EndpointId))` predicate with a safe two-step flow that loads `EndpointDependencies` via `ToArrayAsync`, filters in-memory with an ordinal `HashSet` (`endpointIdSet.Contains(x.EndpointId)`), groups and produces a `Dictionary<string,IReadOnlyList<string>>` using `ToDictionary` and `StringComparer.Ordinal`.
- Add a local `endpointIdSet` (`ToHashSet(StringComparer.Ordinal)`) to make filtering deterministic and ordinal, and keep parent name resolution and ordering unchanged.
- Link to the tracking issue and close it with this PR: `Fixes #80`.

### Testing
- Created issue #80 to track the bug before implementation and linked the PR to it with `Fixes #80` (issue created successfully). 
- Installed and validated runtime tooling with `dotnet --info` and `pwsh --version` after installing the .NET 10 SDK and PowerShell. 
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -v minimal` and the build succeeded with zero warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c51018b9d4832aa70d08335b127f76)