### PR TITLE
Add safe remove flows for agents and endpoints (typed confirmation, preserve history)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -182,6 +182,14 @@ Represents one explicit direct dependency edge between two endpoints.
 
 **State is per MonitorAssignment, not per Endpoint.**
 
+## Operational removal semantics
+
+Remove actions are logical deactivation, not destructive deletion.
+
+- Removing an **Endpoint** disables the endpoint and disables related monitor assignments.
+- Removing an **Agent** disables the agent and revokes its API key, preventing future authentication.
+- Historical records are preserved (for example: check results, endpoint state, state transitions, alert history, and assignment history).
+
 ---
 
 ### ApplicationSettings

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
@@ -10,6 +10,7 @@ public sealed class AgentsController : Controller
 {
     private const string StatusMessageKey = "Agents.StatusMessage";
     private const string ErrorMessageKey = "Agents.ErrorMessage";
+    private const string RemoveConfirmationKeyword = "REMOVE";
 
     private readonly IAgentProvisioningService _agentProvisioningService;
     private readonly IAgentManagementQueryService _agentManagementQueryService;
@@ -107,6 +108,50 @@ public sealed class AgentsController : Controller
         }
     }
 
+    [HttpGet("{id}/remove")]
+    public async Task<IActionResult> Remove([FromRoute] string id, CancellationToken cancellationToken)
+    {
+        var details = await _agentManagementQueryService.GetRemoveDetailsAsync(id, cancellationToken);
+        if (details is null)
+        {
+            return NotFound();
+        }
+
+        return View("Remove", BuildRemoveViewModel(details));
+    }
+
+    [HttpPost("{id}/remove")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Remove([FromRoute] string id, [FromForm] RemoveAgentPageViewModel model, CancellationToken cancellationToken)
+    {
+        var details = await _agentManagementQueryService.GetRemoveDetailsAsync(id, cancellationToken);
+        if (details is null)
+        {
+            return NotFound();
+        }
+
+        var viewModel = BuildRemoveViewModel(details, model.ConfirmationText);
+        if (!string.Equals(model.ConfirmationText?.Trim(), RemoveConfirmationKeyword, StringComparison.Ordinal))
+        {
+            viewModel.ErrorMessage = $"Type {RemoveConfirmationKeyword} to confirm removing this agent.";
+            return View("Remove", viewModel);
+        }
+
+        try
+        {
+            var changed = await _agentProvisioningService.RemoveAsync(id, cancellationToken);
+            TempData[StatusMessageKey] = changed
+                ? "Agent removed. Authentication is revoked and active assignments are disabled. Historical data is preserved."
+                : "Agent was already removed.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData[ErrorMessageKey] = ex.Message;
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+
     private async Task<IActionResult> SetEnabledAsync(string agentId, bool enabled, CancellationToken cancellationToken)
     {
         try
@@ -131,5 +176,18 @@ public sealed class AgentsController : Controller
         }
 
         return RedirectToAction(nameof(Index));
+    }
+
+    private static RemoveAgentPageViewModel BuildRemoveViewModel(RemoveAgentDetails details, string? confirmationText = null)
+    {
+        return new RemoveAgentPageViewModel
+        {
+            AgentId = details.AgentId,
+            AgentName = details.Name,
+            InstanceId = details.InstanceId,
+            AssignmentCount = details.AssignmentCount,
+            ConfirmationText = confirmationText ?? string.Empty,
+            RequiredConfirmationText = RemoveConfirmationKeyword
+        };
     }
 }

--- a/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
@@ -8,6 +8,10 @@ namespace PingMonitor.Web.Controllers;
 [Route("endpoints")]
 public sealed class EndpointsController : Controller
 {
+    private const string RemoveConfirmationKeyword = "REMOVE";
+    private const string StatusMessageKey = "Endpoints.StatusMessage";
+    private const string ErrorMessageKey = "Endpoints.ErrorMessage";
+
     private readonly IEndpointCreationQueryService _endpointCreationQueryService;
     private readonly IEndpointManagementQueryService _endpointManagementQueryService;
     private readonly IEndpointManagementService _endpointManagementService;
@@ -29,6 +33,8 @@ public sealed class EndpointsController : Controller
     public async Task<IActionResult> Index(CancellationToken cancellationToken)
     {
         var model = await _endpointManagementQueryService.GetManagePageAsync(cancellationToken);
+        model.StatusMessage = TempData[StatusMessageKey] as string;
+        model.ErrorMessage = TempData[ErrorMessageKey] as string;
         return View("Index", model);
     }
 
@@ -155,6 +161,50 @@ public sealed class EndpointsController : Controller
         return Redirect("/endpoints");
     }
 
+    [HttpGet("{assignmentId}/remove")]
+    public async Task<IActionResult> Remove([FromRoute] string assignmentId, CancellationToken cancellationToken)
+    {
+        var details = await _endpointManagementQueryService.GetRemoveDetailsAsync(assignmentId, cancellationToken);
+        if (details is null)
+        {
+            return NotFound();
+        }
+
+        return View("Remove", BuildRemoveViewModel(details));
+    }
+
+    [HttpPost("{assignmentId}/remove")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Remove(
+        [FromRoute] string assignmentId,
+        [FromForm] RemoveEndpointPageViewModel model,
+        CancellationToken cancellationToken)
+    {
+        var details = await _endpointManagementQueryService.GetRemoveDetailsAsync(assignmentId, cancellationToken);
+        if (details is null)
+        {
+            return NotFound();
+        }
+
+        var viewModel = BuildRemoveViewModel(details, model.ConfirmationText);
+        if (!string.Equals(model.ConfirmationText?.Trim(), RemoveConfirmationKeyword, StringComparison.Ordinal))
+        {
+            viewModel.ErrorMessage = $"Type {RemoveConfirmationKeyword} to confirm removing this endpoint.";
+            return View("Remove", viewModel);
+        }
+
+        var result = await _endpointManagementService.RemoveByAssignmentAsync(assignmentId, cancellationToken);
+        if (!result.Found)
+        {
+            return NotFound();
+        }
+
+        TempData[StatusMessageKey] = result.Changed
+            ? "Endpoint removed. Endpoint and related assignments are disabled. Historical data is preserved."
+            : "Endpoint was already removed.";
+        return Redirect("/endpoints");
+    }
+
     private async Task PopulateOptionsAsync(CreateEndpointPageViewModel model, CancellationToken cancellationToken)
     {
         var options = await _endpointCreationQueryService.GetOptionsAsync(cancellationToken);
@@ -176,5 +226,19 @@ public sealed class EndpointsController : Controller
             var modelKey = validationError.Field;
             ModelState.AddModelError(modelKey, validationError.Message);
         }
+    }
+
+    private static RemoveEndpointPageViewModel BuildRemoveViewModel(RemoveEndpointDetails details, string? confirmationText = null)
+    {
+        return new RemoveEndpointPageViewModel
+        {
+            AssignmentId = details.AssignmentId,
+            EndpointId = details.EndpointId,
+            EndpointName = details.EndpointName,
+            Target = details.Target,
+            AgentDisplay = details.AgentDisplay,
+            ConfirmationText = confirmationText ?? string.Empty,
+            RequiredConfirmationText = RemoveConfirmationKeyword
+        };
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/AgentProvisioningService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentProvisioningService.cs
@@ -103,6 +103,54 @@ internal sealed class AgentProvisioningService : IAgentProvisioningService
         return true;
     }
 
+    public async Task<bool> RemoveAsync(string agentId, CancellationToken cancellationToken)
+    {
+        var normalizedAgentId = NormalizeAgentId(agentId);
+        var agent = await _dbContext.Agents.SingleOrDefaultAsync(x => x.AgentId == normalizedAgentId, cancellationToken);
+        if (agent is null)
+        {
+            throw new InvalidOperationException("Agent not found.");
+        }
+
+        var assignments = await _dbContext.MonitorAssignments
+            .Where(x => x.AgentId == normalizedAgentId && x.Enabled)
+            .ToListAsync(cancellationToken);
+
+        var changed = false;
+        if (agent.Enabled)
+        {
+            agent.Enabled = false;
+            changed = true;
+        }
+
+        if (!agent.ApiKeyRevoked)
+        {
+            agent.ApiKeyRevoked = true;
+            changed = true;
+        }
+
+        if (assignments.Count > 0)
+        {
+            var now = DateTimeOffset.UtcNow;
+            foreach (var assignment in assignments)
+            {
+                assignment.Enabled = false;
+                assignment.UpdatedAtUtc = now;
+            }
+
+            changed = true;
+        }
+
+        if (!changed)
+        {
+            return false;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("Removed agent {AgentId}. Agent disabled, API key revoked, and active assignments disabled.", agent.AgentId);
+        return true;
+    }
+
     public async Task<AgentProvisioningResult> RotatePackageAsync(string agentId, CancellationToken cancellationToken)
     {
         var normalizedAgentId = NormalizeAgentId(agentId);

--- a/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementQueryService.cs
@@ -61,4 +61,39 @@ internal sealed class AgentManagementQueryService : IAgentManagementQueryService
             })
             .ToList();
     }
