### PR TITLE
Fix MySQL dependency ID validation crash in endpoint management

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementService.cs
@@ -416,14 +416,12 @@ internal sealed class EndpointManagementService : IEndpointManagementService
         var dependencyIds = normalizedDependencies.ToArray();
         if (dependencyIds.Length > 0)
         {
-            var existingDependencyIds = await _dbContext.Endpoints.AsNoTracking()
-                .Where(x => dependencyIds.Contains(x.EndpointId))
-                .Select(x => x.EndpointId)
-                .ToArrayAsync(cancellationToken);
-
             foreach (var dependencyId in dependencyIds)
             {
-                if (!existingDependencyIds.Contains(dependencyId, StringComparer.Ordinal))
+                var dependencyExists = await _dbContext.Endpoints.AsNoTracking()
+                    .AnyAsync(x => x.EndpointId == dependencyId, cancellationToken);
+
+                if (!dependencyExists)
                 {
                     errors.Add(new EndpointValidationError(nameof(UpdateEndpointCommand.DependsOnEndpointIds), $"Dependency endpoint '{dependencyId}' does not exist."));
                 }


### PR DESCRIPTION
### Motivation
- Endpoint creation/update could throw `System.InvalidOperationException: Expression '@dependencyIds' in the SQL tree does not have a type mapping assigned.` because validation used `Contains` over a local string array which does not translate with the MySQL EF provider.

### Description
- Replace the provider-incompatible query (`.Where(x => dependencyIds.Contains(x.EndpointId))`) with explicit per-dependency `AnyAsync(x => x.EndpointId == dependencyId)` checks inside `ValidateAgentAndDependenciesAndGroupsAsync` in `src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementService.cs` to avoid the EF Core/MySQL translation error.
- Preserve the original validation semantics and error messages for missing dependency IDs, and leave agent/group validation and cycle detection logic unchanged.
- This change is linked to the tracking issue and fixes it (`Fixes #112`).

### Testing
- Verified toolchain with `dotnet --version` and `pwsh --version`, both succeeded.
- Executed `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the project built successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c575a4e1dc832ab257f400c18acce6)