### PR TITLE
Fix MySQL endpoint metrics query type mapping for assignment IDs

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Metrics/EndpointMetricsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/EndpointMetricsService.cs
@@ -31,32 +31,37 @@ internal sealed class EndpointMetricsService : IEndpointMetricsService
 
         var now = DateTimeOffset.UtcNow;
         var windowStart = now - Window;
-        var assignmentIdSet = assignmentIds
+        var normalizedAssignmentIds = assignmentIds
             .Where(x => !string.IsNullOrWhiteSpace(x))
             .Select(x => x.Trim())
             .Distinct(StringComparer.Ordinal)
-            .ToHashSet(StringComparer.Ordinal);
+            .ToArray();
+
+        if (normalizedAssignmentIds.Length == 0)
+        {
+            return new Dictionary<string, EndpointMetricSummary>(StringComparer.Ordinal);
+        }
 
         var endpointStates = await _dbContext.EndpointStates
             .AsNoTracking()
-            .Where(x => assignmentIdSet.Contains(x.AssignmentId))
+            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId))
             .ToDictionaryAsync(x => x.AssignmentId, cancellationToken);
 
         var transitionsInWindow = await _dbContext.StateTransitions
             .AsNoTracking()
-            .Where(x => assignmentIdSet.Contains(x.AssignmentId) && x.TransitionAtUtc >= windowStart && x.TransitionAtUtc <= now)
+            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId) && x.TransitionAtUtc >= windowStart && x.TransitionAtUtc <= now)
             .OrderBy(x => x.TransitionAtUtc)
             .ToListAsync(cancellationToken);
 
         var transitionsBeforeWindow = await _dbContext.StateTransitions
             .AsNoTracking()
-            .Where(x => assignmentIdSet.Contains(x.AssignmentId) && x.TransitionAtUtc < windowStart)
+            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId) && x.TransitionAtUtc < windowStart)
             .OrderBy(x => x.TransitionAtUtc)
             .ToListAsync(cancellationToken);
 
         var successfulResults = await _dbContext.CheckResults
             .AsNoTracking()
-            .Where(x => assignmentIdSet.Contains(x.AssignmentId)
+            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId)
                         && x.CheckedAtUtc >= windowStart
                         && x.CheckedAtUtc <= now
                         && x.Success
@@ -84,7 +89,7 @@ internal sealed class EndpointMetricsService : IEndpointMetricsService
                 StringComparer.Ordinal);
 
         var summaries = new Dictionary<string, EndpointMetricSummary>(StringComparer.Ordinal);
-        foreach (var assignmentId in assignmentIdSet)
+        foreach (var assignmentId in normalizedAssignmentIds)
         {
             endpointStates.TryGetValue(assignmentId, out var endpointState);
             transitionsInWindowByAssignment.TryGetValue(assignmentId, out var stateTransitions);


### PR DESCRIPTION
### Motivation
- Status page requests were failing with `InvalidOperationException: Expression '@assignmentIdSet' in the SQL tree does not have a type mapping assigned.` when the EF Core MySQL provider attempted to translate queries that used a hashed set for assignment IDs.
- Ensure the metrics queries are translated reliably by MySQL provider and avoid runtime 500s for the `/` status page.

### Description
- Normalize, trim and de-duplicate incoming `assignmentIds` into a plain `string[]` named `normalizedAssignmentIds` and return early when it is empty to avoid empty/invalid parameterization paths.
- Replace all EF `Contains` filters that previously used a `HashSet` with `normalizedAssignmentIds.Contains(...)` so the MySQL provider can assign stable parameter type mappings.
- Iterate over the `normalizedAssignmentIds` array when building the per-assignment summaries so the result assembly matches the query filters.
- Links the fix to the tracking issue: Fixes #97.

### Testing
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which succeeded under .NET SDK `10.0.104`.
- Ran `dotnet test src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj --no-build` which executed and returned successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c535059250832aacecf610a6143357)