### PR TITLE
Fix endpoint edit crash during group validation on MySQL

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementService.cs
@@ -434,14 +434,12 @@ internal sealed class EndpointManagementService : IEndpointManagementService
         var selectedGroupIds = normalizedGroups.ToArray();
         if (selectedGroupIds.Length > 0)
         {
-            var existingGroupIds = await _dbContext.Groups.AsNoTracking()
-                .Where(x => selectedGroupIds.Contains(x.GroupId))
-                .Select(x => x.GroupId)
-                .ToArrayAsync(cancellationToken);
-
             foreach (var selectedGroupId in selectedGroupIds)
             {
-                if (!existingGroupIds.Contains(selectedGroupId, StringComparer.Ordinal))
+                var groupExists = await _dbContext.Groups.AsNoTracking()
+                    .AnyAsync(x => x.GroupId == selectedGroupId, cancellationToken);
+
+                if (!groupExists)
                 {
                     errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.GroupIds), $"Group '{selectedGroupId}' does not exist."));
                 }


### PR DESCRIPTION
### Motivation
- Prevent an EF Core/MySQL translation failure (`Expression '@selectedGroupIds' in the SQL tree does not have a type mapping assigned`) that can occur when editing an endpoint with selected groups.

### Description
- Replace the `Where(... selectedGroupIds.Contains(x.GroupId) ...)` query with individual `AnyAsync(x => x.GroupId == selectedGroupId)` lookups in `ValidateAgentAndDependenciesAndGroupsAsync` to avoid provider `IN` translation/type-mapping issues.
- Preserve existing validation behavior and error messages so invalid group IDs still produce the same `EndpointValidationError` entries.
- Modified file: `src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementService.cs`; Fixes #93.

### Testing
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which completed successfully and produced the web assembly (`PingMonitor.Web.dll`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c52c861adc832a8511ecf14513ca45)