### PR TITLE
Fix EF Core MySQL type mapping failure in endpoint metrics query

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Metrics/EndpointMetricsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/EndpointMetricsService.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
@@ -42,27 +43,21 @@ internal sealed class EndpointMetricsService : IEndpointMetricsService
             return new Dictionary<string, EndpointMetricSummary>(StringComparer.Ordinal);
         }
 
-        var endpointStates = await _dbContext.EndpointStates
-            .AsNoTracking()
-            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId))
+        var endpointStates = await ApplyAssignmentFilter(_dbContext.EndpointStates.AsNoTracking(), x => x.AssignmentId, normalizedAssignmentIds)
             .ToDictionaryAsync(x => x.AssignmentId, cancellationToken);
 
-        var transitionsInWindow = await _dbContext.StateTransitions
-            .AsNoTracking()
-            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId) && x.TransitionAtUtc >= windowStart && x.TransitionAtUtc <= now)
+        var transitionsInWindow = await ApplyAssignmentFilter(_dbContext.StateTransitions.AsNoTracking(), x => x.AssignmentId, normalizedAssignmentIds)
+            .Where(x => x.TransitionAtUtc >= windowStart && x.TransitionAtUtc <= now)
             .OrderBy(x => x.TransitionAtUtc)
             .ToListAsync(cancellationToken);
 
-        var transitionsBeforeWindow = await _dbContext.StateTransitions
-            .AsNoTracking()
-            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId) && x.TransitionAtUtc < windowStart)
+        var transitionsBeforeWindow = await ApplyAssignmentFilter(_dbContext.StateTransitions.AsNoTracking(), x => x.AssignmentId, normalizedAssignmentIds)
+            .Where(x => x.TransitionAtUtc < windowStart)
             .OrderBy(x => x.TransitionAtUtc)
             .ToListAsync(cancellationToken);
 
-        var successfulResults = await _dbContext.CheckResults
-            .AsNoTracking()
-            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId)
-                        && x.CheckedAtUtc >= windowStart
+        var successfulResults = await ApplyAssignmentFilter(_dbContext.CheckResults.AsNoTracking(), x => x.AssignmentId, normalizedAssignmentIds)
+            .Where(x => x.CheckedAtUtc >= windowStart
                         && x.CheckedAtUtc <= now
                         && x.Success
                         && x.RoundTripMs.HasValue)
@@ -213,5 +208,33 @@ internal sealed class EndpointMetricsService : IEndpointMetricsService
             AverageRttMs = values.Average(),
             JitterMs = jitter
         };
+    }
+
+    private static IQueryable<T> ApplyAssignmentFilter<T>(
+        IQueryable<T> query,
+        Expression<Func<T, string>> assignmentIdSelector,
+        IReadOnlyList<string> assignmentIds)
+    {
+        Expression? filterExpression = null;
+        var parameter = assignmentIdSelector.Parameters[0];
+
+        foreach (var assignmentId in assignmentIds)
+        {
+            var equalsExpression = Expression.Equal(
+                assignmentIdSelector.Body,
+                Expression.Constant(assignmentId));
+
+            filterExpression = filterExpression is null
+                ? equalsExpression
+                : Expression.OrElse(filterExpression, equalsExpression);
+        }
+
+        if (filterExpression is null)
+        {
+            return query.Where(_ => false);
+        }
+
+        var predicate = Expression.Lambda<Func<T, bool>>(filterExpression, parameter);
+        return query.Where(predicate);
     }
 }


### PR DESCRIPTION
### Motivation
- Status page requests could throw `System.InvalidOperationException: Expression '@normalizedAssignmentIds' in the SQL tree does not have a type mapping assigned` when EF Core/MySQL failed to map a list-parameter for `Contains(...)`-based filtering.
- The change ensures assignment-id filtering compiles to an expression shape that the MySQL EF Core provider can translate reliably without changing semantics.

### Description
- Add a helper `ApplyAssignmentFilter<T>(IQueryable<T>, Expression<Func<T,string>>, IReadOnlyList<string>)` that builds an explicit `AssignmentId == A || AssignmentId == B || ...` predicate using expression trees.
- Replace `normalizedAssignmentIds.Contains(x.AssignmentId)` uses with `ApplyAssignmentFilter(...)` for `EndpointStates`, `StateTransitions`, and `CheckResults` queries inside `GetEndpointMetricSummariesAsync` in `EndpointMetricsService`.
- Preserve existing normalization, ordering and summary calculation logic so runtime behavior and metrics semantics remain unchanged.
- Link the change to the created issue and mark the PR to `Fixes #105` for traceability.

### Testing
- Installed .NET 10 and PowerShell in the environment and resolved a transient apt fetch error during the install process (initial `apt` attempt hit `502 Bad Gateway`).
- Verified runtime tooling with `dotnet --version` and `pwsh --version` which returned the installed versions successfully.
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -v minimal` and the build succeeded with `0 Error(s)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c55c86efd0832ab71c6fc5b07be88f)