### PR TITLE
Add v1 uptime and RTT summary metrics across status, endpoints, and agents

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -86,6 +86,29 @@ Represents a monitoring agent instance.
 
 ---
 
+### AgentHeartbeatHistory
+
+Represents one persisted heartbeat event for an agent.
+
+#### Purpose
+
+- support explicit agent-uptime summaries over a rolling window
+- preserve auditable heartbeat availability history
+
+#### Key fields
+
+- `agentHeartbeatHistoryId`
+- `agentId`
+- `heartbeatAtUtc`
+- `recordedAtUtc`
+
+#### Constraints
+
+- append-only
+- indexed by (`agentId`, `heartbeatAtUtc`)
+
+---
+
 ### Endpoint
 
 Represents a logical target to monitor.
@@ -506,6 +529,37 @@ Use flags:
 
 - `batchId` must be used to prevent duplicate inserts  
 - duplicate batches must not duplicate CheckResults  
+
+---
+
+## v1 summary metrics (24-hour rolling window)
+
+These read-side metrics are derived from existing facts and are intended for operational UI summaries.
+
+### Endpoint uptime (v1)
+
+- computed from assignment-scoped state history (`EndpointState` + `StateTransition`)
+- numerator: time in `UP` or `DEGRADED`
+- denominator: full selected window (v1 fixed to last 24 hours)
+- `DOWN` and `SUPPRESSED` count as not-up
+- `UNKNOWN` is never counted as up
+
+### Agent uptime (v1)
+
+- computed from `AgentHeartbeatHistory`
+- v1 uses minute-level availability buckets across the last 24 hours
+- a minute counts as available when at least one heartbeat exists in that minute bucket
+
+### RTT summary (v1)
+
+- source: successful `CheckResult` rows only (`success = true` with non-null `roundTripMs`)
+- fixed window: last 24 hours
+- summary values:
+  - last RTT (most recent successful sample)
+  - high RTT (maximum successful sample)
+  - low RTT (minimum successful sample)
+  - average RTT (arithmetic mean of successful samples)
+  - jitter = average absolute delta between consecutive successful RTT samples
 
 ---
 

--- a/docs/monitoring-state-machine.md
+++ b/docs/monitoring-state-machine.md
@@ -398,3 +398,12 @@ Degraded must remain:
 - `UNKNOWN` = insufficient data  
 
 The system must remain predictable, auditable, and explainable at all times.
+
+---
+
+## v1 uptime interpretation note (read model)
+
+- Operational uptime summaries use assignment-scoped state history over a rolling 24-hour window.
+- Time in `UP` and `DEGRADED` is counted as up-time.
+- Time in `DOWN`, `SUPPRESSED`, and `UNKNOWN` is not counted as up-time.
+- This note defines read-side reporting semantics only; it does not change transition rules above.

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
@@ -42,7 +42,8 @@ public sealed class AgentsController : Controller
                 MachineName = row.MachineName,
                 Platform = row.Platform,
                 CreatedAtUtc = row.CreatedAtUtc,
-                AssignmentCount = row.AssignmentCount
+                AssignmentCount = row.AssignmentCount,
+                UptimePercent = row.UptimePercent
             }).ToList(),
             StatusMessage = TempData[StatusMessageKey] as string,
             ErrorMessage = TempData[ErrorMessageKey] as string

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -17,6 +17,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
     }
 
     public DbSet<Agent> Agents => Set<Agent>();
+    public DbSet<AgentHeartbeatHistory> AgentHeartbeatHistories => Set<AgentHeartbeatHistory>();
     public DbSet<EndpointModel> Endpoints => Set<EndpointModel>();
     public DbSet<EndpointDependency> EndpointDependencies => Set<EndpointDependency>();
     public DbSet<Group> Groups => Set<Group>();
@@ -66,6 +67,15 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         agent.Property(x => x.ApiKeyRevoked).HasDefaultValue(false);
         agent.Property(x => x.Status).HasConversion<string>().HasMaxLength(16);
         agent.HasIndex(x => x.InstanceId).IsUnique();
+
+        var agentHeartbeatHistory = modelBuilder.Entity<AgentHeartbeatHistory>();
+        agentHeartbeatHistory.ToTable("AgentHeartbeatHistory");
+        agentHeartbeatHistory.HasKey(x => x.AgentHeartbeatHistoryId);
+        agentHeartbeatHistory.Property(x => x.AgentHeartbeatHistoryId).HasMaxLength(64);
+        agentHeartbeatHistory.Property(x => x.AgentId).HasMaxLength(64).IsRequired();
+        agentHeartbeatHistory.Property(x => x.HeartbeatAtUtc).IsRequired();
+        agentHeartbeatHistory.Property(x => x.RecordedAtUtc).IsRequired();
+        agentHeartbeatHistory.HasIndex(x => new { x.AgentId, x.HeartbeatAtUtc });
 
         var endpoint = modelBuilder.Entity<EndpointModel>();
         endpoint.ToTable("Endpoints");

