### PR TITLE
Add endpoint-level group management and filtering

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -115,6 +115,47 @@ Represents a logical target to monitor.
 
 ---
 
+
+### Group
+
+Represents an operational endpoint grouping used for organization and filtering.
+
+#### Purpose
+
+- organize endpoints into named sets
+- support simple control-plane filtering
+
+#### Key fields
+
+- `groupId`
+- `name` (unique)
+- `description` (nullable)
+- `createdAtUtc`
+
+---
+
+### EndpointGroupMembership
+
+Represents one endpoint-to-group membership row.
+
+#### Purpose
+
+- model endpoint-level group membership explicitly
+- support many-to-many endpoint/group relationships
+
+#### Key fields
+
+- `endpointGroupMembershipId`
+- `endpointId`
+- `groupId`
+- `createdAtUtc`
+
+#### Constraints
+
+- (`endpointId`, `groupId`) must be unique
+
+---
+
 ### MonitorAssignment
 
 Defines what an agent monitors and how.
@@ -356,6 +397,8 @@ Represents an alert lifecycle.
 - Endpoint 1 → many MonitorAssignments  
 - Endpoint 1 → many EndpointDependency (as child)  
 - Endpoint 1 → many EndpointDependency (as parent)  
+- Endpoint 1 → many EndpointGroupMembership  
+- Group 1 → many EndpointGroupMembership  
 
 - MonitorAssignment 1 → many CheckResults  
 - MonitorAssignment 1 → 1 EndpointState  
@@ -516,3 +559,11 @@ This data model enforces:
 - Dependency updates block self-reference and cycle creation to preserve a directed acyclic dependency graph.
 - Dependency updates may add or remove multiple direct parents for the same endpoint.
 - Reassignment updates the existing `MonitorAssignment.agentId` explicitly; this flow does not create duplicate assignments.
+
+
+## Endpoint grouping note (v1)
+
+- Endpoints may belong to zero, one, or many groups.
+- Grouping is endpoint-level in v1 (not assignment-level).
+- Groups are used for organization and basic filtering in control-plane pages.
+- Group-based permissions are out of scope for v1 and may be added later.

--- a/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.Endpoints;
+using PingMonitor.Web.Services.Groups;
 using PingMonitor.Web.ViewModels.Endpoints;
 
 namespace PingMonitor.Web.Controllers;
@@ -16,23 +17,26 @@ public sealed class EndpointsController : Controller
     private readonly IEndpointManagementQueryService _endpointManagementQueryService;
     private readonly IEndpointManagementService _endpointManagementService;
     private readonly IApplicationSettingsService _applicationSettingsService;
+    private readonly IGroupManagementService _groupManagementService;
 
     public EndpointsController(
         IEndpointCreationQueryService endpointCreationQueryService,
         IEndpointManagementQueryService endpointManagementQueryService,
         IEndpointManagementService endpointManagementService,
-        IApplicationSettingsService applicationSettingsService)
+        IApplicationSettingsService applicationSettingsService,
+        IGroupManagementService groupManagementService)
     {
         _endpointCreationQueryService = endpointCreationQueryService;
         _endpointManagementQueryService = endpointManagementQueryService;
         _endpointManagementService = endpointManagementService;
         _applicationSettingsService = applicationSettingsService;
+        _groupManagementService = groupManagementService;
     }
 
     [HttpGet("")]
-    public async Task<IActionResult> Index(CancellationToken cancellationToken)
+    public async Task<IActionResult> Index([FromQuery] string? groupId, CancellationToken cancellationToken)
     {
-        var model = await _endpointManagementQueryService.GetManagePageAsync(cancellationToken);
+        var model = await _endpointManagementQueryService.GetManagePageAsync(groupId, cancellationToken);
         model.StatusMessage = TempData[StatusMessageKey] as string;
         model.ErrorMessage = TempData[ErrorMessageKey] as string;
         return View("Index", model);
@@ -72,6 +76,7 @@ public sealed class EndpointsController : Controller
                 Target = model.Target,
                 AgentId = model.AgentId,
                 DependsOnEndpointIds = model.DependsOnEndpointIds,
+                GroupIds = model.GroupIds,
                 PingIntervalSeconds = model.PingIntervalSeconds,
                 RetryIntervalSeconds = model.RetryIntervalSeconds,
                 TimeoutMs = model.TimeoutMs,
@@ -108,6 +113,7 @@ public sealed class EndpointsController : Controller
             Target = editModel.Target,
             AgentId = editModel.AgentId,
             DependsOnEndpointIds = editModel.DependsOnEndpointIds.ToList(),
+            GroupIds = editModel.GroupIds.ToList(),
             EndpointEnabled = editModel.EndpointEnabled,
             AssignmentEnabled = editModel.AssignmentEnabled,
             PingIntervalSeconds = editModel.PingIntervalSeconds,
@@ -142,6 +148,7 @@ public sealed class EndpointsController : Controller
                 Target = model.Target,
                 AgentId = model.AgentId,
                 DependsOnEndpointIds = model.DependsOnEndpointIds,
+                GroupIds = model.GroupIds,
                 EndpointEnabled = model.EndpointEnabled,
                 AssignmentEnabled = model.AssignmentEnabled,
                 PingIntervalSeconds = model.PingIntervalSeconds,
@@ -210,6 +217,7 @@ public sealed class EndpointsController : Controller
         var options = await _endpointCreationQueryService.GetOptionsAsync(cancellationToken);
         model.AvailableAgents = options.Agents;
         model.AvailableDependencyEndpoints = options.DependencyEndpoints;
+        model.AvailableGroups = await _groupManagementService.GetGroupOptionsAsync(cancellationToken);
     }
 
     private async Task PopulateEditOptionsAsync(EditEndpointPageViewModel model, CancellationToken cancellationToken)
@@ -217,6 +225,7 @@ public sealed class EndpointsController : Controller
         var options = await _endpointManagementQueryService.GetEditOptionsAsync(model.AssignmentId, cancellationToken);
         model.AvailableAgents = options.Agents;
         model.AvailableDependencies = options.Dependencies;
+        model.AvailableGroups = await _groupManagementService.GetGroupOptionsAsync(cancellationToken);
     }
 
     private void AddValidationErrorsToModelState(IReadOnlyList<EndpointValidationError> validationErrors)

