### PR TITLE
Fix MySQL EF translation in parent dependency evaluation

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
@@ -170,9 +170,18 @@ internal sealed class StateEvaluationService : IStateEvaluationService
             return ParentStateContext.None;
         }
 
-        var parentAssignments = await _dbContext.MonitorAssignments.AsNoTracking()
-            .Where(x => x.AgentId == assignment.AgentId && directParentEndpointIds.Contains(x.EndpointId))
-            .ToDictionaryAsync(x => x.EndpointId, x => x.AssignmentId, cancellationToken);
+        var parentAssignments = await _dbContext.EndpointDependencies.AsNoTracking()
+            .Where(x => x.EndpointId == endpointId)
+            .Join(
+                _dbContext.MonitorAssignments.AsNoTracking().Where(x => x.AgentId == assignment.AgentId),
+                dependency => dependency.DependsOnEndpointId,
+                monitorAssignment => monitorAssignment.EndpointId,
+                (dependency, monitorAssignment) => new
+                {
+                    ParentEndpointId = dependency.DependsOnEndpointId,
+                    monitorAssignment.AssignmentId
+                })
+            .ToDictionaryAsync(x => x.ParentEndpointId, x => x.AssignmentId, cancellationToken);
 
         if (parentAssignments.Count == 0)
         {
@@ -180,18 +189,26 @@ internal sealed class StateEvaluationService : IStateEvaluationService
         }
 
         var parentStates = await _dbContext.EndpointStates.AsNoTracking()
-            .Where(x => parentAssignments.Values.Contains(x.AssignmentId))
-            .Select(x => new { x.AssignmentId, x.CurrentState })
+            .Where(x => x.AgentId == assignment.AgentId)
+            .Join(
+                _dbContext.MonitorAssignments.AsNoTracking(),
+                state => state.AssignmentId,
+                monitorAssignment => monitorAssignment.AssignmentId,
+                (state, monitorAssignment) => new
+                {
+                    monitorAssignment.EndpointId,
+                    state.CurrentState
+                })
             .ToArrayAsync(cancellationToken);
 
         foreach (var parentEndpointId in directParentEndpointIds)
         {
-            if (!parentAssignments.TryGetValue(parentEndpointId, out var parentAssignmentId))
+            if (!parentAssignments.ContainsKey(parentEndpointId))
             {
                 continue;
             }
 
-            if (parentStates.Any(x => x.AssignmentId == parentAssignmentId && x.CurrentState == EndpointStateKind.Down))
+            if (parentStates.Any(x => x.EndpointId == parentEndpointId && x.CurrentState == EndpointStateKind.Down))
             {
                 return new ParentStateContext(parentEndpointId, true);
             }


### PR DESCRIPTION
### Motivation
- Result ingestion could fail on MySQL with `Expression '@directParentEndpointIds' ... does not have a type mapping assigned` when evaluating parent dependencies, causing state evaluation and ingestion to fail. 

### Description
- Replace the `Contains(...)`-based parent assignment lookup in `StateEvaluationService.GetParentContextAsync` with an explicit join between `EndpointDependencies` and `MonitorAssignments` to avoid provider-side unmapped SQL parameters (file: `src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs`).
- Replace the parent state lookup that used a local collection check with a join between `EndpointStates` and `MonitorAssignments` (scoped by agent) and then evaluate dependency-down status by iterating the previously retrieved `directParentEndpointIds`, preserving suppression semantics and deterministic evaluation order.
- Small defensive change to check parent presence with `ContainsKey` instead of trying to retrieve a value that may not exist.
- Links this work to issue `#114` for traceability (PR includes `Fixes #114`).

### Testing
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which succeeded with no warnings or errors. 
- Ran `dotnet test src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj --no-build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c57c33f714832aa235ddac0d6db1d5)