### PR TITLE
Handle post-persist state evaluation failures in result ingestion

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
@@ -10,13 +10,16 @@ internal sealed class ResultIngestionService : IResultIngestionService
 {
     private readonly PingMonitorDbContext _dbContext;
     private readonly IStateEvaluationService _stateEvaluationService;
+    private readonly ILogger<ResultIngestionService> _logger;
 
     public ResultIngestionService(
         PingMonitorDbContext dbContext,
-        IStateEvaluationService stateEvaluationService)
+        IStateEvaluationService stateEvaluationService,
+        ILogger<ResultIngestionService> logger)
     {
         _dbContext = dbContext;
         _stateEvaluationService = stateEvaluationService;
+        _logger = logger;
     }
 
     public async Task<SubmitResultsResponse> IngestAsync(Agent agent, SubmitResultsRequest request, CancellationToken cancellationToken)
@@ -137,7 +140,19 @@ internal sealed class ResultIngestionService : IResultIngestionService
                 .Distinct(StringComparer.Ordinal)
                 .ToArray();
 
-            await _stateEvaluationService.EvaluateAssignmentsAsync(affectedAssignmentIds, cancellationToken);
+            try
+            {
+                await _stateEvaluationService.EvaluateAssignmentsAsync(affectedAssignmentIds, CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Result ingestion persisted batch {BatchId} for agent {AgentId}, but state evaluation failed for assignments: {AssignmentIds}.",
+                    normalizedBatchId,
+                    agent.AgentId,
+                    affectedAssignmentIds);
+            }
 
             return new SubmitResultsResponse(true, storedResults.Length, false, serverTimeUtc);
         }


### PR DESCRIPTION
### Motivation
- Ingestion was returning a server error when post-persist state evaluation encountered cancellations or transient DB failures even though the results were already committed to the database (observed `TaskCanceledException` from MySQL pool).
- Persisted result batches must be acknowledged reliably and any follow-up state-evaluation failures must be auditable without causing ingestion to fail.
- Decouple follow-up work from the request's cancellation to avoid false-negative ingestion responses and to preserve observability.
- This change is tracked in issue `#122` and implements the intended safe behaviour for post-persist evaluation errors.\

### Description
- Injected `ILogger<ResultIngestionService>` into `ResultIngestionService` for explicit logging of post-persist failures. (file: `src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs`) 
- Run the post-commit call to `_stateEvaluationService.EvaluateAssignmentsAsync` with `CancellationToken.None` instead of the request token to decouple it from request cancellation. (file: `ResultIngestionService.cs`) 
- Wrapped the state-evaluation call in a `try/catch` and log any exception as an error while still returning a successful `SubmitResultsResponse` when persistence has completed. (file: `ResultIngestionService.cs`) 
- Behavior: ingestion still commits and returns success when DB writes succeed; state evaluation failures are logged for audit/observability and do not cause the API to return a server error. Fixes #122

### Testing
- `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` completed successfully. 
- `dotnet test src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` completed with no test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7ccff663c832aa6edd73f234603b6)