### PR TITLE
Add user management and scoped read-only access (Admin/User)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,3 +265,10 @@ Startup gate and agent API endpoints are in place, with MySQL used in all enviro
 ## License
 
 TBD
+
+
+## Access roles (v1)
+
+- `Admin`: full read/write access to control-plane pages and actions.
+- `User`: read-only access; visible endpoints are the union of explicit endpoint grants and endpoints in explicitly granted groups.
+- Visibility enforcement is server-side in query/service logic (not UI-only hiding).

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -179,6 +179,40 @@ Represents one endpoint-to-group membership row.
 
 ---
 
+
+### UserGroupAccess
+
+Represents one explicit user-to-group read-scope grant.
+
+#### Key fields
+
+- `userGroupAccessId`
+- `userId`
+- `groupId`
+- `createdAtUtc`
+
+#### Constraints
+
+- (`userId`, `groupId`) must be unique
+
+---
+
+### UserEndpointAccess
+
+Represents one explicit user-to-endpoint read-scope grant.
+
+#### Key fields
+
+- `userEndpointAccessId`
+- `userId`
+- `endpointId`
+- `createdAtUtc`
+
+#### Constraints
+
+- (`userId`, `endpointId`) must be unique
+
+---
 ### MonitorAssignment
 
 Defines what an agent monitors and how.
@@ -628,4 +662,4 @@ This data model enforces:
 - Endpoints may belong to zero, one, or many groups.
 - Grouping is endpoint-level in v1 (not assignment-level).
 - Groups are used for organization and basic filtering in control-plane pages.
-- Group-based permissions are out of scope for v1 and may be added later.
+- Read-only user visibility may be granted by explicit endpoint scope and/or group scope.