--- a/src/WebApp/PingMonitor.Web/Models/AgentHeartbeatHistory.cs
+++ b/src/WebApp/PingMonitor.Web/Models/AgentHeartbeatHistory.cs
@@ -1,0 +1,9 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class AgentHeartbeatHistory
+{
+    public string AgentHeartbeatHistoryId { get; set; } = string.Empty;
+    public string AgentId { get; set; } = string.Empty;
+    public DateTimeOffset HeartbeatAtUtc { get; set; }
+    public DateTimeOffset RecordedAtUtc { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
@@ -5,6 +5,6 @@ public sealed class StartupGateOptions
     public const string SectionName = "StartupGate";
 
     public string StorageDirectory { get; set; } = "App_Data/StartupGate";
-    public int RequiredSchemaVersion { get; set; } = 4;
+    public int RequiredSchemaVersion { get; set; } = 5;
     public int DefaultMySqlPort { get; set; } = 3306;
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -10,6 +10,7 @@ using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.Agents;
 using PingMonitor.Web.Services.Endpoints;
 using PingMonitor.Web.Services.Groups;
+using PingMonitor.Web.Services.Metrics;
 using PingMonitor.Web.Services.StartupGate;
 using PingMonitor.Web.Services.Status;
 using PingMonitor.Web.Support;
@@ -100,6 +101,8 @@ builder.Services.AddScoped<IEndpointManagementQueryService, EndpointManagementQu
 builder.Services.AddScoped<IEndpointManagementService, EndpointManagementService>();
 builder.Services.AddScoped<IGroupManagementService, GroupManagementService>();
 builder.Services.AddScoped<IAgentManagementQueryService, AgentManagementQueryService>();
+builder.Services.AddScoped<IEndpointMetricsService, EndpointMetricsService>();
+builder.Services.AddScoped<IAgentMetricsService, AgentMetricsService>();
 
 var app = builder.Build();
 

--- a/src/WebApp/PingMonitor.Web/Services/AgentHeartbeatService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentHeartbeatService.cs
@@ -26,6 +26,13 @@ internal sealed class AgentHeartbeatService : IHeartbeatService
         agent.LastSeenUtc = now;
         agent.AgentVersion = request.AgentVersion.Trim();
         agent.Status = AgentHealthStatus.Online;
+        _dbContext.AgentHeartbeatHistories.Add(new AgentHeartbeatHistory
+        {
+            AgentHeartbeatHistoryId = $"ahh_{Guid.NewGuid():N}",
+            AgentId = agent.AgentId,
+            HeartbeatAtUtc = now,
+            RecordedAtUtc = now
+        });
 
         await _dbContext.SaveChangesAsync(cancellationToken);
 

--- a/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementQueryService.cs
@@ -1,15 +1,18 @@
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
+using PingMonitor.Web.Services.Metrics;
 
 namespace PingMonitor.Web.Services.Agents;
 
 internal sealed class AgentManagementQueryService : IAgentManagementQueryService
 {
     private readonly PingMonitorDbContext _dbContext;
+    private readonly IAgentMetricsService _agentMetricsService;
 
-    public AgentManagementQueryService(PingMonitorDbContext dbContext)
+    public AgentManagementQueryService(PingMonitorDbContext dbContext, IAgentMetricsService agentMetricsService)
     {
         _dbContext = dbContext;
+        _agentMetricsService = agentMetricsService;
     }
 
     public async Task<IReadOnlyList<AgentManagementRow>> ListAsync(CancellationToken cancellationToken)
@@ -44,6 +47,10 @@ internal sealed class AgentManagementQueryService : IAgentManagementQueryService
             })
             .ToListAsync(cancellationToken);
 
+        var uptimeByAgentId = await _agentMetricsService.GetAgentMetricSummariesAsync(
+            agents.Select(x => x.AgentId).ToArray(),
+            cancellationToken);
+
         return agents.Select(agent => new AgentManagementRow
             {
                 AgentId = agent.AgentId,
@@ -57,7 +64,8 @@ internal sealed class AgentManagementQueryService : IAgentManagementQueryService
                 MachineName = agent.MachineName ?? "Unknown",
                 Platform = agent.Platform ?? "Unknown",
                 CreatedAtUtc = agent.CreatedAtUtc,
-                AssignmentCount = assignmentCounts.GetValueOrDefault(agent.AgentId, 0)
+                AssignmentCount = assignmentCounts.GetValueOrDefault(agent.AgentId, 0),
+                UptimePercent = uptimeByAgentId.GetValueOrDefault(agent.AgentId)?.UptimePercent
             })
             .ToList();
     }