+
+    public async Task<RemoveAgentDetails?> GetRemoveDetailsAsync(string agentId, CancellationToken cancellationToken)
+    {
+        var normalizedAgentId = agentId.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedAgentId))
+        {
+            return null;
+        }
+
+        var details = await _dbContext.Agents.AsNoTracking()
+            .Where(x => x.AgentId == normalizedAgentId)
+            .Select(x => new
+            {
+                x.AgentId,
+                x.Name,
+                x.InstanceId
+            })
+            .SingleOrDefaultAsync(cancellationToken);
+
+        if (details is null)
+        {
+            return null;
+        }
+
+        var assignmentCount = await _dbContext.MonitorAssignments.AsNoTracking()
+            .CountAsync(x => x.AgentId == normalizedAgentId, cancellationToken);
+
+        return new RemoveAgentDetails
+        {
+            AgentId = details.AgentId,
+            Name = string.IsNullOrWhiteSpace(details.Name) ? "(unnamed agent)" : details.Name,
+            InstanceId = details.InstanceId,
+            AssignmentCount = assignmentCount
+        };
+    }
 }

--- a/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementRow.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementRow.cs
@@ -15,3 +15,11 @@ public sealed class AgentManagementRow
     public required DateTimeOffset CreatedAtUtc { get; init; }
     public required int AssignmentCount { get; init; }
 }
