### PR TITLE
Fix EF Core MySQL type mapping crash in endpoint metrics queries

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Metrics/EndpointMetricsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/EndpointMetricsService.cs
@@ -42,26 +42,30 @@ internal sealed class EndpointMetricsService : IEndpointMetricsService
             return new Dictionary<string, EndpointMetricSummary>(StringComparer.Ordinal);
         }
 
+        // MySQL provider can fail to apply type mapping when assignment ID collections are parameterized.
+        // Force constants into the SQL tree so the provider can translate IN predicates deterministically.
+        var assignmentIdsInQuery = EF.Constant(normalizedAssignmentIds);
+
         var endpointStates = await _dbContext.EndpointStates
             .AsNoTracking()
-            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId))
+            .Where(x => assignmentIdsInQuery.Contains(x.AssignmentId))
             .ToDictionaryAsync(x => x.AssignmentId, cancellationToken);
 
         var transitionsInWindow = await _dbContext.StateTransitions
             .AsNoTracking()
-            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId) && x.TransitionAtUtc >= windowStart && x.TransitionAtUtc <= now)
+            .Where(x => assignmentIdsInQuery.Contains(x.AssignmentId) && x.TransitionAtUtc >= windowStart && x.TransitionAtUtc <= now)
             .OrderBy(x => x.TransitionAtUtc)
             .ToListAsync(cancellationToken);
 
         var transitionsBeforeWindow = await _dbContext.StateTransitions
             .AsNoTracking()
-            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId) && x.TransitionAtUtc < windowStart)
+            .Where(x => assignmentIdsInQuery.Contains(x.AssignmentId) && x.TransitionAtUtc < windowStart)
             .OrderBy(x => x.TransitionAtUtc)
             .ToListAsync(cancellationToken);
 
         var successfulResults = await _dbContext.CheckResults
             .AsNoTracking()
-            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId)
+            .Where(x => assignmentIdsInQuery.Contains(x.AssignmentId)
                         && x.CheckedAtUtc >= windowStart
                         && x.CheckedAtUtc <= now
                         && x.Success


### PR DESCRIPTION
### Motivation
- Requests to the status page were crashing with EF Core/MySQL: `Expression '@normalizedAssignmentIds' in the SQL tree does not have a type mapping assigned`, so the query generation for assignment-id filters needed to be made provider-friendly.

### Description
- Update `EndpointMetricsService` to force the assignment-id array into the EF expression tree via `EF.Constant(normalizedAssignmentIds)` and use `assignmentIdsInQuery.Contains(...)` in all filters instead of directly using the parameterized collection.
- Add a comment explaining the MySQL provider type-mapping issue so the change's intent is clear and the query semantics are preserved.
- Link this fix to an issue to satisfy repository traceability: `Fixes #99`.

### Testing
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the build completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c536a6919c832ab5a14e9b12fe310f)