### PR TITLE
Fix MySQL status metrics query crash when filtering assignment IDs

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Metrics/EndpointMetricsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/EndpointMetricsService.cs
@@ -44,24 +44,24 @@ internal sealed class EndpointMetricsService : IEndpointMetricsService
 
         var endpointStates = await _dbContext.EndpointStates
             .AsNoTracking()
-            .Where(x => EF.Constant(normalizedAssignmentIds).Contains(x.AssignmentId))
+            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId))
             .ToDictionaryAsync(x => x.AssignmentId, cancellationToken);
 
         var transitionsInWindow = await _dbContext.StateTransitions
             .AsNoTracking()
-            .Where(x => EF.Constant(normalizedAssignmentIds).Contains(x.AssignmentId) && x.TransitionAtUtc >= windowStart && x.TransitionAtUtc <= now)
+            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId) && x.TransitionAtUtc >= windowStart && x.TransitionAtUtc <= now)
             .OrderBy(x => x.TransitionAtUtc)
             .ToListAsync(cancellationToken);
 
         var transitionsBeforeWindow = await _dbContext.StateTransitions
             .AsNoTracking()
-            .Where(x => EF.Constant(normalizedAssignmentIds).Contains(x.AssignmentId) && x.TransitionAtUtc < windowStart)
+            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId) && x.TransitionAtUtc < windowStart)
             .OrderBy(x => x.TransitionAtUtc)
             .ToListAsync(cancellationToken);
 
         var successfulResults = await _dbContext.CheckResults
             .AsNoTracking()
-            .Where(x => EF.Constant(normalizedAssignmentIds).Contains(x.AssignmentId)
+            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId)
                         && x.CheckedAtUtc >= windowStart
                         && x.CheckedAtUtc <= now
                         && x.Success


### PR DESCRIPTION
### Motivation
- Fix a runtime crash on the status page where EF Core/MySQL failed to assign a type mapping to the `EF.Constant(normalizedAssignmentIds)` expression, causing `InvalidOperationException` during metrics queries.

### Description
- Replace `EF.Constant(normalizedAssignmentIds).Contains(x.AssignmentId)` with `normalizedAssignmentIds.Contains(x.AssignmentId)` in `src/WebApp/PingMonitor.Web/Services/Metrics/EndpointMetricsService.cs` for the endpoint-states, transitions-in-window, transitions-before-window, and successful-check-results queries to avoid provider type-mapping failures; Closes #103.

### Testing
- Installed and used `.NET SDK 10.0.104` to match `global.json` and ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c55ae78a18832ab90ea0597dd0980f)