--- a/src/WebApp/PingMonitor.Web/Controllers/GroupsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/GroupsController.cs
@@ -1,0 +1,103 @@
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Services.Groups;
+using PingMonitor.Web.ViewModels.Groups;
+
+namespace PingMonitor.Web.Controllers;
+
+[Route("groups")]
+public sealed class GroupsController : Controller
+{
+    private const string StatusMessageKey = "Groups.StatusMessage";
+    private readonly IGroupManagementService _groupManagementService;
+
+    public GroupsController(IGroupManagementService groupManagementService)
+    {
+        _groupManagementService = groupManagementService;
+    }
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index(CancellationToken cancellationToken)
+    {
+        var model = await _groupManagementService.GetManagePageAsync(cancellationToken);
+        model.StatusMessage = TempData[StatusMessageKey] as string;
+        return View("Index", model);
+    }
+
+    [HttpGet("new")]
+    public IActionResult New()
+    {
+        return View("New", new GroupEditPageViewModel());
+    }
+
+    [HttpPost("new")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> New([FromForm] GroupEditPageViewModel model, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            return View("New", model);
+        }
+
+        var result = await _groupManagementService.CreateAsync(new GroupUpsertCommand
+        {
+            Name = model.Name,
+            Description = model.Description
+        }, cancellationToken);
+
+        if (!result.Success)
+        {
+            foreach (var validationError in result.ValidationErrors)
+            {
+                ModelState.AddModelError(nameof(GroupEditPageViewModel.Name), validationError);
+            }
+
+            return View("New", model);
+        }
+
+        TempData[StatusMessageKey] = "Group created.";
+        return Redirect("/groups");
+    }
+
+    [HttpGet("{id}/edit")]
+    public async Task<IActionResult> Edit([FromRoute] string id, CancellationToken cancellationToken)
+    {
+        var model = await _groupManagementService.GetEditPageAsync(id, cancellationToken);
+        return model is null ? NotFound() : View("Edit", model);
+    }
+
+    [HttpPost("{id}/edit")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Edit([FromRoute] string id, [FromForm] GroupEditPageViewModel model, CancellationToken cancellationToken)
+    {
+        model.GroupId = id;
+        if (!ModelState.IsValid)
+        {
+            return View("Edit", model);
+        }
+
+        var result = await _groupManagementService.UpdateAsync(new GroupUpsertCommand
+        {
+            GroupId = id,
+            Name = model.Name,
+            Description = model.Description
+        }, cancellationToken);
+
+        if (!result.Found)
+        {
+            return NotFound();
+        }
+
+        if (!result.Success)
+        {
+            foreach (var validationError in result.ValidationErrors)
+            {
+                ModelState.AddModelError(nameof(GroupEditPageViewModel.Name), validationError);
+            }
+
+            return View("Edit", model);
+        }
+
+        TempData[StatusMessageKey] = "Group updated.";
+        return Redirect("/groups");
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Controllers/StatusController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/StatusController.cs
@@ -15,9 +15,9 @@ public sealed class StatusController : Controller
 
     [HttpGet("")]
     [HttpGet("/")]
-    public async Task<IActionResult> Index([FromQuery] string? state, [FromQuery] string? agent, [FromQuery] string? search, CancellationToken cancellationToken)
+    public async Task<IActionResult> Index([FromQuery] string? state, [FromQuery] string? agent, [FromQuery] string? groupId, [FromQuery] string? search, CancellationToken cancellationToken)
     {
-        var viewModel = await _endpointStatusQueryService.GetStatusPageAsync(state, agent, search, cancellationToken);
+        var viewModel = await _endpointStatusQueryService.GetStatusPageAsync(state, agent, groupId, search, cancellationToken);
         return View("Index", viewModel);
     }
 }

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -19,6 +19,8 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
     public DbSet<Agent> Agents => Set<Agent>();
     public DbSet<EndpointModel> Endpoints => Set<EndpointModel>();
     public DbSet<EndpointDependency> EndpointDependencies => Set<EndpointDependency>();
+    public DbSet<Group> Groups => Set<Group>();
+    public DbSet<EndpointGroupMembership> EndpointGroupMemberships => Set<EndpointGroupMembership>();
     public DbSet<MonitorAssignment> MonitorAssignments => Set<MonitorAssignment>();
     public DbSet<CheckResult> CheckResults => Set<CheckResult>();
     public DbSet<ResultBatch> ResultBatches => Set<ResultBatch>();
@@ -84,6 +86,25 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         endpointDependency.Property(x => x.DependsOnEndpointId).HasMaxLength(64).IsRequired();
         endpointDependency.Property(x => x.CreatedAtUtc).IsRequired();
         endpointDependency.HasIndex(x => new { x.EndpointId, x.DependsOnEndpointId }).IsUnique();
+
+
+        var group = modelBuilder.Entity<Group>();
+        group.ToTable("Groups");
+        group.HasKey(x => x.GroupId);
+        group.Property(x => x.GroupId).HasMaxLength(64);
+        group.Property(x => x.Name).HasMaxLength(255).IsRequired();
+        group.Property(x => x.Description).HasMaxLength(2048);
+        group.Property(x => x.CreatedAtUtc).IsRequired();
+        group.HasIndex(x => x.Name).IsUnique();
+
+        var endpointGroupMembership = modelBuilder.Entity<EndpointGroupMembership>();
+        endpointGroupMembership.ToTable("EndpointGroupMemberships");
+        endpointGroupMembership.HasKey(x => x.EndpointGroupMembershipId);
+        endpointGroupMembership.Property(x => x.EndpointGroupMembershipId).HasMaxLength(64);
+        endpointGroupMembership.Property(x => x.EndpointId).HasMaxLength(64).IsRequired();
+        endpointGroupMembership.Property(x => x.GroupId).HasMaxLength(64).IsRequired();
+        endpointGroupMembership.Property(x => x.CreatedAtUtc).IsRequired();
+        endpointGroupMembership.HasIndex(x => new { x.EndpointId, x.GroupId }).IsUnique();
 
         var assignment = modelBuilder.Entity<MonitorAssignment>();
         assignment.ToTable("MonitorAssignments");

--- a/src/WebApp/PingMonitor.Web/Models/EndpointGroupMembership.cs
+++ b/src/WebApp/PingMonitor.Web/Models/EndpointGroupMembership.cs
@@ -1,0 +1,9 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class EndpointGroupMembership
+{
+    public string EndpointGroupMembershipId { get; set; } = string.Empty;
+    public string EndpointId { get; set; } = string.Empty;
+    public string GroupId { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAtUtc { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Models/Group.cs
+++ b/src/WebApp/PingMonitor.Web/Models/Group.cs
@@ -1,0 +1,9 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class Group
+{
+    public string GroupId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public DateTimeOffset CreatedAtUtc { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -9,6 +9,7 @@ using PingMonitor.Web.Options;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.Agents;
 using PingMonitor.Web.Services.Endpoints;
+using PingMonitor.Web.Services.Groups;
 using PingMonitor.Web.Services.StartupGate;
 using PingMonitor.Web.Services.Status;
 using PingMonitor.Web.Support;
@@ -97,6 +98,7 @@ builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsServi
 builder.Services.AddScoped<IEndpointCreationQueryService, EndpointCreationQueryService>();
 builder.Services.AddScoped<IEndpointManagementQueryService, EndpointManagementQueryService>();
 builder.Services.AddScoped<IEndpointManagementService, EndpointManagementService>();
+builder.Services.AddScoped<IGroupManagementService, GroupManagementService>();
 builder.Services.AddScoped<IAgentManagementQueryService, AgentManagementQueryService>();
 
 var app = builder.Build();

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointCreationQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointCreationQueryService.cs
@@ -36,10 +36,20 @@ internal sealed class EndpointCreationQueryService : IEndpointCreationQueryServi
             })
             .ToArrayAsync(cancellationToken);
 
+        var groupOptions = await _dbContext.Groups.AsNoTracking()
+            .OrderBy(x => x.Name)
+            .Select(x => new EndpointGroupOptionViewModel
+            {
+                GroupId = x.GroupId,
+                Name = x.Name
+            })
+            .ToArrayAsync(cancellationToken);
+
         return new CreateEndpointPageOptions
         {
             Agents = agentOptions,
-            DependencyEndpoints = endpointOptions
+            DependencyEndpoints = endpointOptions,
+            Groups = groupOptions
         };
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
@@ -14,8 +14,10 @@ internal sealed class EndpointManagementQueryService : IEndpointManagementQueryS
         _dbContext = dbContext;
     }
 
-    public async Task<ManageEndpointsPageViewModel> GetManagePageAsync(CancellationToken cancellationToken)
+    public async Task<ManageEndpointsPageViewModel> GetManagePageAsync(string? groupId, CancellationToken cancellationToken)
     {
+        var normalizedGroupId = string.IsNullOrWhiteSpace(groupId) ? null : groupId.Trim();
+
         var rows = await (
             from assignment in _dbContext.MonitorAssignments.AsNoTracking()
             join endpoint in _dbContext.Endpoints.AsNoTracking() on assignment.EndpointId equals endpoint.EndpointId
@@ -42,10 +44,25 @@ internal sealed class EndpointManagementQueryService : IEndpointManagementQueryS
                 CurrentState = state != null ? state.CurrentState : EndpointStateKind.Unknown
             }).ToArrayAsync(cancellationToken);
 
+        var groupLookup = (await _dbContext.EndpointGroupMemberships.AsNoTracking().ToArrayAsync(cancellationToken))
+            .GroupBy(x => x.EndpointId, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => (IReadOnlyList<string>)group.Select(x => x.GroupId).ToArray(), StringComparer.Ordinal);
+
+        if (!string.IsNullOrWhiteSpace(normalizedGroupId))
+        {
+            rows = rows.Where(x => groupLookup.GetValueOrDefault(x.EndpointId, Array.Empty<string>()).Contains(normalizedGroupId, StringComparer.Ordinal)).ToArray();
+        }
+
         var endpointIds = rows.Select(x => x.EndpointId).Distinct(StringComparer.Ordinal).ToArray();
         var endpointIdSet = endpointIds.ToHashSet(StringComparer.Ordinal);
         var endpointNames = await _dbContext.Endpoints.AsNoTracking()
             .ToDictionaryAsync(x => x.EndpointId, x => x.Name, cancellationToken);
+        var groups = await _dbContext.Groups.AsNoTracking()
+            .OrderBy(x => x.Name)
+            .ToArrayAsync(cancellationToken);
+
+        var groupNameLookup = groups.ToDictionary(x => x.GroupId, x => x.Name, StringComparer.Ordinal);
+
         var dependencies = await _dbContext.EndpointDependencies.AsNoTracking()
             .ToArrayAsync(cancellationToken);
         var dependencyLookup = dependencies
@@ -58,6 +75,8 @@ internal sealed class EndpointManagementQueryService : IEndpointManagementQueryS
 
         return new ManageEndpointsPageViewModel
         {
+            GroupId = normalizedGroupId,
+            AvailableGroups = groups.Select(x => new EndpointGroupOptionViewModel { GroupId = x.GroupId, Name = x.Name }).ToArray(),
             Rows = rows.Select(row => new ManageEndpointRowViewModel
             {
                 AssignmentId = row.AssignmentId,
@@ -66,6 +85,10 @@ internal sealed class EndpointManagementQueryService : IEndpointManagementQueryS
                 AgentDisplay = row.AgentDisplay,
                 DependencyEndpointNames = dependencyLookup.GetValueOrDefault(row.EndpointId, Array.Empty<string>())
                     .Select(endpointId => endpointNames.GetValueOrDefault(endpointId, endpointId))
+                    .OrderBy(x => x)
+                    .ToArray(),
+                GroupNames = groupLookup.GetValueOrDefault(row.EndpointId, Array.Empty<string>())
+                    .Select(selectedGroupId => groupNameLookup.GetValueOrDefault(selectedGroupId, selectedGroupId))
                     .OrderBy(x => x)
                     .ToArray(),
                 EndpointEnabled = row.Enabled,
@@ -116,10 +139,20 @@ internal sealed class EndpointManagementQueryService : IEndpointManagementQueryS
             })
             .ToArrayAsync(cancellationToken);
 
+        var groups = await _dbContext.Groups.AsNoTracking()
+            .OrderBy(x => x.Name)
+            .Select(x => new EndpointGroupOptionViewModel
+            {
+                GroupId = x.GroupId,
+                Name = x.Name
+            })
+            .ToArrayAsync(cancellationToken);
+
         return new EditEndpointOptionsViewModel
         {
             Agents = agents,
-            Dependencies = dependencies
+            Dependencies = dependencies,
+            Groups = groups
         };
     }
 

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementService.cs
@@ -65,6 +65,17 @@ internal sealed class EndpointManagementService : IEndpointManagementService
             });
         }
 
+        foreach (var groupId in NormalizeGroups(command.GroupIds))
+        {
+            _dbContext.EndpointGroupMemberships.Add(new EndpointGroupMembership
+            {
+                EndpointGroupMembershipId = Guid.NewGuid().ToString(),
+                EndpointId = endpointId,
+                GroupId = groupId,
+                CreatedAtUtc = now
+            });
+        }
+
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         return CreateEndpointResult.Succeeded(endpointId, assignmentId);
@@ -109,6 +120,12 @@ internal sealed class EndpointManagementService : IEndpointManagementService
             .Select(x => x.DependsOnEndpointId)
             .ToArrayAsync(cancellationToken);
 
+        var groupIds = await _dbContext.EndpointGroupMemberships.AsNoTracking()
+            .Where(x => x.EndpointId == model.EndpointId)
+            .OrderBy(x => x.GroupId)
+            .Select(x => x.GroupId)
+            .ToArrayAsync(cancellationToken);
+
         return new EditEndpointModel
         {
             AssignmentId = model.AssignmentId,
@@ -117,6 +134,7 @@ internal sealed class EndpointManagementService : IEndpointManagementService
             Target = model.Target,
             AgentId = model.AgentId,
             DependsOnEndpointIds = dependencyIds,
+            GroupIds = groupIds,
             EndpointEnabled = model.EndpointEnabled,
             AssignmentEnabled = model.AssignmentEnabled,
             PingIntervalSeconds = model.PingIntervalSeconds,
@@ -175,6 +193,33 @@ internal sealed class EndpointManagementService : IEndpointManagementService
                     EndpointDependencyId = Guid.NewGuid().ToString(),
                     EndpointId = endpoint.EndpointId,
                     DependsOnEndpointId = dependencyId,
+                    CreatedAtUtc = DateTimeOffset.UtcNow
+                });
+            }
+        }
+
+        var groupIds = NormalizeGroups(command.GroupIds);
+        var existingMemberships = await _dbContext.EndpointGroupMemberships
+            .Where(x => x.EndpointId == endpoint.EndpointId)
+            .ToListAsync(cancellationToken);
+
+        var membershipsToRemove = existingMemberships
+            .Where(x => !groupIds.Contains(x.GroupId, StringComparer.Ordinal))
+            .ToArray();
+        if (membershipsToRemove.Length > 0)
+        {
+            _dbContext.EndpointGroupMemberships.RemoveRange(membershipsToRemove);
+        }
+
+        foreach (var groupId in groupIds)
+        {
+            if (existingMemberships.All(x => !string.Equals(x.GroupId, groupId, StringComparison.Ordinal)))
+            {
+                _dbContext.EndpointGroupMemberships.Add(new EndpointGroupMembership
+                {
+                    EndpointGroupMembershipId = Guid.NewGuid().ToString(),
+                    EndpointId = endpoint.EndpointId,
+                    GroupId = groupId,
                     CreatedAtUtc = DateTimeOffset.UtcNow
                 });
             }
@@ -256,7 +301,7 @@ internal sealed class EndpointManagementService : IEndpointManagementService
             return errors;
         }
 