+
+public sealed class RemoveAgentDetails
+{
+    public required string AgentId { get; init; }
+    public required string Name { get; init; }
+    public required string InstanceId { get; init; }
+    public required int AssignmentCount { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Agents/IAgentManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Agents/IAgentManagementQueryService.cs
@@ -3,4 +3,5 @@ namespace PingMonitor.Web.Services.Agents;
 public interface IAgentManagementQueryService
 {
     Task<IReadOnlyList<AgentManagementRow>> ListAsync(CancellationToken cancellationToken);
+    Task<RemoveAgentDetails?> GetRemoveDetailsAsync(string agentId, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
@@ -122,4 +122,32 @@ internal sealed class EndpointManagementQueryService : IEndpointManagementQueryS
             Dependencies = dependencies
         };
     }
+
+    public async Task<RemoveEndpointDetails?> GetRemoveDetailsAsync(string assignmentId, CancellationToken cancellationToken)
+    {
+        var normalizedAssignmentId = assignmentId.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedAssignmentId))
+        {
+            return null;
+        }
+
+        var details = await (
+            from assignment in _dbContext.MonitorAssignments.AsNoTracking()
+            join endpoint in _dbContext.Endpoints.AsNoTracking() on assignment.EndpointId equals endpoint.EndpointId
+            join agent in _dbContext.Agents.AsNoTracking() on assignment.AgentId equals agent.AgentId
+            where assignment.AssignmentId == normalizedAssignmentId
+            select new RemoveEndpointDetails
+            {
+                AssignmentId = assignment.AssignmentId,
+                EndpointId = endpoint.EndpointId,
+                EndpointName = endpoint.Name,
+                Target = endpoint.Target,
+                AgentDisplay = string.IsNullOrWhiteSpace(agent.Name)
+                    ? agent.InstanceId
+                    : $"{agent.Name} ({agent.InstanceId})"
+            })
+            .SingleOrDefaultAsync(cancellationToken);
+
+        return details;
+    }
 }

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementService.cs
@@ -185,6 +185,57 @@ internal sealed class EndpointManagementService : IEndpointManagementService
         return UpdateEndpointResult.Succeeded();
     }
 
