### PR TITLE
Fix MySQL translation error in agent config dependency lookup

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/AgentConfigurationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentConfigurationService.cs
@@ -30,9 +30,10 @@ internal sealed class AgentConfigurationService : IAgentConfigurationService
             .OrderBy(x => x.Endpoint.Name)
             .ToListAsync(cancellationToken);
 
-        var endpointIds = assignments.Select(x => x.Endpoint.EndpointId).Distinct(StringComparer.Ordinal).ToArray();
         var dependencyLookup = await _dbContext.EndpointDependencies.AsNoTracking()
-            .Where(x => endpointIds.Contains(x.EndpointId))
+            .Where(x => _dbContext.MonitorAssignments.Any(assignment =>
+                assignment.AgentId == agent.AgentId &&
+                assignment.EndpointId == x.EndpointId))
             .GroupBy(x => x.EndpointId)
             .ToDictionaryAsync(
                 group => group.Key,


### PR DESCRIPTION
### Motivation
- The agent config endpoint could throw `System.InvalidOperationException: Expression '@endpointIds' in the SQL tree does not have a type mapping assigned` when EF Core translated `endpointIds.Contains(...)` against the MySQL provider. 
- The change aims to avoid provider-specific translation failures while preserving the existing agent configuration response semantics.

### Description
- Replace the client-side `endpointIds.Contains(x.EndpointId)` filter with a correlated query using `_dbContext.MonitorAssignments.Any(...)` scoped to the requesting `agent.AgentId` in `AgentConfigurationService.GetConfigurationAsync`.
- Remove the local `endpointIds` array and perform dependency lookup using a provider-friendly correlated subquery to avoid parameterized collection translation issues. 
- Preserve response shape and behavior for `AgentConfigResponse` and `MonitorAssignmentDto`. 
- Links this work to the tracking issue: Fixes #83.

### Testing
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully. 
- Ran `dotnet test src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully (no tests executed for the project).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c51785f864832ab7597f6a6bd61164)