### PR TITLE
Add assignment performance graphs for RTT, failures, and jitter

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -561,6 +561,14 @@ These read-side metrics are derived from existing facts and are intended for ope
   - average RTT (arithmetic mean of successful samples)
   - jitter = average absolute delta between consecutive successful RTT samples
 
+### Endpoint performance graphs (v1)
+
+- source: assignment-scoped `CheckResult` rows only
+- supported graph windows: `1h`, `24h`, `7d`
+- RTT graph uses successful checks with non-null `roundTripMs`
+- jitter graph uses absolute deltas between consecutive successful RTT samples
+- failure/drop graph uses failed `CheckResult` rows (`success = false`) bucketed by time; successful counts may be shown in the same buckets for context
+
 ---
 
 ## Future extensions

--- a/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
@@ -18,19 +18,22 @@ public sealed class EndpointsController : Controller
     private readonly IEndpointManagementService _endpointManagementService;
     private readonly IApplicationSettingsService _applicationSettingsService;
     private readonly IGroupManagementService _groupManagementService;
+    private readonly IEndpointPerformanceQueryService _endpointPerformanceQueryService;
 
     public EndpointsController(
         IEndpointCreationQueryService endpointCreationQueryService,
         IEndpointManagementQueryService endpointManagementQueryService,
         IEndpointManagementService endpointManagementService,
         IApplicationSettingsService applicationSettingsService,
-        IGroupManagementService groupManagementService)
+        IGroupManagementService groupManagementService,
+        IEndpointPerformanceQueryService endpointPerformanceQueryService)
     {
         _endpointCreationQueryService = endpointCreationQueryService;
         _endpointManagementQueryService = endpointManagementQueryService;
         _endpointManagementService = endpointManagementService;
         _applicationSettingsService = applicationSettingsService;
         _groupManagementService = groupManagementService;
+        _endpointPerformanceQueryService = endpointPerformanceQueryService;
     }
 
     [HttpGet("")]
@@ -166,6 +169,18 @@ public sealed class EndpointsController : Controller
         }
 
         return Redirect("/endpoints");
+    }
+
+    [HttpGet("{assignmentId}/performance")]
+    public async Task<IActionResult> Performance([FromRoute] string assignmentId, [FromQuery] string? range, CancellationToken cancellationToken)
+    {
+        var model = await _endpointPerformanceQueryService.GetPerformancePageAsync(assignmentId, range, cancellationToken);
+        if (model is null)
+        {
+            return NotFound();
+        }
+
+        return View("Performance", model);
     }
 
     [HttpGet("{assignmentId}/remove")]

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -99,6 +99,7 @@ builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsServi
 builder.Services.AddScoped<IEndpointCreationQueryService, EndpointCreationQueryService>();
 builder.Services.AddScoped<IEndpointManagementQueryService, EndpointManagementQueryService>();
 builder.Services.AddScoped<IEndpointManagementService, EndpointManagementService>();