+    public async Task<RemoveEndpointResult> RemoveByAssignmentAsync(string assignmentId, CancellationToken cancellationToken)
+    {
+        var normalizedAssignmentId = NormalizeRequired(assignmentId);
+        if (normalizedAssignmentId is null)
+        {
+            return RemoveEndpointResult.NotFound();
+        }
+
+        var assignment = await _dbContext.MonitorAssignments
+            .SingleOrDefaultAsync(x => x.AssignmentId == normalizedAssignmentId, cancellationToken);
+
+        if (assignment is null)
+        {
+            return RemoveEndpointResult.NotFound();
+        }
+
+        var endpoint = await _dbContext.Endpoints
+            .SingleAsync(x => x.EndpointId == assignment.EndpointId, cancellationToken);
+
+        var endpointAssignments = await _dbContext.MonitorAssignments
+            .Where(x => x.EndpointId == endpoint.EndpointId)
+            .ToListAsync(cancellationToken);
+
+        var changed = false;
+        if (endpoint.Enabled)
+        {
+            endpoint.Enabled = false;
+            changed = true;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        foreach (var endpointAssignment in endpointAssignments)
+        {
+            if (!endpointAssignment.Enabled)
+            {
+                continue;
+            }
+
+            endpointAssignment.Enabled = false;
+            endpointAssignment.UpdatedAtUtc = now;
+            changed = true;
+        }
+
+        if (changed)
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return RemoveEndpointResult.Completed(changed);
+    }
+
     private async Task<List<EndpointValidationError>> ValidateCreateAsync(CreateEndpointCommand command, CancellationToken cancellationToken)
     {
         var errors = new List<EndpointValidationError>();

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointManagementQueryService.cs
@@ -6,4 +6,14 @@ public interface IEndpointManagementQueryService
 {
     Task<ManageEndpointsPageViewModel> GetManagePageAsync(CancellationToken cancellationToken);
     Task<EditEndpointOptionsViewModel> GetEditOptionsAsync(string assignmentId, CancellationToken cancellationToken);
+    Task<RemoveEndpointDetails?> GetRemoveDetailsAsync(string assignmentId, CancellationToken cancellationToken);
+}
+
+public sealed class RemoveEndpointDetails
+{
+    public string AssignmentId { get; init; } = string.Empty;
+    public string EndpointId { get; init; } = string.Empty;
+    public string EndpointName { get; init; } = string.Empty;
+    public string Target { get; init; } = string.Empty;
+    public string AgentDisplay { get; init; } = string.Empty;
 }

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointManagementService.cs
@@ -5,6 +5,7 @@ public interface IEndpointManagementService
     Task<CreateEndpointResult> CreateEndpointWithAssignmentAsync(CreateEndpointCommand command, CancellationToken cancellationToken);
     Task<EditEndpointModel?> GetEditModelAsync(string assignmentId, CancellationToken cancellationToken);
     Task<UpdateEndpointResult> UpdateEndpointWithAssignmentAsync(UpdateEndpointCommand command, CancellationToken cancellationToken);
+    Task<RemoveEndpointResult> RemoveByAssignmentAsync(string assignmentId, CancellationToken cancellationToken);
 }
 
 public sealed class CreateEndpointCommand
@@ -110,4 +111,14 @@ public sealed class EndpointValidationError
 
     public string Field { get; }
     public string Message { get; }
+}
+
+public sealed class RemoveEndpointResult
+{
+    public bool Found { get; init; }
+    public bool Changed { get; init; }
+
+    public static RemoveEndpointResult NotFound() => new() { Found = false, Changed = false };
+
+    public static RemoveEndpointResult Completed(bool changed) => new() { Found = true, Changed = changed };
 }