--- a/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementRow.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementRow.cs
@@ -14,6 +14,7 @@ public sealed class AgentManagementRow
     public required string Platform { get; init; }
     public required DateTimeOffset CreatedAtUtc { get; init; }
     public required int AssignmentCount { get; init; }
+    public double? UptimePercent { get; init; }
 }
 
 public sealed class RemoveAgentDetails

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.Metrics;
 using PingMonitor.Web.ViewModels.Endpoints;
 
 namespace PingMonitor.Web.Services.Endpoints;
@@ -8,10 +9,12 @@ namespace PingMonitor.Web.Services.Endpoints;
 internal sealed class EndpointManagementQueryService : IEndpointManagementQueryService
 {
     private readonly PingMonitorDbContext _dbContext;
+    private readonly IEndpointMetricsService _endpointMetricsService;
 
-    public EndpointManagementQueryService(PingMonitorDbContext dbContext)
+    public EndpointManagementQueryService(PingMonitorDbContext dbContext, IEndpointMetricsService endpointMetricsService)
     {
         _dbContext = dbContext;
+        _endpointMetricsService = endpointMetricsService;
     }
 
     public async Task<ManageEndpointsPageViewModel> GetManagePageAsync(string? groupId, CancellationToken cancellationToken)
@@ -73,12 +76,21 @@ internal sealed class EndpointManagementQueryService : IEndpointManagementQueryS
                 group => (IReadOnlyList<string>)group.Select(x => x.DependsOnEndpointId).ToArray(),
                 StringComparer.Ordinal);
 
