### PR TITLE
Phase 1: configuration backup export, listing, and secure download

### DIFF
--- a/docs/config-backup-and-restore.md
+++ b/docs/config-backup-and-restore.md
@@ -85,3 +85,13 @@ Example:
     "identity": [...]
   }
 }
+```
+
+## Phase 1 implementation notes
+
+- This phase implements **export only**.
+- Restore and upload workflows are intentionally not implemented yet.
+- Backup name is required for export.
+- Notes are stored in the backup document metadata (`notes`) and displayed in backup listings.
+- Backup files are stored server-side under the configured `Backup:StoragePath` location (default `App_Data/Backups`), which is outside public static web content.
+- Backup format remains JSON and configuration-only.

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminBackupsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminBackupsController.cs
@@ -1,0 +1,146 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Services.Backups;
+using PingMonitor.Web.Services.Identity;
+using PingMonitor.Web.ViewModels.Backups;
+
+namespace PingMonitor.Web.Controllers;
+
+[Authorize(Roles = ApplicationRoles.Admin)]
+[Route("admin/backups")]
+public sealed class AdminBackupsController : Controller
+{
+    private readonly IConfigurationBackupService _backupService;
+    private readonly IConfigurationBackupQueryService _backupQueryService;
+
+    public AdminBackupsController(
+        IConfigurationBackupService backupService,
+        IConfigurationBackupQueryService backupQueryService)
+    {
+        _backupService = backupService;
+        _backupQueryService = backupQueryService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Index(CancellationToken cancellationToken)
+    {
+        var viewModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), statusMessage: null, cancellationToken);
+        return View("Index", viewModel);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create([FromForm] CreateBackupPageForm form, CancellationToken cancellationToken)
+    {
+        var selectedSections = GetSelectedSections(form);
+        if (selectedSections.Count == 0)
+        {
+            ModelState.AddModelError(string.Empty, "Select at least one configuration section to export.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            var invalidModel = await BuildPageViewModelAsync(form, statusMessage: null, cancellationToken);
+            return View("Index", invalidModel);
+        }
+
+        try
+        {
+            await _backupService.CreateBackupAsync(
+                new CreateConfigurationBackupRequest
+                {
+                    BackupName = form.BackupName,
+                    Notes = form.Notes,
+                    SelectedSections = selectedSections,
+                    ExportedBy = User?.Identity?.Name
+                },
+                cancellationToken);
+
+            return RedirectToAction(nameof(Index), new { status = "Backup created successfully." });
+        }
+        catch (InvalidOperationException ex)
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+            var invalidModel = await BuildPageViewModelAsync(form, statusMessage: null, cancellationToken);
+            return View("Index", invalidModel);
+        }
+    }
+
+    [HttpGet("download")]
+    public IActionResult Download([FromQuery] string id)
+    {
+        try
+        {
+            var fullPath = _backupQueryService.ResolveDownloadPath(id);
+            var fileName = Path.GetFileName(fullPath);
+            return PhysicalFile(fullPath, "application/json", fileName);
+        }
+        catch (FileNotFoundException)
+        {
+            return NotFound();
+        }
+    }
+
+    private async Task<AdminBackupsPageViewModel> BuildPageViewModelAsync(CreateBackupPageForm form, string? statusMessage, CancellationToken cancellationToken)
+    {
+        var backups = await _backupQueryService.ListBackupsAsync(cancellationToken);
+        return new AdminBackupsPageViewModel
+        {
+            Form = form,
+            StatusMessage = statusMessage ?? Request.Query["status"],
+            Backups = backups
+                .Select(item => new BackupRowViewModel
+                {
+                    FileName = item.FileName,
+                    FileId = item.FileId,
+                    BackupName = string.IsNullOrWhiteSpace(item.BackupName) ? "(unknown)" : item.BackupName,
+                    AppVersion = item.AppVersion,
+                    ExportedAtUtc = item.ExportedAtUtc,
+                    FileCreatedAtUtc = item.FileCreatedAtUtc,
+                    IncludedSectionsDisplay = item.IncludedSections.Count == 0
+                        ? "(not detected)"
+                        : string.Join(", ", item.IncludedSections.Select(ToDisplaySectionName)),
+                    NotesSummary = item.NotesSummary
+                })
+                .ToArray()
+        };
+    }
+
+    private static List<string> GetSelectedSections(CreateBackupPageForm form)
+    {
+        var sections = new List<string>();
+        if (form.IncludeAgents)
+        {
+            sections.Add(ConfigurationBackupSections.Agents);
+        }
+
+        if (form.IncludeEndpoints)
+        {
+            sections.Add(ConfigurationBackupSections.Endpoints);
+        }
+
+        if (form.IncludeAssignments)
+        {
+            sections.Add(ConfigurationBackupSections.Assignments);
+        }
+
+        if (form.IncludeIdentity)
+        {
+            sections.Add(ConfigurationBackupSections.Identity);
+        }
+
+        return sections;
+    }
+
+    private static string ToDisplaySectionName(string section)
+    {
+        return section switch
+        {
+            ConfigurationBackupSections.Agents => "Agents",
+            ConfigurationBackupSections.Endpoints => "Endpoints",
+            ConfigurationBackupSections.Assignments => "Assignments",
+            ConfigurationBackupSections.Identity => "Identity",
+            _ => section
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Options/BackupOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/BackupOptions.cs
@@ -1,0 +1,8 @@
+namespace PingMonitor.Web.Options;
+
+public sealed class BackupOptions
+{
+    public const string SectionName = "Backup";
+
+    public string StoragePath { get; set; } = "App_Data/Backups";
+}

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -9,6 +9,7 @@ using PingMonitor.Web.Models.Identity;
 using PingMonitor.Web.Options;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.Agents;
+using PingMonitor.Web.Services.Backups;
 using PingMonitor.Web.Services.Endpoints;
 using PingMonitor.Web.Services.Groups;
 using PingMonitor.Web.Services.Identity;
@@ -28,6 +29,7 @@ builder.Services.Configure<AgentApiOptions>(builder.Configuration.GetSection(Age
 builder.Services.Configure<DevelopmentSeedAgentOptions>(builder.Configuration.GetSection(DevelopmentSeedAgentOptions.SectionName));
 builder.Services.Configure<StartupGateOptions>(builder.Configuration.GetSection(StartupGateOptions.SectionName));
 builder.Services.Configure<AgentProvisioningOptions>(builder.Configuration.GetSection(AgentProvisioningOptions.SectionName));
+builder.Services.Configure<BackupOptions>(builder.Configuration.GetSection(BackupOptions.SectionName));
 
 builder.Services.AddSingleton<IDbContextFactory<PingMonitorDbContext>, DynamicPingMonitorDbContextFactory>();
 builder.Services.AddScoped(sp => sp.GetRequiredService<IDbContextFactory<PingMonitorDbContext>>().CreateDbContext());
@@ -126,6 +128,9 @@ builder.Services.AddScoped<IEndpointMetricsService, EndpointMetricsService>();
 builder.Services.AddScoped<IAgentMetricsService, AgentMetricsService>();
 builder.Services.AddScoped<IUserAccessScopeService, UserAccessScopeService>();
 builder.Services.AddScoped<IUserManagementService, UserManagementService>();
+builder.Services.AddScoped<IConfigurationBackupFileNameGenerator, ConfigurationBackupFileNameGenerator>();
+builder.Services.AddScoped<IConfigurationBackupService, ConfigurationBackupService>();
+builder.Services.AddScoped<IConfigurationBackupQueryService, ConfigurationBackupQueryService>();
 
 var app = builder.Build();
 

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupFileNameGenerator.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupFileNameGenerator.cs
@@ -1,0 +1,63 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace PingMonitor.Web.Services.Backups;
+
+public interface IConfigurationBackupFileNameGenerator
+{
+    string CreateFileName(string backupName, string appVersion, DateTimeOffset exportedAtUtc);
+}
+
+public sealed partial class ConfigurationBackupFileNameGenerator : IConfigurationBackupFileNameGenerator
+{
+    private const int MaxNameLength = 64;
+
+    public string CreateFileName(string backupName, string appVersion, DateTimeOffset exportedAtUtc)
+    {
+        if (string.IsNullOrWhiteSpace(backupName))
+        {
+            throw new ArgumentException("Backup name is required.", nameof(backupName));
+        }
+
+        var safeBackupName = SanitizeBackupName(backupName);
+        var safeVersion = SanitizeBackupName(appVersion);
+        var timestamp = exportedAtUtc.UtcDateTime.ToString("yyyy-MM-dd-HH-mm-ss");
+        return $"config-backup-{safeBackupName}-{safeVersion}-{timestamp}.json";
+    }
+
+    private static string SanitizeBackupName(string input)
+    {
+        var lowered = input.Trim().ToLowerInvariant();
+        var spaced = WhitespaceRegex().Replace(lowered, "-");
+
+        var builder = new StringBuilder(spaced.Length);
+        foreach (var c in spaced)
+        {
+            if (Path.GetInvalidFileNameChars().Contains(c))
+            {
+                continue;
+            }
+
+            if (char.IsLetterOrDigit(c) || c is '-' or '_')
+            {
+                builder.Append(c);
+            }
+        }
+
+        var sanitized = builder.ToString().Trim('-');
+        if (sanitized.Length > MaxNameLength)
+        {
+            sanitized = sanitized[..MaxNameLength].Trim('-');
+        }
+
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            return "backup";
+        }
+
+        return sanitized;
+    }
+
+    [GeneratedRegex("\\s+")]
+    private static partial Regex WhitespaceRegex();
+}

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs
@@ -1,0 +1,199 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace PingMonitor.Web.Services.Backups;
+
+public static class ConfigurationBackupSections
+{
+    public const string Agents = "agents";
+    public const string Endpoints = "endpoints";
+    public const string Assignments = "assignments";
+    public const string Identity = "identity";
+
+    public static readonly string[] All = [Agents, Endpoints, Assignments, Identity];
+}
+
+public sealed class ConfigurationBackupMetadata
+{
+    public const int CurrentFormatVersion = 1;
+
+    public int FormatVersion { get; init; } = CurrentFormatVersion;
+    public string AppVersion { get; init; } = string.Empty;
+    public string BackupName { get; init; } = string.Empty;
+    public string? Notes { get; init; }
+    public DateTimeOffset ExportedAtUtc { get; init; }
+    public string? ExportedBy { get; init; }
+    public string MachineName { get; init; } = string.Empty;
+}
+
+public sealed class ConfigurationBackupDocument
+{
+    [JsonPropertyOrder(1)]
+    [JsonPropertyName("formatVersion")]
+    public int FormatVersion { get; init; }
+
+    [JsonPropertyOrder(2)]
+    [JsonPropertyName("appVersion")]
+    public string AppVersion { get; init; } = string.Empty;
+
+    [JsonPropertyOrder(3)]
+    [JsonPropertyName("backupName")]
+    public string BackupName { get; init; } = string.Empty;
+
+    [JsonPropertyOrder(4)]
+    [JsonPropertyName("notes")]
+    public string? Notes { get; init; }
+
+    [JsonPropertyOrder(5)]
+    [JsonPropertyName("exportedAtUtc")]
+    public DateTimeOffset ExportedAtUtc { get; init; }
+
+    [JsonPropertyOrder(6)]
+    [JsonPropertyName("exportedBy")]
+    public string? ExportedBy { get; init; }
+
+    [JsonPropertyOrder(7)]
+    [JsonPropertyName("machineName")]
+    public string MachineName { get; init; } = string.Empty;
+
+    [JsonPropertyOrder(8)]
+    [JsonPropertyName("sections")]
+    public ConfigurationBackupSectionData Sections { get; init; } = new();
+
+    public static ConfigurationBackupDocument Create(ConfigurationBackupMetadata metadata, ConfigurationBackupSectionData sections)
+    {
+        return new ConfigurationBackupDocument
+        {
+            FormatVersion = metadata.FormatVersion,
+            AppVersion = metadata.AppVersion,
+            BackupName = metadata.BackupName,
+            Notes = metadata.Notes,
+            ExportedAtUtc = metadata.ExportedAtUtc,
+            ExportedBy = metadata.ExportedBy,
+            MachineName = metadata.MachineName,
+            Sections = sections
+        };
+    }
+}
+
+public sealed class ConfigurationBackupSectionData
+{
+    [JsonPropertyName("agents")]
+    public IReadOnlyList<BackupAgentRecord>? Agents { get; init; }
+
+    [JsonPropertyName("endpoints")]
+    public IReadOnlyList<BackupEndpointRecord>? Endpoints { get; init; }
+
+    [JsonPropertyName("assignments")]
+    public IReadOnlyList<BackupAssignmentRecord>? Assignments { get; init; }
+
+    [JsonPropertyName("identity")]
+    public BackupIdentitySection? Identity { get; init; }
+}
+
+public sealed class BackupAgentRecord
+{
+    public string AgentId { get; init; } = string.Empty;
+    public string InstanceId { get; init; } = string.Empty;
+    public string? Name { get; init; }
+    public string? Site { get; init; }
+    public bool Enabled { get; init; }
+    public string? AgentVersion { get; init; }
+    public string? Platform { get; init; }
+    public string? MachineName { get; init; }
+    public DateTimeOffset CreatedAtUtc { get; init; }
+}
+
+public sealed class BackupEndpointRecord
+{
+    public string EndpointId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string Target { get; init; } = string.Empty;
+    public string IconKey { get; init; } = string.Empty;
+    public bool Enabled { get; init; }
+    public IReadOnlyList<string> Tags { get; init; } = [];
+    public string? Notes { get; init; }
+    public DateTimeOffset CreatedAtUtc { get; init; }
+}
+
+public sealed class BackupAssignmentRecord
+{
+    public string AssignmentId { get; init; } = string.Empty;
+    public string AgentId { get; init; } = string.Empty;
+    public string EndpointId { get; init; } = string.Empty;
+    public string CheckType { get; init; } = string.Empty;
+    public bool Enabled { get; init; }
+    public int PingIntervalSeconds { get; init; }
+    public int RetryIntervalSeconds { get; init; }
+    public int TimeoutMs { get; init; }
+    public int FailureThreshold { get; init; }
+    public int RecoveryThreshold { get; init; }
+    public DateTimeOffset CreatedAtUtc { get; init; }
+    public DateTimeOffset UpdatedAtUtc { get; init; }
+}
+
+public sealed class BackupIdentitySection
+{
+    public IReadOnlyList<BackupIdentityUserRecord> Users { get; init; } = [];
+    public IReadOnlyList<BackupIdentityRoleRecord> Roles { get; init; } = [];
+    public IReadOnlyList<BackupIdentityUserRoleRecord> UserRoles { get; init; } = [];
+}
+
+public sealed class BackupIdentityUserRecord
+{
+    public string Id { get; init; } = string.Empty;
+    public string? UserName { get; init; }
+    public string? NormalizedUserName { get; init; }
+    public string? Email { get; init; }
+    public string? NormalizedEmail { get; init; }
+    public bool EmailConfirmed { get; init; }
+    public bool LockoutEnabled { get; init; }
+    public DateTimeOffset? LockoutEnd { get; init; }
+    public int AccessFailedCount { get; init; }
+}
+
+public sealed class BackupIdentityRoleRecord
+{
+    public string Id { get; init; } = string.Empty;
+    public string? Name { get; init; }
+    public string? NormalizedName { get; init; }
+}
+
+public sealed class BackupIdentityUserRoleRecord
+{
+    public string UserId { get; init; } = string.Empty;
+    public string RoleId { get; init; } = string.Empty;
+}
+
+public sealed class BackupFileListItem
+{
+    public string FileName { get; init; } = string.Empty;
+    public string FileId { get; init; } = string.Empty;
+    public DateTimeOffset FileCreatedAtUtc { get; init; }
+    public DateTimeOffset? ExportedAtUtc { get; init; }
+    public string? BackupName { get; init; }
+    public string? AppVersion { get; init; }
+    public IReadOnlyList<string> IncludedSections { get; init; } = [];
+    public string? NotesSummary { get; init; }
+}
+
+public sealed class CreateConfigurationBackupRequest
+{
+    [Required(ErrorMessage = "Backup name is required.")]
+    public string BackupName { get; init; } = string.Empty;
+
+    public string? Notes { get; init; }
+
+    public required IReadOnlyList<string> SelectedSections { get; init; }
+
+    public string? ExportedBy { get; init; }
+}
+
+public sealed class CreateConfigurationBackupResponse
+{
+    public string FileName { get; init; } = string.Empty;
+    public string FileId { get; init; } = string.Empty;
+    public string BackupName { get; init; } = string.Empty;
+    public DateTimeOffset ExportedAtUtc { get; init; }
+    public IReadOnlyList<string> IncludedSections { get; init; } = [];
+}

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupQueryService.cs
@@ -1,0 +1,184 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Options;
+using PingMonitor.Web.Options;
+
+namespace PingMonitor.Web.Services.Backups;
+
+public interface IConfigurationBackupQueryService
+{
+    Task<IReadOnlyList<BackupFileListItem>> ListBackupsAsync(CancellationToken cancellationToken);
+    string ResolveDownloadPath(string fileId);
+}
+
+public sealed class ConfigurationBackupQueryService : IConfigurationBackupQueryService
+{
+    private readonly IWebHostEnvironment _environment;
+    private readonly BackupOptions _options;
+
+    public ConfigurationBackupQueryService(IWebHostEnvironment environment, IOptions<BackupOptions> options)
+    {
+        _environment = environment;
+        _options = options.Value;
+    }
+
+    public async Task<IReadOnlyList<BackupFileListItem>> ListBackupsAsync(CancellationToken cancellationToken)
+    {
+        var storagePath = ResolveStoragePath();
+        if (!Directory.Exists(storagePath))
+        {
+            return [];
+        }
+
+        var files = Directory.EnumerateFiles(storagePath, "config-backup-*.json", SearchOption.TopDirectoryOnly)
+            .OrderByDescending(path => path, StringComparer.Ordinal)
+            .ToArray();
+
+        var rows = new List<BackupFileListItem>(files.Length);
+        foreach (var fullPath in files)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var fileInfo = new FileInfo(fullPath);
+            var metadata = await TryReadMetadataAsync(fullPath, cancellationToken);
+
+            rows.Add(new BackupFileListItem
+            {
+                FileName = fileInfo.Name,
+                FileId = fileInfo.Name,
+                FileCreatedAtUtc = fileInfo.CreationTimeUtc,
+                ExportedAtUtc = metadata.ExportedAtUtc,
+                BackupName = metadata.BackupName,
+                AppVersion = metadata.AppVersion,
+                IncludedSections = metadata.IncludedSections,
+                NotesSummary = metadata.NotesSummary
+            });
+        }
+
+        return rows;
+    }
+
+    public string ResolveDownloadPath(string fileId)
+    {
+        if (string.IsNullOrWhiteSpace(fileId))
+        {
+            throw new FileNotFoundException("Backup file was not found.");
+        }
+
+        var fileName = Path.GetFileName(fileId);
+        if (!string.Equals(fileName, fileId, StringComparison.Ordinal))
+        {
+            throw new FileNotFoundException("Backup file was not found.");
+        }
+
+        var rootPath = Path.GetFullPath(ResolveStoragePath());
+        var fullPath = Path.GetFullPath(Path.Combine(rootPath, fileName));
+
+        if (!fullPath.StartsWith(rootPath, StringComparison.Ordinal))
+        {
+            throw new FileNotFoundException("Backup file was not found.");
+        }
+
+        if (!File.Exists(fullPath))
+        {
+            throw new FileNotFoundException("Backup file was not found.");
+        }
+
+        return fullPath;
+    }
+
+    private string ResolveStoragePath()
+    {
+        return Path.IsPathRooted(_options.StoragePath)
+            ? _options.StoragePath
+            : Path.Combine(_environment.ContentRootPath, _options.StoragePath);
+    }
+
+    private static async Task<BackupListMetadata> TryReadMetadataAsync(string fullPath, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var stream = File.OpenRead(fullPath);
+            using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+            var root = document.RootElement;
+
+            DateTimeOffset? exportedAtUtc = null;
+            if (root.TryGetProperty("exportedAtUtc", out var exportedAtProperty)
+                && exportedAtProperty.ValueKind == JsonValueKind.String
+                && DateTimeOffset.TryParse(exportedAtProperty.GetString(), out var parsedExportedAt))
+            {
+                exportedAtUtc = parsedExportedAt;
+            }
+
+            var includedSections = new List<string>();
+            if (root.TryGetProperty("sections", out var sectionsElement) && sectionsElement.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var section in ConfigurationBackupSections.All)
+                {
+                    if (sectionsElement.TryGetProperty(section, out var sectionNode) && sectionNode.ValueKind != JsonValueKind.Null)
+                    {
+                        includedSections.Add(section);
+                    }
+                }
+            }
+
+            string? notes = null;
+            if (root.TryGetProperty("notes", out var notesProperty) && notesProperty.ValueKind == JsonValueKind.String)
+            {
+                notes = notesProperty.GetString();
+            }
+
+            return new BackupListMetadata
+            {
+                ExportedAtUtc = exportedAtUtc,
+                BackupName = TryReadString(root, "backupName"),
+                AppVersion = TryReadString(root, "appVersion"),
+                IncludedSections = includedSections,
+                NotesSummary = ToNotesSummary(notes)
+            };
+        }
+        catch (JsonException)
+        {
+            return new BackupListMetadata();
+        }
+        catch (IOException)
+        {
+            return new BackupListMetadata();
+        }
+    }
+
+    private static string? TryReadString(JsonElement root, string propertyName)
+    {
+        if (root.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String)
+        {
+            return property.GetString();
+        }
+
+        return null;
+    }
+
+    private static string? ToNotesSummary(string? notes)
+    {
+        if (string.IsNullOrWhiteSpace(notes))
+        {
+            return null;
+        }
+
+        var trimmed = notes.Trim();
+        if (trimmed.Length <= 100)
+        {
+            return trimmed;
+        }
+
+        return $"{trimmed[..100]}...";
+    }
+
+    private sealed class BackupListMetadata
+    {
+        public DateTimeOffset? ExportedAtUtc { get; init; }
+        public string? BackupName { get; init; }
+        public string? AppVersion { get; init; }
+        public IReadOnlyList<string> IncludedSections { get; init; } = [];
+        public string? NotesSummary { get; init; }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupService.cs
@@ -1,0 +1,230 @@
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Options;
+
+namespace PingMonitor.Web.Services.Backups;
+
+public interface IConfigurationBackupService
+{
+    Task<CreateConfigurationBackupResponse> CreateBackupAsync(CreateConfigurationBackupRequest request, CancellationToken cancellationToken);
+}
+
+public sealed class ConfigurationBackupService : IConfigurationBackupService
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly IWebHostEnvironment _environment;
+    private readonly BackupOptions _options;
+    private readonly IConfigurationBackupFileNameGenerator _fileNameGenerator;
+
+    public ConfigurationBackupService(
+        PingMonitorDbContext dbContext,
+        IWebHostEnvironment environment,
+        IOptions<BackupOptions> options,
+        IConfigurationBackupFileNameGenerator fileNameGenerator)
+    {
+        _dbContext = dbContext;
+        _environment = environment;
+        _options = options.Value;
+        _fileNameGenerator = fileNameGenerator;
+    }
+
+    public async Task<CreateConfigurationBackupResponse> CreateBackupAsync(CreateConfigurationBackupRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.BackupName))
+        {
+            throw new InvalidOperationException("Backup name is required.");
+        }
+
+        if (request.SelectedSections.Count == 0)
+        {
+            throw new InvalidOperationException("At least one section must be selected.");
+        }
+
+        var selectedSections = request.SelectedSections
+            .Select(section => section.Trim().ToLowerInvariant())
+            .Where(section => ConfigurationBackupSections.All.Contains(section, StringComparer.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        if (selectedSections.Length == 0)
+        {
+            throw new InvalidOperationException("At least one valid section must be selected.");
+        }
+
+        var exportedAtUtc = DateTimeOffset.UtcNow;
+        var appVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
+        var metadata = new ConfigurationBackupMetadata
+        {
+            AppVersion = appVersion,
+            BackupName = request.BackupName.Trim(),
+            Notes = string.IsNullOrWhiteSpace(request.Notes) ? null : request.Notes.Trim(),
+            ExportedAtUtc = exportedAtUtc,
+            ExportedBy = request.ExportedBy,
+            MachineName = Environment.MachineName
+        };
+
+        var sections = new ConfigurationBackupSectionData
+        {
+            Agents = selectedSections.Contains(ConfigurationBackupSections.Agents, StringComparer.Ordinal)
+                ? await LoadAgentsAsync(cancellationToken)
+                : null,
+            Endpoints = selectedSections.Contains(ConfigurationBackupSections.Endpoints, StringComparer.Ordinal)
+                ? await LoadEndpointsAsync(cancellationToken)
+                : null,
+            Assignments = selectedSections.Contains(ConfigurationBackupSections.Assignments, StringComparer.Ordinal)
+                ? await LoadAssignmentsAsync(cancellationToken)
+                : null,
+            Identity = selectedSections.Contains(ConfigurationBackupSections.Identity, StringComparer.Ordinal)
+                ? await LoadIdentityAsync(cancellationToken)
+                : null
+        };
+
+        var document = ConfigurationBackupDocument.Create(metadata, sections);
+
+        var storagePath = ResolveStoragePath();
+        Directory.CreateDirectory(storagePath);
+
+        var fileName = _fileNameGenerator.CreateFileName(metadata.BackupName, metadata.AppVersion, metadata.ExportedAtUtc);
+        var fullPath = Path.Combine(storagePath, fileName);
+
+        var json = JsonSerializer.Serialize(document, SerializerOptions);
+        await File.WriteAllTextAsync(fullPath, json, cancellationToken);
+
+        return new CreateConfigurationBackupResponse
+        {
+            FileName = fileName,
+            FileId = fileName,
+            BackupName = metadata.BackupName,
+            ExportedAtUtc = metadata.ExportedAtUtc,
+            IncludedSections = selectedSections
+        };
+    }
+
+    private string ResolveStoragePath()
+    {
+        return Path.IsPathRooted(_options.StoragePath)
+            ? _options.StoragePath
+            : Path.Combine(_environment.ContentRootPath, _options.StoragePath);
+    }
+
+    private async Task<IReadOnlyList<BackupAgentRecord>> LoadAgentsAsync(CancellationToken cancellationToken)
+    {
+        return await _dbContext.Agents
+            .AsNoTracking()
+            .OrderBy(x => x.InstanceId)
+            .Select(x => new BackupAgentRecord
+            {
+                AgentId = x.AgentId,
+                InstanceId = x.InstanceId,
+                Name = x.Name,
+                Site = x.Site,
+                Enabled = x.Enabled,
+                AgentVersion = x.AgentVersion,
+                Platform = x.Platform,
+                MachineName = x.MachineName,
+                CreatedAtUtc = x.CreatedAtUtc
+            })
+            .ToListAsync(cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<BackupEndpointRecord>> LoadEndpointsAsync(CancellationToken cancellationToken)
+    {
+        return await _dbContext.Endpoints
+            .AsNoTracking()
+            .OrderBy(x => x.Name)
+            .Select(x => new BackupEndpointRecord
+            {
+                EndpointId = x.EndpointId,
+                Name = x.Name,
+                Target = x.Target,
+                IconKey = x.IconKey,
+                Enabled = x.Enabled,
+                Tags = x.Tags,
+                Notes = x.Notes,
+                CreatedAtUtc = x.CreatedAtUtc
+            })
+            .ToListAsync(cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<BackupAssignmentRecord>> LoadAssignmentsAsync(CancellationToken cancellationToken)
+    {
+        return await _dbContext.MonitorAssignments
+            .AsNoTracking()
+            .OrderBy(x => x.AgentId)
+            .ThenBy(x => x.EndpointId)
+            .Select(x => new BackupAssignmentRecord
+            {
+                AssignmentId = x.AssignmentId,
+                AgentId = x.AgentId,
+                EndpointId = x.EndpointId,
+                CheckType = x.CheckType.ToString().ToLowerInvariant(),
+                Enabled = x.Enabled,
+                PingIntervalSeconds = x.PingIntervalSeconds,
+                RetryIntervalSeconds = x.RetryIntervalSeconds,
+                TimeoutMs = x.TimeoutMs,
+                FailureThreshold = x.FailureThreshold,
+                RecoveryThreshold = x.RecoveryThreshold,
+                CreatedAtUtc = x.CreatedAtUtc,
+                UpdatedAtUtc = x.UpdatedAtUtc
+            })
+            .ToListAsync(cancellationToken);
+    }
+
+    private async Task<BackupIdentitySection> LoadIdentityAsync(CancellationToken cancellationToken)
+    {
+        var users = await _dbContext.Users
+            .AsNoTracking()
+            .OrderBy(x => x.UserName)
+            .Select(x => new BackupIdentityUserRecord
+            {
+                Id = x.Id,
+                UserName = x.UserName,
+                NormalizedUserName = x.NormalizedUserName,
+                Email = x.Email,
+                NormalizedEmail = x.NormalizedEmail,
+                EmailConfirmed = x.EmailConfirmed,
+                LockoutEnabled = x.LockoutEnabled,
+                LockoutEnd = x.LockoutEnd,
+                AccessFailedCount = x.AccessFailedCount
+            })
+            .ToListAsync(cancellationToken);
+
+        var roles = await _dbContext.Roles
+            .AsNoTracking()
+            .OrderBy(x => x.Name)
+            .Select(x => new BackupIdentityRoleRecord
+            {
+                Id = x.Id,
+                Name = x.Name,
+                NormalizedName = x.NormalizedName
+            })
+            .ToListAsync(cancellationToken);
+
+        var userRoles = await _dbContext.UserRoles
+            .AsNoTracking()
+            .OrderBy(x => x.UserId)
+            .ThenBy(x => x.RoleId)
+            .Select(x => new BackupIdentityUserRoleRecord
+            {
+                UserId = x.UserId,
+                RoleId = x.RoleId
+            })
+            .ToListAsync(cancellationToken);
+
+        return new BackupIdentitySection
+        {
+            Users = users,
+            Roles = roles,
+            UserRoles = userRoles
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/Backups/BackupsPageViewModels.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Backups/BackupsPageViewModels.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PingMonitor.Web.ViewModels.Backups;
+
+public sealed class CreateBackupPageForm
+{
+    [Required(ErrorMessage = "Backup name is required.")]
+    [Display(Name = "Backup name")]
+    public string BackupName { get; set; } = string.Empty;
+
+    [Display(Name = "Notes")]
+    public string? Notes { get; set; }
+
+    [Display(Name = "Include agents")]
+    public bool IncludeAgents { get; set; } = true;
+
+    [Display(Name = "Include endpoints")]
+    public bool IncludeEndpoints { get; set; } = true;
+
+    [Display(Name = "Include assignments")]
+    public bool IncludeAssignments { get; set; } = true;
+
+    [Display(Name = "Include identity")]
+    public bool IncludeIdentity { get; set; }
+}
+
+public sealed class BackupRowViewModel
+{
+    public required string FileName { get; init; }
+    public required string FileId { get; init; }
+    public string BackupName { get; init; } = "(unknown)";
+    public string? AppVersion { get; init; }
+    public DateTimeOffset? ExportedAtUtc { get; init; }
+    public DateTimeOffset FileCreatedAtUtc { get; init; }
+    public string IncludedSectionsDisplay { get; init; } = string.Empty;
+    public string? NotesSummary { get; init; }
+}
+
+public sealed class AdminBackupsPageViewModel
+{
+    public required CreateBackupPageForm Form { get; init; }
+    public required IReadOnlyList<BackupRowViewModel> Backups { get; init; } = [];
+    public string? StatusMessage { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
@@ -47,6 +47,7 @@
             <p class="muted">Configure application-level settings used by agent provisioning and new endpoint defaults.</p>
             <div class="button-row">
                 <a class="button-secondary" href="/status">Back to status</a>
+                <a class="button-secondary" href="/admin/backups">Configuration backups</a>
             </div>
         </section>
 

--- a/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
@@ -1,0 +1,149 @@
+@model PingMonitor.Web.ViewModels.Backups.AdminBackupsPageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Configuration backups</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #f3f6f8;
+            --card: #ffffff;
+            --text: #102a43;
+            --muted: #52606d;
+            --border: #d9e2ec;
+            --accent: #0f62fe;
+            --success: #137333;
+            --error-bg: #fee4e2;
+            --error-text: #b42318;
+        }
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 960px; margin: 0 auto; padding: 1rem; }
+        .stack { display: grid; gap: 1rem; }
+        .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
+        .muted { color: var(--muted); }
+        label { display: block; font-weight: 600; margin-bottom: .35rem; }
+        input, textarea { width: 100%; border: 1px solid var(--border); border-radius: 10px; min-height: 48px; padding: .8rem; font: inherit; }
+        textarea { min-height: 96px; }
+        .check-list { display: grid; gap: .6rem; }
+        .check-item { display: flex; align-items: center; gap: .6rem; }
+        .check-item input { width: 24px; height: 24px; min-height: 24px; }
+        .button-row { display: flex; gap: .75rem; flex-wrap: wrap; }
+        .button, .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 48px; padding: .8rem 1rem; border-radius: 10px; font-weight: 600; text-decoration: none; }
+        .button { border: 0; background: var(--accent); color: white; }
+        .button-secondary { border: 1px solid var(--border); color: var(--text); background: white; }
+        .errors { border: 1px solid #fda29b; background: var(--error-bg); color: var(--error-text); border-radius: 10px; padding: .8rem; }
+        .saved { border: 1px solid #c2f0c2; background: #ebffee; color: var(--success); border-radius: 10px; padding: .8rem; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { text-align: left; vertical-align: top; padding: .6rem .4rem; border-bottom: 1px solid var(--border); }
+        .field-error { color: var(--error-text); font-size: .9rem; margin-top: .25rem; }
+    </style>
+</head>
+<body>
+<main>
+    <div class="stack">
+        <section class="card">
+            <h1>Configuration backups</h1>
+            <p class="muted">Create and download configuration-only JSON backups. Restore is not implemented in this phase.</p>
+            <div class="button-row">
+                <a class="button-secondary" href="/admin">Back to admin settings</a>
+                <a class="button-secondary" href="/status">Back to status</a>
+            </div>
+        </section>
+
+        <form method="post" action="/admin/backups" class="stack">
+            @Html.AntiForgeryToken()
+
+            @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
+            {
+                <div class="saved" role="status">@Model.StatusMessage</div>
+            }
+
+            @if (!ViewData.ModelState.IsValid)
+            {
+                <div class="errors" asp-validation-summary="ModelOnly"></div>
+            }
+
+            <section class="card">
+                <h2>Create backup</h2>
+                <div class="stack">
+                    <div>
+                        <label asp-for="Form.BackupName"></label>
+                        <input asp-for="Form.BackupName" />
+                        <div class="field-error"><span asp-validation-for="Form.BackupName"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="Form.Notes"></label>
+                        <textarea asp-for="Form.Notes"></textarea>
+                    </div>
+                    <div>
+                        <label>Sections</label>
+                        <div class="check-list">
+                            <label class="check-item"><input asp-for="Form.IncludeAgents" /> Agents</label>
+                            <label class="check-item"><input asp-for="Form.IncludeEndpoints" /> Endpoints</label>
+                            <label class="check-item"><input asp-for="Form.IncludeAssignments" /> Assignments</label>
+                            <label class="check-item"><input asp-for="Form.IncludeIdentity" /> Identity (optional; disabled by default)</label>
+                        </div>
+                    </div>
+                </div>
+                <div class="button-row" style="margin-top:1rem;">
+                    <button class="button" type="submit">Create JSON backup</button>
+                </div>
+            </section>
+        </form>
+
+        <section class="card">
+            <h2>Stored backups</h2>
+            @if (Model.Backups.Count == 0)
+            {
+                <p class="muted">No backups found in the configured storage folder.</p>
+            }
+            else
+            {
+                <div style="overflow-x:auto;">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Backup</th>
+                            <th>Exported</th>
+                            <th>App version</th>
+                            <th>Sections</th>
+                            <th>Notes</th>
+                            <th></th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach (var backup in Model.Backups)
+                        {
+                            <tr>
+                                <td>
+                                    <strong>@backup.BackupName</strong>
+                                    <div class="muted">@backup.FileName</div>
+                                </td>
+                                <td>
+                                    @if (backup.ExportedAtUtc.HasValue)
+                                    {
+                                        @backup.ExportedAtUtc.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")
+                                    }
+                                    else
+                                    {
+                                        @backup.FileCreatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")
+                                    }
+                                </td>
+                                <td>@(backup.AppVersion ?? "(unknown)")</td>
+                                <td>@backup.IncludedSectionsDisplay</td>
+                                <td>@(backup.NotesSummary ?? "")</td>
+                                <td><a class="button-secondary" href="/admin/backups/download?id=@Uri.EscapeDataString(backup.FileId)">Download</a></td>
+                            </tr>
+                        }
+                        </tbody>
+                    </table>
+                </div>
+            }
+        </section>
+    </div>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -29,5 +29,8 @@
   },
   "AgentProvisioning": {
     "ServerUrl": "https://localhost:5001"
+  },
+  "Backup": {
+    "StoragePath": "App_Data/Backups.Development"
   }
 }

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -30,5 +30,8 @@
   "AllowedHosts": "*",
   "AgentProvisioning": {
     "ServerUrl": "https://monitor.example.com"
+  },
+  "Backup": {
+    "StoragePath": "App_Data/Backups"
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a safe, server-side, configuration-only backup export as JSON following the documented constraints (no operational data, optional identity, backups stored outside public web roots). 
- Deliver a minimal admin workflow to create a named backup with notes, list available backups, and download selected files while keeping behavior explicit and boring. 
- Meet repository rules by creating an associated GitHub issue and linking the work to it. 

### Description
- Add `BackupOptions` (`Backup:StoragePath`) and register it in DI with a safe app-local default of `App_Data/Backups` (and `App_Data/Backups.Development`).
- Implement export models/DTOs in `Services/Backups/ConfigurationBackupModels.cs` to represent `ConfigurationBackupDocument`, `ConfigurationBackupMetadata`, section payloads (`agents`, `endpoints`, `assignments`, optional `identity`), and request/response/list item shapes separate from EF entities.
- Add deterministic filename generation and sanitisation via `ConfigurationBackupFileNameGenerator` implementing `IConfigurationBackupFileNameGenerator` with the pattern `config-backup-{backupName}-{appVersion}-{YYYY-MM-DD-HH-mm-ss}.json` (lowercase, spaces→hyphens, invalid chars removed, max length cap).
- Implement `IConfigurationBackupService` / `ConfigurationBackupService` to read configuration entities from the database, map to backup DTOs, compose the backup document with required metadata near the top, serialize indented JSON, and save to the configured non-public storage folder.
- Implement `IConfigurationBackupQueryService` / `ConfigurationBackupQueryService` to enumerate `config-backup-*.json` files, read basic metadata from each JSON for listings, and safely resolve download paths while preventing path traversal or arbitrary file access.
- Add admin UI and controller at `/admin/backups` (`AdminBackupsController`, viewmodels, and `Views/AdminBackups/Index.cshtml`) to create backups (name required, notes optional, explicit section checkboxes), list stored backups, and download files via a secure endpoint; add navigation link from admin settings.
- Update `Program.cs` to wire the new services into DI and update `docs/config-backup-and-restore.md` with a Phase 1 note; link this work to the created GitHub issue (`Fixes #124`).

### Testing
- Created GitHub issue #124 to track the work and linked the PR to it, which succeeded. 
- Installed and used the .NET 10 SDK (`10.0.104`) in the environment and ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully (build succeeded with 0 warnings/errors). 
- Verified configuration files (`appsettings.json` and `appsettings.Development.json`) were updated to include the `Backup:StoragePath` defaults and DI registration was added to `Program.cs`. 
- No automated unit tests were added for this phase; runtime/manual UI validation (creating an actual backup from a running server) was not performed here, but the project compiles and the export/list/download code paths were added and wired for manual testing in the next step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7ce93d07c832a85fffefddd2770ea)