### PR TITLE
Add configuration restore preview and merge-mode restore workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ States:
 
 - No silent failures
 - All actions are traceable
+
+### Configuration Backup and Restore
+
+- Admin backup page supports server-side JSON configuration backups.
+- Restore is explicit and preview-first from existing server-side backup files.
+- Restore currently supports **merge mode only** (insert missing + update matching).
+- Replace mode, operational data restore, and backup upload are intentionally not implemented yet.
 - Logs are treated as first-class outputs
 
 ---

--- a/docs/config-backup-and-restore.md
+++ b/docs/config-backup-and-restore.md
@@ -87,11 +87,23 @@ Example:
 }
 ```
 
-## Phase 1 implementation notes
+## Restore behaviour (current)
 
-- This phase implements **export only**.
-- Restore and upload workflows are intentionally not implemented yet.
-- Backup name is required for export.
-- Notes are stored in the backup document metadata (`notes`) and displayed in backup listings.
-- Backup files are stored server-side under the configured `Backup:StoragePath` location (default `App_Data/Backups`), which is outside public static web content.
-- Backup format remains JSON and configuration-only.
+- Restore is **configuration-only** and uses **merge mode only**.
+- Restore must be **previewed before apply**.
+- Preview must display backup metadata including `notes` prominently before restore is run.
+- Restore is driven from existing **server-side backup files** in the configured `Backup:StoragePath`.
+- Restore supports these sections:
+  - `agents`
+  - `endpoints`
+  - `assignments`
+  - `identity` (optional and explicit)
+- Merge mode updates matching records and inserts missing records.
+- Merge mode in this phase does **not delete existing configuration**.
+- Replace mode is not implemented in this phase.
+- Restore does **not** import operational data (results, state transitions, alerts, logs, metrics, runtime state).
+
+## Historical phase note
+
+- Phase 1 introduced export-only backup creation and listing.
+- Restore/upload workflows were intentionally deferred in that phase.

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminBackupsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminBackupsController.cs
@@ -12,19 +12,25 @@ public sealed class AdminBackupsController : Controller
 {
     private readonly IConfigurationBackupService _backupService;
     private readonly IConfigurationBackupQueryService _backupQueryService;
+    private readonly IConfigurationRestorePreviewService _restorePreviewService;
+    private readonly IConfigurationRestoreService _restoreService;
 
     public AdminBackupsController(
         IConfigurationBackupService backupService,
-        IConfigurationBackupQueryService backupQueryService)
+        IConfigurationBackupQueryService backupQueryService,
+        IConfigurationRestorePreviewService restorePreviewService,
+        IConfigurationRestoreService restoreService)
     {
         _backupService = backupService;
         _backupQueryService = backupQueryService;
+        _restorePreviewService = restorePreviewService;
+        _restoreService = restoreService;
     }
 
     [HttpGet]
     public async Task<IActionResult> Index(CancellationToken cancellationToken)
     {
-        var viewModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), statusMessage: null, cancellationToken);
+        var viewModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), new RestorePreviewForm(), new RestoreApplyForm(), statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
         return View("Index", viewModel);
     }
 
@@ -32,7 +38,7 @@ public sealed class AdminBackupsController : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Create([FromForm] CreateBackupPageForm form, CancellationToken cancellationToken)
     {
-        var selectedSections = GetSelectedSections(form);
+        var selectedSections = GetSelectedExportSections(form);
         if (selectedSections.Count == 0)
         {
             ModelState.AddModelError(string.Empty, "Select at least one configuration section to export.");
@@ -40,7 +46,7 @@ public sealed class AdminBackupsController : Controller
 
         if (!ModelState.IsValid)
         {
-            var invalidModel = await BuildPageViewModelAsync(form, statusMessage: null, cancellationToken);
+            var invalidModel = await BuildPageViewModelAsync(form, new RestorePreviewForm(), new RestoreApplyForm(), statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
             return View("Index", invalidModel);
         }
 
@@ -61,9 +67,105 @@ public sealed class AdminBackupsController : Controller
         catch (InvalidOperationException ex)
         {
             ModelState.AddModelError(string.Empty, ex.Message);
-            var invalidModel = await BuildPageViewModelAsync(form, statusMessage: null, cancellationToken);
+            var invalidModel = await BuildPageViewModelAsync(form, new RestorePreviewForm(), new RestoreApplyForm(), statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
             return View("Index", invalidModel);
         }
+    }
+
+    [HttpPost("preview")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> PreviewRestore([FromForm] RestorePreviewForm form, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            var invalidModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), form, new RestoreApplyForm(), statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
+            return View("Index", invalidModel);
+        }
+
+        try
+        {
+            var preview = await _restorePreviewService.GetPreviewAsync(form.SelectedFileId, cancellationToken);
+            var previewViewModel = ToPreviewViewModel(preview);
+            var applyForm = new RestoreApplyForm
+            {
+                SelectedFileId = preview.FileId,
+                IncludeAgents = preview.IncludedSections.Contains(ConfigurationBackupSections.Agents, StringComparer.Ordinal),
+                IncludeEndpoints = preview.IncludedSections.Contains(ConfigurationBackupSections.Endpoints, StringComparer.Ordinal),
+                IncludeAssignments = preview.IncludedSections.Contains(ConfigurationBackupSections.Assignments, StringComparer.Ordinal),
+                IncludeIdentity = false
+            };
+
+            var model = await BuildPageViewModelAsync(new CreateBackupPageForm(), form, applyForm, statusMessage: null, preview: previewViewModel, restoreSummary: null, cancellationToken);
+            return View("Index", model);
+        }
+        catch (FileNotFoundException)
+        {
+            ModelState.AddModelError(string.Empty, "Backup file was not found.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+        }
+
+        var failedModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), form, new RestoreApplyForm(), statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
+        return View("Index", failedModel);
+    }
+
+    [HttpPost("restore")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Restore([FromForm] RestoreApplyForm form, CancellationToken cancellationToken)
+    {
+        var selectedSections = GetSelectedRestoreSections(form);
+        if (selectedSections.Count == 0)
+        {
+            ModelState.AddModelError(string.Empty, "Select at least one section for merge restore.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            var invalidModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), new RestorePreviewForm { SelectedFileId = form.SelectedFileId }, form, statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
+            return View("Index", invalidModel);
+        }
+
+        try
+        {
+            var response = await _restoreService.RestoreMergeAsync(
+                new RestoreConfigurationRequest
+                {
+                    FileId = form.SelectedFileId,
+                    SelectedSections = selectedSections
+                },
+                cancellationToken);
+
+            var preview = await _restorePreviewService.GetPreviewAsync(form.SelectedFileId, cancellationToken);
+            var model = await BuildPageViewModelAsync(
+                new CreateBackupPageForm(),
+                new RestorePreviewForm { SelectedFileId = form.SelectedFileId },
+                form,
+                statusMessage: "Merge restore completed.",
+                preview: ToPreviewViewModel(preview),
+                restoreSummary: ToRestoreSummaryViewModel(response),
+                cancellationToken);
+            return View("Index", model);
+        }
+        catch (FileNotFoundException)
+        {
+            ModelState.AddModelError(string.Empty, "Backup file was not found.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+        }
+
+        var failedModel = await BuildPageViewModelAsync(
+            new CreateBackupPageForm(),
+            new RestorePreviewForm { SelectedFileId = form.SelectedFileId },
+            form,
+            statusMessage: null,
+            preview: null,
+            restoreSummary: null,
+            cancellationToken);
+        return View("Index", failedModel);
     }
 
     [HttpGet("download")]
@@ -81,12 +183,23 @@ public sealed class AdminBackupsController : Controller
         }
     }
 
-    private async Task<AdminBackupsPageViewModel> BuildPageViewModelAsync(CreateBackupPageForm form, string? statusMessage, CancellationToken cancellationToken)
+    private async Task<AdminBackupsPageViewModel> BuildPageViewModelAsync(
+        CreateBackupPageForm form,
+        RestorePreviewForm restorePreviewForm,
+        RestoreApplyForm restoreApplyForm,
+        string? statusMessage,
+        BackupRestorePreviewViewModel? preview,
+        BackupRestoreSummaryViewModel? restoreSummary,
+        CancellationToken cancellationToken)
     {
         var backups = await _backupQueryService.ListBackupsAsync(cancellationToken);
         return new AdminBackupsPageViewModel
         {
             Form = form,
+            RestorePreviewForm = restorePreviewForm,
+            RestoreApplyForm = restoreApplyForm,
+            Preview = preview,
+            RestoreSummary = restoreSummary,
             StatusMessage = statusMessage ?? Request.Query["status"],
             Backups = backups
                 .Select(item => new BackupRowViewModel
@@ -106,7 +219,7 @@ public sealed class AdminBackupsController : Controller
         };
     }
 
-    private static List<string> GetSelectedSections(CreateBackupPageForm form)
+    private static List<string> GetSelectedExportSections(CreateBackupPageForm form)
     {
         var sections = new List<string>();
         if (form.IncludeAgents)
@@ -130,6 +243,74 @@ public sealed class AdminBackupsController : Controller
         }
 
         return sections;
+    }
+
+    private static List<string> GetSelectedRestoreSections(RestoreApplyForm form)
+    {
+        var sections = new List<string>();
+        if (form.IncludeAgents)
+        {
+            sections.Add(ConfigurationBackupSections.Agents);
+        }
+
+        if (form.IncludeEndpoints)
+        {
+            sections.Add(ConfigurationBackupSections.Endpoints);
+        }
+
+        if (form.IncludeAssignments)
+        {
+            sections.Add(ConfigurationBackupSections.Assignments);
+        }
+
+        if (form.IncludeIdentity)
+        {
+            sections.Add(ConfigurationBackupSections.Identity);
+        }
+
+        return sections;
+    }
+
+    private static BackupRestorePreviewViewModel ToPreviewViewModel(ConfigurationBackupPreview preview)
+    {
+        return new BackupRestorePreviewViewModel
+        {
+            FileId = preview.FileId,
+            BackupName = preview.Metadata.BackupName,
+            Notes = preview.Metadata.Notes,
+            ExportedAtUtc = preview.Metadata.ExportedAtUtc,
+            AppVersion = preview.Metadata.AppVersion,
+            FormatVersion = preview.Metadata.FormatVersion,
+            IncludedSections = preview.IncludedSections,
+            Counts = new ConfigurationBackupSectionCountViewModel
+            {
+                Agents = preview.Counts.Agents,
+                Endpoints = preview.Counts.Endpoints,
+                Assignments = preview.Counts.Assignments,
+                IdentityUsers = preview.Counts.IdentityUsers,
+                IdentityRoles = preview.Counts.IdentityRoles,
+                IdentityUserRoles = preview.Counts.IdentityUserRoles
+            }
+        };
+    }
+
+    private static BackupRestoreSummaryViewModel ToRestoreSummaryViewModel(RestoreConfigurationResponse response)
+    {
+        return new BackupRestoreSummaryViewModel
+        {
+            FileId = response.FileId,
+            BackupName = response.BackupName,
+            SelectedSections = response.SelectedSections,
+            Sections = response.SectionResults.Select(x => new BackupRestoreSectionResultViewModel
+            {
+                Section = x.Section,
+                InsertedCount = x.InsertedCount,
+                UpdatedCount = x.UpdatedCount,
+                SkippedCount = x.SkippedCount,
+                ErrorCount = x.ErrorCount,
+                Warnings = x.Warnings
+            }).ToArray()
+        };
     }
 
     private static string ToDisplaySectionName(string section)

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -130,7 +130,10 @@ builder.Services.AddScoped<IUserAccessScopeService, UserAccessScopeService>();
 builder.Services.AddScoped<IUserManagementService, UserManagementService>();
 builder.Services.AddScoped<IConfigurationBackupFileNameGenerator, ConfigurationBackupFileNameGenerator>();
 builder.Services.AddScoped<IConfigurationBackupService, ConfigurationBackupService>();
+builder.Services.AddScoped<IConfigurationBackupDocumentLoader, ConfigurationBackupDocumentLoader>();
 builder.Services.AddScoped<IConfigurationBackupQueryService, ConfigurationBackupQueryService>();
+builder.Services.AddScoped<IConfigurationRestorePreviewService, ConfigurationRestorePreviewService>();
+builder.Services.AddScoped<IConfigurationRestoreService, ConfigurationRestoreService>();
 
 var app = builder.Build();
 

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentLoader.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentLoader.cs
@@ -1,0 +1,280 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Options;
+using PingMonitor.Web.Options;
+
+namespace PingMonitor.Web.Services.Backups;
+
+public interface IConfigurationBackupDocumentLoader
+{
+    Task<IReadOnlyList<BackupFileListItem>> ListBackupsAsync(CancellationToken cancellationToken);
+    string ResolveBackupPath(string fileId);
+    Task<ConfigurationBackupDocument> LoadValidatedDocumentAsync(string fileId, CancellationToken cancellationToken);
+}
+
+public sealed class ConfigurationBackupDocumentLoader : IConfigurationBackupDocumentLoader
+{
+    private readonly IWebHostEnvironment _environment;
+    private readonly BackupOptions _options;
+    private readonly ILogger<ConfigurationBackupDocumentLoader> _logger;
+
+    public ConfigurationBackupDocumentLoader(
+        IWebHostEnvironment environment,
+        IOptions<BackupOptions> options,
+        ILogger<ConfigurationBackupDocumentLoader> logger)
+    {
+        _environment = environment;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<BackupFileListItem>> ListBackupsAsync(CancellationToken cancellationToken)
+    {
+        var storagePath = ResolveStoragePath();
+        if (!Directory.Exists(storagePath))
+        {
+            return [];
+        }
+
+        var files = Directory.EnumerateFiles(storagePath, "config-backup-*.json", SearchOption.TopDirectoryOnly)
+            .OrderByDescending(path => path, StringComparer.Ordinal)
+            .ToArray();
+
+        var rows = new List<BackupFileListItem>(files.Length);
+        foreach (var fullPath in files)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var fileInfo = new FileInfo(fullPath);
+            var metadata = await TryReadMetadataAsync(fullPath, cancellationToken);
+
+            rows.Add(new BackupFileListItem
+            {
+                FileName = fileInfo.Name,
+                FileId = fileInfo.Name,
+                FileCreatedAtUtc = fileInfo.CreationTimeUtc,
+                ExportedAtUtc = metadata.ExportedAtUtc,
+                BackupName = metadata.BackupName,
+                AppVersion = metadata.AppVersion,
+                IncludedSections = metadata.IncludedSections,
+                NotesSummary = metadata.NotesSummary
+            });
+        }
+
+        return rows;
+    }
+
+    public string ResolveBackupPath(string fileId)
+    {
+        if (string.IsNullOrWhiteSpace(fileId))
+        {
+            throw new FileNotFoundException("Backup file was not found.");
+        }
+
+        var fileName = Path.GetFileName(fileId);
+        if (!string.Equals(fileName, fileId, StringComparison.Ordinal))
+        {
+            throw new FileNotFoundException("Backup file was not found.");
+        }
+
+        var rootPath = Path.GetFullPath(ResolveStoragePath());
+        var fullPath = Path.GetFullPath(Path.Combine(rootPath, fileName));
+
+        if (!fullPath.StartsWith(rootPath, StringComparison.Ordinal))
+        {
+            throw new FileNotFoundException("Backup file was not found.");
+        }
+
+        if (!File.Exists(fullPath))
+        {
+            throw new FileNotFoundException("Backup file was not found.");
+        }
+
+        return fullPath;
+    }
+
+    public async Task<ConfigurationBackupDocument> LoadValidatedDocumentAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var fullPath = ResolveBackupPath(fileId);
+
+        await using var stream = File.OpenRead(fullPath);
+        var document = await JsonSerializer.DeserializeAsync<ConfigurationBackupDocument>(stream, cancellationToken: cancellationToken);
+        if (document is null)
+        {
+            throw new InvalidOperationException("Backup file could not be parsed.");
+        }
+
+        ValidateDocument(document, fileId);
+        return document;
+    }
+
+    private string ResolveStoragePath()
+    {
+        return Path.IsPathRooted(_options.StoragePath)
+            ? _options.StoragePath
+            : Path.Combine(_environment.ContentRootPath, _options.StoragePath);
+    }
+
+    private void ValidateDocument(ConfigurationBackupDocument document, string fileId)
+    {
+        if (document.FormatVersion != ConfigurationBackupMetadata.CurrentFormatVersion)
+        {
+            throw BuildValidationException(fileId, $"Backup formatVersion {document.FormatVersion} is not supported.");
+        }
+
+        if (string.IsNullOrWhiteSpace(document.BackupName)
+            || string.IsNullOrWhiteSpace(document.AppVersion)
+            || document.ExportedAtUtc == default
+            || string.IsNullOrWhiteSpace(document.MachineName))
+        {
+            throw BuildValidationException(fileId, "Backup metadata is incomplete.");
+        }
+
+        if (document.Sections is null)
+        {
+            throw BuildValidationException(fileId, "Backup sections are missing.");
+        }
+
+        if (document.Sections.Agents is not null)
+        {
+            foreach (var agent in document.Sections.Agents)
+            {
+                if (string.IsNullOrWhiteSpace(agent.InstanceId))
+                {
+                    throw BuildValidationException(fileId, "Agent section contains an invalid record (instanceId missing).");
+                }
+            }
+        }
+
+        if (document.Sections.Endpoints is not null)
+        {
+            foreach (var endpoint in document.Sections.Endpoints)
+            {
+                if (string.IsNullOrWhiteSpace(endpoint.Name) || string.IsNullOrWhiteSpace(endpoint.Target))
+                {
+                    throw BuildValidationException(fileId, "Endpoint section contains an invalid record (name/target missing).");
+                }
+            }
+        }
+
+        if (document.Sections.Assignments is not null)
+        {
+            foreach (var assignment in document.Sections.Assignments)
+            {
+                if (string.IsNullOrWhiteSpace(assignment.AgentId)
+                    || string.IsNullOrWhiteSpace(assignment.EndpointId)
+                    || string.IsNullOrWhiteSpace(assignment.CheckType))
+                {
+                    throw BuildValidationException(fileId, "Assignment section contains an invalid record.");
+                }
+            }
+        }
+
+        if (document.Sections.Identity is not null)
+        {
+            foreach (var user in document.Sections.Identity.Users)
+            {
+                if (string.IsNullOrWhiteSpace(user.NormalizedUserName) && string.IsNullOrWhiteSpace(user.NormalizedEmail))
+                {
+                    throw BuildValidationException(fileId, "Identity section contains a user without normalized username/email.");
+                }
+            }
+        }
+
+        _logger.LogInformation("Validated configuration backup {FileId} for restore workflow.", fileId);
+    }
+
+    private InvalidOperationException BuildValidationException(string fileId, string message)
+    {
+        _logger.LogWarning("Backup validation failed for {FileId}: {ValidationMessage}", fileId, message);
+        return new InvalidOperationException(message);
+    }
+
+    private static async Task<BackupListMetadata> TryReadMetadataAsync(string fullPath, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var stream = File.OpenRead(fullPath);
+            using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+            var root = document.RootElement;
+
+            DateTimeOffset? exportedAtUtc = null;
+            if (root.TryGetProperty("exportedAtUtc", out var exportedAtProperty)
+                && exportedAtProperty.ValueKind == JsonValueKind.String
+                && DateTimeOffset.TryParse(exportedAtProperty.GetString(), out var parsedExportedAt))
+            {
+                exportedAtUtc = parsedExportedAt;
+            }
+
+            var includedSections = new List<string>();
+            if (root.TryGetProperty("sections", out var sectionsElement) && sectionsElement.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var section in ConfigurationBackupSections.All)
+                {
+                    if (sectionsElement.TryGetProperty(section, out var sectionNode) && sectionNode.ValueKind != JsonValueKind.Null)
+                    {
+                        includedSections.Add(section);
+                    }
+                }
+            }
+
+            string? notes = null;
+            if (root.TryGetProperty("notes", out var notesProperty) && notesProperty.ValueKind == JsonValueKind.String)
+            {
+                notes = notesProperty.GetString();
+            }
+
+            return new BackupListMetadata
+            {
+                ExportedAtUtc = exportedAtUtc,
+                BackupName = TryReadString(root, "backupName"),
+                AppVersion = TryReadString(root, "appVersion"),
+                IncludedSections = includedSections,
+                NotesSummary = ToNotesSummary(notes)
+            };
+        }
+        catch (JsonException)
+        {
+            return new BackupListMetadata();
+        }
+        catch (IOException)
+        {
+            return new BackupListMetadata();
+        }
+    }
+
+    private static string? TryReadString(JsonElement root, string propertyName)
+    {
+        if (root.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String)
+        {
+            return property.GetString();
+        }
+
+        return null;
+    }
+
+    private static string? ToNotesSummary(string? notes)
+    {
+        if (string.IsNullOrWhiteSpace(notes))
+        {
+            return null;
+        }
+
+        var trimmed = notes.Trim();
+        if (trimmed.Length <= 100)
+        {
+            return trimmed;
+        }
+
+        return $"{trimmed[..100]}...";
+    }
+
+    private sealed class BackupListMetadata
+    {
+        public DateTimeOffset? ExportedAtUtc { get; init; }
+        public string? BackupName { get; init; }
+        public string? AppVersion { get; init; }
+        public IReadOnlyList<string> IncludedSections { get; init; } = [];
+        public string? NotesSummary { get; init; }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs
@@ -112,6 +112,7 @@ public sealed class BackupEndpointRecord
     public string IconKey { get; init; } = string.Empty;
     public bool Enabled { get; init; }
     public IReadOnlyList<string> Tags { get; init; } = [];
+    public IReadOnlyList<string> DependsOnEndpointIds { get; init; } = [];
     public string? Notes { get; init; }
     public DateTimeOffset CreatedAtUtc { get; init; }
 }
@@ -196,4 +197,59 @@ public sealed class CreateConfigurationBackupResponse
     public string BackupName { get; init; } = string.Empty;
     public DateTimeOffset ExportedAtUtc { get; init; }
     public IReadOnlyList<string> IncludedSections { get; init; } = [];
+}
+
+public sealed class RestorePreviewMetadata
+{
+    public string BackupName { get; init; } = string.Empty;
+    public DateTimeOffset ExportedAtUtc { get; init; }
+    public string AppVersion { get; init; } = string.Empty;
+    public int FormatVersion { get; init; }
+    public string? Notes { get; init; }
+}
+
+public sealed class ConfigurationBackupSectionCounts
+{
+    public int Agents { get; init; }
+    public int Endpoints { get; init; }
+    public int Assignments { get; init; }
+    public int IdentityUsers { get; init; }
+    public int IdentityRoles { get; init; }
+    public int IdentityUserRoles { get; init; }
+}
+
+public sealed class ConfigurationBackupPreview
+{
+    public string FileId { get; init; } = string.Empty;
+    public string FileName { get; init; } = string.Empty;
+    public RestorePreviewMetadata Metadata { get; init; } = new();
+    public IReadOnlyList<string> IncludedSections { get; init; } = [];
+    public ConfigurationBackupSectionCounts Counts { get; init; } = new();
+}
+
+public sealed class RestoreConfigurationRequest
+{
+    [Required(ErrorMessage = "Backup file is required.")]
+    public string FileId { get; init; } = string.Empty;
+
+    [Required]
+    public IReadOnlyList<string> SelectedSections { get; init; } = [];
+}
+
+public sealed class RestoreSectionResult
+{
+    public string Section { get; init; } = string.Empty;
+    public int InsertedCount { get; set; }
+    public int UpdatedCount { get; set; }
+    public int SkippedCount { get; set; }
+    public int ErrorCount { get; set; }
+    public List<string> Warnings { get; init; } = [];
+}
+
+public sealed class RestoreConfigurationResponse
+{
+    public string FileId { get; init; } = string.Empty;
+    public string BackupName { get; init; } = string.Empty;
+    public IReadOnlyList<string> SelectedSections { get; init; } = [];
+    public IReadOnlyList<RestoreSectionResult> SectionResults { get; init; } = [];
 }

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupQueryService.cs
@@ -1,8 +1,3 @@
-using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Options;
-using PingMonitor.Web.Options;
-
 namespace PingMonitor.Web.Services.Backups;
 
 public interface IConfigurationBackupQueryService
@@ -13,172 +8,20 @@ public interface IConfigurationBackupQueryService
 
 public sealed class ConfigurationBackupQueryService : IConfigurationBackupQueryService
 {
-    private readonly IWebHostEnvironment _environment;
-    private readonly BackupOptions _options;
+    private readonly IConfigurationBackupDocumentLoader _documentLoader;
 
-    public ConfigurationBackupQueryService(IWebHostEnvironment environment, IOptions<BackupOptions> options)
+    public ConfigurationBackupQueryService(IConfigurationBackupDocumentLoader documentLoader)
     {
-        _environment = environment;
-        _options = options.Value;
+        _documentLoader = documentLoader;
     }
 
-    public async Task<IReadOnlyList<BackupFileListItem>> ListBackupsAsync(CancellationToken cancellationToken)
+    public Task<IReadOnlyList<BackupFileListItem>> ListBackupsAsync(CancellationToken cancellationToken)
     {
-        var storagePath = ResolveStoragePath();
-        if (!Directory.Exists(storagePath))
-        {
-            return [];
-        }
-
-        var files = Directory.EnumerateFiles(storagePath, "config-backup-*.json", SearchOption.TopDirectoryOnly)
-            .OrderByDescending(path => path, StringComparer.Ordinal)
-            .ToArray();
-
-        var rows = new List<BackupFileListItem>(files.Length);
-        foreach (var fullPath in files)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var fileInfo = new FileInfo(fullPath);
-            var metadata = await TryReadMetadataAsync(fullPath, cancellationToken);
-
-            rows.Add(new BackupFileListItem
-            {
-                FileName = fileInfo.Name,
-                FileId = fileInfo.Name,
-                FileCreatedAtUtc = fileInfo.CreationTimeUtc,
-                ExportedAtUtc = metadata.ExportedAtUtc,
-                BackupName = metadata.BackupName,
-                AppVersion = metadata.AppVersion,
-                IncludedSections = metadata.IncludedSections,
-                NotesSummary = metadata.NotesSummary
-            });
-        }
-
-        return rows;
+        return _documentLoader.ListBackupsAsync(cancellationToken);
     }
 
     public string ResolveDownloadPath(string fileId)
     {
-        if (string.IsNullOrWhiteSpace(fileId))
-        {
-            throw new FileNotFoundException("Backup file was not found.");
-        }
-
-        var fileName = Path.GetFileName(fileId);
-        if (!string.Equals(fileName, fileId, StringComparison.Ordinal))
-        {
-            throw new FileNotFoundException("Backup file was not found.");
-        }
-
-        var rootPath = Path.GetFullPath(ResolveStoragePath());
-        var fullPath = Path.GetFullPath(Path.Combine(rootPath, fileName));
-
-        if (!fullPath.StartsWith(rootPath, StringComparison.Ordinal))
-        {
-            throw new FileNotFoundException("Backup file was not found.");
-        }
-
-        if (!File.Exists(fullPath))
-        {
-            throw new FileNotFoundException("Backup file was not found.");
-        }
-
-        return fullPath;
-    }
-
-    private string ResolveStoragePath()
-    {
-        return Path.IsPathRooted(_options.StoragePath)
-            ? _options.StoragePath
-            : Path.Combine(_environment.ContentRootPath, _options.StoragePath);
-    }
-
-    private static async Task<BackupListMetadata> TryReadMetadataAsync(string fullPath, CancellationToken cancellationToken)
-    {
-        try
-        {
-            await using var stream = File.OpenRead(fullPath);
-            using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
-            var root = document.RootElement;
-
-            DateTimeOffset? exportedAtUtc = null;
-            if (root.TryGetProperty("exportedAtUtc", out var exportedAtProperty)
-                && exportedAtProperty.ValueKind == JsonValueKind.String
-                && DateTimeOffset.TryParse(exportedAtProperty.GetString(), out var parsedExportedAt))
-            {
-                exportedAtUtc = parsedExportedAt;
-            }
-
-            var includedSections = new List<string>();
-            if (root.TryGetProperty("sections", out var sectionsElement) && sectionsElement.ValueKind == JsonValueKind.Object)
-            {
-                foreach (var section in ConfigurationBackupSections.All)
-                {
-                    if (sectionsElement.TryGetProperty(section, out var sectionNode) && sectionNode.ValueKind != JsonValueKind.Null)
-                    {
-                        includedSections.Add(section);
-                    }
-                }
-            }
-
-            string? notes = null;
-            if (root.TryGetProperty("notes", out var notesProperty) && notesProperty.ValueKind == JsonValueKind.String)
-            {
-                notes = notesProperty.GetString();
-            }
-
-            return new BackupListMetadata
-            {
-                ExportedAtUtc = exportedAtUtc,
-                BackupName = TryReadString(root, "backupName"),
-                AppVersion = TryReadString(root, "appVersion"),
-                IncludedSections = includedSections,
-                NotesSummary = ToNotesSummary(notes)
-            };
-        }
-        catch (JsonException)
-        {
-            return new BackupListMetadata();
-        }
-        catch (IOException)
-        {
-            return new BackupListMetadata();
-        }
-    }
-
-    private static string? TryReadString(JsonElement root, string propertyName)
-    {
-        if (root.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String)
-        {
-            return property.GetString();
-        }
-
-        return null;
-    }
-
-    private static string? ToNotesSummary(string? notes)
-    {
-        if (string.IsNullOrWhiteSpace(notes))
-        {
-            return null;
-        }
-
-        var trimmed = notes.Trim();
-        if (trimmed.Length <= 100)
-        {
-            return trimmed;
-        }
-
-        return $"{trimmed[..100]}...";
-    }
-
-    private sealed class BackupListMetadata
-    {
-        public DateTimeOffset? ExportedAtUtc { get; init; }
-        public string? BackupName { get; init; }
-        public string? AppVersion { get; init; }
-        public IReadOnlyList<string> IncludedSections { get; init; } = [];
-        public string? NotesSummary { get; init; }
+        return _documentLoader.ResolveBackupPath(fileId);
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupService.cs
@@ -138,9 +138,25 @@ public sealed class ConfigurationBackupService : IConfigurationBackupService
 
     private async Task<IReadOnlyList<BackupEndpointRecord>> LoadEndpointsAsync(CancellationToken cancellationToken)
     {
-        return await _dbContext.Endpoints
+        var dependencies = await _dbContext.EndpointDependencies
+            .AsNoTracking()
+            .OrderBy(x => x.EndpointId)
+            .ThenBy(x => x.DependsOnEndpointId)
+            .ToListAsync(cancellationToken);
+
+        var dependencyLookup = dependencies
+            .GroupBy(x => x.EndpointId, StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<string>)group.Select(x => x.DependsOnEndpointId).ToArray(),
+                StringComparer.Ordinal);
+
+        var endpoints = await _dbContext.Endpoints
             .AsNoTracking()
             .OrderBy(x => x.Name)
+            .ToListAsync(cancellationToken);
+
+        return endpoints
             .Select(x => new BackupEndpointRecord
             {
                 EndpointId = x.EndpointId,
@@ -149,10 +165,13 @@ public sealed class ConfigurationBackupService : IConfigurationBackupService
                 IconKey = x.IconKey,
                 Enabled = x.Enabled,
                 Tags = x.Tags,
+                DependsOnEndpointIds = dependencyLookup.TryGetValue(x.EndpointId, out var dependsOnIds)
+                    ? dependsOnIds
+                    : [],
                 Notes = x.Notes,
                 CreatedAtUtc = x.CreatedAtUtc
             })
-            .ToListAsync(cancellationToken);
+            .ToArray();
     }
 
     private async Task<IReadOnlyList<BackupAssignmentRecord>> LoadAssignmentsAsync(CancellationToken cancellationToken)

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestorePreviewService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestorePreviewService.cs
@@ -1,0 +1,80 @@
+namespace PingMonitor.Web.Services.Backups;
+
+public interface IConfigurationRestorePreviewService
+{
+    Task<ConfigurationBackupPreview> GetPreviewAsync(string fileId, CancellationToken cancellationToken);
+}
+
+public sealed class ConfigurationRestorePreviewService : IConfigurationRestorePreviewService
+{
+    private readonly IConfigurationBackupDocumentLoader _documentLoader;
+    private readonly ILogger<ConfigurationRestorePreviewService> _logger;
+
+    public ConfigurationRestorePreviewService(
+        IConfigurationBackupDocumentLoader documentLoader,
+        ILogger<ConfigurationRestorePreviewService> logger)
+    {
+        _documentLoader = documentLoader;
+        _logger = logger;
+    }
+
+    public async Task<ConfigurationBackupPreview> GetPreviewAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var document = await _documentLoader.LoadValidatedDocumentAsync(fileId, cancellationToken);
+
+        var includedSections = GetIncludedSections(document).ToArray();
+        var preview = new ConfigurationBackupPreview
+        {
+            FileId = fileId,
+            FileName = fileId,
+            Metadata = new RestorePreviewMetadata
+            {
+                BackupName = document.BackupName,
+                ExportedAtUtc = document.ExportedAtUtc,
+                AppVersion = document.AppVersion,
+                FormatVersion = document.FormatVersion,
+                Notes = document.Notes
+            },
+            IncludedSections = includedSections,
+            Counts = new ConfigurationBackupSectionCounts
+            {
+                Agents = document.Sections.Agents?.Count ?? 0,
+                Endpoints = document.Sections.Endpoints?.Count ?? 0,
+                Assignments = document.Sections.Assignments?.Count ?? 0,
+                IdentityUsers = document.Sections.Identity?.Users.Count ?? 0,
+                IdentityRoles = document.Sections.Identity?.Roles.Count ?? 0,
+                IdentityUserRoles = document.Sections.Identity?.UserRoles.Count ?? 0
+            }
+        };
+
+        _logger.LogInformation(
+            "Loaded restore preview for {FileId}. Included sections: {Sections}.",
+            fileId,
+            string.Join(",", includedSections));
+
+        return preview;
+    }
+
+    private static IEnumerable<string> GetIncludedSections(ConfigurationBackupDocument document)
+    {
+        if (document.Sections.Agents is not null)
+        {
+            yield return ConfigurationBackupSections.Agents;
+        }
+
+        if (document.Sections.Endpoints is not null)
+        {
+            yield return ConfigurationBackupSections.Endpoints;
+        }
+
+        if (document.Sections.Assignments is not null)
+        {
+            yield return ConfigurationBackupSections.Assignments;
+        }
+
+        if (document.Sections.Identity is not null)
+        {
+            yield return ConfigurationBackupSections.Identity;
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs
@@ -1,0 +1,521 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Models.Identity;
+using EndpointModel = PingMonitor.Web.Models.Endpoint;
+
+namespace PingMonitor.Web.Services.Backups;
+
+public interface IConfigurationRestoreService
+{
+    Task<RestoreConfigurationResponse> RestoreMergeAsync(RestoreConfigurationRequest request, CancellationToken cancellationToken);
+}
+
+public sealed class ConfigurationRestoreService : IConfigurationRestoreService
+{
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly IConfigurationBackupDocumentLoader _documentLoader;
+    private readonly ILogger<ConfigurationRestoreService> _logger;
+
+    public ConfigurationRestoreService(
+        PingMonitorDbContext dbContext,
+        IConfigurationBackupDocumentLoader documentLoader,
+        ILogger<ConfigurationRestoreService> logger)
+    {
+        _dbContext = dbContext;
+        _documentLoader = documentLoader;
+        _logger = logger;
+    }
+
+    public async Task<RestoreConfigurationResponse> RestoreMergeAsync(RestoreConfigurationRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.FileId))
+        {
+            throw new InvalidOperationException("Backup file is required.");
+        }
+
+        var selectedSections = request.SelectedSections
+            .Select(x => x.Trim().ToLowerInvariant())
+            .Where(x => ConfigurationBackupSections.All.Contains(x, StringComparer.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        if (selectedSections.Length == 0)
+        {
+            throw new InvalidOperationException("Select at least one restore section.");
+        }
+
+        var backup = await _documentLoader.LoadValidatedDocumentAsync(request.FileId, cancellationToken);
+        EnsureSelectedSectionsExist(selectedSections, backup);
+
+        _logger.LogInformation(
+            "Starting configuration restore in merge mode for {FileId}. Sections: {Sections}.",
+            request.FileId,
+            string.Join(",", selectedSections));
+
+        var sectionResults = new List<RestoreSectionResult>();
+        var endpointIdMapping = new Dictionary<string, string>(StringComparer.Ordinal);
+        var agentIdMapping = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        if (selectedSections.Contains(ConfigurationBackupSections.Agents, StringComparer.Ordinal))
+        {
+            sectionResults.Add(await RestoreAgentsAsync(backup, agentIdMapping, cancellationToken));
+        }
+
+        if (selectedSections.Contains(ConfigurationBackupSections.Endpoints, StringComparer.Ordinal))
+        {
+            sectionResults.Add(await RestoreEndpointsAsync(backup, endpointIdMapping, cancellationToken));
+        }
+
+        if (selectedSections.Contains(ConfigurationBackupSections.Assignments, StringComparer.Ordinal))
+        {
+            sectionResults.Add(await RestoreAssignmentsAsync(backup, endpointIdMapping, agentIdMapping, cancellationToken));
+        }
+
+        if (selectedSections.Contains(ConfigurationBackupSections.Identity, StringComparer.Ordinal))
+        {
+            sectionResults.Add(await RestoreIdentityAsync(backup, cancellationToken));
+        }
+
+        _logger.LogInformation(
+            "Completed configuration restore in merge mode for {FileId}.",
+            request.FileId);
+
+        return new RestoreConfigurationResponse
+        {
+            FileId = request.FileId,
+            BackupName = backup.BackupName,
+            SelectedSections = selectedSections,
+            SectionResults = sectionResults
+        };
+    }
+
+    private static void EnsureSelectedSectionsExist(IReadOnlyCollection<string> selectedSections, ConfigurationBackupDocument backup)
+    {
+        foreach (var section in selectedSections)
+        {
+            var present = section switch
+            {
+                ConfigurationBackupSections.Agents => backup.Sections.Agents is not null,
+                ConfigurationBackupSections.Endpoints => backup.Sections.Endpoints is not null,
+                ConfigurationBackupSections.Assignments => backup.Sections.Assignments is not null,
+                ConfigurationBackupSections.Identity => backup.Sections.Identity is not null,
+                _ => false
+            };
+
+            if (!present)
+            {
+                throw new InvalidOperationException($"Section '{section}' is not present in the selected backup.");
+            }
+        }
+    }
+
+    private async Task<RestoreSectionResult> RestoreAgentsAsync(
+        ConfigurationBackupDocument backup,
+        IDictionary<string, string> agentIdMapping,
+        CancellationToken cancellationToken)
+    {
+        var result = new RestoreSectionResult { Section = ConfigurationBackupSections.Agents };
+        var sourceAgents = backup.Sections.Agents ?? [];
+
+        await using var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+        var existingAgents = await _dbContext.Agents.ToListAsync(cancellationToken);
+        foreach (var source in sourceAgents)
+        {
+            var target = existingAgents.FirstOrDefault(x => string.Equals(x.InstanceId, source.InstanceId, StringComparison.OrdinalIgnoreCase));
+            if (target is null)
+            {
+                var createdAgentId = string.IsNullOrWhiteSpace(source.AgentId) ? Guid.NewGuid().ToString() : source.AgentId;
+                var newAgent = new Agent
+                {
+                    AgentId = createdAgentId,
+                    InstanceId = source.InstanceId,
+                    Name = source.Name,
+                    Site = source.Site,
+                    Enabled = source.Enabled,
+                    AgentVersion = source.AgentVersion,
+                    Platform = source.Platform,
+                    MachineName = source.MachineName,
+                    CreatedAtUtc = source.CreatedAtUtc == default ? DateTimeOffset.UtcNow : source.CreatedAtUtc,
+                    ApiKeyHash = "RESTORE_REQUIRED",
+                    ApiKeyCreatedAtUtc = DateTimeOffset.UtcNow,
+                    ApiKeyRevoked = true,
+                    Status = AgentHealthStatus.Offline
+                };
+
+                _dbContext.Agents.Add(newAgent);
+                existingAgents.Add(newAgent);
+                result.InsertedCount++;
+                agentIdMapping[source.AgentId] = newAgent.AgentId;
+            }
+            else
+            {
+                target.Name = source.Name;
+                target.Site = source.Site;
+                target.Enabled = source.Enabled;
+                target.AgentVersion = source.AgentVersion;
+                target.Platform = source.Platform;
+                target.MachineName = source.MachineName;
+                result.UpdatedCount++;
+                agentIdMapping[source.AgentId] = target.AgentId;
+            }
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Restored section {Section}. Inserted {InsertedCount}, updated {UpdatedCount}, skipped {SkippedCount}, errors {ErrorCount}.",
+            result.Section,
+            result.InsertedCount,
+            result.UpdatedCount,
+            result.SkippedCount,
+            result.ErrorCount);
+
+        return result;
+    }
+
+    private async Task<RestoreSectionResult> RestoreEndpointsAsync(
+        ConfigurationBackupDocument backup,
+        IDictionary<string, string> endpointIdMapping,
+        CancellationToken cancellationToken)
+    {
+        var result = new RestoreSectionResult { Section = ConfigurationBackupSections.Endpoints };
+        var sourceEndpoints = backup.Sections.Endpoints ?? [];
+
+        await using var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+        var existingEndpoints = await _dbContext.Endpoints.ToListAsync(cancellationToken);
+        var existingDependencies = await _dbContext.EndpointDependencies.ToListAsync(cancellationToken);
+
+        foreach (var source in sourceEndpoints)
+        {
+            var target = existingEndpoints.FirstOrDefault(x =>
+                string.Equals(x.Name, source.Name, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(x.Target, source.Target, StringComparison.OrdinalIgnoreCase));
+
+            if (target is null)
+            {
+                var createdEndpointId = string.IsNullOrWhiteSpace(source.EndpointId) ? Guid.NewGuid().ToString() : source.EndpointId;
+                var newEndpoint = new EndpointModel
+                {
+                    EndpointId = createdEndpointId,
+                    Name = source.Name,
+                    Target = source.Target,
+                    IconKey = string.IsNullOrWhiteSpace(source.IconKey) ? "generic" : source.IconKey,
+                    Enabled = source.Enabled,
+                    Tags = source.Tags.ToList(),
+                    Notes = source.Notes,
+                    CreatedAtUtc = source.CreatedAtUtc == default ? DateTimeOffset.UtcNow : source.CreatedAtUtc
+                };
+
+                _dbContext.Endpoints.Add(newEndpoint);
+                existingEndpoints.Add(newEndpoint);
+                endpointIdMapping[source.EndpointId] = newEndpoint.EndpointId;
+                result.InsertedCount++;
+            }
+            else
+            {
+                target.IconKey = string.IsNullOrWhiteSpace(source.IconKey) ? "generic" : source.IconKey;
+                target.Enabled = source.Enabled;
+                target.Tags = source.Tags.ToList();
+                target.Notes = source.Notes;
+                endpointIdMapping[source.EndpointId] = target.EndpointId;
+                result.UpdatedCount++;
+            }
+        }
+
+        foreach (var source in sourceEndpoints)
+        {
+            if (!endpointIdMapping.TryGetValue(source.EndpointId, out var endpointId))
+            {
+                continue;
+            }
+
+            foreach (var sourceDependencyId in source.DependsOnEndpointIds)
+            {
+                if (!endpointIdMapping.TryGetValue(sourceDependencyId, out var dependsOnEndpointId))
+                {
+                    result.SkippedCount++;
+                    result.Warnings.Add($"Skipped dependency mapping for endpoint '{source.Name}' because dependency endpoint id '{sourceDependencyId}' was not available in restore scope.");
+                    continue;
+                }
+
+                if (string.Equals(endpointId, dependsOnEndpointId, StringComparison.Ordinal))
+                {
+                    result.SkippedCount++;
+                    result.Warnings.Add($"Skipped self-dependency for endpoint '{source.Name}'.");
+                    continue;
+                }
+
+                var exists = existingDependencies.Any(x => string.Equals(x.EndpointId, endpointId, StringComparison.Ordinal)
+                    && string.Equals(x.DependsOnEndpointId, dependsOnEndpointId, StringComparison.Ordinal));
+                if (exists)
+                {
+                    continue;
+                }
+
+                var dependency = new EndpointDependency
+                {
+                    EndpointDependencyId = Guid.NewGuid().ToString(),
+                    EndpointId = endpointId,
+                    DependsOnEndpointId = dependsOnEndpointId,
+                    CreatedAtUtc = DateTimeOffset.UtcNow
+                };
+
+                _dbContext.EndpointDependencies.Add(dependency);
+                existingDependencies.Add(dependency);
+                result.InsertedCount++;
+            }
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Restored section {Section}. Inserted {InsertedCount}, updated {UpdatedCount}, skipped {SkippedCount}, errors {ErrorCount}.",
+            result.Section,
+            result.InsertedCount,
+            result.UpdatedCount,
+            result.SkippedCount,
+            result.ErrorCount);
+
+        return result;
+    }
+
+    private async Task<RestoreSectionResult> RestoreAssignmentsAsync(
+        ConfigurationBackupDocument backup,
+        IDictionary<string, string> endpointIdMapping,
+        IDictionary<string, string> agentIdMapping,
+        CancellationToken cancellationToken)
+    {
+        var result = new RestoreSectionResult { Section = ConfigurationBackupSections.Assignments };
+        var sourceAssignments = backup.Sections.Assignments ?? [];
+
+        await using var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+        var existingAssignments = await _dbContext.MonitorAssignments.ToListAsync(cancellationToken);
+        var existingAgentIds = await _dbContext.Agents.AsNoTracking().Select(x => x.AgentId).ToListAsync(cancellationToken);
+        var existingEndpointIds = await _dbContext.Endpoints.AsNoTracking().Select(x => x.EndpointId).ToListAsync(cancellationToken);
+        var existingAgentIdSet = existingAgentIds.ToHashSet(StringComparer.Ordinal);
+        var existingEndpointIdSet = existingEndpointIds.ToHashSet(StringComparer.Ordinal);
+
+        foreach (var source in sourceAssignments)
+        {
+            var resolvedAgentId = ResolveMappedOrExistingId(source.AgentId, agentIdMapping, existingAgentIdSet);
+            var resolvedEndpointId = ResolveMappedOrExistingId(source.EndpointId, endpointIdMapping, existingEndpointIdSet);
+            if (resolvedAgentId is null || resolvedEndpointId is null)
+            {
+                result.SkippedCount++;
+                result.Warnings.Add($"Skipped assignment '{source.AssignmentId}' because referenced agent/endpoint could not be resolved in merge scope.");
+                continue;
+            }
+
+            if (!TryParseCheckType(source.CheckType, out var checkType))
+            {
+                result.SkippedCount++;
+                result.Warnings.Add($"Skipped assignment '{source.AssignmentId}' due to unsupported checkType '{source.CheckType}'.");
+                continue;
+            }
+
+            var target = existingAssignments.FirstOrDefault(x =>
+                string.Equals(x.AgentId, resolvedAgentId, StringComparison.Ordinal)
+                && string.Equals(x.EndpointId, resolvedEndpointId, StringComparison.Ordinal)
+                && x.CheckType == checkType);
+
+            if (target is null)
+            {
+                var assignment = new MonitorAssignment
+                {
+                    AssignmentId = string.IsNullOrWhiteSpace(source.AssignmentId) ? Guid.NewGuid().ToString() : source.AssignmentId,
+                    AgentId = resolvedAgentId,
+                    EndpointId = resolvedEndpointId,
+                    CheckType = checkType,
+                    Enabled = source.Enabled,
+                    PingIntervalSeconds = source.PingIntervalSeconds,
+                    RetryIntervalSeconds = source.RetryIntervalSeconds,
+                    TimeoutMs = source.TimeoutMs,
+                    FailureThreshold = source.FailureThreshold,
+                    RecoveryThreshold = source.RecoveryThreshold,
+                    CreatedAtUtc = source.CreatedAtUtc == default ? DateTimeOffset.UtcNow : source.CreatedAtUtc,
+                    UpdatedAtUtc = DateTimeOffset.UtcNow
+                };
+
+                _dbContext.MonitorAssignments.Add(assignment);
+                existingAssignments.Add(assignment);
+                result.InsertedCount++;
+            }
+            else
+            {
+                target.Enabled = source.Enabled;
+                target.PingIntervalSeconds = source.PingIntervalSeconds;
+                target.RetryIntervalSeconds = source.RetryIntervalSeconds;
+                target.TimeoutMs = source.TimeoutMs;
+                target.FailureThreshold = source.FailureThreshold;
+                target.RecoveryThreshold = source.RecoveryThreshold;
+                target.UpdatedAtUtc = DateTimeOffset.UtcNow;
+                result.UpdatedCount++;
+            }
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Restored section {Section}. Inserted {InsertedCount}, updated {UpdatedCount}, skipped {SkippedCount}, errors {ErrorCount}.",
+            result.Section,
+            result.InsertedCount,
+            result.UpdatedCount,
+            result.SkippedCount,
+            result.ErrorCount);
+
+        return result;
+    }
+
+    private async Task<RestoreSectionResult> RestoreIdentityAsync(ConfigurationBackupDocument backup, CancellationToken cancellationToken)
+    {
+        var result = new RestoreSectionResult { Section = ConfigurationBackupSections.Identity };
+        var sourceIdentity = backup.Sections.Identity;
+        if (sourceIdentity is null)
+        {
+            throw new InvalidOperationException("Identity section is missing in selected backup.");
+        }
+
+        await using var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+        var existingRoles = await _dbContext.Roles.ToListAsync(cancellationToken);
+        var existingUsers = await _dbContext.Users.ToListAsync(cancellationToken);
+        var existingUserRoles = await _dbContext.UserRoles.ToListAsync(cancellationToken);
+
+        var roleIdMapping = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var sourceRole in sourceIdentity.Roles)
+        {
+            var normalizedRoleName = sourceRole.NormalizedName ?? sourceRole.Name?.ToUpperInvariant();
+            if (string.IsNullOrWhiteSpace(normalizedRoleName))
+            {
+                result.SkippedCount++;
+                result.Warnings.Add("Skipped role with no normalized name.");
+                continue;
+            }
+
+            var targetRole = existingRoles.FirstOrDefault(x => string.Equals(x.NormalizedName, normalizedRoleName, StringComparison.Ordinal));
+            if (targetRole is null)
+            {
+                targetRole = new ApplicationRole
+                {
+                    Id = string.IsNullOrWhiteSpace(sourceRole.Id) ? Guid.NewGuid().ToString("N") : sourceRole.Id,
+                    Name = sourceRole.Name ?? normalizedRoleName,
+                    NormalizedName = normalizedRoleName
+                };
+
+                _dbContext.Roles.Add(targetRole);
+                existingRoles.Add(targetRole);
+                result.InsertedCount++;
+            }
+            else
+            {
+                targetRole.Name = sourceRole.Name ?? targetRole.Name;
+                result.UpdatedCount++;
+            }
+
+            roleIdMapping[sourceRole.Id] = targetRole.Id;
+        }
+
+        var userIdMapping = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var sourceUser in sourceIdentity.Users)
+        {
+            var normalizedUserName = sourceUser.NormalizedUserName;
+            var normalizedEmail = sourceUser.NormalizedEmail;
+
+            var targetUser = existingUsers.FirstOrDefault(x =>
+                (!string.IsNullOrWhiteSpace(normalizedUserName) && string.Equals(x.NormalizedUserName, normalizedUserName, StringComparison.Ordinal))
+                || (!string.IsNullOrWhiteSpace(normalizedEmail) && string.Equals(x.NormalizedEmail, normalizedEmail, StringComparison.Ordinal)));
+
+            if (targetUser is null)
+            {
+                result.SkippedCount++;
+                result.Warnings.Add($"Skipped creating identity user '{sourceUser.UserName ?? sourceUser.Email ?? sourceUser.Id}' because password hash is not part of configuration backups.");
+                continue;
+            }
+
+            targetUser.UserName = sourceUser.UserName ?? targetUser.UserName;
+            targetUser.NormalizedUserName = sourceUser.NormalizedUserName ?? targetUser.NormalizedUserName;
+            targetUser.Email = sourceUser.Email ?? targetUser.Email;
+            targetUser.NormalizedEmail = sourceUser.NormalizedEmail ?? targetUser.NormalizedEmail;
+            targetUser.EmailConfirmed = sourceUser.EmailConfirmed;
+            targetUser.LockoutEnabled = sourceUser.LockoutEnabled;
+            targetUser.LockoutEnd = sourceUser.LockoutEnd;
+            targetUser.AccessFailedCount = sourceUser.AccessFailedCount;
+            result.UpdatedCount++;
+            userIdMapping[sourceUser.Id] = targetUser.Id;
+        }
+
+        foreach (var sourceUserRole in sourceIdentity.UserRoles)
+        {
+            var hasUser = userIdMapping.TryGetValue(sourceUserRole.UserId, out var resolvedUserId);
+            var hasRole = roleIdMapping.TryGetValue(sourceUserRole.RoleId, out var resolvedRoleId);
+            if (!hasUser || !hasRole)
+            {
+                result.SkippedCount++;
+                result.Warnings.Add($"Skipped user-role mapping for user '{sourceUserRole.UserId}' and role '{sourceUserRole.RoleId}'.");
+                continue;
+            }
+
+            var exists = existingUserRoles.Any(x => string.Equals(x.UserId, resolvedUserId, StringComparison.Ordinal)
+                && string.Equals(x.RoleId, resolvedRoleId, StringComparison.Ordinal));
+            if (exists)
+            {
+                continue;
+            }
+
+            var userRole = new Microsoft.AspNetCore.Identity.IdentityUserRole<string>
+            {
+                UserId = resolvedUserId!,
+                RoleId = resolvedRoleId!
+            };
+
+            _dbContext.UserRoles.Add(userRole);
+            existingUserRoles.Add(userRole);
+            result.InsertedCount++;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Restored section {Section}. Inserted {InsertedCount}, updated {UpdatedCount}, skipped {SkippedCount}, errors {ErrorCount}.",
+            result.Section,
+            result.InsertedCount,
+            result.UpdatedCount,
+            result.SkippedCount,
+            result.ErrorCount);
+
+        return result;
+    }
+
+    private static string? ResolveMappedOrExistingId(
+        string sourceId,
+        IDictionary<string, string> mapping,
+        IReadOnlySet<string> existingIds)
+    {
+        if (mapping.TryGetValue(sourceId, out var mappedId))
+        {
+            return mappedId;
+        }
+
+        return existingIds.Contains(sourceId) ? sourceId : null;
+    }
+
+    private static bool TryParseCheckType(string rawCheckType, out CheckType checkType)
+    {
+        if (string.Equals(rawCheckType, "icmp", StringComparison.OrdinalIgnoreCase))
+        {
+            checkType = CheckType.Icmp;
+            return true;
+        }
+
+        checkType = default;
+        return false;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/Backups/BackupsPageViewModels.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Backups/BackupsPageViewModels.cs
@@ -41,4 +41,73 @@ public sealed class AdminBackupsPageViewModel
     public required CreateBackupPageForm Form { get; init; }
     public required IReadOnlyList<BackupRowViewModel> Backups { get; init; } = [];
     public string? StatusMessage { get; init; }
+    public RestorePreviewForm RestorePreviewForm { get; init; } = new();
+    public RestoreApplyForm RestoreApplyForm { get; init; } = new();
+    public BackupRestorePreviewViewModel? Preview { get; init; }
+    public BackupRestoreSummaryViewModel? RestoreSummary { get; init; }
+}
+
+public sealed class RestorePreviewForm
+{
+    [Required(ErrorMessage = "Backup file is required.")]
+    [Display(Name = "Backup file")]
+    public string SelectedFileId { get; set; } = string.Empty;
+}
+
+public sealed class RestoreApplyForm
+{
+    [Required(ErrorMessage = "Backup file is required.")]
+    public string SelectedFileId { get; set; } = string.Empty;
+
+    [Display(Name = "Restore agents")]
+    public bool IncludeAgents { get; set; } = true;
+
+    [Display(Name = "Restore endpoints")]
+    public bool IncludeEndpoints { get; set; } = true;
+
+    [Display(Name = "Restore assignments")]
+    public bool IncludeAssignments { get; set; } = true;
+
+    [Display(Name = "Restore identity")]
+    public bool IncludeIdentity { get; set; }
+}
+
+public sealed class BackupRestorePreviewViewModel
+{
+    public string FileId { get; init; } = string.Empty;
+    public string BackupName { get; init; } = string.Empty;
+    public string? Notes { get; init; }
+    public DateTimeOffset ExportedAtUtc { get; init; }
+    public string AppVersion { get; init; } = string.Empty;
+    public int FormatVersion { get; init; }
+    public IReadOnlyList<string> IncludedSections { get; init; } = [];
+    public ConfigurationBackupSectionCountViewModel Counts { get; init; } = new();
+}
+
+public sealed class ConfigurationBackupSectionCountViewModel
+{
+    public int Agents { get; init; }
+    public int Endpoints { get; init; }
+    public int Assignments { get; init; }
+    public int IdentityUsers { get; init; }
+    public int IdentityRoles { get; init; }
+    public int IdentityUserRoles { get; init; }
+}
+
+public sealed class BackupRestoreSectionResultViewModel
+{
+    public string Section { get; init; } = string.Empty;
+    public int InsertedCount { get; init; }
+    public int UpdatedCount { get; init; }
+    public int SkippedCount { get; init; }
+    public int ErrorCount { get; init; }
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+}
+
+public sealed class BackupRestoreSummaryViewModel
+{
+    public string FileId { get; init; } = string.Empty;
+    public string BackupName { get; init; } = string.Empty;
+    public IReadOnlyList<string> SelectedSections { get; init; } = [];
+    public IReadOnlyList<BackupRestoreSectionResultViewModel> Sections { get; init; } = [];
 }

--- a/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
@@ -17,7 +17,10 @@
             --success: #137333;
             --error-bg: #fee4e2;
             --error-text: #b42318;
+            --warning-bg: #fff7e6;
+            --warning-border: #f4b400;
         }
+
         * { box-sizing: border-box; }
         body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
         main { max-width: 960px; margin: 0 auto; padding: 1rem; }
@@ -25,7 +28,7 @@
         .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
         .muted { color: var(--muted); }
         label { display: block; font-weight: 600; margin-bottom: .35rem; }
-        input, textarea { width: 100%; border: 1px solid var(--border); border-radius: 10px; min-height: 48px; padding: .8rem; font: inherit; }
+        input, textarea, select { width: 100%; border: 1px solid var(--border); border-radius: 10px; min-height: 48px; padding: .8rem; font: inherit; }
         textarea { min-height: 96px; }
         .check-list { display: grid; gap: .6rem; }
         .check-item { display: flex; align-items: center; gap: .6rem; }
@@ -36,9 +39,15 @@
         .button-secondary { border: 1px solid var(--border); color: var(--text); background: white; }
         .errors { border: 1px solid #fda29b; background: var(--error-bg); color: var(--error-text); border-radius: 10px; padding: .8rem; }
         .saved { border: 1px solid #c2f0c2; background: #ebffee; color: var(--success); border-radius: 10px; padding: .8rem; }
+        .warning { border: 1px solid var(--warning-border); background: var(--warning-bg); border-radius: 10px; padding: .8rem; }
+        .notes { border: 1px solid var(--warning-border); background: var(--warning-bg); border-radius: 10px; padding: .8rem; white-space: pre-wrap; }
         table { width: 100%; border-collapse: collapse; }
         th, td { text-align: left; vertical-align: top; padding: .6rem .4rem; border-bottom: 1px solid var(--border); }
         .field-error { color: var(--error-text); font-size: .9rem; margin-top: .25rem; }
+        .split { display: grid; gap: 1rem; }
+        @@media (min-width: 780px) {
+            .split { grid-template-columns: 1fr 1fr; }
+        }
     </style>
 </head>
 <body>
@@ -46,26 +55,25 @@
     <div class="stack">
         <section class="card">
             <h1>Configuration backups</h1>
-            <p class="muted">Create and download configuration-only JSON backups. Restore is not implemented in this phase.</p>
+            <p class="muted">Create/download configuration-only JSON backups and restore from server-side files with explicit preview. Restore mode in this phase is <strong>MERGE only</strong> (no deletes, no replace mode).</p>
             <div class="button-row">
                 <a class="button-secondary" href="/admin">Back to admin settings</a>
                 <a class="button-secondary" href="/status">Back to status</a>
             </div>
         </section>
 
+        @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
+        {
+            <div class="saved" role="status">@Model.StatusMessage</div>
+        }
+
+        @if (!ViewData.ModelState.IsValid)
+        {
+            <div class="errors" asp-validation-summary="ModelOnly"></div>
+        }
+
         <form method="post" action="/admin/backups" class="stack">
             @Html.AntiForgeryToken()
-
-            @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
-            {
-                <div class="saved" role="status">@Model.StatusMessage</div>
-            }
-
-            @if (!ViewData.ModelState.IsValid)
-            {
-                <div class="errors" asp-validation-summary="ModelOnly"></div>
-            }
-
             <section class="card">
                 <h2>Create backup</h2>
                 <div class="stack">
@@ -93,6 +101,130 @@
                 </div>
             </section>
         </form>
+
+        <section class="card">
+            <h2>Restore (merge mode only)</h2>
+            <div class="warning">
+                <strong>Mode:</strong> MERGE only in this phase. Existing records are updated and missing records are inserted. No records are deleted.
+            </div>
+
+            <form method="post" action="/admin/backups/preview" class="stack" style="margin-top:1rem;">
+                @Html.AntiForgeryToken()
+                <div>
+                    <label asp-for="RestorePreviewForm.SelectedFileId"></label>
+                    <select asp-for="RestorePreviewForm.SelectedFileId">
+                        <option value="">Select a stored backup...</option>
+                        @foreach (var backup in Model.Backups)
+                        {
+                            <option value="@backup.FileId">@backup.BackupName (@backup.FileName)</option>
+                        }
+                    </select>
+                </div>
+                <div class="button-row">
+                    <button class="button" type="submit">Load restore preview</button>
+                </div>
+            </form>
+
+            @if (Model.Preview is not null)
+            {
+                <div class="stack" style="margin-top:1rem;">
+                    <div class="card" style="background:#f9fcff;">
+                        <h3>Selected backup preview</h3>
+                        <p><strong>Backup:</strong> @Model.Preview.BackupName</p>
+                        <p><strong>File:</strong> @Model.Preview.FileId</p>
+                        <p><strong>Exported:</strong> @Model.Preview.ExportedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</p>
+                        <p><strong>App version:</strong> @Model.Preview.AppVersion</p>
+                        <p><strong>Format version:</strong> @Model.Preview.FormatVersion</p>
+                        <p><strong>Included sections:</strong> @string.Join(", ", Model.Preview.IncludedSections)</p>
+                        <div>
+                            <strong>Notes</strong>
+                            <div class="notes">@(string.IsNullOrWhiteSpace(Model.Preview.Notes) ? "(none)" : Model.Preview.Notes)</div>
+                        </div>
+                        <div style="overflow-x:auto; margin-top:.75rem;">
+                            <table>
+                                <thead>
+                                    <tr>
+                                        <th>Section</th>
+                                        <th>Count</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr><td>Agents</td><td>@Model.Preview.Counts.Agents</td></tr>
+                                    <tr><td>Endpoints</td><td>@Model.Preview.Counts.Endpoints</td></tr>
+                                    <tr><td>Assignments</td><td>@Model.Preview.Counts.Assignments</td></tr>
+                                    <tr><td>Identity users</td><td>@Model.Preview.Counts.IdentityUsers</td></tr>
+                                    <tr><td>Identity roles</td><td>@Model.Preview.Counts.IdentityRoles</td></tr>
+                                    <tr><td>Identity user-role links</td><td>@Model.Preview.Counts.IdentityUserRoles</td></tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <form method="post" action="/admin/backups/restore" class="card stack">
+                        @Html.AntiForgeryToken()
+                        <input type="hidden" asp-for="RestoreApplyForm.SelectedFileId" value="@Model.Preview.FileId" />
+                        <h3>Apply merge restore</h3>
+                        <p class="muted">Select one or more sections. Only selected sections are restored. Replace mode is not available in this phase.</p>
+                        <div class="check-list">
+                            <label class="check-item"><input asp-for="RestoreApplyForm.IncludeAgents" /> Agents</label>
+                            <label class="check-item"><input asp-for="RestoreApplyForm.IncludeEndpoints" /> Endpoints (includes endpoint dependency links)</label>
+                            <label class="check-item"><input asp-for="RestoreApplyForm.IncludeAssignments" /> Assignments</label>
+                            <label class="check-item"><input asp-for="RestoreApplyForm.IncludeIdentity" /> Identity (sensitive and optional)</label>
+                        </div>
+                        <div class="warning">Identity restore is explicit and optional. Password hashes are not restored from configuration backups.</div>
+                        <div class="button-row">
+                            <button class="button" type="submit">Run merge restore</button>
+                        </div>
+                    </form>
+                </div>
+            }
+
+            @if (Model.RestoreSummary is not null)
+            {
+                <div class="card" style="margin-top:1rem; background:#f7fffb;">
+                    <h3>Restore summary</h3>
+                    <p><strong>File restored:</strong> @Model.RestoreSummary.FileId</p>
+                    <p><strong>Backup name:</strong> @Model.RestoreSummary.BackupName</p>
+                    <p><strong>Selected sections:</strong> @string.Join(", ", Model.RestoreSummary.SelectedSections)</p>
+                    <div style="overflow-x:auto;">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Section</th>
+                                    <th>Inserted</th>
+                                    <th>Updated</th>
+                                    <th>Skipped</th>
+                                    <th>Errors</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            @foreach (var section in Model.RestoreSummary.Sections)
+                            {
+                                <tr>
+                                    <td>
+                                        @(section.Section)
+                                        @if (section.Warnings.Count > 0)
+                                        {
+                                            <ul>
+                                                @foreach (var warning in section.Warnings)
+                                                {
+                                                    <li class="muted">@warning</li>
+                                                }
+                                            </ul>
+                                        }
+                                    </td>
+                                    <td>@(section.InsertedCount)</td>
+                                    <td>@(section.UpdatedCount)</td>
+                                    <td>@(section.SkippedCount)</td>
+                                    <td>@(section.ErrorCount)</td>
+                                </tr>
+                            }
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            }
+        </section>
 
         <section class="card">
             <h2>Stored backups</h2>


### PR DESCRIPTION
### Motivation
- Implement a safe, preview-first configuration restore flow that follows the repository backup/restore design and platform constraints (JSON-only, MySQL/.NET 10, configuration-only). 
- Provide deterministic merge-mode behavior that updates matching records and inserts missing ones without deleting existing configuration. 
- Preserve endpoint dependency relationships and keep identity restore explicit and opt-in due to sensitivity.

### Description
- Add preview and restore DTOs and models (`ConfigurationBackupPreview`, `ConfigurationBackupSectionCounts`, `RestoreConfigurationRequest`, `RestoreConfigurationResponse`, `RestoreSectionResult`, `RestorePreviewMetadata`) and extend endpoint backup records to include `DependsOnEndpointIds` for dependency reconstruction. 
- Implement a validated backup document loader (`IConfigurationBackupDocumentLoader`) that enumerates server-side backup files, protects against path traversal, deserializes JSON, and validates metadata/sections before restore. 
- Add `IConfigurationRestorePreviewService` / `ConfigurationRestorePreviewService` to produce backup previews and `IConfigurationRestoreService` / `ConfigurationRestoreService` to apply merge-mode restores for agents, endpoints (including dependency mapping), assignments, and optional identity with explicit matching rules and per-section result reporting. 
- Extend admin UI at `/admin/backups` with preview-first restore flow, section selection, clear merge-mode labeling, and a restore result summary; register new services in DI and update docs/README to describe preview + merge-only behavior. 
- Fixes #126

### Testing
- Installed .NET 10 SDK and ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully with zero errors. 
- Verified the web project compiles after changes (build output: `PingMonitor.Web -> .../PingMonitor.Web.dll`). 
- No automated unit tests were added for this change; UI screenshot capture was not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7d8539f78832a872339fc114d73cc)