### PR TITLE
Fix /agents crash caused by EF Core type mapping for agent id filters

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Metrics/AgentMetricsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/AgentMetricsService.cs
@@ -30,24 +30,24 @@ internal sealed class AgentMetricsService : IAgentMetricsService
             .Distinct(StringComparer.Ordinal)
             .ToArray();
 
-        var historyRows = await _dbContext.AgentHeartbeatHistories
-            .AsNoTracking()
-            .Where(x => normalizedAgentIds.Contains(x.AgentId) && x.HeartbeatAtUtc >= windowStart && x.HeartbeatAtUtc <= now)
-            .Select(x => new { x.AgentId, x.HeartbeatAtUtc })
-            .ToListAsync(cancellationToken);
-
         var summaries = normalizedAgentIds.ToDictionary(
             x => x,
             _ => new AgentMetricSummary { UptimePercent = 0d },
             StringComparer.Ordinal);
 
         const int totalWindowMinutes = 24 * 60;
-        foreach (var group in historyRows.GroupBy(x => x.AgentId, StringComparer.Ordinal))
+        foreach (var agentId in normalizedAgentIds)
         {
             var minuteBuckets = new HashSet<int>();
-            foreach (var heartbeat in group)
+            var heartbeats = await _dbContext.AgentHeartbeatHistories
+                .AsNoTracking()
+                .Where(x => x.AgentId == agentId && x.HeartbeatAtUtc >= windowStart && x.HeartbeatAtUtc <= now)
+                .Select(x => x.HeartbeatAtUtc)
+                .ToListAsync(cancellationToken);
+
+            foreach (var heartbeatAtUtc in heartbeats)
             {
-                var minuteIndex = (int)Math.Floor((heartbeat.HeartbeatAtUtc - windowStart).TotalMinutes);
+                var minuteIndex = (int)Math.Floor((heartbeatAtUtc - windowStart).TotalMinutes);
                 if (minuteIndex < 0 || minuteIndex >= totalWindowMinutes)
                 {
                     continue;
@@ -57,7 +57,7 @@ internal sealed class AgentMetricsService : IAgentMetricsService
             }
 
             var uptimePercent = minuteBuckets.Count / (double)totalWindowMinutes * 100d;
-            summaries[group.Key] = new AgentMetricSummary { UptimePercent = uptimePercent };
+            summaries[agentId] = new AgentMetricSummary { UptimePercent = uptimePercent };
         }
 
         return summaries;


### PR DESCRIPTION
### Motivation
- The MySQL EF Core provider failed translating the `normalizedAgentIds.Contains(x.AgentId)` expression, causing `System.InvalidOperationException: Expression '@normalizedAgentIds' in the SQL tree does not have a type mapping assigned.` when loading `/agents` metrics.  
- The change avoids provider-specific translation paths while preserving existing uptime bucketing semantics.  
- This PR is linked to the tracking issue and will close it: `Closes #120`.

### Description
- Replace the single `IN`-style query over `normalizedAgentIds` with explicit per-agent scalar-filtered queries using `x.AgentId == agentId` to avoid the EF Core/MySQL type-mapping bug.  
- Preserve the 24-hour minute-bucket uptime calculation and the default `0%` summary for agents with no history.  
- Modified file: `src/WebApp/PingMonitor.Web/Services/Metrics/AgentMetricsService.cs` (query and iteration logic updated).  

### Testing
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -c Release` and the build succeeded.  
- Verified `dotnet --version` after installing the required SDK (`10.0.104`) to match `global.json` and ensure the project compiles under the intended runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c599917a40832a80b151819dafbe8f)