### PR TITLE
Fix group creation when description is empty

### DIFF
--- a/src/WebApp/PingMonitor.Web/ViewModels/Groups/GroupPageViewModels.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Groups/GroupPageViewModels.cs
@@ -23,5 +23,5 @@ public sealed class GroupEditPageViewModel
     [Required(ErrorMessage = "Group name is required.")]
     public string Name { get; set; } = string.Empty;
 
-    public string Description { get; set; } = string.Empty;
+    public string? Description { get; set; }
 }


### PR DESCRIPTION
### Motivation
- Creating a group failed validation when the description field was left empty because the create/edit view model used a non-nullable `Description`, which caused implicit model-binding validation to reject empty submissions.

### Description
- Make the group description optional by changing `GroupEditPageViewModel.Description` to nullable in `src/WebApp/PingMonitor.Web/ViewModels/Groups/GroupPageViewModels.cs`, preserving existing service behavior that normalizes empty/whitespace descriptions to `null` and thereby preventing unintended validation failures; Fixes #91.

### Testing
- Installed .NET 10 and PowerShell and ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which succeeded (build succeeded, 0 warnings, 0 errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c52b534388832aa683f130a09f0d64)