+builder.Services.AddScoped<IEndpointPerformanceQueryService, EndpointPerformanceQueryService>();
 builder.Services.AddScoped<IGroupManagementService, GroupManagementService>();
 builder.Services.AddScoped<IAgentManagementQueryService, AgentManagementQueryService>();
 builder.Services.AddScoped<IEndpointMetricsService, EndpointMetricsService>();

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointPerformanceQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointPerformanceQueryService.cs
@@ -1,0 +1,184 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.ViewModels.Endpoints;
+
+namespace PingMonitor.Web.Services.Endpoints;
+
+internal sealed class EndpointPerformanceQueryService : IEndpointPerformanceQueryService
+{
+    private sealed class CheckResultRow
+    {
+        public required DateTimeOffset CheckedAtUtc { get; init; }
+        public required bool Success { get; init; }
+        public int? RoundTripMs { get; init; }
+    }
+
+    private readonly PingMonitorDbContext _dbContext;
+
+    public EndpointPerformanceQueryService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<EndpointPerformancePageViewModel?> GetPerformancePageAsync(
+        string assignmentId,
+        string? range,
+        CancellationToken cancellationToken)
+    {
+        var normalizedAssignmentId = assignmentId.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedAssignmentId))
+        {
+            return null;
+        }
+
+        var context = await (
+            from assignment in _dbContext.MonitorAssignments.AsNoTracking()
+            join endpoint in _dbContext.Endpoints.AsNoTracking() on assignment.EndpointId equals endpoint.EndpointId
+            join agent in _dbContext.Agents.AsNoTracking() on assignment.AgentId equals agent.AgentId
+            where assignment.AssignmentId == normalizedAssignmentId
+            select new
+            {
+                assignment.AssignmentId,
+                EndpointName = endpoint.Name,
+                endpoint.Target,
+                AgentDisplay = string.IsNullOrWhiteSpace(agent.Name)
+                    ? agent.InstanceId
+                    : $"{agent.Name} ({agent.InstanceId})"
+            })
+            .SingleOrDefaultAsync(cancellationToken);
+
+        if (context is null)
+        {
+            return null;
+        }
+
+        var parsedRange = EndpointPerformanceRange.Parse(range);
+        var windowEnd = DateTimeOffset.UtcNow;
+        var windowStart = windowEnd - parsedRange.Duration;
+
+        var checkResults = await _dbContext.CheckResults.AsNoTracking()
+            .Where(x => x.AssignmentId == normalizedAssignmentId
+                        && x.CheckedAtUtc >= windowStart
+                        && x.CheckedAtUtc <= windowEnd)
+            .OrderBy(x => x.CheckedAtUtc)
+            .Select(x => new CheckResultRow
+            {
+                CheckedAtUtc = x.CheckedAtUtc,
+                Success = x.Success,
+                RoundTripMs = x.RoundTripMs
+            })
+            .ToArrayAsync(cancellationToken);
+
+        var successfulRttSamples = checkResults
+            .Where(x => x.Success && x.RoundTripMs.HasValue)
+            .Select(x => new TimeSeriesPointViewModel
+            {
+                TimestampUtc = x.CheckedAtUtc,
+                Value = x.RoundTripMs!.Value
+            })
+            .ToArray();
+
+        var jitterSeries = BuildJitterSeries(successfulRttSamples);
+        var failureSeries = BuildFailureSeries(checkResults, windowStart, windowEnd, parsedRange.BucketSize);
+
+        return new EndpointPerformancePageViewModel
+        {
+            AssignmentId = context.AssignmentId,
+            EndpointName = context.EndpointName,
+            Target = context.Target,
+            AgentDisplay = context.AgentDisplay,
+            SelectedRange = parsedRange.Range,
+            WindowStartUtc = windowStart,
+            WindowEndUtc = windowEnd,
+            AvailableRanges = EndpointPerformanceRange.Options,
+            RttSeries = successfulRttSamples,
+            JitterSeries = jitterSeries,
+            FailureSeries = failureSeries
+        };
+    }
+
+    private static IReadOnlyList<JitterPointViewModel> BuildJitterSeries(IReadOnlyList<TimeSeriesPointViewModel> successfulRttSamples)
+    {
+        if (successfulRttSamples.Count < 2)
+        {
+            return [];
+        }
+
+        var jitterPoints = new List<JitterPointViewModel>(successfulRttSamples.Count - 1);
+        for (var index = 1; index < successfulRttSamples.Count; index++)
+        {
+            var current = successfulRttSamples[index];
+            var previous = successfulRttSamples[index - 1];
+            jitterPoints.Add(new JitterPointViewModel
+            {
+                TimestampUtc = current.TimestampUtc,
+                JitterMs = Math.Abs(current.Value - previous.Value)
+            });
+        }
+
+        return jitterPoints;
+    }
+
+    private static IReadOnlyList<FailureBucketViewModel> BuildFailureSeries(
+        IReadOnlyList<CheckResultRow> checkResults,
+        DateTimeOffset windowStart,
+        DateTimeOffset windowEnd,
+        TimeSpan bucketSize)
+    {
+        var bucketCount = (int)Math.Ceiling((windowEnd - windowStart).TotalSeconds / bucketSize.TotalSeconds);
+        if (bucketCount <= 0)
+        {
+            return [];
+        }
+
+        var buckets = new FailureBucketViewModel[bucketCount];
+        for (var index = 0; index < bucketCount; index++)
+        {
+            var bucketStart = windowStart + TimeSpan.FromSeconds(index * bucketSize.TotalSeconds);
+            var bucketEnd = bucketStart + bucketSize;
+            buckets[index] = new FailureBucketViewModel
+            {
+                BucketStartUtc = bucketStart,
+                BucketEndUtc = bucketEnd,
+                SuccessfulCount = 0,
+                FailedCount = 0
+            };
+        }
+
+        foreach (var checkResult in checkResults)
+        {
+            var checkedAtUtc = checkResult.CheckedAtUtc;
+            var bucketIndex = (int)Math.Floor((checkedAtUtc - windowStart).TotalSeconds / bucketSize.TotalSeconds);
+            if (bucketIndex < 0)
+            {
+                continue;
+            }
+
+            if (bucketIndex >= bucketCount)
+            {
+                bucketIndex = bucketCount - 1;
+            }
+
+            var bucket = buckets[bucketIndex];
+            bucket = checkResult.Success
+                ? new FailureBucketViewModel
+                {
+                    BucketStartUtc = bucket.BucketStartUtc,
+                    BucketEndUtc = bucket.BucketEndUtc,
+                    SuccessfulCount = bucket.SuccessfulCount + 1,
+                    FailedCount = bucket.FailedCount
+                }
+                : new FailureBucketViewModel
+                {
+                    BucketStartUtc = bucket.BucketStartUtc,
+                    BucketEndUtc = bucket.BucketEndUtc,
+                    SuccessfulCount = bucket.SuccessfulCount,
+                    FailedCount = bucket.FailedCount + 1
+                };
+
+            buckets[bucketIndex] = bucket;
+        }
+
+        return buckets;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointPerformanceQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointPerformanceQueryService.cs
@@ -1,0 +1,8 @@
+using PingMonitor.Web.ViewModels.Endpoints;
+
+namespace PingMonitor.Web.Services.Endpoints;
+
+public interface IEndpointPerformanceQueryService
+{
+    Task<EndpointPerformancePageViewModel?> GetPerformancePageAsync(string assignmentId, string? range, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/EndpointPerformancePageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/EndpointPerformancePageViewModel.cs
@@ -1,0 +1,68 @@
+namespace PingMonitor.Web.ViewModels.Endpoints;
+
+public sealed class EndpointPerformancePageViewModel
+{
+    public string AssignmentId { get; init; } = string.Empty;
+    public string EndpointName { get; init; } = string.Empty;
+    public string Target { get; init; } = string.Empty;
+    public string AgentDisplay { get; init; } = string.Empty;
+    public string SelectedRange { get; init; } = EndpointPerformanceRange.Default;
+    public DateTimeOffset WindowStartUtc { get; init; }
+    public DateTimeOffset WindowEndUtc { get; init; }
+    public IReadOnlyList<EndpointPerformanceRangeOptionViewModel> AvailableRanges { get; init; } = [];
+    public IReadOnlyList<TimeSeriesPointViewModel> RttSeries { get; init; } = [];
+    public IReadOnlyList<JitterPointViewModel> JitterSeries { get; init; } = [];
+    public IReadOnlyList<FailureBucketViewModel> FailureSeries { get; init; } = [];
+}
+
+public sealed class EndpointPerformanceRangeOptionViewModel
+{
+    public string Value { get; init; } = string.Empty;
+    public string Label { get; init; } = string.Empty;
+}
+
+public sealed class TimeSeriesPointViewModel
+{
+    public DateTimeOffset TimestampUtc { get; init; }
+    public double Value { get; init; }
+}
+
+public sealed class JitterPointViewModel
+{
+    public DateTimeOffset TimestampUtc { get; init; }
+    public double JitterMs { get; init; }
+}
+
+public sealed class FailureBucketViewModel
+{
+    public DateTimeOffset BucketStartUtc { get; init; }
+    public DateTimeOffset BucketEndUtc { get; init; }
+    public int SuccessfulCount { get; init; }
+    public int FailedCount { get; init; }
+}
+
+public static class EndpointPerformanceRange
+{
+    public const string OneHour = "1h";
+    public const string TwentyFourHours = "24h";
+    public const string SevenDays = "7d";
+    public const string Default = TwentyFourHours;
+
+    public static IReadOnlyList<EndpointPerformanceRangeOptionViewModel> Options { get; } =
+    [
+        new EndpointPerformanceRangeOptionViewModel { Value = OneHour, Label = "Last 1 hour" },
+        new EndpointPerformanceRangeOptionViewModel { Value = TwentyFourHours, Label = "Last 24 hours" },
+        new EndpointPerformanceRangeOptionViewModel { Value = SevenDays, Label = "Last 7 days" }
+    ];
+
+    public static (string Range, TimeSpan Duration, TimeSpan BucketSize) Parse(string? requestedRange)
+    {
+        var normalized = requestedRange?.Trim().ToLowerInvariant();
+        return normalized switch
+        {
+            OneHour => (OneHour, TimeSpan.FromHours(1), TimeSpan.FromMinutes(5)),
+            SevenDays => (SevenDays, TimeSpan.FromDays(7), TimeSpan.FromHours(6)),
+            _ => (TwentyFourHours, TimeSpan.FromHours(24), TimeSpan.FromHours(1))
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
@@ -128,6 +128,7 @@
                                 <div class="meta-item"><span>Recovery threshold</span><div>@row.RecoveryThreshold</div></div>
                             </div>
                             <div class="button-row" style="margin-top:.85rem;">
+                                <a class="button-secondary" href="/endpoints/@row.AssignmentId/performance">View performance</a>
                                 <a class="button-secondary" href="/endpoints/@row.AssignmentId/edit">Edit assignment</a>
                                 <a class="button-secondary" href="/endpoints/@row.AssignmentId/remove">Remove endpoint</a>
                             </div>

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml
@@ -1,0 +1,209 @@
+@model PingMonitor.Web.ViewModels.Endpoints.EndpointPerformancePageViewModel
+@using System.Text.Json
+@{
+    static string FormatDate(DateTimeOffset value) => value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'");
+
+    var rttLabels = Model.RttSeries.Select(x => x.TimestampUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")).ToArray();
+    var rttValues = Model.RttSeries.Select(x => x.Value).ToArray();
+    var jitterLabels = Model.JitterSeries.Select(x => x.TimestampUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")).ToArray();
+    var jitterValues = Model.JitterSeries.Select(x => x.JitterMs).ToArray();
+    var failureLabels = Model.FailureSeries.Select(x => x.BucketStartUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm")).ToArray();
+    var failureCounts = Model.FailureSeries.Select(x => x.FailedCount).ToArray();
+    var successCounts = Model.FailureSeries.Select(x => x.SuccessfulCount).ToArray();
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Endpoint performance</title>
+    <style>
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; --danger:#b42318; --ok:#137333; }
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 1180px; margin: 0 auto; padding: 1rem; }
+        .stack { display: grid; gap: 1rem; }
+        .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
+        .meta-grid { display: grid; gap: .75rem; grid-template-columns: repeat(1, minmax(0, 1fr)); }
+        .meta-item span { display:block; font-size: .85rem; color:var(--muted); margin-bottom: .25rem; }
+        .button-row { display: flex; gap: .75rem; flex-wrap: wrap; }
+        .button,.button-secondary { display:inline-flex; align-items:center; justify-content:center; min-height:48px; padding:.8rem 1rem; border-radius:10px; font-weight:600; text-decoration:none; }
+        .button { border:0; background:var(--accent); color:#fff; }
+        .button-secondary { border:1px solid var(--border); color:var(--text); background:#fff; }
+        .range-grid { display:grid; gap: .75rem; grid-template-columns: 1fr; align-items:end; }
+        label { display:block; font-weight: 600; margin-bottom: .3rem; }
+        select { width:100%; padding:.85rem; border:1px solid var(--border); border-radius:10px; font-size:1rem; }
+        .chart-wrap { position: relative; min-height: 230px; }
+        .empty { border: 1px dashed var(--border); border-radius: 10px; padding: .9rem; color: var(--muted); background: #f8fafc; }
+        .muted { color: var(--muted); }
+        @@media (min-width: 720px) {
+            .meta-grid { grid-template-columns: repeat(3, minmax(0,1fr)); }
+            .range-grid { grid-template-columns: 220px auto; }
+        }
+    </style>
+</head>
+<body>
+<main>
+    <div class="stack">
+        <section class="card">
+            <h1>Endpoint performance</h1>
+            <p style="margin-top:.2rem; color: var(--muted);">Operational graph view from raw check results for one assignment.</p>
+            <div class="button-row">
+                <a class="button-secondary" href="/endpoints">Back to endpoints</a>
+                <a class="button-secondary" href="/status">Back to status</a>
+                <a class="button" href="/endpoints/@Model.AssignmentId/edit">Edit assignment</a>
+            </div>
+        </section>
+
+        <section class="card">
+            <div class="meta-grid">
+                <div class="meta-item"><span>Endpoint</span><strong>@Model.EndpointName</strong></div>
+                <div class="meta-item"><span>Target</span><strong>@Model.Target</strong></div>
+                <div class="meta-item"><span>Agent</span><strong>@Model.AgentDisplay</strong></div>
+                <div class="meta-item"><span>Assignment ID</span><div>@Model.AssignmentId</div></div>
+                <div class="meta-item"><span>Window start</span><div>@FormatDate(Model.WindowStartUtc)</div></div>
+                <div class="meta-item"><span>Window end</span><div>@FormatDate(Model.WindowEndUtc)</div></div>
+            </div>
+        </section>
+
+        <section class="card">
+            <form method="get" class="range-grid" action="/endpoints/@Model.AssignmentId/performance">
+                <div>
+                    <label for="range">Time range</label>
+                    <select id="range" name="range">
+                        @foreach (var range in Model.AvailableRanges)
+                        {
+                            <option value="@range.Value" selected="@(string.Equals(range.Value, Model.SelectedRange, StringComparison.Ordinal))">@range.Label</option>
+                        }
+                    </select>
+                </div>
+                <div class="button-row">
+                    <button class="button" type="submit">Apply range</button>
+                </div>
+            </form>
+        </section>
+
+        <section class="card">
+            <h2>RTT (successful checks only)</h2>
+            <p class="muted">X axis = check timestamp (UTC), Y axis = round-trip time in milliseconds.</p>
+            @if (Model.RttSeries.Count == 0)
+            {
+                <div class="empty">No successful RTT samples are available in this range.</div>
+            }
+            else
+            {
+                <div class="chart-wrap"><canvas id="rttChart" aria-label="RTT chart"></canvas></div>
+            }
+        </section>
+
+        <section class="card">
+            <h2>Check outcomes per time bucket</h2>
+            <p class="muted">Failed check counts are shown per bucket, with successful checks included for operational context.</p>
+            @if (Model.FailureSeries.Count == 0)
+            {
+                <div class="empty">No check results are available in this range.</div>
+            }
+            else
+            {
+                <div class="chart-wrap"><canvas id="failureChart" aria-label="Failure chart"></canvas></div>
+            }
+        </section>
+
+        <section class="card">
+            <h2>Jitter (consecutive successful RTT delta)</h2>
+            <p class="muted">Each point is |current successful RTT - previous successful RTT| in milliseconds.</p>
+            @if (Model.JitterSeries.Count == 0)
+            {
+                <div class="empty">At least two successful RTT samples are required to plot jitter.</div>
+            }
+            else
+            {
+                <div class="chart-wrap"><canvas id="jitterChart" aria-label="Jitter chart"></canvas></div>
+            }
+        </section>
+    </div>
+</main>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<script>
+    const rttLabels = @Html.Raw(JsonSerializer.Serialize(rttLabels));
+    const rttValues = @Html.Raw(JsonSerializer.Serialize(rttValues));
+    const jitterLabels = @Html.Raw(JsonSerializer.Serialize(jitterLabels));
+    const jitterValues = @Html.Raw(JsonSerializer.Serialize(jitterValues));
+    const failureLabels = @Html.Raw(JsonSerializer.Serialize(failureLabels));
+    const failureCounts = @Html.Raw(JsonSerializer.Serialize(failureCounts));
+    const successCounts = @Html.Raw(JsonSerializer.Serialize(successCounts));
+
+    if (rttValues.length > 0) {
+        new Chart(document.getElementById('rttChart'), {
+            type: 'line',
+            data: {
+                labels: rttLabels,
+                datasets: [{
+                    label: 'RTT (ms)',
+                    data: rttValues,
+                    borderColor: '#0f62fe',
+                    backgroundColor: '#0f62fe',
+                    tension: 0.1,
+                    pointRadius: 2
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    x: { title: { display: true, text: 'Timestamp (UTC)' } },
+                    y: { title: { display: true, text: 'RTT (ms)' } }
+                }
+            }
+        });
+    }
+
+    if (failureLabels.length > 0) {
+        new Chart(document.getElementById('failureChart'), {
+            type: 'bar',
+            data: {
+                labels: failureLabels,
+                datasets: [
+                    { label: 'Failed checks', data: failureCounts, backgroundColor: '#b42318' },
+                    { label: 'Successful checks', data: successCounts, backgroundColor: '#137333' }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    x: { title: { display: true, text: 'Bucket start (UTC)' } },
+                    y: { title: { display: true, text: 'Count' }, beginAtZero: true }
+                }
+            }
+        });
+    }
+
+    if (jitterValues.length > 0) {
+        new Chart(document.getElementById('jitterChart'), {
+            type: 'line',
+            data: {
+                labels: jitterLabels,
+                datasets: [{
+                    label: 'Jitter (ms)',
+                    data: jitterValues,
+                    borderColor: '#b54708',
+                    backgroundColor: '#b54708',
+                    tension: 0.1,
+                    pointRadius: 2
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    x: { title: { display: true, text: 'Timestamp (UTC)' } },
+                    y: { title: { display: true, text: 'Jitter (ms)' }, beginAtZero: true }
+                }
+            }
+        });
+    }
+</script>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -71,6 +71,7 @@
         .meta-item { min-width: 0; }
         .meta-item span { display: block; font-size: .85rem; color: var(--muted); margin-bottom: .2rem; }
         .empty { text-align: center; padding: 1rem; border: 1px dashed var(--border); border-radius: 12px; }
+        .inline-actions { margin-top: .85rem; }
         .nowrap { white-space: nowrap; }
         @@media (min-width: 720px) {
             .summary-grid { grid-template-columns: repeat(6, minmax(0, 1fr)); }
@@ -194,6 +195,9 @@
                                 <div class="meta-item"><span>Endpoint enabled</span><div>@(row.EndpointEnabled ? "Enabled" : "Disabled")</div></div>
                                 <div class="meta-item"><span>Assignment ID</span><div>@row.AssignmentId</div></div>
                                 <div class="meta-item"><span>Endpoint ID</span><div>@row.EndpointId</div></div>
+                            </div>
+                            <div class="inline-actions">
+                                <a class="button-secondary" href="/endpoints/@row.AssignmentId/performance">View performance</a>
                             </div>
                         </article>
                     }


### PR DESCRIPTION
### Motivation

- Provide a simple operational view of endpoint performance (RTT, failures, jitter) using existing `CheckResult` data without adding heavy analytics infrastructure.
- Keep behaviour explicit and read-only per platform constraints so agents still only submit facts and the server derives meaning.
- Support basic operational needs with server-rendered charts and small, maintainable read-side code rather than a SPA.

### Description

- Add a focused read/query service `IEndpointPerformanceQueryService` and `EndpointPerformanceQueryService` that loads assignment-scoped `CheckResult` rows and shapes series for RTT, jitter (absolute delta between consecutive successful RTTs), and failure/success buckets; new files: `src/WebApp/PingMonitor.Web/Services/Endpoints/IEndpointPerformanceQueryService.cs` and `EndpointPerformanceQueryService.cs`.
- Introduce `EndpointPerformancePageViewModel` and related small view-model types in `src/WebApp/PingMonitor.Web/ViewModels/Endpoints/EndpointPerformancePageViewModel.cs` with explicit range parsing for `1h`, `24h` (default), and `7d` and deterministic bucket sizes.
- Add server-rendered route and page `GET /endpoints/{assignmentId}/performance` via a new `Performance` action in `EndpointsController` and a Razor view `src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml` that renders three charts (RTT, failures per bucket, jitter) using `Chart.js` and shows clear empty states and context (endpoint, target, agent, range).
- Wire DI in `Program.cs`, add navigation links from the Manage Endpoints and Status pages to the new performance page, and add a concise docs note in `docs/data-model.md` describing the graphs and data semantics (Fixes #107).

### Testing

- Created GitHub issue `#107` before implementation and linked the work to it (issue created programmatically during the rollout). 
- Verified `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` completed successfully with the installed .NET 10 SDK.
- Launched the web app and performed an HTTP request to `GET /endpoints/test-assignment/performance?range=24h` which resolved and produced a startup-gate redirect (`302` to `/startup-gate`), confirming route wiring and startup-gate behaviour in this environment.
- Note: full end-to-end UI rendering with real DB data was not validated here because the environment triggers the startup-gate and no runtime DB migration/seed was applied, so chart rendering with live `CheckResult` rows remains to be validated in an integrated environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c55fbd02f8832aa1f811a3e0fadb1c)