### PR TITLE
Fix group create flow routes under non-root path

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/GroupsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/GroupsController.cs
@@ -55,7 +55,7 @@ public sealed class GroupsController : Controller
         }
 
         TempData[StatusMessageKey] = "Group created.";
-        return Redirect("/groups");
+        return RedirectToAction(nameof(Index));
     }
 
     [HttpGet("{id}/edit")]
@@ -98,6 +98,6 @@ public sealed class GroupsController : Controller
         }
 
         TempData[StatusMessageKey] = "Group updated.";
-        return Redirect("/groups");
+        return RedirectToAction(nameof(Index));
     }
 }

--- a/src/WebApp/PingMonitor.Web/Views/Groups/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/Edit.cshtml
@@ -23,7 +23,7 @@
 </head>
 <body>
 <main>
-    <form method="post" action="/groups/@Model.GroupId/edit" class="stack">
+    <form method="post" asp-controller="Groups" asp-action="Edit" asp-route-id="@Model.GroupId" class="stack">
         @Html.AntiForgeryToken()
         <section class="card">
             <h1>Edit group</h1>
@@ -39,7 +39,7 @@
         </section>
         <div>
             <button class="button" type="submit">Save group</button>
-            <a class="button-secondary" href="/groups">Cancel</a>
+            <a class="button-secondary" asp-controller="Groups" asp-action="Index">Cancel</a>
         </div>
     </form>
 </main>

--- a/src/WebApp/PingMonitor.Web/Views/Groups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/Index.cshtml
@@ -27,8 +27,8 @@
             <h1>Manage groups</h1>
             <p class="muted">Groups organize endpoints and support status and management filtering.</p>
             <div class="button-row">
-                <a class="button" href="/groups/new">Create group</a>
-                <a class="button-secondary" href="/endpoints">Manage endpoints</a>
+                <a class="button" asp-controller="Groups" asp-action="New">Create group</a>
+                <a class="button-secondary" asp-controller="Endpoints" asp-action="Index">Manage endpoints</a>
             </div>
             @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
             {
@@ -48,7 +48,7 @@
                         <div><strong>@row.Name</strong></div>
                         <div class="muted">@(string.IsNullOrWhiteSpace(row.Description) ? "No description" : row.Description)</div>
                         <div class="muted">Created @row.CreatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</div>
-                        <div class="button-row"><a class="button-secondary" href="/groups/@row.GroupId/edit">Edit group</a></div>
+                        <div class="button-row"><a class="button-secondary" asp-controller="Groups" asp-action="Edit" asp-route-id="@row.GroupId">Edit group</a></div>
                     </article>
                 }
             }

--- a/src/WebApp/PingMonitor.Web/Views/Groups/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/New.cshtml
@@ -23,7 +23,7 @@
 </head>
 <body>
 <main>
-    <form method="post" action="/groups/new" class="stack">
+    <form method="post" asp-controller="Groups" asp-action="New" class="stack">
         @Html.AntiForgeryToken()
         <section class="card">
             <h1>Create group</h1>
@@ -39,7 +39,7 @@
         </section>
         <div>
             <button class="button" type="submit">Create group</button>
-            <a class="button-secondary" href="/groups">Cancel</a>
+            <a class="button-secondary" asp-controller="Groups" asp-action="Index">Cancel</a>
         </div>
     </form>
 </main>


### PR DESCRIPTION
### Motivation
- The groups create/edit flow used hard-coded absolute paths which caused navigation and form postbacks to fail when the app is hosted under a non-root base path.
- Ensure navigation and post-success redirects are robust and respect MVC routing so the UI works correctly in all deployment base-path configurations.

### Description
- Replaced hard-coded links and form `action` attributes in `Views/Groups/Index.cshtml`, `New.cshtml`, and `Edit.cshtml` with MVC tag helpers (`asp-controller`/`asp-action`/`asp-route-id`).
- Replaced hard-coded `Redirect("/groups")` calls in `GroupsController` with `RedirectToAction(nameof(Index))` to avoid path-root assumptions.
- Changes keep existing behavior and messages intact while making routing resilient to application base paths.
- Links the related issue and bug report for traceability: Fixes #89

### Testing
- Installed and used the .NET installer to obtain the required SDK (`10.0.104`) as part of validation, and the installer completed successfully.
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the project built successfully with `0 Error(s)` and `0 Warning(s)`.
- No unit tests were present; build validation was used to verify the change compiled and integrated with the project successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c526d0c098832a9e4f880b206894e3)