-        await ValidateAgentAndDependenciesAsync(command.AgentId, command.DependsOnEndpointIds, null, errors, cancellationToken);
+        await ValidateAgentAndDependenciesAndGroupsAsync(command.AgentId, command.DependsOnEndpointIds, command.GroupIds, null, errors, cancellationToken);
 
         var normalizedEndpointName = command.EndpointName.Trim();
         var endpointNameExists = await _dbContext.Endpoints.AsNoTracking()
@@ -327,7 +372,7 @@ internal sealed class EndpointManagementService : IEndpointManagementService
             return errors;
         }
 
-        await ValidateAgentAndDependenciesAsync(command.AgentId, command.DependsOnEndpointIds, normalizedEndpointId, errors, cancellationToken);
+        await ValidateAgentAndDependenciesAndGroupsAsync(command.AgentId, command.DependsOnEndpointIds, command.GroupIds, normalizedEndpointId, errors, cancellationToken);
 
         var normalizedEndpointName = command.EndpointName.Trim();
         var duplicateNameExists = await _dbContext.Endpoints.AsNoTracking()
@@ -349,9 +394,10 @@ internal sealed class EndpointManagementService : IEndpointManagementService
         return errors;
     }
 
-    private async Task ValidateAgentAndDependenciesAsync(
+    private async Task ValidateAgentAndDependenciesAndGroupsAsync(
         string agentId,
         IReadOnlyList<string> dependsOnEndpointIds,
+        IReadOnlyList<string> groupIds,
         string? currentEndpointId,
         ICollection<EndpointValidationError> errors,
         CancellationToken cancellationToken)
@@ -368,21 +414,37 @@ internal sealed class EndpointManagementService : IEndpointManagementService
         var normalizedDependencies = NormalizeDependencies(dependsOnEndpointIds);
 
         var dependencyIds = normalizedDependencies.ToArray();
-        if (dependencyIds.Length == 0)
+        if (dependencyIds.Length > 0)
         {
-            return;
+            var existingDependencyIds = await _dbContext.Endpoints.AsNoTracking()
+                .Where(x => dependencyIds.Contains(x.EndpointId))
+                .Select(x => x.EndpointId)
+                .ToArrayAsync(cancellationToken);
+
+            foreach (var dependencyId in dependencyIds)
+            {
+                if (!existingDependencyIds.Contains(dependencyId, StringComparer.Ordinal))
+                {
+                    errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.DependsOnEndpointIds), $"Dependency endpoint '{dependencyId}' does not exist."));
+                }
+            }
         }
 