+        var metricsByAssignmentId = await _endpointMetricsService.GetEndpointMetricSummariesAsync(
+            rows.Select(x => x.AssignmentId).ToArray(),
+            cancellationToken);
+
         return new ManageEndpointsPageViewModel
         {
             GroupId = normalizedGroupId,
             AvailableGroups = groups.Select(x => new EndpointGroupOptionViewModel { GroupId = x.GroupId, Name = x.Name }).ToArray(),
             Rows = rows.Select(row => new ManageEndpointRowViewModel
             {
+                LastRttMs = metricsByAssignmentId.GetValueOrDefault(row.AssignmentId)?.LastRttMs,
+                AverageRttMs = metricsByAssignmentId.GetValueOrDefault(row.AssignmentId)?.AverageRttMs,
+                HighestRttMs = metricsByAssignmentId.GetValueOrDefault(row.AssignmentId)?.HighestRttMs,
+                LowestRttMs = metricsByAssignmentId.GetValueOrDefault(row.AssignmentId)?.LowestRttMs,
+                JitterMs = metricsByAssignmentId.GetValueOrDefault(row.AssignmentId)?.JitterMs,
                 AssignmentId = row.AssignmentId,
                 EndpointName = row.EndpointName,
                 Target = row.Target,

--- a/src/WebApp/PingMonitor.Web/Services/Metrics/AgentMetricsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/AgentMetricsService.cs
@@ -1,0 +1,65 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+
+namespace PingMonitor.Web.Services.Metrics;
+
+internal sealed class AgentMetricsService : IAgentMetricsService
+{
+    private static readonly TimeSpan Window = TimeSpan.FromHours(24);
+    private readonly PingMonitorDbContext _dbContext;
+
+    public AgentMetricsService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyDictionary<string, AgentMetricSummary>> GetAgentMetricSummariesAsync(
+        IReadOnlyCollection<string> agentIds,
+        CancellationToken cancellationToken)
+    {
+        if (agentIds.Count == 0)
+        {
+            return new Dictionary<string, AgentMetricSummary>(StringComparer.Ordinal);
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var windowStart = now - Window;
+        var normalizedAgentIds = agentIds
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        var historyRows = await _dbContext.AgentHeartbeatHistories
+            .AsNoTracking()
+            .Where(x => normalizedAgentIds.Contains(x.AgentId) && x.HeartbeatAtUtc >= windowStart && x.HeartbeatAtUtc <= now)
+            .Select(x => new { x.AgentId, x.HeartbeatAtUtc })
+            .ToListAsync(cancellationToken);
+
+        var summaries = normalizedAgentIds.ToDictionary(
+            x => x,
+            _ => new AgentMetricSummary { UptimePercent = 0d },
+            StringComparer.Ordinal);
+
+        const int totalWindowMinutes = 24 * 60;
+        foreach (var group in historyRows.GroupBy(x => x.AgentId, StringComparer.Ordinal))
+        {
+            var minuteBuckets = new HashSet<int>();
+            foreach (var heartbeat in group)
+            {
+                var minuteIndex = (int)Math.Floor((heartbeat.HeartbeatAtUtc - windowStart).TotalMinutes);
+                if (minuteIndex < 0 || minuteIndex >= totalWindowMinutes)
+                {
+                    continue;
+                }
+
+                minuteBuckets.Add(minuteIndex);
+            }
+
+            var uptimePercent = minuteBuckets.Count / (double)totalWindowMinutes * 100d;
+            summaries[group.Key] = new AgentMetricSummary { UptimePercent = uptimePercent };
+        }
+
+        return summaries;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Metrics/EndpointMetricsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/EndpointMetricsService.cs
@@ -1,0 +1,212 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.Metrics;
+
+internal sealed class EndpointMetricsService : IEndpointMetricsService
+{
+    private static readonly TimeSpan Window = TimeSpan.FromHours(24);
+    private readonly PingMonitorDbContext _dbContext;
+    
+    private sealed class RttSample
+    {
+        public required double RoundTripMs { get; init; }
+        public required DateTimeOffset CheckedAtUtc { get; init; }
+    }
+
+    public EndpointMetricsService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyDictionary<string, EndpointMetricSummary>> GetEndpointMetricSummariesAsync(
+        IReadOnlyCollection<string> assignmentIds,
+        CancellationToken cancellationToken)
+    {
+        if (assignmentIds.Count == 0)
+        {
+            return new Dictionary<string, EndpointMetricSummary>(StringComparer.Ordinal);
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var windowStart = now - Window;
+        var assignmentIdSet = assignmentIds
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var endpointStates = await _dbContext.EndpointStates
+            .AsNoTracking()
+            .Where(x => assignmentIdSet.Contains(x.AssignmentId))
+            .ToDictionaryAsync(x => x.AssignmentId, cancellationToken);
+
+        var transitionsInWindow = await _dbContext.StateTransitions
+            .AsNoTracking()
+            .Where(x => assignmentIdSet.Contains(x.AssignmentId) && x.TransitionAtUtc >= windowStart && x.TransitionAtUtc <= now)
+            .OrderBy(x => x.TransitionAtUtc)
+            .ToListAsync(cancellationToken);
+
+        var transitionsBeforeWindow = await _dbContext.StateTransitions
+            .AsNoTracking()
+            .Where(x => assignmentIdSet.Contains(x.AssignmentId) && x.TransitionAtUtc < windowStart)
+            .OrderBy(x => x.TransitionAtUtc)
+            .ToListAsync(cancellationToken);
+
+        var successfulResults = await _dbContext.CheckResults
+            .AsNoTracking()
+            .Where(x => assignmentIdSet.Contains(x.AssignmentId)
+                        && x.CheckedAtUtc >= windowStart
+                        && x.CheckedAtUtc <= now
+                        && x.Success
+                        && x.RoundTripMs.HasValue)
+            .OrderBy(x => x.CheckedAtUtc)
+            .Select(x => new { x.AssignmentId, RoundTripMs = (double)x.RoundTripMs!.Value, x.CheckedAtUtc })
+            .ToListAsync(cancellationToken);
+
+        var transitionsInWindowByAssignment = transitionsInWindow
+            .GroupBy(x => x.AssignmentId, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.OrderBy(x => x.TransitionAtUtc).ToList(), StringComparer.Ordinal);
+
+        var latestTransitionBeforeWindow = transitionsBeforeWindow
+            .GroupBy(x => x.AssignmentId, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.OrderByDescending(x => x.TransitionAtUtc).First(), StringComparer.Ordinal);
+
+        var resultsByAssignment = successfulResults
+            .GroupBy(x => x.AssignmentId, StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<RttSample>)group
+                    .OrderBy(x => x.CheckedAtUtc)
+                    .Select(x => new RttSample { RoundTripMs = x.RoundTripMs, CheckedAtUtc = x.CheckedAtUtc })
+                    .ToList(),
+                StringComparer.Ordinal);
+
+        var summaries = new Dictionary<string, EndpointMetricSummary>(StringComparer.Ordinal);
+        foreach (var assignmentId in assignmentIdSet)
+        {
+            endpointStates.TryGetValue(assignmentId, out var endpointState);
+            transitionsInWindowByAssignment.TryGetValue(assignmentId, out var stateTransitions);
+            latestTransitionBeforeWindow.TryGetValue(assignmentId, out var stateBeforeWindow);
+            resultsByAssignment.TryGetValue(assignmentId, out var rttResults);
+
+            var uptimePercent = CalculateUptimePercent(endpointState, stateTransitions ?? [], stateBeforeWindow, windowStart, now);
+            var rttSummary = CalculateRttSummary(rttResults ?? []);
+
+            summaries[assignmentId] = new EndpointMetricSummary
+            {
+                UptimePercent = uptimePercent,
+                LastRttMs = rttSummary.LastRttMs,
+                HighestRttMs = rttSummary.HighestRttMs,
+                LowestRttMs = rttSummary.LowestRttMs,
+                AverageRttMs = rttSummary.AverageRttMs,
+                JitterMs = rttSummary.JitterMs
+            };
+        }
+
+        return summaries;
+    }
+
+    private static double? CalculateUptimePercent(
+        EndpointState? endpointState,
+        IReadOnlyList<StateTransition> transitionsInWindow,
+        StateTransition? transitionBeforeWindow,
+        DateTimeOffset windowStart,
+        DateTimeOffset now)
+    {
+        if (endpointState is null)
+        {
+            return null;
+        }
+
+        var stateAtWindowStart = DetermineStateAtWindowStart(endpointState, transitionBeforeWindow, windowStart);
+
+        var segmentStart = windowStart;
+        var activeState = stateAtWindowStart;
+        var upDuration = TimeSpan.Zero;
+
+        foreach (var transition in transitionsInWindow)
+        {
+            var transitionAt = transition.TransitionAtUtc;
+            if (transitionAt < windowStart || transitionAt > now)
+            {
+                continue;
+            }
+
+            if (IsUpState(activeState))
+            {
+                upDuration += transitionAt - segmentStart;
+            }
+
+            segmentStart = transitionAt;
+            activeState = transition.NewState;
+        }
+
+        if (IsUpState(activeState) && now > segmentStart)
+        {
+            upDuration += now - segmentStart;
+        }
+
+        var totalDuration = now - windowStart;
+        if (totalDuration <= TimeSpan.Zero)
+        {
+            return null;
+        }
+
+        return upDuration.TotalSeconds / totalDuration.TotalSeconds * 100d;
+    }
+
+    private static EndpointStateKind DetermineStateAtWindowStart(
+        EndpointState endpointState,
+        StateTransition? transitionBeforeWindow,
+        DateTimeOffset windowStart)
+    {
+        if (endpointState.LastStateChangeUtc.HasValue && endpointState.LastStateChangeUtc.Value <= windowStart)
+        {
+            return endpointState.CurrentState;
+        }
+
+        if (transitionBeforeWindow is not null)
+        {
+            return transitionBeforeWindow.NewState;
+        }
+
+        return EndpointStateKind.Unknown;
+    }
+
+    private static bool IsUpState(EndpointStateKind state)
+    {
+        return state is EndpointStateKind.Up or EndpointStateKind.Degraded;
+    }
+
+    private static EndpointMetricSummary CalculateRttSummary(IReadOnlyList<RttSample> rttResults)
+    {
+        if (rttResults.Count == 0)
+        {
+            return new EndpointMetricSummary();
+        }
+
+        var values = rttResults.Select(x => x.RoundTripMs).ToArray();
+        double? jitter = null;
+        if (values.Length >= 2)
+        {
+            var deltas = new List<double>(values.Length - 1);
+            for (var index = 1; index < values.Length; index++)
+            {
+                deltas.Add(Math.Abs(values[index] - values[index - 1]));
+            }
+
+            jitter = deltas.Average();
+        }
+
+        return new EndpointMetricSummary
+        {
+            LastRttMs = values.Last(),
+            HighestRttMs = values.Max(),
+            LowestRttMs = values.Min(),
+            AverageRttMs = values.Average(),
+            JitterMs = jitter
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Metrics/IAgentMetricsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/IAgentMetricsService.cs
@@ -1,0 +1,13 @@
+namespace PingMonitor.Web.Services.Metrics;
+
+public interface IAgentMetricsService
+{
+    Task<IReadOnlyDictionary<string, AgentMetricSummary>> GetAgentMetricSummariesAsync(
+        IReadOnlyCollection<string> agentIds,
+        CancellationToken cancellationToken);
+}
+
+public sealed class AgentMetricSummary
+{
+    public double? UptimePercent { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Metrics/IEndpointMetricsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/IEndpointMetricsService.cs
@@ -1,0 +1,18 @@
+namespace PingMonitor.Web.Services.Metrics;
+
+public interface IEndpointMetricsService
+{
+    Task<IReadOnlyDictionary<string, EndpointMetricSummary>> GetEndpointMetricSummariesAsync(
+        IReadOnlyCollection<string> assignmentIds,
+        CancellationToken cancellationToken);
+}
+
+public sealed class EndpointMetricSummary
+{
+    public double? UptimePercent { get; init; }
+    public double? LastRttMs { get; init; }
+    public double? HighestRttMs { get; init; }
+    public double? LowestRttMs { get; init; }
+    public double? AverageRttMs { get; init; }
+    public double? JitterMs { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -16,6 +16,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "AspNetUserRoles",
         "AspNetUsers",
         "Agents",
+        "AgentHeartbeatHistory",
         "Endpoints",
         "EndpointDependencies",
         "Groups",
@@ -214,6 +215,17 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             );
             """;
 
+        const string createAgentHeartbeatHistorySql = """
+            CREATE TABLE IF NOT EXISTS `AgentHeartbeatHistory` (
+                `AgentHeartbeatHistoryId` varchar(64) NOT NULL,
+                `AgentId` varchar(64) NOT NULL,
+                `HeartbeatAtUtc` datetime(6) NOT NULL,
+                `RecordedAtUtc` datetime(6) NOT NULL,
+                PRIMARY KEY (`AgentHeartbeatHistoryId`),
+                KEY `IX_AgentHeartbeatHistory_AgentId_HeartbeatAtUtc` (`AgentId`, `HeartbeatAtUtc`)
+            );
+            """;
+
         const string createGroupsSql = """
             CREATE TABLE IF NOT EXISTS `Groups` (
                 `GroupId` varchar(64) NOT NULL,
@@ -240,6 +252,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await dbContext.Database.ExecuteSqlRawAsync(createStateTransitionsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createApplicationSettingsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointDependenciesSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createAgentHeartbeatHistorySql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createGroupsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointGroupMembershipsSql, cancellationToken);
         await EnsureEndpointDependenciesColumnsAsync(dbContext, cancellationToken);

--- a/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.Metrics;
 using PingMonitor.Web.ViewModels.Status;
 
 namespace PingMonitor.Web.Services.Status;
@@ -8,10 +9,12 @@ namespace PingMonitor.Web.Services.Status;
 internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
 {
     private readonly PingMonitorDbContext _dbContext;
+    private readonly IEndpointMetricsService _endpointMetricsService;
 
-    public EndpointStatusQueryService(PingMonitorDbContext dbContext)
+    public EndpointStatusQueryService(PingMonitorDbContext dbContext, IEndpointMetricsService endpointMetricsService)
     {
         _dbContext = dbContext;
+        _endpointMetricsService = endpointMetricsService;
     }
 
     public async Task<EndpointStatusPageViewModel> GetStatusPageAsync(
@@ -149,6 +152,41 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
             };
         }).ToArray();
 
+        var endpointMetricsByAssignmentId = await _endpointMetricsService.GetEndpointMetricSummariesAsync(
+            projectedRows.Select(x => x.AssignmentId).ToArray(),
+            cancellationToken);
+
+        var rowsWithMetrics = projectedRows.Select(row =>
+        {
+            endpointMetricsByAssignmentId.TryGetValue(row.AssignmentId, out var metrics);
+            return new EndpointStatusRowViewModel
+            {
+                AssignmentId = row.AssignmentId,
+                EndpointId = row.EndpointId,
+                EndpointName = row.EndpointName,
+                Target = row.Target,
+                AgentId = row.AgentId,
+                AgentInstanceId = row.AgentInstanceId,
+                AgentName = row.AgentName,
+                CurrentState = row.CurrentState,
+                LastCheckUtc = row.LastCheckUtc,
+                LastStateChangeUtc = row.LastStateChangeUtc,
+                ConsecutiveFailureCount = row.ConsecutiveFailureCount,
+                ConsecutiveSuccessCount = row.ConsecutiveSuccessCount,
+                CheckType = row.CheckType,
+                AssignmentEnabled = row.AssignmentEnabled,
+                EndpointEnabled = row.EndpointEnabled,
+                ParentEndpointIds = row.ParentEndpointIds,
+                ParentEndpointNames = row.ParentEndpointNames,
+                SuppressedByEndpointId = row.SuppressedByEndpointId,
+                SuppressedByEndpointName = row.SuppressedByEndpointName,
+                GroupNames = row.GroupNames,
+                UptimePercent = metrics?.UptimePercent,
+                LastRttMs = metrics?.LastRttMs,
+                AverageRttMs = metrics?.AverageRttMs
+            };
+        }).ToArray();
+
         return new EndpointStatusPageViewModel
         {
             Summary = new EndpointStatusSummaryViewModel
@@ -169,7 +207,7 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
                 AvailableAgents = availableAgents,
                 AvailableGroups = availableGroups
             },
-            Rows = projectedRows
+            Rows = rowsWithMetrics
         };
     }
 

--- a/src/WebApp/PingMonitor.Web/ViewModels/Agents/ManageAgentsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Agents/ManageAgentsPageViewModel.cs
@@ -21,6 +21,7 @@ public sealed class ManageAgentRowViewModel
     public required string Platform { get; init; }
     public required DateTimeOffset CreatedAtUtc { get; init; }
     public required int AssignmentCount { get; init; }
+    public required double? UptimePercent { get; init; }
 }
 
 public sealed class RemoveAgentPageViewModel

--- a/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/ManageEndpointsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/ManageEndpointsPageViewModel.cs
@@ -28,6 +28,11 @@ public sealed class ManageEndpointRowViewModel
     public int FailureThreshold { get; init; }
     public int RecoveryThreshold { get; init; }
     public EndpointStateKind CurrentState { get; init; } = EndpointStateKind.Unknown;
+    public double? LastRttMs { get; init; }
+    public double? AverageRttMs { get; init; }
+    public double? HighestRttMs { get; init; }
+    public double? LowestRttMs { get; init; }
+    public double? JitterMs { get; init; }
 }
 
 public sealed class EditEndpointPageViewModel

--- a/src/WebApp/PingMonitor.Web/ViewModels/Status/EndpointStatusPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Status/EndpointStatusPageViewModel.cs
@@ -59,6 +59,9 @@ public sealed class EndpointStatusRowViewModel
     public string? SuppressedByEndpointId { get; init; }
     public string? SuppressedByEndpointName { get; init; }
     public IReadOnlyList<string> GroupNames { get; init; } = [];
+    public double? UptimePercent { get; init; }
+    public double? LastRttMs { get; init; }
+    public double? AverageRttMs { get; init; }
 }
 
 public sealed class StatusGroupOptionViewModel

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
@@ -1,6 +1,7 @@
 @model PingMonitor.Web.ViewModels.Agents.ManageAgentsPageViewModel
 @{
     static string FormatDate(DateTimeOffset? value) => value.HasValue ? value.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") : "Never";
+    static string FormatPercent(double? value) => value.HasValue ? $"{value.Value:F1}%" : "Unknown";
 }
 <!DOCTYPE html>
 <html lang="en">
@@ -108,6 +109,7 @@
                                 <div class="meta-item"><span>Created</span><div>@FormatDate(agent.CreatedAtUtc)</div></div>
                                 <div class="meta-item"><span>Last seen</span><div>@FormatDate(agent.LastSeenUtc)</div></div>
                                 <div class="meta-item"><span>Last heartbeat</span><div>@FormatDate(agent.LastHeartbeatUtc)</div></div>
+                                <div class="meta-item"><span>Agent uptime (24h)</span><div>@FormatPercent(agent.UptimePercent)</div></div>
                                 <div class="meta-item"><span>Agent version</span><div>@agent.AgentVersion</div></div>
                                 <div class="meta-item"><span>Machine name</span><div>@agent.MachineName</div></div>
                                 <div class="meta-item"><span>Platform</span><div>@agent.Platform</div></div>

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
@@ -9,6 +9,7 @@
         EndpointStateKind.Degraded => "state-degraded",
         _ => "state-unknown"
     };
+    static string FormatRtt(double? value) => value.HasValue ? $"{value.Value:F1} ms" : "No data";
 }
 <!DOCTYPE html>
 <html lang="en">
@@ -118,6 +119,11 @@
                                 <div class="meta-item"><span>Ping interval</span><div>@row.PingIntervalSeconds s</div></div>
                                 <div class="meta-item"><span>Retry interval</span><div>@row.RetryIntervalSeconds s</div></div>
                                 <div class="meta-item"><span>Timeout</span><div>@row.TimeoutMs ms</div></div>
+                                <div class="meta-item"><span>Last RTT (24h)</span><div>@FormatRtt(row.LastRttMs)</div></div>
+                                <div class="meta-item"><span>Average RTT (24h)</span><div>@FormatRtt(row.AverageRttMs)</div></div>
+                                <div class="meta-item"><span>High RTT (24h)</span><div>@FormatRtt(row.HighestRttMs)</div></div>
+                                <div class="meta-item"><span>Low RTT (24h)</span><div>@FormatRtt(row.LowestRttMs)</div></div>
+                                <div class="meta-item"><span>Jitter (24h)</span><div>@FormatRtt(row.JitterMs)</div></div>
                                 <div class="meta-item"><span>Failure threshold</span><div>@row.FailureThreshold</div></div>
                                 <div class="meta-item"><span>Recovery threshold</span><div>@row.RecoveryThreshold</div></div>
                             </div>

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -8,6 +8,8 @@
             ? string.Join(", ", endpointIds)
             : string.Join(", ", endpointNames);
     static string FormatDependency(string? endpointId, string? endpointName, string emptyText) => string.IsNullOrWhiteSpace(endpointId) ? emptyText : string.IsNullOrWhiteSpace(endpointName) ? $"{endpointId} (name unavailable)" : endpointName;
+    static string FormatPercent(double? value) => value.HasValue ? $"{value.Value:F1}%" : "Unknown";
+    static string FormatRtt(double? value) => value.HasValue ? $"{value.Value:F1} ms" : "No data";
     static string StateClass(EndpointStateKind state) => state switch
     {
         EndpointStateKind.Up => "state-up",
@@ -182,6 +184,9 @@
                                 <div class="meta-item"><span>Last state change</span><div class="nowrap">@FormatDate(row.LastStateChangeUtc)</div></div>
                                 <div class="meta-item"><span>Consecutive failures</span><div>@row.ConsecutiveFailureCount</div></div>
                                 <div class="meta-item"><span>Consecutive successes</span><div>@row.ConsecutiveSuccessCount</div></div>
+                                <div class="meta-item"><span>Endpoint uptime (24h)</span><div>@FormatPercent(row.UptimePercent)</div></div>
+                                <div class="meta-item"><span>Last RTT (24h)</span><div>@FormatRtt(row.LastRttMs)</div></div>
+                                <div class="meta-item"><span>Average RTT (24h)</span><div>@FormatRtt(row.AverageRttMs)</div></div>
                                 <div class="meta-item"><span>Groups</span><div>@(row.GroupNames.Count == 0 ? "None" : string.Join(", ", row.GroupNames))</div></div>
                                 <div class="meta-item"><span>Dependency parents</span><div>@FormatDependencies(row.ParentEndpointIds, row.ParentEndpointNames, "None")</div></div>
                                 <div class="meta-item"><span>Suppressed by</span><div>@FormatDependency(row.SuppressedByEndpointId, row.SuppressedByEndpointName, "Not suppressed")</div></div>

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 4,
+    "RequiredSchemaVersion": 5,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 4,
+    "RequiredSchemaVersion": 5,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
### Motivation
- Provide simple, explicit v1 uptime and RTT summary metrics that can be shown in existing control-plane pages using authoritative read-side semantics (fixed 24-hour rolling window). 
- Keep the implementation operational, auditable, and aligned with `docs/data-model.md`, `docs/monitoring-state-machine.md`, and `docs/PLATFORM_CONSTRAINTS.md` without adding charts or alerting logic. 

### Description
- Add minimal heartbeat persistence with a new model `AgentHeartbeatHistory` and DbContext mapping, and persist one history row per accepted heartbeat in `AgentHeartbeatService`. 
- Implement metrics query services: `IEndpointMetricsService` / `EndpointMetricsService` (computes endpoint uptime from `EndpointState` + `StateTransition` and RTT summaries from successful `CheckResult` rows including `last`, `high`, `low`, `average` and `jitter` defined as the average absolute delta between consecutive RTT samples) and `IAgentMetricsService` / `AgentMetricsService` (computes agent uptime using minute-level heartbeat buckets over the last 24 hours). 
- Wire metrics into UI read services and pages: status page shows endpoint uptime, last RTT, average RTT; endpoints management shows last/avg/high/low RTT and jitter; agents list shows agent uptime; register services in `Program.cs`. 
- Update startup-gate schema logic and SQL to create `AgentHeartbeatHistory`, bump required schema version to `5`, and add concise docs describing v1 metric semantics and the jitter definition. 
- Link this work to the created GitHub issue `#95` (issue created before implementation) and include the change in the commit message (`Fixes #95`).

### Testing
- Built the web application with `dotnet build src/WebApp/PingMonitor.WebApp.slnx` and the build succeeded with `0 Error(s)`; the solution compiles. 
- Confirmed the GitHub issue for this work was created via the API and referenced (`#95`) before implementing code. 
- No unit tests were added in this change; manual verification was limited to build and repository-level checks in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c530d797e0832ab76e7e2929310f32)