### PR TITLE
Follow-up: keep status-page dependency filtering in SQL

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.ViewModels.Status;
+using System.Linq.Expressions;
 
 namespace PingMonitor.Web.Services.Status;
 
@@ -85,11 +86,10 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
         var endpointIds = rows.Select(x => x.EndpointId).Distinct(StringComparer.Ordinal).ToArray();
         var endpointNames = await _dbContext.Endpoints.AsNoTracking()
             .ToDictionaryAsync(x => x.EndpointId, x => x.Name, cancellationToken);
-        var endpointIdSet = endpointIds.ToHashSet(StringComparer.Ordinal);
-        var dependencyLookup = endpointIdSet.Count == 0
+        var dependencyLookup = endpointIds.Length == 0
             ? new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
-            : (await _dbContext.EndpointDependencies.AsNoTracking().ToArrayAsync(cancellationToken))
-                .Where(x => endpointIdSet.Contains(x.EndpointId))
+            : (await BuildDependencyQuery(endpointIds)
+                .ToArrayAsync(cancellationToken))
                 .GroupBy(x => x.EndpointId)
                 .ToDictionary(
                     group => group.Key,
@@ -160,5 +160,22 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
         return Enum.TryParse<EndpointStateKind>(value, ignoreCase: true, out var parsedValue)
             ? parsedValue
             : null;
+    }
+
+    private IQueryable<EndpointDependency> BuildDependencyQuery(IReadOnlyList<string> endpointIds)
+    {
+        var dependencyParameter = Expression.Parameter(typeof(EndpointDependency), "dependency");
+        var endpointIdProperty = Expression.Property(dependencyParameter, nameof(EndpointDependency.EndpointId));
+        Expression predicateBody = Expression.Constant(false);
+
+        foreach (var endpointId in endpointIds)
+        {
+            var endpointIdValue = Expression.Constant(endpointId, typeof(string));
+            var endpointMatches = Expression.Equal(endpointIdProperty, endpointIdValue);
+            predicateBody = Expression.OrElse(predicateBody, endpointMatches);
+        }
+
+        var predicate = Expression.Lambda<Func<EndpointDependency, bool>>(predicateBody, dependencyParameter);
+        return _dbContext.EndpointDependencies.AsNoTracking().Where(predicate);
     }
 }


### PR DESCRIPTION
### Motivation
- The status page previously crashed on EF Core + MySQL when translating a `Contains`/`IN` predicate over runtime endpoint IDs, and a prior workaround materialized the entire `EndpointDependencies` table into memory which caused a scalability regression on the hot path. 
- The change must restore server-side filtering to avoid large latency and memory usage while still avoiding the MySQL translation error.

### Description
- Added an expression-based helper `BuildDependencyQuery(IReadOnlyList<string> endpointIds)` that constructs an `OR` predicate (`EndpointId == ... || ...`) and returns an `IQueryable<EndpointDependency>` so filtering happens in SQL. 
- Replaced the previous full-table materialization + in-memory `Where` with `BuildDependencyQuery(endpointIds).ToArrayAsync(cancellationToken)` and retained the existing grouping, ordering, and parent-name resolution behavior. 
- Added `using System.Linq.Expressions;` and preserved the empty-case behavior by returning an empty `Dictionary<string,IReadOnlyList<string>>` when no endpoint IDs are present.

### Testing
- Attempted a local build with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -v minimal`, but the environment lacked the `dotnet` SDK so the build could not be executed in this container (failed: `dotnet: command not found`). 
- No automated test suite was run in this environment and no test files were modified by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c513423694832a9506e860e704897d)