-        var existingDependencyIds = await _dbContext.Endpoints.AsNoTracking()
-            .Where(x => dependencyIds.Contains(x.EndpointId))
-            .Select(x => x.EndpointId)
-            .ToArrayAsync(cancellationToken);
-
-        foreach (var dependencyId in dependencyIds)
+        var normalizedGroups = NormalizeGroups(groupIds);
+        var selectedGroupIds = normalizedGroups.ToArray();
+        if (selectedGroupIds.Length > 0)
         {
-            if (!existingDependencyIds.Contains(dependencyId, StringComparer.Ordinal))
+            var existingGroupIds = await _dbContext.Groups.AsNoTracking()
+                .Where(x => selectedGroupIds.Contains(x.GroupId))
+                .Select(x => x.GroupId)
+                .ToArrayAsync(cancellationToken);
+
+            foreach (var selectedGroupId in selectedGroupIds)
             {
-                errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.DependsOnEndpointIds), $"Dependency endpoint '{dependencyId}' does not exist."));
+                if (!existingGroupIds.Contains(selectedGroupId, StringComparer.Ordinal))
+                {
+                    errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.GroupIds), $"Group '{selectedGroupId}' does not exist."));
+                }
             }
         }
 
@@ -479,6 +541,22 @@ internal sealed class EndpointManagementService : IEndpointManagementService
         foreach (var dependencyId in dependencyIds)
         {
             var value = NormalizeRequired(dependencyId);
+            if (value is not null)
+            {
+                normalized.Add(value);
+            }
+        }
+
+        return normalized;
+    }
+
+
+    private static HashSet<string> NormalizeGroups(IReadOnlyList<string> groupIds)
+    {
+        var normalized = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var groupId in groupIds)
+        {
+            var value = NormalizeRequired(groupId);
             if (value is not null)
             {
                 normalized.Add(value);

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointCreationQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointCreationQueryService.cs
@@ -11,4 +11,5 @@ public sealed class CreateEndpointPageOptions
 {
     public IReadOnlyList<CreateEndpointAgentOptionViewModel> Agents { get; init; } = [];
     public IReadOnlyList<CreateEndpointDependencyOptionViewModel> DependencyEndpoints { get; init; } = [];
+    public IReadOnlyList<EndpointGroupOptionViewModel> Groups { get; init; } = [];
 }

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointManagementQueryService.cs
@@ -4,7 +4,7 @@ namespace PingMonitor.Web.Services.Endpoints;
 
 public interface IEndpointManagementQueryService
 {
-    Task<ManageEndpointsPageViewModel> GetManagePageAsync(CancellationToken cancellationToken);
+    Task<ManageEndpointsPageViewModel> GetManagePageAsync(string? groupId, CancellationToken cancellationToken);
     Task<EditEndpointOptionsViewModel> GetEditOptionsAsync(string assignmentId, CancellationToken cancellationToken);
     Task<RemoveEndpointDetails?> GetRemoveDetailsAsync(string assignmentId, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointManagementService.cs
@@ -14,6 +14,7 @@ public sealed class CreateEndpointCommand
     public string Target { get; init; } = string.Empty;
     public string AgentId { get; init; } = string.Empty;
     public IReadOnlyList<string> DependsOnEndpointIds { get; init; } = [];
+    public IReadOnlyList<string> GroupIds { get; init; } = [];
     public int PingIntervalSeconds { get; init; }
     public int RetryIntervalSeconds { get; init; }
     public int TimeoutMs { get; init; }
@@ -31,6 +32,7 @@ public sealed class UpdateEndpointCommand
     public string Target { get; init; } = string.Empty;
     public string AgentId { get; init; } = string.Empty;
     public IReadOnlyList<string> DependsOnEndpointIds { get; init; } = [];
+    public IReadOnlyList<string> GroupIds { get; init; } = [];
     public bool EndpointEnabled { get; init; }
     public bool AssignmentEnabled { get; init; }
     public int PingIntervalSeconds { get; init; }
@@ -48,6 +50,7 @@ public sealed class EditEndpointModel
     public string Target { get; init; } = string.Empty;
     public string AgentId { get; init; } = string.Empty;
     public IReadOnlyList<string> DependsOnEndpointIds { get; init; } = [];
+    public IReadOnlyList<string> GroupIds { get; init; } = [];
     public bool EndpointEnabled { get; init; }
     public bool AssignmentEnabled { get; init; }
     public int PingIntervalSeconds { get; init; }

--- a/src/WebApp/PingMonitor.Web/Services/Groups/GroupManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Groups/GroupManagementService.cs
@@ -1,0 +1,136 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.ViewModels.Endpoints;
+using PingMonitor.Web.ViewModels.Groups;
+
+namespace PingMonitor.Web.Services.Groups;
+
+internal sealed class GroupManagementService : IGroupManagementService
+{
+    private readonly PingMonitorDbContext _dbContext;
+
+    public GroupManagementService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<GroupCreateResult> CreateAsync(GroupUpsertCommand command, CancellationToken cancellationToken)
+    {
+        var errors = await ValidateAsync(command, isCreate: true, cancellationToken);
+        if (errors.Count > 0)
+        {
+            return new GroupCreateResult { Success = false, ValidationErrors = errors };
+        }
+
+        var group = new Group
+        {
+            GroupId = Guid.NewGuid().ToString(),
+            Name = command.Name.Trim(),
+            Description = string.IsNullOrWhiteSpace(command.Description) ? null : command.Description.Trim(),
+            CreatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        _dbContext.Groups.Add(group);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return new GroupCreateResult { Success = true, GroupId = group.GroupId };
+    }
+
+    public async Task<GroupUpdateResult> UpdateAsync(GroupUpsertCommand command, CancellationToken cancellationToken)
+    {
+        var groupId = command.GroupId?.Trim();
+        if (string.IsNullOrWhiteSpace(groupId))
+        {
+            return new GroupUpdateResult { Success = false, Found = false, ValidationErrors = ["Group ID is required."] };
+        }
+
+        var group = await _dbContext.Groups.SingleOrDefaultAsync(x => x.GroupId == groupId, cancellationToken);
+        if (group is null)
+        {
+            return new GroupUpdateResult { Success = false, Found = false };
+        }
+
+        var errors = await ValidateAsync(command, isCreate: false, cancellationToken);
+        if (errors.Count > 0)
+        {
+            return new GroupUpdateResult { Success = false, Found = true, ValidationErrors = errors };
+        }
+
+        group.Name = command.Name.Trim();
+        group.Description = string.IsNullOrWhiteSpace(command.Description) ? null : command.Description.Trim();
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return new GroupUpdateResult { Success = true, Found = true };
+    }
+
+    public async Task<ManageGroupsPageViewModel> GetManagePageAsync(CancellationToken cancellationToken)
+    {
+        var groups = await _dbContext.Groups.AsNoTracking()
+            .OrderBy(x => x.Name)
+            .Select(x => new ManageGroupRowViewModel
+            {
+                GroupId = x.GroupId,
+                Name = x.Name,
+                Description = x.Description,
+                CreatedAtUtc = x.CreatedAtUtc
+            })
+            .ToArrayAsync(cancellationToken);
+
+        return new ManageGroupsPageViewModel { Rows = groups };
+    }
+
+    public async Task<GroupEditPageViewModel?> GetEditPageAsync(string groupId, CancellationToken cancellationToken)
+    {
+        var normalizedGroupId = groupId.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedGroupId))
+        {
+            return null;
+        }
+
+        return await _dbContext.Groups.AsNoTracking()
+            .Where(x => x.GroupId == normalizedGroupId)
+            .Select(x => new GroupEditPageViewModel
+            {
+                GroupId = x.GroupId,
+                Name = x.Name,
+                Description = x.Description ?? string.Empty
+            })
+            .SingleOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<EndpointGroupOptionViewModel>> GetGroupOptionsAsync(CancellationToken cancellationToken)
+    {
+        return await _dbContext.Groups.AsNoTracking()
+            .OrderBy(x => x.Name)
+            .Select(x => new EndpointGroupOptionViewModel
+            {
+                GroupId = x.GroupId,
+                Name = x.Name
+            })
+            .ToArrayAsync(cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<string>> ValidateAsync(GroupUpsertCommand command, bool isCreate, CancellationToken cancellationToken)
+    {
+        var errors = new List<string>();
+        var name = command.Name.Trim();
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            errors.Add("Group name is required.");
+            return errors;
+        }
+
+        var groupId = command.GroupId?.Trim();
+        var duplicate = await _dbContext.Groups.AsNoTracking()
+            .AnyAsync(x => x.Name == name && (isCreate || x.GroupId != groupId), cancellationToken);
+
+        if (duplicate)
+        {
+            errors.Add("A group with this name already exists.");
+        }
+
+        return errors;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Groups/IGroupManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Groups/IGroupManagementService.cs
@@ -1,0 +1,34 @@
+using PingMonitor.Web.ViewModels.Endpoints;
+using PingMonitor.Web.ViewModels.Groups;
+
+namespace PingMonitor.Web.Services.Groups;
+
+public interface IGroupManagementService
+{
+    Task<GroupCreateResult> CreateAsync(GroupUpsertCommand command, CancellationToken cancellationToken);
+    Task<GroupUpdateResult> UpdateAsync(GroupUpsertCommand command, CancellationToken cancellationToken);
+    Task<ManageGroupsPageViewModel> GetManagePageAsync(CancellationToken cancellationToken);
+    Task<GroupEditPageViewModel?> GetEditPageAsync(string groupId, CancellationToken cancellationToken);
+    Task<IReadOnlyList<EndpointGroupOptionViewModel>> GetGroupOptionsAsync(CancellationToken cancellationToken);
+}
+
+public sealed class GroupUpsertCommand
+{
+    public string? GroupId { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public string? Description { get; init; }
+}
+
+public sealed class GroupCreateResult
+{
+    public bool Success { get; init; }
+    public string? GroupId { get; init; }
+    public IReadOnlyList<string> ValidationErrors { get; init; } = [];
+}
+
+public sealed class GroupUpdateResult
+{
+    public bool Success { get; init; }
+    public bool Found { get; init; }
+    public IReadOnlyList<string> ValidationErrors { get; init; } = [];
+}

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -18,6 +18,8 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "Agents",
         "Endpoints",
         "EndpointDependencies",
+        "Groups",
+        "EndpointGroupMemberships",
         "MonitorAssignments",
         "CheckResults",
         "ResultBatches",
@@ -212,10 +214,34 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             );
             """;
 
+        const string createGroupsSql = """
+            CREATE TABLE IF NOT EXISTS `Groups` (
+                `GroupId` varchar(64) NOT NULL,
+                `Name` varchar(255) NOT NULL,
+                `Description` varchar(2048) NULL,
+                `CreatedAtUtc` datetime(6) NOT NULL,
+                PRIMARY KEY (`GroupId`),
+                UNIQUE KEY `UX_Groups_Name` (`Name`)
+            );
+            """;
+
+        const string createEndpointGroupMembershipsSql = """
+            CREATE TABLE IF NOT EXISTS `EndpointGroupMemberships` (
+                `EndpointGroupMembershipId` varchar(64) NOT NULL,
+                `EndpointId` varchar(64) NOT NULL,
+                `GroupId` varchar(64) NOT NULL,
+                `CreatedAtUtc` datetime(6) NOT NULL,
+                PRIMARY KEY (`EndpointGroupMembershipId`),
+                UNIQUE KEY `UX_EndpointGroupMemberships_EndpointId_GroupId` (`EndpointId`, `GroupId`)
+            );
+            """;
+
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointStatesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createStateTransitionsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createApplicationSettingsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointDependenciesSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createGroupsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createEndpointGroupMembershipsSql, cancellationToken);
         await EnsureEndpointDependenciesColumnsAsync(dbContext, cancellationToken);
         await MigrateLegacyEndpointDependenciesAsync(dbContext, cancellationToken);
     }

--- a/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
@@ -17,11 +17,13 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
     public async Task<EndpointStatusPageViewModel> GetStatusPageAsync(
         string? state,
         string? agent,
+        string? groupId,
         string? search,
         CancellationToken cancellationToken)
     {
         var normalizedState = Normalize(state);
         var normalizedAgent = Normalize(agent);
+        var normalizedGroupId = Normalize(groupId);
         var normalizedSearch = Normalize(search);
         var parsedState = TryParseState(normalizedState);
 
@@ -76,11 +78,31 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
             .Select(x => x.InstanceId)
             .ToArrayAsync(cancellationToken);
 
+        var availableGroups = await _dbContext.Groups.AsNoTracking()
+            .OrderBy(x => x.Name)
+            .Select(x => new StatusGroupOptionViewModel
+            {
+                GroupId = x.GroupId,
+                Name = x.Name
+            })
+            .ToArrayAsync(cancellationToken);
+        var groupNameLookup = availableGroups.ToDictionary(x => x.GroupId, x => x.Name, StringComparer.Ordinal);
+
         var rows = await baseQuery
             .OrderBy(row => row.CurrentState)
             .ThenBy(row => row.EndpointName)
             .ThenBy(row => row.AgentInstanceId)
             .ToArrayAsync(cancellationToken);
+
+        var memberships = await _dbContext.EndpointGroupMemberships.AsNoTracking().ToArrayAsync(cancellationToken);
+        var groupLookup = memberships
+            .GroupBy(x => x.EndpointId, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => (IReadOnlyList<string>)group.Select(x => x.GroupId).ToArray(), StringComparer.Ordinal);
+
+        if (!string.IsNullOrWhiteSpace(normalizedGroupId))
+        {
+            rows = rows.Where(x => groupLookup.GetValueOrDefault(x.EndpointId, Array.Empty<string>()).Contains(normalizedGroupId, StringComparer.Ordinal)).ToArray();
+        }
 
         var endpointIds = rows.Select(x => x.EndpointId).Distinct(StringComparer.Ordinal).ToArray();
         var endpointNames = await _dbContext.Endpoints.AsNoTracking()
@@ -119,7 +141,11 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
                 ParentEndpointIds = parentIds,
                 ParentEndpointNames = parentIds.Select(x => endpointNames.GetValueOrDefault(x, x)).OrderBy(x => x).ToArray(),
                 SuppressedByEndpointId = row.SuppressedByEndpointId,
-                SuppressedByEndpointName = row.SuppressedByEndpointName
+                SuppressedByEndpointName = row.SuppressedByEndpointName,
+                GroupNames = groupLookup.GetValueOrDefault(row.EndpointId, Array.Empty<string>())
+                    .Select(selectedGroupId => groupNameLookup.GetValueOrDefault(selectedGroupId, selectedGroupId))
+                    .OrderBy(x => x)
+                    .ToArray()
             };
         }).ToArray();
 
@@ -138,8 +164,10 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
             {
                 State = normalizedState,
                 Agent = normalizedAgent,
+                GroupId = normalizedGroupId,
                 Search = normalizedSearch,
-                AvailableAgents = availableAgents
+                AvailableAgents = availableAgents,
+                AvailableGroups = availableGroups
             },
             Rows = projectedRows
         };

--- a/src/WebApp/PingMonitor.Web/Services/Status/IEndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/IEndpointStatusQueryService.cs
@@ -4,5 +4,5 @@ namespace PingMonitor.Web.Services.Status;
 
 public interface IEndpointStatusQueryService
 {
-    Task<EndpointStatusPageViewModel> GetStatusPageAsync(string? state, string? agent, string? search, CancellationToken cancellationToken);
+    Task<EndpointStatusPageViewModel> GetStatusPageAsync(string? state, string? agent, string? groupId, string? search, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/CreateEndpointPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/CreateEndpointPageViewModel.cs
@@ -19,6 +19,9 @@ public sealed class CreateEndpointPageViewModel
     [Display(Name = "Depends on endpoints")]
     public List<string> DependsOnEndpointIds { get; set; } = [];
 
+    [Display(Name = "Groups")]
+    public List<string> GroupIds { get; set; } = [];
+
     [Range(1, int.MaxValue, ErrorMessage = "Ping interval must be at least 1 second.")]
     [Display(Name = "Ping interval (seconds)")]
     public int PingIntervalSeconds { get; set; } = 60;
@@ -48,6 +51,7 @@ public sealed class CreateEndpointPageViewModel
     public IReadOnlyList<CreateEndpointAgentOptionViewModel> AvailableAgents { get; set; } = [];
 
     public IReadOnlyList<CreateEndpointDependencyOptionViewModel> AvailableDependencyEndpoints { get; set; } = [];
+    public IReadOnlyList<EndpointGroupOptionViewModel> AvailableGroups { get; set; } = [];
 }
 
 public sealed class CreateEndpointAgentOptionViewModel
@@ -60,4 +64,10 @@ public sealed class CreateEndpointDependencyOptionViewModel
 {
     public string EndpointId { get; init; } = string.Empty;
     public string EndpointName { get; init; } = string.Empty;
+}
+
+public sealed class EndpointGroupOptionViewModel
+{
+    public string GroupId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
 }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/ManageEndpointsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/ManageEndpointsPageViewModel.cs
@@ -6,6 +6,8 @@ namespace PingMonitor.Web.ViewModels.Endpoints;
 public sealed class ManageEndpointsPageViewModel
 {
     public IReadOnlyList<ManageEndpointRowViewModel> Rows { get; init; } = [];
+    public string? GroupId { get; set; }
+    public IReadOnlyList<EndpointGroupOptionViewModel> AvailableGroups { get; init; } = [];
     public string? StatusMessage { get; set; }
     public string? ErrorMessage { get; set; }
 }
@@ -17,6 +19,7 @@ public sealed class ManageEndpointRowViewModel
     public string Target { get; init; } = string.Empty;
     public string AgentDisplay { get; init; } = string.Empty;
     public IReadOnlyList<string> DependencyEndpointNames { get; init; } = [];
+    public IReadOnlyList<string> GroupNames { get; init; } = [];
     public bool EndpointEnabled { get; init; }
     public bool AssignmentEnabled { get; init; }
     public int PingIntervalSeconds { get; init; }
@@ -50,6 +53,9 @@ public sealed class EditEndpointPageViewModel
     [Display(Name = "Depends on endpoints")]
     public List<string> DependsOnEndpointIds { get; set; } = [];
 
+    [Display(Name = "Groups")]
+    public List<string> GroupIds { get; set; } = [];
+
     [Display(Name = "Endpoint enabled")]
     public bool EndpointEnabled { get; set; }
 
@@ -78,6 +84,7 @@ public sealed class EditEndpointPageViewModel
 
     public IReadOnlyList<EndpointAgentOptionViewModel> AvailableAgents { get; set; } = [];
     public IReadOnlyList<EndpointDependencyOptionViewModel> AvailableDependencies { get; set; } = [];
+    public IReadOnlyList<EndpointGroupOptionViewModel> AvailableGroups { get; set; } = [];
 }
 
 public sealed class EndpointAgentOptionViewModel
@@ -96,6 +103,7 @@ public sealed class EditEndpointOptionsViewModel
 {
     public IReadOnlyList<EndpointAgentOptionViewModel> Agents { get; init; } = [];
     public IReadOnlyList<EndpointDependencyOptionViewModel> Dependencies { get; init; } = [];
+    public IReadOnlyList<EndpointGroupOptionViewModel> Groups { get; init; } = [];
 }
 
 public sealed class RemoveEndpointPageViewModel

--- a/src/WebApp/PingMonitor.Web/ViewModels/Groups/GroupPageViewModels.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Groups/GroupPageViewModels.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PingMonitor.Web.ViewModels.Groups;
+
+public sealed class ManageGroupsPageViewModel
+{
+    public IReadOnlyList<ManageGroupRowViewModel> Rows { get; init; } = [];
+    public string? StatusMessage { get; set; }
+}
+
+public sealed class ManageGroupRowViewModel
+{
+    public string GroupId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public DateTimeOffset CreatedAtUtc { get; init; }
+}
+
+public sealed class GroupEditPageViewModel
+{
+    public string GroupId { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Group name is required.")]
+    public string Name { get; set; } = string.Empty;
+
+    public string Description { get; set; } = string.Empty;
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/Status/EndpointStatusPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Status/EndpointStatusPageViewModel.cs
@@ -24,7 +24,9 @@ public sealed class EndpointStatusFiltersViewModel
     public string? State { get; init; }
     public string? Agent { get; init; }
     public string? Search { get; init; }
+    public string? GroupId { get; init; }
     public IReadOnlyList<string> AvailableAgents { get; init; } = [];
+    public IReadOnlyList<StatusGroupOptionViewModel> AvailableGroups { get; init; } = [];
     public IReadOnlyList<EndpointStateKind> AvailableStates { get; init; } =
     [
         EndpointStateKind.Unknown,
@@ -56,4 +58,11 @@ public sealed class EndpointStatusRowViewModel
     public IReadOnlyList<string> ParentEndpointNames { get; init; } = [];
     public string? SuppressedByEndpointId { get; init; }
     public string? SuppressedByEndpointName { get; init; }
+    public IReadOnlyList<string> GroupNames { get; init; } = [];
+}
+
+public sealed class StatusGroupOptionViewModel
+{
+    public string GroupId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
 }

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Edit.cshtml
@@ -72,6 +72,19 @@
                         <div class="field-error"><span asp-validation-for="AgentId"></span></div>
                     </div>
                     <div>
+                        <label asp-for="GroupIds"></label>
+                        <div class="checkbox-list">
+                            @foreach (var group in Model.AvailableGroups)
+                            {
+                                <label class="checkbox">
+                                    <input type="checkbox" name="GroupIds" value="@group.GroupId" checked="@Model.GroupIds.Contains(group.GroupId)" />
+                                    <span>@group.Name</span>
+                                </label>
+                            }
+                        </div>
+                        <div class="field-error"><span asp-validation-for="GroupIds"></span></div>
+                    </div>
+                    <div>
                         <label asp-for="DependsOnEndpointIds"></label>
                         <div class="checkbox-list">
                             @foreach (var endpoint in Model.AvailableDependencies)
@@ -128,6 +141,7 @@
 
             <div class="actions">
                 <button class="button" type="submit">Save changes</button>
+                <a class="button-secondary" href="/groups">Manage groups</a>
                 <a class="button-secondary" href="/endpoints">Cancel</a>
             </div>
         </form>

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
@@ -56,8 +56,27 @@
             <p class="muted">Edit endpoint and assignment records without changing assignment-scoped state behavior.</p>
             <div class="button-row">
                 <a class="button" href="/endpoints/new">Add new endpoint</a>
+                <a class="button-secondary" href="/groups">Manage groups</a>
                 <a class="button-secondary" href="/status">View status</a>
             </div>
+        </section>
+
+        <section class="card">
+            <h2>Filters</h2>
+            <form method="get" action="/endpoints">
+                <label for="groupId">Group</label>
+                <select id="groupId" name="groupId">
+                    <option value="">All groups</option>
+                    @foreach (var group in Model.AvailableGroups)
+                    {
+                        <option value="@group.GroupId" selected="@(string.Equals(Model.GroupId, group.GroupId, StringComparison.Ordinal))">@group.Name</option>
+                    }
+                </select>
+                <div class="button-row" style="margin-top:.75rem;">
+                    <button class="button" type="submit">Apply filter</button>
+                    <a class="button-secondary" href="/endpoints">Clear</a>
+                </div>
+            </form>
         </section>
 
         <section class="card">
@@ -92,6 +111,7 @@
                             <div class="row-meta">
                                 <div class="meta-item"><span>Assignment ID</span><div>@row.AssignmentId</div></div>
                                 <div class="meta-item"><span>Agent / instance</span><div>@row.AgentDisplay</div></div>
+                                <div class="meta-item"><span>Groups</span><div>@(row.GroupNames.Count == 0 ? "None" : string.Join(", ", row.GroupNames))</div></div>
                                 <div class="meta-item"><span>Dependency parents</span><div>@(row.DependencyEndpointNames.Count == 0 ? "None" : string.Join(", ", row.DependencyEndpointNames))</div></div>
                                 <div class="meta-item"><span>Endpoint enabled</span><div>@(row.EndpointEnabled ? "Enabled" : "Disabled")</div></div>
                                 <div class="meta-item"><span>Assignment enabled</span><div>@(row.AssignmentEnabled ? "Enabled" : "Disabled")</div></div>

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/New.cshtml
@@ -88,6 +88,24 @@
             </section>
 
             <section class="card">
+                <h2 class="section-title">Grouping</h2>
+                <div class="field-grid">
+                    <div>
+                        <label asp-for="GroupIds"></label>
+                        <div class="checkbox-list">
+                            @foreach (var group in Model.AvailableGroups)
+                            {
+                                <label class="checkbox">
+                                    <input type="checkbox" name="GroupIds" value="@group.GroupId" checked="@Model.GroupIds.Contains(group.GroupId)" />
+                                    <span>@group.Name</span>
+                                </label>
+                            }
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="card">
                 <h2 class="section-title">Dependency</h2>
                 <div class="field-grid">
                     <div>
@@ -143,6 +161,7 @@
 
             <div class="actions">
                 <button class="button" type="submit">Create endpoint</button>
+                <a class="button-secondary" href="/groups">Manage groups</a>
                 <a class="button-secondary" href="/status">Cancel</a>
             </div>
         </form>

--- a/src/WebApp/PingMonitor.Web/Views/Groups/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/Edit.cshtml
@@ -1,0 +1,47 @@
+@model PingMonitor.Web.ViewModels.Groups.GroupEditPageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Edit group</title>
+    <style>
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --border:#d9e2ec; --accent:#0f62fe; --danger:#b42318; }
+        * { box-sizing: border-box; }
+        body { margin:0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width:760px; margin:0 auto; padding:1rem; }
+        .card { background:var(--card); border-radius:14px; padding:1rem; box-shadow: 0 1px 2px rgba(16,24,40,.08); }
+        .stack{ display:grid; gap:1rem; }
+        label { display:block; font-weight:600; margin-bottom:.35rem; }
+        input, textarea { width:100%; min-height:48px; padding:.8rem; border:1px solid var(--border); border-radius:10px; font-size:1rem; }
+        textarea { min-height:120px; resize:vertical; }
+        .field-error { color: var(--danger); }
+        .button,.button-secondary { display:inline-flex; align-items:center; justify-content:center; min-height:48px; padding:.8rem 1rem; border-radius:10px; font-weight:600; text-decoration:none; }
+        .button { border:0; background:var(--accent); color:#fff; }
+        .button-secondary { border:1px solid var(--border); color:var(--text); background:#fff; }
+    </style>
+</head>
+<body>
+<main>
+    <form method="post" action="/groups/@Model.GroupId/edit" class="stack">
+        @Html.AntiForgeryToken()
+        <section class="card">
+            <h1>Edit group</h1>
+            <div>
+                <label asp-for="Name"></label>
+                <input asp-for="Name" />
+                <div class="field-error"><span asp-validation-for="Name"></span></div>
+            </div>
+            <div>
+                <label asp-for="Description"></label>
+                <textarea asp-for="Description"></textarea>
+            </div>
+        </section>
+        <div>
+            <button class="button" type="submit">Save group</button>
+            <a class="button-secondary" href="/groups">Cancel</a>
+        </div>
+    </form>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Groups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/Index.cshtml
@@ -1,0 +1,59 @@
+@model PingMonitor.Web.ViewModels.Groups.ManageGroupsPageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Manage groups</title>
+    <style>
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; }
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 960px; margin: 0 auto; padding: 1rem; }
+        .stack { display:grid; gap:1rem; }
+        .card { background:var(--card); border-radius:14px; padding:1rem; box-shadow: 0 1px 2px rgba(16,24,40,.08); }
+        .row { border:1px solid var(--border); border-radius:10px; padding:.85rem; }
+        .muted { color: var(--muted); }
+        .button,.button-secondary { display:inline-flex; align-items:center; justify-content:center; min-height:48px; padding:.8rem 1rem; border-radius:10px; font-weight:600; text-decoration:none; }
+        .button { border:0; background:var(--accent); color:#fff; }
+        .button-secondary { border:1px solid var(--border); color:var(--text); background:#fff; }
+        .button-row { display:flex; gap:.75rem; flex-wrap:wrap; margin-top:.75rem; }
+    </style>
+</head>
+<body>
+<main>
+    <div class="stack">
+        <section class="card">
+            <h1>Manage groups</h1>
+            <p class="muted">Groups organize endpoints and support status and management filtering.</p>
+            <div class="button-row">
+                <a class="button" href="/groups/new">Create group</a>
+                <a class="button-secondary" href="/endpoints">Manage endpoints</a>
+            </div>
+            @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
+            {
+                <p><strong>@Model.StatusMessage</strong></p>
+            }
+        </section>
+        <section class="card">
+            @if (Model.Rows.Count == 0)
+            {
+                <p class="muted">No groups are configured yet.</p>
+            }
+            else
+            {
+                @foreach (var row in Model.Rows)
+                {
+                    <article class="row">
+                        <div><strong>@row.Name</strong></div>
+                        <div class="muted">@(string.IsNullOrWhiteSpace(row.Description) ? "No description" : row.Description)</div>
+                        <div class="muted">Created @row.CreatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</div>
+                        <div class="button-row"><a class="button-secondary" href="/groups/@row.GroupId/edit">Edit group</a></div>
+                    </article>
+                }
+            }
+        </section>
+    </div>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Groups/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/New.cshtml
@@ -1,0 +1,47 @@
+@model PingMonitor.Web.ViewModels.Groups.GroupEditPageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Create group</title>
+    <style>
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; --danger:#b42318; }
+        * { box-sizing: border-box; }
+        body { margin:0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width:760px; margin:0 auto; padding:1rem; }
+        .card { background:var(--card); border-radius:14px; padding:1rem; box-shadow: 0 1px 2px rgba(16,24,40,.08); }
+        .stack{ display:grid; gap:1rem; }
+        label { display:block; font-weight:600; margin-bottom:.35rem; }
+        input, textarea { width:100%; min-height:48px; padding:.8rem; border:1px solid var(--border); border-radius:10px; font-size:1rem; }
+        textarea { min-height:120px; resize:vertical; }
+        .field-error { color: var(--danger); }
+        .button,.button-secondary { display:inline-flex; align-items:center; justify-content:center; min-height:48px; padding:.8rem 1rem; border-radius:10px; font-weight:600; text-decoration:none; }
+        .button { border:0; background:var(--accent); color:#fff; }
+        .button-secondary { border:1px solid var(--border); color:var(--text); background:#fff; }
+    </style>
+</head>
+<body>
+<main>
+    <form method="post" action="/groups/new" class="stack">
+        @Html.AntiForgeryToken()
+        <section class="card">
+            <h1>Create group</h1>
+            <div>
+                <label asp-for="Name"></label>
+                <input asp-for="Name" />
+                <div class="field-error"><span asp-validation-for="Name"></span></div>
+            </div>
+            <div>
+                <label asp-for="Description"></label>
+                <textarea asp-for="Description"></textarea>
+            </div>
+        </section>
+        <div>
+            <button class="button" type="submit">Create group</button>
+            <a class="button-secondary" href="/groups">Cancel</a>
+        </div>
+    </form>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -72,7 +72,7 @@
         .nowrap { white-space: nowrap; }
         @@media (min-width: 720px) {
             .summary-grid { grid-template-columns: repeat(6, minmax(0, 1fr)); }
-            .filter-grid { grid-template-columns: 1fr 220px 220px; align-items: end; }
+            .filter-grid { grid-template-columns: 1fr 220px 220px 220px; align-items: end; }
             .row-header { flex-direction: row; justify-content: space-between; align-items: start; }
             .row-meta { grid-template-columns: repeat(4, minmax(0, 1fr)); }
         }
@@ -87,6 +87,7 @@
             <div class="button-row">
                 <a class="button" href="/agents">Manage agents</a>
                 <a class="button-secondary" href="/agents/deploy">Deploy new agent</a>
+                <a class="button-secondary" href="/groups">Manage groups</a>
                 <a class="button-secondary" href="/endpoints">Manage endpoints</a>
                 <a class="button-secondary" href="/endpoints/new">Add new endpoint</a>
                 <a class="button-secondary" href="/admin">Admin settings</a>
@@ -133,6 +134,16 @@
                             }
                         </select>
                     </div>
+                    <div>
+                        <label for="groupId">Group</label>
+                        <select id="groupId" name="groupId">
+                            <option value="">All groups</option>
+                            @foreach (var group in Model.Filters.AvailableGroups)
+                            {
+                                <option value="@group.GroupId" selected="@(string.Equals(Model.Filters.GroupId, group.GroupId, StringComparison.Ordinal))">@group.Name</option>
+                            }
+                        </select>
+                    </div>
                 </div>
                 <div class="button-row">
                     <button class="button" type="submit">Apply filters</button>
@@ -171,6 +182,7 @@
                                 <div class="meta-item"><span>Last state change</span><div class="nowrap">@FormatDate(row.LastStateChangeUtc)</div></div>
                                 <div class="meta-item"><span>Consecutive failures</span><div>@row.ConsecutiveFailureCount</div></div>
                                 <div class="meta-item"><span>Consecutive successes</span><div>@row.ConsecutiveSuccessCount</div></div>
+                                <div class="meta-item"><span>Groups</span><div>@(row.GroupNames.Count == 0 ? "None" : string.Join(", ", row.GroupNames))</div></div>
                                 <div class="meta-item"><span>Dependency parents</span><div>@FormatDependencies(row.ParentEndpointIds, row.ParentEndpointNames, "None")</div></div>
                                 <div class="meta-item"><span>Suppressed by</span><div>@FormatDependency(row.SuppressedByEndpointId, row.SuppressedByEndpointName, "Not suppressed")</div></div>
                                 <div class="meta-item"><span>Assignment enabled</span><div>@(row.AssignmentEnabled ? "Enabled" : "Disabled")</div></div>


### PR DESCRIPTION
### Motivation
- Provide a simple operational way to organise endpoints by allowing endpoints to belong to zero, one, or many groups for management and status filtering while keeping behaviour explicit and endpoint-level (v1).
- Follow platform constraints: no nested groups, no permissions logic, explicit relational model and startup-gate schema handling.

### Description
- Add persistence models `Group` and `EndpointGroupMembership`, register them in `PingMonitorDbContext` and add EF schema configuration with unique constraints on `Group.Name` and `(EndpointId, GroupId)` to prevent duplicate memberships.
- Extend the startup-gate schema service to create/check `Groups` and `EndpointGroupMemberships` tables so the app validates schema on startup.
- Implement `IGroupManagementService` / `GroupManagementService` for creating, editing and listing groups and for loading group options for endpoint forms; register the service in DI.
- Add server-rendered group management pages and routes: `GET /groups`, `GET /groups/new`, `POST /groups/new`, `GET /groups/{id}/edit`, `POST /groups/{id}/edit` with compact mobile-friendly views.
- Update endpoint create/edit flows to support selecting zero/one/many groups (checkbox list), persist memberships on create, and sync add/remove memberships on edit; validation ensures selected groups exist.
- Add server-side group filtering to `/endpoints` and `/status` via query-string `groupId`, and display endpoint group names on management and status pages.
- Minimal docs update to `docs/data-model.md` describing `Group` and `EndpointGroupMembership` and a short v1 grouping note; links this work to the created issue (see Fixes #87).

### Testing
- Created GitHub issue to track work and linked changes (Issue #87 was created prior to implementation). (Automated via GitHub API.)
- Built the web application: `export PATH=/tmp/dotnet:$PATH && export DOTNET_CLI_HOME=/tmp && dotnet --version && dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` completed successfully with 0 errors.
- No additional automated unit/integration tests exist for this feature in the repository; manual/functional testing recommended in a local environment with MySQL to exercise startup-gate schema apply and the new pages/filters.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c521d22e54832a8ff52cde3552cfff)