--- a/src/WebApp/PingMonitor.Web/Services/IAgentProvisioningService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IAgentProvisioningService.cs
@@ -4,5 +4,6 @@ public interface IAgentProvisioningService
 {
     Task<AgentProvisioningResult> ProvisionAsync(string agentName, CancellationToken cancellationToken);
     Task<bool> SetEnabledAsync(string agentId, bool enabled, CancellationToken cancellationToken);
+    Task<bool> RemoveAsync(string agentId, CancellationToken cancellationToken);
     Task<AgentProvisioningResult> RotatePackageAsync(string agentId, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Agents/ManageAgentsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Agents/ManageAgentsPageViewModel.cs
@@ -22,3 +22,14 @@ public sealed class ManageAgentRowViewModel
     public required DateTimeOffset CreatedAtUtc { get; init; }
     public required int AssignmentCount { get; init; }
 }
+
+public sealed class RemoveAgentPageViewModel
+{
+    public string AgentId { get; init; } = string.Empty;
+    public string AgentName { get; init; } = string.Empty;
+    public string InstanceId { get; init; } = string.Empty;
+    public int AssignmentCount { get; init; }
+    public string ConfirmationText { get; set; } = string.Empty;
+    public string RequiredConfirmationText { get; init; } = string.Empty;
+    public string? ErrorMessage { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/ManageEndpointsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/ManageEndpointsPageViewModel.cs
@@ -6,6 +6,8 @@ namespace PingMonitor.Web.ViewModels.Endpoints;
 public sealed class ManageEndpointsPageViewModel
 {
     public IReadOnlyList<ManageEndpointRowViewModel> Rows { get; init; } = [];
+    public string? StatusMessage { get; set; }
+    public string? ErrorMessage { get; set; }
 }
 
 public sealed class ManageEndpointRowViewModel
@@ -94,4 +96,16 @@ public sealed class EditEndpointOptionsViewModel
 {
     public IReadOnlyList<EndpointAgentOptionViewModel> Agents { get; init; } = [];
     public IReadOnlyList<EndpointDependencyOptionViewModel> Dependencies { get; init; } = [];
+}
+
+public sealed class RemoveEndpointPageViewModel
+{
+    public string AssignmentId { get; init; } = string.Empty;
+    public string EndpointId { get; init; } = string.Empty;
+    public string EndpointName { get; init; } = string.Empty;
+    public string Target { get; init; } = string.Empty;
+    public string AgentDisplay { get; init; } = string.Empty;
+    public string ConfirmationText { get; set; } = string.Empty;
+    public string RequiredConfirmationText { get; init; } = string.Empty;
+    public string? ErrorMessage { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
@@ -133,6 +133,8 @@
                                     @Html.AntiForgeryToken()
                                     <button class="button-secondary" type="submit">Rotate credentials + download package</button>
                                 </form>
+
+                                <a class="button-warning" href="/agents/@agent.AgentId/remove">Remove agent</a>
                             </div>
                         </article>
                     }

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Remove.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Remove.cshtml
@@ -1,0 +1,59 @@
+@model PingMonitor.Web.ViewModels.Agents.RemoveAgentPageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Remove agent</title>
+    <style>
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --warn:#b54708; --danger:#b42318; }
+        * { box-sizing: border-box; }
+        body { margin:0; font-family:Arial,sans-serif; background:var(--bg); color:var(--text); }
+        main { max-width:780px; margin:0 auto; padding:1rem; }
+        .card { background:var(--card); border-radius:14px; box-shadow:0 1px 2px rgba(16,24,40,.08); padding:1rem; display:grid; gap:.85rem; }
+        .warning { border:1px solid #fdb022; border-radius:10px; background:#fffaeb; color:var(--warn); padding:.8rem; }
+        .error { border:1px solid #fda29b; border-radius:10px; background:#fee4e2; color:var(--danger); padding:.8rem; }
+        label { display:block; font-weight:600; margin-bottom:.3rem; }
+        input[type=text] { width:100%; min-height:46px; padding:.7rem; border-radius:10px; border:1px solid var(--border); }
+        .button-row { display:flex; gap:.65rem; flex-wrap:wrap; }
+        .button,.button-secondary,.button-danger { display:inline-flex; min-height:46px; align-items:center; justify-content:center; border-radius:10px; padding:.7rem .95rem; font-weight:600; text-decoration:none; border:0; }
+        .button-danger { background:var(--danger); color:#fff; }
+        .button-secondary { background:#fff; border:1px solid var(--border); color:var(--text); }
+        .muted { color:var(--muted); }
+    </style>
+</head>
+<body>
+<main>
+    <section class="card">
+        <h1>Remove agent</h1>
+        <p class="muted">This action disables the agent, revokes its API key, and disables active assignments. Historical monitoring data is preserved.</p>
+
+        <div>
+            <div><strong>@Model.AgentName</strong></div>
+            <div class="muted">Instance: @Model.InstanceId</div>
+            <div class="muted">Agent ID: @Model.AgentId</div>
+            <div class="muted">Assignments: @Model.AssignmentCount</div>
+        </div>
+
+        <div class="warning">
+            Removal is operational, not destructive. The agent will no longer authenticate to <code>/api/v1/agent/hello</code>, <code>/api/v1/agent/config</code>, <code>/api/v1/agent/heartbeat</code>, or <code>/api/v1/agent/results</code>.
+        </div>
+
+        @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
+        {
+            <div class="error" role="alert">@Model.ErrorMessage</div>
+        }
+
+        <form method="post" action="/agents/@Model.AgentId/remove">
+            @Html.AntiForgeryToken()
+            <label for="ConfirmationText">Type <strong>@Model.RequiredConfirmationText</strong> to confirm</label>
+            <input id="ConfirmationText" name="ConfirmationText" type="text" value="@Model.ConfirmationText" autocomplete="off" />
+            <div class="button-row" style="margin-top:.85rem;">
+                <button class="button-danger" type="submit">Remove agent</button>
+                <a class="button-secondary" href="/agents">Cancel</a>
+            </div>
+        </form>
+    </section>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
@@ -39,6 +39,9 @@
         .state-unknown { color: var(--unknown); background: #eaecf0; }
         .state-degraded { color: var(--degraded); background: #fff7e6; }
         .muted { color: var(--muted); }
+        .notice, .error { border-radius: 10px; padding: .75rem; }
+        .notice { border: 1px solid #b7e4c7; background: #ebffee; color: #137333; }
+        .error { border: 1px solid #fda29b; background: #fee4e2; color: #b42318; }
         @@media (min-width: 720px) {
             .row-header { flex-direction: row; justify-content: space-between; align-items: start; }
             .row-meta { grid-template-columns: repeat(4, minmax(0, 1fr)); }
@@ -59,6 +62,16 @@
 
         <section class="card">
             <h2>Assignments</h2>
+            @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
+            {
+                <div class="notice" role="status">@Model.StatusMessage</div>
+            }
+
+            @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
+            {
+                <div class="error" role="alert">@Model.ErrorMessage</div>
+            }
+
             @if (Model.Rows.Count == 0)
             {
                 <p class="muted">No endpoint assignments are available.</p>
@@ -90,6 +103,7 @@
                             </div>
                             <div class="button-row" style="margin-top:.85rem;">
                                 <a class="button-secondary" href="/endpoints/@row.AssignmentId/edit">Edit assignment</a>
+                                <a class="button-secondary" href="/endpoints/@row.AssignmentId/remove">Remove endpoint</a>
                             </div>
                         </article>
                     }

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Remove.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Remove.cshtml
@@ -1,0 +1,59 @@
+@model PingMonitor.Web.ViewModels.Endpoints.RemoveEndpointPageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Remove endpoint</title>
+    <style>
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --warn:#b54708; --danger:#b42318; }
+        * { box-sizing: border-box; }
+        body { margin:0; font-family:Arial,sans-serif; background:var(--bg); color:var(--text); }
+        main { max-width:780px; margin:0 auto; padding:1rem; }
+        .card { background:var(--card); border-radius:14px; box-shadow:0 1px 2px rgba(16,24,40,.08); padding:1rem; display:grid; gap:.85rem; }
+        .warning { border:1px solid #fdb022; border-radius:10px; background:#fffaeb; color:var(--warn); padding:.8rem; }
+        .error { border:1px solid #fda29b; border-radius:10px; background:#fee4e2; color:var(--danger); padding:.8rem; }
+        label { display:block; font-weight:600; margin-bottom:.3rem; }
+        input[type=text] { width:100%; min-height:46px; padding:.7rem; border-radius:10px; border:1px solid var(--border); }
+        .button-row { display:flex; gap:.65rem; flex-wrap:wrap; }
+        .button-danger,.button-secondary { display:inline-flex; min-height:46px; align-items:center; justify-content:center; border-radius:10px; padding:.7rem .95rem; font-weight:600; text-decoration:none; border:0; }
+        .button-danger { background:var(--danger); color:#fff; }
+        .button-secondary { background:#fff; border:1px solid var(--border); color:var(--text); }
+        .muted { color:var(--muted); }
+    </style>
+</head>
+<body>
+<main>
+    <section class="card">
+        <h1>Remove endpoint</h1>
+        <p class="muted">This action disables the endpoint and disables all assignments for this endpoint. Historical monitoring data is preserved.</p>
+
+        <div>
+            <div><strong>@Model.EndpointName</strong></div>
+            <div class="muted">Target: @Model.Target</div>
+            <div class="muted">Assignment: @Model.AssignmentId</div>
+            <div class="muted">Agent: @Model.AgentDisplay</div>
+        </div>
+
+        <div class="warning">
+            Removal is operational, not destructive. Existing results, states, transitions, and alerts remain available for audit and history.
+        </div>
+
+        @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
+        {
+            <div class="error" role="alert">@Model.ErrorMessage</div>
+        }
+
+        <form method="post" action="/endpoints/@Model.AssignmentId/remove">
+            @Html.AntiForgeryToken()
+            <label for="ConfirmationText">Type <strong>@Model.RequiredConfirmationText</strong> to confirm</label>
+            <input id="ConfirmationText" name="ConfirmationText" type="text" value="@Model.ConfirmationText" autocomplete="off" />
+            <div class="button-row" style="margin-top:.85rem;">
+                <button class="button-danger" type="submit">Remove endpoint</button>
+                <a class="button-secondary" href="/endpoints">Cancel</a>
+            </div>
+        </form>
+    </section>
+</main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- Provide explicit, safe operational removal for agents and endpoints that cannot be accidentally triggered. 
- Ensure removal stops active monitoring and authentication but does not hard-delete historical records. 
- Follow platform constraints requiring typed confirmations and clear, auditable state changes. 

### Description

- Added GET/POST remove routes and confirmation pages for agents and endpoints: `GET/POST /agents/{id}/remove` and `GET/POST /endpoints/{assignmentId}/remove`, with dedicated Razor views. 
- Enforced typed confirmation by requiring the user to enter `REMOVE` on the confirmation pages before the action proceeds. 
- Implemented logical removal behavior for agents in `AgentProvisioningService.RemoveAsync`: sets `Agent.Enabled = false`, sets `Agent.ApiKeyRevoked = true`, and disables the agent's active `MonitorAssignment` rows (preserving history). 
- Implemented logical removal behavior for endpoints in `EndpointManagementService.RemoveByAssignmentAsync`: sets `Endpoint.Enabled = false` and disables all `MonitorAssignment` rows for the endpoint (preserving history). 
- Exposed query helpers to populate confirmation pages (`IAgentManagementQueryService.GetRemoveDetailsAsync` and `IEndpointManagementQueryService.GetRemoveDetailsAsync`) and updated management views to surface remove actions and status messages. 
- Updated `docs/data-model.md` with a concise note describing operational (non-destructive) removal semantics. 
- Linked this work to the created issue `#85` (implementation tracked and referenced). 

### Testing

- Built the .NET solution with `dotnet build src/WebApp/PingMonitor.WebApp.slnx` and the build succeeded. 
- Created GitHub issue `#85` via the API and implemented the work against it. 
- Verified authentication gate will block removed agents by checking the existing `AgentAuthenticationService` logic that enforces `Enabled` and `ApiKeyRevoked` flags. 
- Scanned the codebase for destructive delete calls to ensure no new hard-deletes were introduced and validated the code changes (no destructive cascading deletes added). 

Fixes #85

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c51d409d64832a9447113d24ba11c9)