### PR TITLE
Fix status page crash from invalid EF.Constant usage

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Metrics/EndpointMetricsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/EndpointMetricsService.cs
@@ -42,30 +42,26 @@ internal sealed class EndpointMetricsService : IEndpointMetricsService
             return new Dictionary<string, EndpointMetricSummary>(StringComparer.Ordinal);
         }
 
-        // MySQL provider can fail to apply type mapping when assignment ID collections are parameterized.
-        // Force constants into the SQL tree so the provider can translate IN predicates deterministically.
-        var assignmentIdsInQuery = EF.Constant(normalizedAssignmentIds);
-
         var endpointStates = await _dbContext.EndpointStates
             .AsNoTracking()
-            .Where(x => assignmentIdsInQuery.Contains(x.AssignmentId))
+            .Where(x => EF.Constant(normalizedAssignmentIds).Contains(x.AssignmentId))
             .ToDictionaryAsync(x => x.AssignmentId, cancellationToken);
 
         var transitionsInWindow = await _dbContext.StateTransitions
             .AsNoTracking()
-            .Where(x => assignmentIdsInQuery.Contains(x.AssignmentId) && x.TransitionAtUtc >= windowStart && x.TransitionAtUtc <= now)
+            .Where(x => EF.Constant(normalizedAssignmentIds).Contains(x.AssignmentId) && x.TransitionAtUtc >= windowStart && x.TransitionAtUtc <= now)
             .OrderBy(x => x.TransitionAtUtc)
             .ToListAsync(cancellationToken);
 
         var transitionsBeforeWindow = await _dbContext.StateTransitions
             .AsNoTracking()
-            .Where(x => assignmentIdsInQuery.Contains(x.AssignmentId) && x.TransitionAtUtc < windowStart)
+            .Where(x => EF.Constant(normalizedAssignmentIds).Contains(x.AssignmentId) && x.TransitionAtUtc < windowStart)
             .OrderBy(x => x.TransitionAtUtc)
             .ToListAsync(cancellationToken);
 
         var successfulResults = await _dbContext.CheckResults
             .AsNoTracking()
-            .Where(x => assignmentIdsInQuery.Contains(x.AssignmentId)
+            .Where(x => EF.Constant(normalizedAssignmentIds).Contains(x.AssignmentId)
                         && x.CheckedAtUtc >= windowStart
                         && x.CheckedAtUtc <= now
                         && x.Success


### PR DESCRIPTION
### Motivation
- The status page could throw `InvalidOperationException` in production because `EF.Constant<T>` was evaluated outside of EF LINQ expressions when parameterizing assignment ID collections, causing the MySQL provider to fail type mapping.

### Description
- Remove the pre-evaluated `assignmentIdsInQuery` variable and invoke `EF.Constant(normalizedAssignmentIds)` directly inside each EF LINQ `.Where` predicate for endpoint states, state transitions (in-window and before-window), and successful check results in `EndpointMetricsService`.
- Preserve existing query semantics and downstream RTT/uptime aggregation logic while avoiding the runtime evaluation that caused the exception.
- Fix is tracked and linked to the issue: `Fixes #101`.

### Testing
- Verified the solution by running `dotnet --version` and `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, and the build succeeded.
- No additional automated unit test suites were present or executed for this change; build verification was used as validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c538600a98832a9c1a8a31ae039916)