--- a/src/WebApp/PingMonitor.Web/Controllers/AccountController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AccountController.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Authorization;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Models.Identity;
+
+namespace PingMonitor.Web.Controllers;
+
+[AllowAnonymous]
+[Route("account")]
+public sealed class AccountController : Controller
+{
+    private readonly SignInManager<ApplicationUser> _signInManager;
+
+    public AccountController(SignInManager<ApplicationUser> signInManager)
+    {
+        _signInManager = signInManager;
+    }
+
+    [HttpGet("login")]
+    public IActionResult Login([FromQuery] string? returnUrl = null)
+    {
+        return View("Login", new LoginViewModel { ReturnUrl = returnUrl ?? "/status" });
+    }
+
+    [HttpPost("login")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Login([FromForm] LoginViewModel model)
+    {
+        if (!ModelState.IsValid)
+        {
+            return View("Login", model);
+        }
+
+        var result = await _signInManager.PasswordSignInAsync(model.UserName, model.Password, isPersistent: false, lockoutOnFailure: true);
+        if (!result.Succeeded)
+        {
+            ModelState.AddModelError(string.Empty, "Invalid credentials.");
+            return View("Login", model);
+        }
+
+        return LocalRedirect(string.IsNullOrWhiteSpace(model.ReturnUrl) ? "/status" : model.ReturnUrl);
+    }
+
+    [HttpPost("logout")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Logout()
+    {
+        await _signInManager.SignOutAsync();
+        return RedirectToAction(nameof(Login));
+    }
+
+    public sealed class LoginViewModel
+    {
+        [Required]
+        public string UserName { get; set; } = string.Empty;
+
+        [Required]
+        [DataType(DataType.Password)]
+        public string Password { get; set; } = string.Empty;
+
+        public string ReturnUrl { get; set; } = "/status";
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminController.cs
@@ -1,9 +1,12 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.ViewModels.Admin;
 
 namespace PingMonitor.Web.Controllers;
 
+[Authorize(Roles = ApplicationRoles.Admin)]
 [Route("admin")]
 public sealed class AdminController : Controller
 {

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentConfigController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentConfigController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Contracts.Config;
 using PingMonitor.Web.Services;
@@ -5,6 +6,7 @@ using PingMonitor.Web.Services;
 namespace PingMonitor.Web.Controllers;
 
 [ApiController]
+[AllowAnonymous]
 [Route("api/v1/agent/config")]
 public sealed class AgentConfigController : ControllerBase
 {

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentHeartbeatController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentHeartbeatController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Contracts.Heartbeat;
 using PingMonitor.Web.Services;
@@ -6,6 +7,7 @@ using PingMonitor.Web.Support;
 namespace PingMonitor.Web.Controllers;
 
 [ApiController]
+[AllowAnonymous]
 [Route("api/v1/agent/heartbeat")]
 public sealed class AgentHeartbeatController : ControllerBase
 {

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentHelloController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentHelloController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Contracts.Hello;
 using PingMonitor.Web.Services;
@@ -6,6 +7,7 @@ using PingMonitor.Web.Support;
 namespace PingMonitor.Web.Controllers;
 
 [ApiController]
+[AllowAnonymous]
 [Route("api/v1/agent/hello")]
 public sealed class AgentHelloController : ControllerBase
 {

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentResultsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentResultsController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Contracts.Results;
 using PingMonitor.Web.Services;
@@ -6,6 +7,7 @@ using PingMonitor.Web.Support;
 namespace PingMonitor.Web.Controllers;
 
 [ApiController]
+[AllowAnonymous]
 [Route("api/v1/agent/results")]
 public sealed class AgentResultsController : ControllerBase
 {

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
@@ -1,10 +1,13 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.Agents;
+using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.ViewModels.Agents;
 
 namespace PingMonitor.Web.Controllers;
 
+[Authorize(Roles = ApplicationRoles.Admin)]
 [Route("agents")]
 public sealed class AgentsController : Controller
 {

--- a/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
@@ -1,11 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.Endpoints;
 using PingMonitor.Web.Services.Groups;
+using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.ViewModels.Endpoints;
 
 namespace PingMonitor.Web.Controllers;
 
+[Authorize]
 [Route("endpoints")]
 public sealed class EndpointsController : Controller
 {
@@ -19,6 +22,7 @@ public sealed class EndpointsController : Controller
     private readonly IApplicationSettingsService _applicationSettingsService;
     private readonly IGroupManagementService _groupManagementService;
     private readonly IEndpointPerformanceQueryService _endpointPerformanceQueryService;
+    private readonly IUserAccessScopeService _userAccessScopeService;
 
     public EndpointsController(
         IEndpointCreationQueryService endpointCreationQueryService,
@@ -26,7 +30,8 @@ public sealed class EndpointsController : Controller
         IEndpointManagementService endpointManagementService,
         IApplicationSettingsService applicationSettingsService,
         IGroupManagementService groupManagementService,
-        IEndpointPerformanceQueryService endpointPerformanceQueryService)
+        IEndpointPerformanceQueryService endpointPerformanceQueryService,
+        IUserAccessScopeService userAccessScopeService)
     {
         _endpointCreationQueryService = endpointCreationQueryService;
         _endpointManagementQueryService = endpointManagementQueryService;
@@ -34,6 +39,7 @@ public sealed class EndpointsController : Controller
         _applicationSettingsService = applicationSettingsService;
         _groupManagementService = groupManagementService;
         _endpointPerformanceQueryService = endpointPerformanceQueryService;
+        _userAccessScopeService = userAccessScopeService;
     }
 
     [HttpGet("")]
@@ -45,6 +51,7 @@ public sealed class EndpointsController : Controller
         return View("Index", model);
     }
 
+    [Authorize(Roles = ApplicationRoles.Admin)]
     [HttpGet("new")]
     public async Task<IActionResult> New(CancellationToken cancellationToken)
     {
@@ -61,6 +68,7 @@ public sealed class EndpointsController : Controller
         return View("New", model);
     }
 
+    [Authorize(Roles = ApplicationRoles.Admin)]
     [HttpPost("new")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> New([FromForm] CreateEndpointPageViewModel model, CancellationToken cancellationToken)
@@ -99,6 +107,7 @@ public sealed class EndpointsController : Controller
         return Redirect("/endpoints");
     }
 
+    [Authorize(Roles = ApplicationRoles.Admin)]
     [HttpGet("{assignmentId}/edit")]
     public async Task<IActionResult> Edit([FromRoute] string assignmentId, CancellationToken cancellationToken)
     {
@@ -130,6 +139,7 @@ public sealed class EndpointsController : Controller
         return View("Edit", model);
     }
 
+    [Authorize(Roles = ApplicationRoles.Admin)]
     [HttpPost("{assignmentId}/edit")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Edit([FromRoute] string assignmentId, [FromForm] EditEndpointPageViewModel model, CancellationToken cancellationToken)
@@ -183,6 +193,7 @@ public sealed class EndpointsController : Controller
         return View("Performance", model);
     }
 
+    [Authorize(Roles = ApplicationRoles.Admin)]
     [HttpGet("{assignmentId}/remove")]
     public async Task<IActionResult> Remove([FromRoute] string assignmentId, CancellationToken cancellationToken)
     {
@@ -195,6 +206,7 @@ public sealed class EndpointsController : Controller
         return View("Remove", BuildRemoveViewModel(details));
     }
 
+    [Authorize(Roles = ApplicationRoles.Admin)]
     [HttpPost("{assignmentId}/remove")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Remove(

--- a/src/WebApp/PingMonitor.Web/Controllers/GroupsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/GroupsController.cs
@@ -1,9 +1,12 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Services.Groups;
+using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.ViewModels.Groups;
 
 namespace PingMonitor.Web.Controllers;
 
+[Authorize(Roles = ApplicationRoles.Admin)]
 [Route("groups")]
 public sealed class GroupsController : Controller
 {

--- a/src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using PingMonitor.Web.Options;
@@ -6,6 +7,7 @@ using PingMonitor.Web.ViewModels.StartupGate;
 
 namespace PingMonitor.Web.Controllers;
 
+[AllowAnonymous]
 [Route("startup-gate")]
 public sealed class StartupGateController : Controller
 {

--- a/src/WebApp/PingMonitor.Web/Controllers/StatusController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/StatusController.cs
@@ -1,8 +1,10 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Services.Status;
 
 namespace PingMonitor.Web.Controllers;
 
+[Authorize]
 [Route("status")]
 public sealed class StatusController : Controller
 {

--- a/src/WebApp/PingMonitor.Web/Controllers/UsersController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/UsersController.cs
@@ -1,0 +1,149 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Services.Identity;
+using PingMonitor.Web.ViewModels.Users;
+
+namespace PingMonitor.Web.Controllers;
+
+[Authorize(Roles = ApplicationRoles.Admin)]
+[Route("users")]
+public sealed class UsersController : Controller
+{
+    private const string StatusMessageKey = "Users.StatusMessage";
+    private readonly IUserManagementService _userManagementService;
+
+    public UsersController(IUserManagementService userManagementService)
+    {
+        _userManagementService = userManagementService;
+    }
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index(CancellationToken cancellationToken)
+    {
+        var users = await _userManagementService.ListUsersAsync(cancellationToken);
+        return View("Index", new ManageUsersPageViewModel
+        {
+            StatusMessage = TempData[StatusMessageKey] as string,
+            Users = users.Select(x => new UserRowViewModel
+            {
+                UserId = x.UserId,
+                UserName = x.UserName,
+                Email = x.Email,
+                Role = x.Role,
+                Enabled = x.Enabled
+            }).ToArray()
+        });
+    }
+
+    [HttpGet("new")]
+    public async Task<IActionResult> New(CancellationToken cancellationToken)
+    {
+        return View("New", await BuildEditModelAsync(new UserEditPageViewModel(), cancellationToken));
+    }
+
+    [HttpPost("new")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> New([FromForm] UserEditPageViewModel model, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(model.Password))
+        {
+            ModelState.AddModelError(nameof(UserEditPageViewModel.Password), "Password is required.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return View("New", await BuildEditModelAsync(model, cancellationToken));
+        }
+
+        var result = await _userManagementService.CreateAsync(new UserManagementSaveCommand
+        {
+            UserName = model.UserName,
+            Email = model.Email,
+            Password = model.Password,
+            Role = model.Role,
+            Enabled = model.Enabled,
+            GroupIds = model.GroupIds,
+            EndpointIds = model.EndpointIds
+        }, cancellationToken);
+
+        if (!result.Success)
+        {
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error);
+            }
+
+            return View("New", await BuildEditModelAsync(model, cancellationToken));
+        }
+
+        TempData[StatusMessageKey] = "User created.";
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpGet("{id}/edit")]
+    public async Task<IActionResult> Edit([FromRoute] string id, CancellationToken cancellationToken)
+    {
+        var user = await _userManagementService.GetUserAsync(id, cancellationToken);
+        if (user is null)
+        {
+            return NotFound();
+        }
+
+        return View("Edit", await BuildEditModelAsync(new UserEditPageViewModel
+        {
+            UserId = user.UserId,
+            UserName = user.UserName,
+            Email = user.Email,
+            Role = user.Role,
+            Enabled = user.Enabled,
+            GroupIds = user.SelectedGroupIds.ToList(),
+            EndpointIds = user.SelectedEndpointIds.ToList()
+        }, cancellationToken));
+    }
+
+    [HttpPost("{id}/edit")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Edit([FromRoute] string id, [FromForm] UserEditPageViewModel model, CancellationToken cancellationToken)
+    {
+        model.UserId = id;
+        if (!ModelState.IsValid)
+        {
+            return View("Edit", await BuildEditModelAsync(model, cancellationToken));
+        }
+
+        var result = await _userManagementService.UpdateAsync(new UserManagementSaveCommand
+        {
+            UserId = id,
+            UserName = model.UserName,
+            Email = model.Email,
+            Role = model.Role,
+            Enabled = model.Enabled,
+            GroupIds = model.GroupIds,
+            EndpointIds = model.EndpointIds
+        }, cancellationToken);
+
+        if (!result.Success)
+        {
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error);
+            }
+
+            return View("Edit", await BuildEditModelAsync(model, cancellationToken));
+        }
+
+        TempData[StatusMessageKey] = "User updated.";
+        return RedirectToAction(nameof(Index));
+    }
+
+    private async Task<UserEditPageViewModel> BuildEditModelAsync(UserEditPageViewModel model, CancellationToken cancellationToken)
+    {
+        model.AvailableGroups = (await _userManagementService.GetGroupOptionsAsync(cancellationToken))
+            .Select(x => new UserOptionViewModel { Id = x.Id, Name = x.Name })
+            .ToArray();
+        model.AvailableEndpoints = (await _userManagementService.GetEndpointOptionsAsync(cancellationToken))
+            .Select(x => new UserOptionViewModel { Id = x.Id, Name = x.Name })
+            .ToArray();
+        return model;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -22,6 +22,8 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
     public DbSet<EndpointDependency> EndpointDependencies => Set<EndpointDependency>();
     public DbSet<Group> Groups => Set<Group>();
     public DbSet<EndpointGroupMembership> EndpointGroupMemberships => Set<EndpointGroupMembership>();
+    public DbSet<UserGroupAccess> UserGroupAccesses => Set<UserGroupAccess>();
+    public DbSet<UserEndpointAccess> UserEndpointAccesses => Set<UserEndpointAccess>();
     public DbSet<MonitorAssignment> MonitorAssignments => Set<MonitorAssignment>();
     public DbSet<CheckResult> CheckResults => Set<CheckResult>();
     public DbSet<ResultBatch> ResultBatches => Set<ResultBatch>();
@@ -115,6 +117,25 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         endpointGroupMembership.Property(x => x.GroupId).HasMaxLength(64).IsRequired();
         endpointGroupMembership.Property(x => x.CreatedAtUtc).IsRequired();
         endpointGroupMembership.HasIndex(x => new { x.EndpointId, x.GroupId }).IsUnique();
+
+
+        var userGroupAccess = modelBuilder.Entity<UserGroupAccess>();
+        userGroupAccess.ToTable("UserGroupAccesses");
+        userGroupAccess.HasKey(x => x.UserGroupAccessId);
+        userGroupAccess.Property(x => x.UserGroupAccessId).HasMaxLength(64);
+        userGroupAccess.Property(x => x.UserId).HasMaxLength(255).IsRequired();
+        userGroupAccess.Property(x => x.GroupId).HasMaxLength(64).IsRequired();
+        userGroupAccess.Property(x => x.CreatedAtUtc).IsRequired();
+        userGroupAccess.HasIndex(x => new { x.UserId, x.GroupId }).IsUnique();
+
+        var userEndpointAccess = modelBuilder.Entity<UserEndpointAccess>();
+        userEndpointAccess.ToTable("UserEndpointAccesses");
+        userEndpointAccess.HasKey(x => x.UserEndpointAccessId);
+        userEndpointAccess.Property(x => x.UserEndpointAccessId).HasMaxLength(64);
+        userEndpointAccess.Property(x => x.UserId).HasMaxLength(255).IsRequired();
+        userEndpointAccess.Property(x => x.EndpointId).HasMaxLength(64).IsRequired();
+        userEndpointAccess.Property(x => x.CreatedAtUtc).IsRequired();
+        userEndpointAccess.HasIndex(x => new { x.UserId, x.EndpointId }).IsUnique();
 
         var assignment = modelBuilder.Entity<MonitorAssignment>();
         assignment.ToTable("MonitorAssignments");

--- a/src/WebApp/PingMonitor.Web/Models/UserEndpointAccess.cs
+++ b/src/WebApp/PingMonitor.Web/Models/UserEndpointAccess.cs
@@ -1,0 +1,9 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class UserEndpointAccess
+{
+    public required string UserEndpointAccessId { get; set; }
+    public required string UserId { get; set; }
+    public required string EndpointId { get; set; }
+    public required DateTimeOffset CreatedAtUtc { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Models/UserGroupAccess.cs
+++ b/src/WebApp/PingMonitor.Web/Models/UserGroupAccess.cs
@@ -1,0 +1,9 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class UserGroupAccess
+{
+    public required string UserGroupAccessId { get; set; }
+    public required string UserId { get; set; }
+    public required string GroupId { get; set; }
+    public required DateTimeOffset CreatedAtUtc { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
@@ -7,6 +8,7 @@ using PingMonitor.Web.Data;
 using PingMonitor.Web.Models.Identity;
 using PingMonitor.Web.Options;
 using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.Services.Agents;
 using PingMonitor.Web.Services.Endpoints;
 using PingMonitor.Web.Services.Groups;
@@ -42,7 +44,24 @@ builder.Services
     })
     .AddRoles<ApplicationRole>()
     .AddEntityFrameworkStores<PingMonitorDbContext>()
+    .AddSignInManager()
     .AddDefaultTokenProviders();
+
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = IdentityConstants.ApplicationScheme;
+    options.DefaultChallengeScheme = IdentityConstants.ApplicationScheme;
+    options.DefaultSignInScheme = IdentityConstants.ApplicationScheme;
+})
+.AddIdentityCookies();
+
+builder.Services.AddAuthorization(options =>
+{
+    options.FallbackPolicy = new AuthorizationPolicyBuilder()
+        .RequireAuthenticatedUser()
+        .Build();
+});
 
 builder.Services.AddControllersWithViews()
     .AddJsonOptions(options =>
@@ -69,6 +88,7 @@ builder.Services.Configure<ApiBehaviorOptions>(options =>
 });
 
 builder.Services.AddHealthChecks();
+builder.Services.AddHttpContextAccessor();
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders =
@@ -104,11 +124,20 @@ builder.Services.AddScoped<IGroupManagementService, GroupManagementService>();
 builder.Services.AddScoped<IAgentManagementQueryService, AgentManagementQueryService>();
 builder.Services.AddScoped<IEndpointMetricsService, EndpointMetricsService>();
 builder.Services.AddScoped<IAgentMetricsService, AgentMetricsService>();
+builder.Services.AddScoped<IUserAccessScopeService, UserAccessScopeService>();
+builder.Services.AddScoped<IUserManagementService, UserManagementService>();
 
 var app = builder.Build();
 
+using (var scope = app.Services.CreateScope())
+{
+    var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<ApplicationRole>>();
+    await RoleBootstrapService.EnsureRolesAsync(roleManager);
+}
+
 app.UseForwardedHeaders();
 app.UseHttpsRedirection();
+app.UseAuthentication();
 app.UseAuthorization();
 app.UseStaticFiles();
 

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Services.Metrics;
+using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.ViewModels.Endpoints;
 
 namespace PingMonitor.Web.Services.Endpoints;
@@ -10,16 +11,23 @@ internal sealed class EndpointManagementQueryService : IEndpointManagementQueryS
 {
     private readonly PingMonitorDbContext _dbContext;
     private readonly IEndpointMetricsService _endpointMetricsService;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IUserAccessScopeService _userAccessScopeService;
 
-    public EndpointManagementQueryService(PingMonitorDbContext dbContext, IEndpointMetricsService endpointMetricsService)
+    public EndpointManagementQueryService(PingMonitorDbContext dbContext, IEndpointMetricsService endpointMetricsService, IHttpContextAccessor httpContextAccessor, IUserAccessScopeService userAccessScopeService)
     {
         _dbContext = dbContext;
         _endpointMetricsService = endpointMetricsService;
+        _httpContextAccessor = httpContextAccessor;
+        _userAccessScopeService = userAccessScopeService;
     }
 
     public async Task<ManageEndpointsPageViewModel> GetManagePageAsync(string? groupId, CancellationToken cancellationToken)
     {
         var normalizedGroupId = string.IsNullOrWhiteSpace(groupId) ? null : groupId.Trim();
+        var principal = _httpContextAccessor.HttpContext?.User;
+        var isAdmin = principal is not null && await _userAccessScopeService.IsAdminAsync(principal);
+        var visibleEndpointIds = isAdmin || principal is null ? null : await _userAccessScopeService.GetVisibleEndpointIdsAsync(principal, cancellationToken);
 
         var rows = await (
             from assignment in _dbContext.MonitorAssignments.AsNoTracking()
@@ -46,6 +54,11 @@ internal sealed class EndpointManagementQueryService : IEndpointManagementQueryS
                 assignment.RecoveryThreshold,
                 CurrentState = state != null ? state.CurrentState : EndpointStateKind.Unknown
             }).ToArrayAsync(cancellationToken);
+
+        if (visibleEndpointIds is not null)
+        {
+            rows = rows.Where(x => visibleEndpointIds.Contains(x.EndpointId)).ToArray();
+        }
 
         var groupLookup = (await _dbContext.EndpointGroupMemberships.AsNoTracking().ToArrayAsync(cancellationToken))
             .GroupBy(x => x.EndpointId, StringComparer.Ordinal)

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointPerformanceQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointPerformanceQueryService.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
+using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.ViewModels.Endpoints;
 
 namespace PingMonitor.Web.Services.Endpoints;
@@ -14,10 +15,14 @@ internal sealed class EndpointPerformanceQueryService : IEndpointPerformanceQuer
     }
 
     private readonly PingMonitorDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IUserAccessScopeService _userAccessScopeService;
 
-    public EndpointPerformanceQueryService(PingMonitorDbContext dbContext)
+    public EndpointPerformanceQueryService(PingMonitorDbContext dbContext, IHttpContextAccessor httpContextAccessor, IUserAccessScopeService userAccessScopeService)
     {
         _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+        _userAccessScopeService = userAccessScopeService;
     }
 
     public async Task<EndpointPerformancePageViewModel?> GetPerformancePageAsync(
@@ -26,6 +31,11 @@ internal sealed class EndpointPerformanceQueryService : IEndpointPerformanceQuer
         CancellationToken cancellationToken)
     {
         var normalizedAssignmentId = assignmentId.Trim();
+        var principal = _httpContextAccessor.HttpContext?.User;
+        if (principal is null || !await _userAccessScopeService.CanAccessAssignmentAsync(principal, normalizedAssignmentId, cancellationToken))
+        {
+            return null;
+        }
         if (string.IsNullOrWhiteSpace(normalizedAssignmentId))
         {
             return null;

--- a/src/WebApp/PingMonitor.Web/Services/Identity/ApplicationRoles.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Identity/ApplicationRoles.cs
@@ -1,0 +1,7 @@
+namespace PingMonitor.Web.Services.Identity;
+
+public static class ApplicationRoles
+{
+    public const string Admin = "Admin";
+    public const string User = "User";
+}

--- a/src/WebApp/PingMonitor.Web/Services/Identity/IUserAccessScopeService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Identity/IUserAccessScopeService.cs
@@ -1,0 +1,10 @@
+using System.Security.Claims;
+
+namespace PingMonitor.Web.Services.Identity;
+
+public interface IUserAccessScopeService
+{
+    Task<bool> IsAdminAsync(ClaimsPrincipal principal);
+    Task<IReadOnlySet<string>> GetVisibleEndpointIdsAsync(ClaimsPrincipal principal, CancellationToken cancellationToken);
+    Task<bool> CanAccessAssignmentAsync(ClaimsPrincipal principal, string assignmentId, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Identity/IUserManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Identity/IUserManagementService.cs
@@ -1,0 +1,11 @@
+namespace PingMonitor.Web.Services.Identity;
+
+public interface IUserManagementService
+{
+    Task<IReadOnlyList<UserManagementListItem>> ListUsersAsync(CancellationToken cancellationToken);
+    Task<UserManagementEditModel?> GetUserAsync(string userId, CancellationToken cancellationToken);
+    Task<IReadOnlyList<UserManagementOption>> GetGroupOptionsAsync(CancellationToken cancellationToken);
+    Task<IReadOnlyList<UserManagementOption>> GetEndpointOptionsAsync(CancellationToken cancellationToken);
+    Task<UserManagementResult> CreateAsync(UserManagementSaveCommand command, CancellationToken cancellationToken);
+    Task<UserManagementResult> UpdateAsync(UserManagementSaveCommand command, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Identity/RoleBootstrapService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Identity/RoleBootstrapService.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Identity;
+using PingMonitor.Web.Models.Identity;
+
+namespace PingMonitor.Web.Services.Identity;
+
+public static class RoleBootstrapService
+{
+    public static async Task EnsureRolesAsync(RoleManager<ApplicationRole> roleManager)
+    {
+        if (!await roleManager.RoleExistsAsync(ApplicationRoles.Admin))
+        {
+            await roleManager.CreateAsync(new ApplicationRole { Name = ApplicationRoles.Admin });
+        }
+
+        if (!await roleManager.RoleExistsAsync(ApplicationRoles.User))
+        {
+            await roleManager.CreateAsync(new ApplicationRole { Name = ApplicationRoles.User });
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Identity/UserAccessScopeService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Identity/UserAccessScopeService.cs
@@ -1,0 +1,85 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models.Identity;
+
+namespace PingMonitor.Web.Services.Identity;
+
+internal sealed class UserAccessScopeService : IUserAccessScopeService
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly PingMonitorDbContext _dbContext;
+
+    public UserAccessScopeService(UserManager<ApplicationUser> userManager, PingMonitorDbContext dbContext)
+    {
+        _userManager = userManager;
+        _dbContext = dbContext;
+    }
+
+    public async Task<bool> IsAdminAsync(ClaimsPrincipal principal)
+    {
+        var user = await _userManager.GetUserAsync(principal);
+        return user is not null && await _userManager.IsInRoleAsync(user, ApplicationRoles.Admin);
+    }
+
+    public async Task<IReadOnlySet<string>> GetVisibleEndpointIdsAsync(ClaimsPrincipal principal, CancellationToken cancellationToken)
+    {
+        var user = await _userManager.GetUserAsync(principal);
+        if (user is null)
+        {
+            return new HashSet<string>(StringComparer.Ordinal);
+        }
+
+        if (await _userManager.IsInRoleAsync(user, ApplicationRoles.Admin))
+        {
+            return (await _dbContext.Endpoints.AsNoTracking().Select(x => x.EndpointId).ToArrayAsync(cancellationToken))
+                .ToHashSet(StringComparer.Ordinal);
+        }
+
+        var direct = await _dbContext.UserEndpointAccesses.AsNoTracking()
+            .Where(x => x.UserId == user.Id)
+            .Select(x => x.EndpointId)
+            .ToArrayAsync(cancellationToken);
+
+        var groupIds = await _dbContext.UserGroupAccesses.AsNoTracking()
+            .Where(x => x.UserId == user.Id)
+            .Select(x => x.GroupId)
+            .ToArrayAsync(cancellationToken);
+
+        var grouped = groupIds.Length == 0
+            ? Array.Empty<string>()
+            : await _dbContext.EndpointGroupMemberships.AsNoTracking()
+                .Where(x => groupIds.Contains(x.GroupId))
+                .Select(x => x.EndpointId)
+                .ToArrayAsync(cancellationToken);
+
+        return direct.Concat(grouped).ToHashSet(StringComparer.Ordinal);
+    }
+
+    public async Task<bool> CanAccessAssignmentAsync(ClaimsPrincipal principal, string assignmentId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(assignmentId))
+        {
+            return false;
+        }
+
+        if (await IsAdminAsync(principal))
+        {
+            return true;
+        }
+
+        var endpointId = await _dbContext.MonitorAssignments.AsNoTracking()
+            .Where(x => x.AssignmentId == assignmentId)
+            .Select(x => x.EndpointId)
+            .SingleOrDefaultAsync(cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(endpointId))
+        {
+            return false;
+        }
+
+        var visible = await GetVisibleEndpointIdsAsync(principal, cancellationToken);
+        return visible.Contains(endpointId);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Identity/UserManagementModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Identity/UserManagementModels.cs
@@ -1,0 +1,46 @@
+namespace PingMonitor.Web.Services.Identity;
+
+public sealed class UserManagementListItem
+{
+    public required string UserId { get; init; }
+    public required string UserName { get; init; }
+    public required string Email { get; init; }
+    public required string Role { get; init; }
+    public required bool Enabled { get; init; }
+}
+
+public sealed class UserManagementEditModel
+{
+    public required string UserId { get; init; }
+    public required string UserName { get; init; }
+    public required string Email { get; init; }
+    public required string Role { get; init; }
+    public required bool Enabled { get; init; }
+    public required IReadOnlyList<string> SelectedGroupIds { get; init; }
+    public required IReadOnlyList<string> SelectedEndpointIds { get; init; }
+}
+
+public sealed class UserManagementSaveCommand
+{
+    public string? UserId { get; init; }
+    public required string UserName { get; init; }
+    public required string Email { get; init; }
+    public string? Password { get; init; }
+    public required string Role { get; init; }
+    public required bool Enabled { get; init; }
+    public required IReadOnlyList<string> GroupIds { get; init; }
+    public required IReadOnlyList<string> EndpointIds { get; init; }
+}
+
+public sealed class UserManagementOption
+{
+    public required string Id { get; init; }
+    public required string Name { get; init; }
+}
+
+public sealed class UserManagementResult
+{
+    public required bool Success { get; init; }
+    public required bool Found { get; init; }
+    public required IReadOnlyList<string> Errors { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Identity/UserManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Identity/UserManagementService.cs
@@ -1,0 +1,171 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Models.Identity;
+
+namespace PingMonitor.Web.Services.Identity;
+
+internal sealed class UserManagementService : IUserManagementService
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly PingMonitorDbContext _dbContext;
+
+    public UserManagementService(UserManager<ApplicationUser> userManager, PingMonitorDbContext dbContext)
+    {
+        _userManager = userManager;
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<UserManagementListItem>> ListUsersAsync(CancellationToken cancellationToken)
+    {
+        var users = await _dbContext.Users.AsNoTracking().OrderBy(x => x.UserName).ToArrayAsync(cancellationToken);
+        var rows = new List<UserManagementListItem>(users.Length);
+        foreach (var user in users)
+        {
+            var role = (await _userManager.GetRolesAsync(user)).FirstOrDefault() ?? ApplicationRoles.User;
+            rows.Add(new UserManagementListItem
+            {
+                UserId = user.Id,
+                UserName = user.UserName ?? string.Empty,
+                Email = user.Email ?? string.Empty,
+                Role = role,
+                Enabled = !user.LockoutEnabled || user.LockoutEnd is null || user.LockoutEnd <= DateTimeOffset.UtcNow
+            });
+        }
+
+        return rows;
+    }
+
+    public async Task<UserManagementEditModel?> GetUserAsync(string userId, CancellationToken cancellationToken)
+    {
+        var user = await _userManager.FindByIdAsync(userId);
+        if (user is null)
+        {
+            return null;
+        }
+
+        var role = (await _userManager.GetRolesAsync(user)).FirstOrDefault() ?? ApplicationRoles.User;
+        var groups = await _dbContext.UserGroupAccesses.AsNoTracking().Where(x => x.UserId == user.Id).Select(x => x.GroupId).ToArrayAsync(cancellationToken);
+        var endpoints = await _dbContext.UserEndpointAccesses.AsNoTracking().Where(x => x.UserId == user.Id).Select(x => x.EndpointId).ToArrayAsync(cancellationToken);
+
+        return new UserManagementEditModel
+        {
+            UserId = user.Id,
+            UserName = user.UserName ?? string.Empty,
+            Email = user.Email ?? string.Empty,
+            Role = role,
+            Enabled = !user.LockoutEnabled || user.LockoutEnd is null || user.LockoutEnd <= DateTimeOffset.UtcNow,
+            SelectedGroupIds = groups,
+            SelectedEndpointIds = endpoints
+        };
+    }
+
+    public async Task<IReadOnlyList<UserManagementOption>> GetGroupOptionsAsync(CancellationToken cancellationToken) =>
+        await _dbContext.Groups.AsNoTracking().OrderBy(x => x.Name).Select(x => new UserManagementOption { Id = x.GroupId, Name = x.Name }).ToArrayAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<UserManagementOption>> GetEndpointOptionsAsync(CancellationToken cancellationToken) =>
+        await _dbContext.Endpoints.AsNoTracking().OrderBy(x => x.Name).Select(x => new UserManagementOption { Id = x.EndpointId, Name = x.Name }).ToArrayAsync(cancellationToken);
+
+    public async Task<UserManagementResult> CreateAsync(UserManagementSaveCommand command, CancellationToken cancellationToken)
+    {
+        var user = new ApplicationUser
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            UserName = command.UserName.Trim(),
+            Email = command.Email.Trim(),
+            EmailConfirmed = true,
+            LockoutEnabled = true
+        };
+
+        var result = await _userManager.CreateAsync(user, command.Password ?? string.Empty);
+        if (!result.Succeeded)
+        {
+            return new UserManagementResult { Success = false, Found = false, Errors = result.Errors.Select(x => x.Description).ToArray() };
+        }
+
+        return await ApplyRoleAndScopeAsync(user, command, cancellationToken);
+    }
+
+    public async Task<UserManagementResult> UpdateAsync(UserManagementSaveCommand command, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(command.UserId))
+        {
+            return new UserManagementResult { Success = false, Found = false, Errors = ["User id is required."] };
+        }
+
+        var user = await _userManager.FindByIdAsync(command.UserId);
+        if (user is null)
+        {
+            return new UserManagementResult { Success = false, Found = false, Errors = ["User not found."] };
+        }
+
+        user.UserName = command.UserName.Trim();
+        user.Email = command.Email.Trim();
+        user.NormalizedUserName = command.UserName.Trim().ToUpperInvariant();
+        user.NormalizedEmail = command.Email.Trim().ToUpperInvariant();
+        user.LockoutEnabled = true;
+        user.LockoutEnd = command.Enabled ? null : DateTimeOffset.MaxValue;
+
+        var update = await _userManager.UpdateAsync(user);
+        if (!update.Succeeded)
+        {
+            return new UserManagementResult { Success = false, Found = true, Errors = update.Errors.Select(x => x.Description).ToArray() };
+        }
+
+        return await ApplyRoleAndScopeAsync(user, command, cancellationToken);
+    }
+
+    private async Task<UserManagementResult> ApplyRoleAndScopeAsync(ApplicationUser user, UserManagementSaveCommand command, CancellationToken cancellationToken)
+    {
+        var existingRoles = await _userManager.GetRolesAsync(user);
+        if (existingRoles.Count > 0)
+        {
+            var removeRoles = await _userManager.RemoveFromRolesAsync(user, existingRoles);
+            if (!removeRoles.Succeeded)
+            {
+                return new UserManagementResult { Success = false, Found = true, Errors = removeRoles.Errors.Select(x => x.Description).ToArray() };
+            }
+        }
+
+        var roleName = string.Equals(command.Role, ApplicationRoles.Admin, StringComparison.Ordinal) ? ApplicationRoles.Admin : ApplicationRoles.User;
+        var addRole = await _userManager.AddToRoleAsync(user, roleName);
+        if (!addRole.Succeeded)
+        {
+            return new UserManagementResult { Success = false, Found = true, Errors = addRole.Errors.Select(x => x.Description).ToArray() };
+        }
+
+        var existingGroupAccess = _dbContext.UserGroupAccesses.Where(x => x.UserId == user.Id);
+        var existingEndpointAccess = _dbContext.UserEndpointAccesses.Where(x => x.UserId == user.Id);
+        _dbContext.UserGroupAccesses.RemoveRange(existingGroupAccess);
+        _dbContext.UserEndpointAccesses.RemoveRange(existingEndpointAccess);
+
+        if (roleName == ApplicationRoles.User)
+        {
+            foreach (var groupId in command.GroupIds.Distinct(StringComparer.Ordinal))
+            {
+                _dbContext.UserGroupAccesses.Add(new UserGroupAccess
+                {
+                    UserGroupAccessId = Guid.NewGuid().ToString("N"),
+                    UserId = user.Id,
+                    GroupId = groupId,
+                    CreatedAtUtc = DateTimeOffset.UtcNow
+                });
+            }
+
+            foreach (var endpointId in command.EndpointIds.Distinct(StringComparer.Ordinal))
+            {
+                _dbContext.UserEndpointAccesses.Add(new UserEndpointAccess
+                {
+                    UserEndpointAccessId = Guid.NewGuid().ToString("N"),
+                    UserId = user.Id,
+                    EndpointId = endpointId,
+                    CreatedAtUtc = DateTimeOffset.UtcNow
+                });
+            }
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return new UserManagementResult { Success = true, Found = true, Errors = [] };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupAdminBootstrapService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupAdminBootstrapService.cs
@@ -2,12 +2,13 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models.Identity;
+using PingMonitor.Web.Services.Identity;
 
 namespace PingMonitor.Web.Services.StartupGate;
 
 internal sealed class StartupAdminBootstrapService : IStartupAdminBootstrapService
 {
-    public const string AdminRoleName = "Admin";
+    public const string AdminRoleName = ApplicationRoles.Admin;
 
     private readonly IDbContextFactory<PingMonitorDbContext> _dbContextFactory;
     private readonly UserManager<ApplicationUser> _userManager;
@@ -71,6 +72,11 @@ internal sealed class StartupAdminBootstrapService : IStartupAdminBootstrapServi
                 _logger.LogWarning("Startup gate failed to create the Admin role.");
                 return (false, roleResult.Errors.Select(error => error.Description).ToArray());
             }
+        }
+
+        if (!await _roleManager.RoleExistsAsync(ApplicationRoles.User))
+        {
+            await _roleManager.CreateAsync(new ApplicationRole { Name = ApplicationRoles.User });
         }
 
         var user = new ApplicationUser

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -21,6 +21,8 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "EndpointDependencies",
         "Groups",
         "EndpointGroupMemberships",
+        "UserGroupAccesses",
+        "UserEndpointAccesses",
         "MonitorAssignments",
         "CheckResults",
         "ResultBatches",
@@ -248,6 +250,28 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             );
             """;
 
+        const string createUserGroupAccessesSql = """
+            CREATE TABLE IF NOT EXISTS `UserGroupAccesses` (
+                `UserGroupAccessId` varchar(64) NOT NULL,
+                `UserId` varchar(255) NOT NULL,
+                `GroupId` varchar(64) NOT NULL,
+                `CreatedAtUtc` datetime(6) NOT NULL,
+                PRIMARY KEY (`UserGroupAccessId`),
+                UNIQUE KEY `UX_UserGroupAccesses_UserId_GroupId` (`UserId`, `GroupId`)
+            );
+            """;
+
+        const string createUserEndpointAccessesSql = """
+            CREATE TABLE IF NOT EXISTS `UserEndpointAccesses` (
+                `UserEndpointAccessId` varchar(64) NOT NULL,
+                `UserId` varchar(255) NOT NULL,
+                `EndpointId` varchar(64) NOT NULL,
+                `CreatedAtUtc` datetime(6) NOT NULL,
+                PRIMARY KEY (`UserEndpointAccessId`),
+                UNIQUE KEY `UX_UserEndpointAccesses_UserId_EndpointId` (`UserId`, `EndpointId`)
+            );
+            """;
+
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointStatesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createStateTransitionsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createApplicationSettingsSql, cancellationToken);
@@ -255,6 +279,8 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await dbContext.Database.ExecuteSqlRawAsync(createAgentHeartbeatHistorySql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createGroupsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointGroupMembershipsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createUserGroupAccessesSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createUserEndpointAccessesSql, cancellationToken);
         await EnsureEndpointDependenciesColumnsAsync(dbContext, cancellationToken);
         await MigrateLegacyEndpointDependenciesAsync(dbContext, cancellationToken);
     }

--- a/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Services.Metrics;
+using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.ViewModels.Status;
 
 namespace PingMonitor.Web.Services.Status;
@@ -10,11 +11,15 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
 {
     private readonly PingMonitorDbContext _dbContext;
     private readonly IEndpointMetricsService _endpointMetricsService;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IUserAccessScopeService _userAccessScopeService;
 
-    public EndpointStatusQueryService(PingMonitorDbContext dbContext, IEndpointMetricsService endpointMetricsService)
+    public EndpointStatusQueryService(PingMonitorDbContext dbContext, IEndpointMetricsService endpointMetricsService, IHttpContextAccessor httpContextAccessor, IUserAccessScopeService userAccessScopeService)
     {
         _dbContext = dbContext;
         _endpointMetricsService = endpointMetricsService;
+        _httpContextAccessor = httpContextAccessor;
+        _userAccessScopeService = userAccessScopeService;
     }
 
     public async Task<EndpointStatusPageViewModel> GetStatusPageAsync(
@@ -25,6 +30,12 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
         CancellationToken cancellationToken)
     {
         var normalizedState = Normalize(state);
+
+        var principal = _httpContextAccessor.HttpContext?.User;
+        var isAdmin = principal is not null && await _userAccessScopeService.IsAdminAsync(principal);
+        var visibleEndpointIds = isAdmin || principal is null
+            ? null
+            : await _userAccessScopeService.GetVisibleEndpointIdsAsync(principal, cancellationToken);
         var normalizedAgent = Normalize(agent);
         var normalizedGroupId = Normalize(groupId);
         var normalizedSearch = Normalize(search);
@@ -58,6 +69,11 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
                 SuppressedByEndpointId = endpointState != null ? endpointState.SuppressedByEndpointId : null,
                 SuppressedByEndpointName = suppressedByEndpoint != null ? suppressedByEndpoint.Name : null
             };
+
+        if (visibleEndpointIds is not null)
+        {
+            baseQuery = baseQuery.Where(row => visibleEndpointIds.Contains(row.EndpointId));
+        }
 
         if (parsedState.HasValue)
         {

--- a/src/WebApp/PingMonitor.Web/ViewModels/Users/UserPageViewModels.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Users/UserPageViewModels.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PingMonitor.Web.ViewModels.Users;
+
+public sealed class ManageUsersPageViewModel
+{
+    public string? StatusMessage { get; set; }
+    public required IReadOnlyList<UserRowViewModel> Users { get; init; } = [];
+}
+
+public sealed class UserRowViewModel
+{
+    public required string UserId { get; init; }
+    public required string UserName { get; init; }
+    public required string Email { get; init; }
+    public required string Role { get; init; }
+    public required bool Enabled { get; init; }
+}
+
+public sealed class UserEditPageViewModel
+{
+    public string? UserId { get; set; }
+
+    [Required]
+    public string UserName { get; set; } = string.Empty;
+
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [DataType(DataType.Password)]
+    public string Password { get; set; } = string.Empty;
+
+    [Required]
+    public string Role { get; set; } = "User";
+
+    public bool Enabled { get; set; } = true;
+
+    public List<string> GroupIds { get; set; } = [];
+    public List<string> EndpointIds { get; set; } = [];
+
+    public IReadOnlyList<UserOptionViewModel> AvailableGroups { get; set; } = [];
+    public IReadOnlyList<UserOptionViewModel> AvailableEndpoints { get; set; } = [];
+}
+
+public sealed class UserOptionViewModel
+{
+    public required string Id { get; init; }
+    public required string Name { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Views/Account/Login.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Account/Login.cshtml
@@ -1,0 +1,18 @@
+@model PingMonitor.Web.Controllers.AccountController.LoginViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Login</title></head>
+<body>
+<main style="max-width:420px;margin:2rem auto;font-family:Arial,sans-serif;">
+    <h1>Sign in</h1>
+    @Html.ValidationSummary(false)
+    <form method="post" action="/account/login" style="display:grid;gap:.75rem;">
+        @Html.AntiForgeryToken()
+        <input type="hidden" asp-for="ReturnUrl" />
+        <label>Username <input asp-for="UserName" /></label>
+        <label>Password <input asp-for="Password" type="password" /></label>
+        <button type="submit">Sign in</button>
+    </form>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
@@ -56,9 +56,12 @@
             <h1>Manage endpoints</h1>
             <p class="muted">Edit endpoint and assignment records without changing assignment-scoped state behavior.</p>
             <div class="button-row">
-                <a class="button" href="/endpoints/new">Add new endpoint</a>
-                <a class="button-secondary" href="/groups">Manage groups</a>
                 <a class="button-secondary" href="/status">View status</a>
+                @if (User.IsInRole("Admin"))
+                {
+                    <a class="button" href="/endpoints/new">Add new endpoint</a>
+                    <a class="button-secondary" href="/groups">Manage groups</a>
+                }
             </div>
         </section>
 
@@ -129,8 +132,11 @@
                             </div>
                             <div class="button-row" style="margin-top:.85rem;">
                                 <a class="button-secondary" href="/endpoints/@row.AssignmentId/performance">View performance</a>
-                                <a class="button-secondary" href="/endpoints/@row.AssignmentId/edit">Edit assignment</a>
-                                <a class="button-secondary" href="/endpoints/@row.AssignmentId/remove">Remove endpoint</a>
+                                @if (User.IsInRole("Admin"))
+                                {
+                                    <a class="button-secondary" href="/endpoints/@row.AssignmentId/edit">Edit assignment</a>
+                                    <a class="button-secondary" href="/endpoints/@row.AssignmentId/remove">Remove endpoint</a>
+                                }
                             </div>
                         </article>
                     }

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml
@@ -51,7 +51,10 @@
             <div class="button-row">
                 <a class="button-secondary" href="/endpoints">Back to endpoints</a>
                 <a class="button-secondary" href="/status">Back to status</a>
-                <a class="button" href="/endpoints/@Model.AssignmentId/edit">Edit assignment</a>
+                @if (User.IsInRole("Admin"))
+                {
+                    <a class="button" href="/endpoints/@Model.AssignmentId/edit">Edit assignment</a>
+                }
             </div>
         </section>
 

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -88,12 +88,16 @@
             <h1>Operational endpoint status</h1>
             <p class="muted">Current assignment-scoped status derived by the server state engine. Missing state rows are shown as <strong>UNKNOWN</strong> until trusted server-side state exists.</p>
             <div class="button-row">
-                <a class="button" href="/agents">Manage agents</a>
-                <a class="button-secondary" href="/agents/deploy">Deploy new agent</a>
-                <a class="button-secondary" href="/groups">Manage groups</a>
-                <a class="button-secondary" href="/endpoints">Manage endpoints</a>
-                <a class="button-secondary" href="/endpoints/new">Add new endpoint</a>
-                <a class="button-secondary" href="/admin">Admin settings</a>
+                <a class="button-secondary" href="/endpoints">Endpoints</a>
+                @if (User.IsInRole("Admin"))
+                {
+                    <a class="button" href="/agents">Manage agents</a>
+                    <a class="button-secondary" href="/agents/deploy">Deploy new agent</a>
+                    <a class="button-secondary" href="/groups">Manage groups</a>
+                    <a class="button-secondary" href="/endpoints/new">Add new endpoint</a>
+                    <a class="button-secondary" href="/admin">Admin settings</a>
+                    <a class="button-secondary" href="/users">Manage users</a>
+                }
             </div>
         </section>
 

--- a/src/WebApp/PingMonitor.Web/Views/Users/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/Edit.cshtml
@@ -1,0 +1,20 @@
+@model PingMonitor.Web.ViewModels.Users.UserEditPageViewModel
+<!DOCTYPE html><html><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Edit User</title></head>
+<body><main style="font-family:Arial;max-width:980px;margin:1rem auto;">
+<h1>Edit user</h1>
+@Html.ValidationSummary(false)
+<form method="post" style="display:grid;gap:.75rem;">
+@Html.AntiForgeryToken()
+<label>Username <input asp-for="UserName" /></label>
+<label>Email <input asp-for="Email" /></label>
+<label>Role <select asp-for="Role"><option>Admin</option><option>User</option></select></label>
+<label><input asp-for="Enabled" type="checkbox"/> Enabled</label>
+<fieldset><legend>Allowed groups</legend>
+@foreach (var group in Model.AvailableGroups) { <label><input type="checkbox" name="GroupIds" value="@group.Id" checked="@(Model.GroupIds.Contains(group.Id))"/> @group.Name</label><br/> }
+</fieldset>
+<fieldset><legend>Allowed endpoints</legend>
+@foreach (var endpoint in Model.AvailableEndpoints) { <label><input type="checkbox" name="EndpointIds" value="@endpoint.Id" checked="@(Model.EndpointIds.Contains(endpoint.Id))"/> @endpoint.Name</label><br/> }
+</fieldset>
+<button type="submit">Save user</button>
+</form>
+</main></body></html>

--- a/src/WebApp/PingMonitor.Web/Views/Users/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/Index.cshtml
@@ -1,0 +1,12 @@
+@model PingMonitor.Web.ViewModels.Users.ManageUsersPageViewModel
+<!DOCTYPE html><html><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Users</title></head>
+<body><main style="font-family:Arial;max-width:980px;margin:1rem auto;">
+<h1>Manage users</h1>
+@if (!string.IsNullOrWhiteSpace(Model.StatusMessage)) { <p>@Model.StatusMessage</p> }
+<p><a href="/users/new">Create user</a> | <a href="/status">Status</a></p>
+<table style="width:100%"><thead><tr><th>User</th><th>Email</th><th>Role</th><th>Enabled</th><th></th></tr></thead><tbody>
+@foreach (var user in Model.Users) {
+<tr><td>@user.UserName</td><td>@user.Email</td><td>@user.Role</td><td>@(user.Enabled?"Yes":"No")</td><td><a href="/users/@user.UserId/edit">Edit</a></td></tr>
+}
+</tbody></table>
+</main></body></html>

--- a/src/WebApp/PingMonitor.Web/Views/Users/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/New.cshtml
@@ -1,0 +1,22 @@
+@model PingMonitor.Web.ViewModels.Users.UserEditPageViewModel
+@{ ViewData["Title"] = "New User"; }
+<!DOCTYPE html><html><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>@ViewData["Title"]</title></head>
+<body><main style="font-family:Arial;max-width:980px;margin:1rem auto;">
+<h1>Create user</h1>
+@Html.ValidationSummary(false)
+<form method="post" style="display:grid;gap:.75rem;">
+@Html.AntiForgeryToken()
+<label>Username <input asp-for="UserName" /></label>
+<label>Email <input asp-for="Email" /></label>
+<label>Password <input asp-for="Password" type="password" /></label>
+<label>Role <select asp-for="Role"><option>Admin</option><option>User</option></select></label>
+<label><input asp-for="Enabled" type="checkbox"/> Enabled</label>
+<fieldset><legend>Allowed groups</legend>
+@foreach (var group in Model.AvailableGroups) { <label><input type="checkbox" name="GroupIds" value="@group.Id" checked="@(Model.GroupIds.Contains(group.Id))"/> @group.Name</label><br/> }
+</fieldset>
+<fieldset><legend>Allowed endpoints</legend>
+@foreach (var endpoint in Model.AvailableEndpoints) { <label><input type="checkbox" name="EndpointIds" value="@endpoint.Id" checked="@(Model.EndpointIds.Contains(endpoint.Id))"/> @endpoint.Name</label><br/> }
+</fieldset>
+<button type="submit">Create user</button>
+</form>
+</main></body></html>


### PR DESCRIPTION
### Motivation
- Provide basic user management and a simple v1 access model so additional admins and scoped read-only users can be created and managed. 
- Reuse the existing ASP.NET Identity foundation and keep the permissions model explicit and minimal (Admin vs User). 
- Ensure visibility is enforced server-side (query/service layer) so non-admins cannot access disallowed endpoints by URL tampering. 

### Description
- Add explicit persistence for scoped grants with `UserGroupAccess` and `UserEndpointAccess` entities, DbSet registrations, unique indexes, and startup-schema SQL to create the tables. 
- Introduce a small identity/management surface: `ApplicationRoles`, `RoleBootstrapService`, `IUserManagementService`/`UserManagementService`, `IUserAccessScopeService`/`UserAccessScopeService`, plus admin-only user-management pages and views (`/users`, `/users/new`, `/users/{id}/edit`) and a login/logout flow (`/account/login`). 
- Wire authentication and authorization into the app (`AddSignInManager`, cookie identity cookies, fallback authenticated policy), bootstrap `Admin`/`User` roles at startup, and restrict write/admin routes (`/admin`, `/agents`, `/groups`, endpoint write actions and user management) to admins. 
- Enforce scoped read-only visibility server-side by filtering in query services used by `/status` and `/endpoints`, and by checking assignment access in the performance query service; visibility = union of directly granted endpoints and endpoints in granted groups. 
- Update docs (`docs/data-model.md`, `README.md`) to describe `UserGroupAccess` and `UserEndpointAccess` and the v1 roles/visibility semantics. 

### Testing
- Created and linked a GitHub issue before implementation (see issue #110). 
- Built the web app with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which succeeded after addressing required-view-model initialization issues. 
- Ran `dotnet test src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which completed without test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c56b880044832a9396e91e1f1c02a0)