### PR TITLE
Add REPLACE restore mode with typed confirmation and section-scoped deletes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ States:
 
 - Admin backup page supports server-side JSON configuration backups.
 - Restore is explicit and preview-first from existing server-side backup files.
-- Restore currently supports **merge mode only** (insert missing + update matching).
+- Restore supports:
+  - **merge mode** (insert missing + update matching; no deletes)
+  - **replace mode** (destructive, section-scoped delete + restore; requires typing `REPLACE`)
 - Replace mode, operational data restore, and backup upload are intentionally not implemented yet.
 - Logs are treated as first-class outputs
 

--- a/docs/config-backup-and-restore.md
+++ b/docs/config-backup-and-restore.md
@@ -87,9 +87,9 @@ Example:
 }
 ```
 
-## Restore behaviour (current)
+## Restore behaviour
 
-- Restore is **configuration-only** and uses **merge mode only**.
+- Restore is **configuration-only**.
 - Restore must be **previewed before apply**.
 - Preview must display backup metadata including `notes` prominently before restore is run.
 - Restore is driven from existing **server-side backup files** in the configured `Backup:StoragePath`.
@@ -97,10 +97,19 @@ Example:
   - `agents`
   - `endpoints`
   - `assignments`
-  - `identity` (optional and explicit)
+  - `identity` (optional and explicit, sensitive)
+- Restore supports two modes:
+  - `merge`
+  - `replace`
 - Merge mode updates matching records and inserts missing records.
-- Merge mode in this phase does **not delete existing configuration**.
-- Replace mode is not implemented in this phase.
+- Merge mode does **not delete existing configuration**.
+- Replace mode is destructive for the **selected sections only**:
+  - selected sections are deleted using explicit section-specific ordering
+  - selected sections are then imported from backup data
+  - non-selected sections are not modified
+- Replace mode requires exact typed confirmation text: `REPLACE`.
+- Replace requests with missing/incorrect confirmation must be rejected.
+- Identity replace is not supported in this phase; identity restore remains merge-only and explicit.
 - Restore does **not** import operational data (results, state transitions, alerts, logs, metrics, runtime state).
 
 ## Historical phase note

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminBackupsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminBackupsController.cs
@@ -92,7 +92,8 @@ public sealed class AdminBackupsController : Controller
                 IncludeAgents = preview.IncludedSections.Contains(ConfigurationBackupSections.Agents, StringComparer.Ordinal),
                 IncludeEndpoints = preview.IncludedSections.Contains(ConfigurationBackupSections.Endpoints, StringComparer.Ordinal),
                 IncludeAssignments = preview.IncludedSections.Contains(ConfigurationBackupSections.Assignments, StringComparer.Ordinal),
-                IncludeIdentity = false
+                IncludeIdentity = false,
+                RestoreMode = ConfigurationRestoreModes.Merge
             };
 
             var model = await BuildPageViewModelAsync(new CreateBackupPageForm(), form, applyForm, statusMessage: null, preview: previewViewModel, restoreSummary: null, cancellationToken);
@@ -118,7 +119,13 @@ public sealed class AdminBackupsController : Controller
         var selectedSections = GetSelectedRestoreSections(form);
         if (selectedSections.Count == 0)
         {
-            ModelState.AddModelError(string.Empty, "Select at least one section for merge restore.");
+            ModelState.AddModelError(string.Empty, "Select at least one section for restore.");
+        }
+
+        if (string.Equals(form.RestoreMode, ConfigurationRestoreModes.Replace, StringComparison.Ordinal)
+            && !string.Equals(form.ConfirmationText, ConfigurationRestoreModes.ReplaceConfirmationText, StringComparison.Ordinal))
+        {
+            ModelState.AddModelError(string.Empty, $"Replace mode requires typed confirmation text '{ConfigurationRestoreModes.ReplaceConfirmationText}'.");
         }
 
         if (!ModelState.IsValid)
@@ -129,11 +136,13 @@ public sealed class AdminBackupsController : Controller
 
         try
         {
-            var response = await _restoreService.RestoreMergeAsync(
+            var response = await _restoreService.RestoreAsync(
                 new RestoreConfigurationRequest
                 {
                     FileId = form.SelectedFileId,
-                    SelectedSections = selectedSections
+                    SelectedSections = selectedSections,
+                    RestoreMode = string.IsNullOrWhiteSpace(form.RestoreMode) ? ConfigurationRestoreModes.Merge : form.RestoreMode,
+                    ConfirmationText = form.ConfirmationText
                 },
                 cancellationToken);
 
@@ -142,7 +151,7 @@ public sealed class AdminBackupsController : Controller
                 new CreateBackupPageForm(),
                 new RestorePreviewForm { SelectedFileId = form.SelectedFileId },
                 form,
-                statusMessage: "Merge restore completed.",
+                statusMessage: $"{response.RestoreMode.ToUpperInvariant()} restore completed.",
                 preview: ToPreviewViewModel(preview),
                 restoreSummary: ToRestoreSummaryViewModel(response),
                 cancellationToken);
@@ -300,10 +309,12 @@ public sealed class AdminBackupsController : Controller
         {
             FileId = response.FileId,
             BackupName = response.BackupName,
+            RestoreMode = response.RestoreMode,
             SelectedSections = response.SelectedSections,
             Sections = response.SectionResults.Select(x => new BackupRestoreSectionResultViewModel
             {
                 Section = x.Section,
+                DeletedCount = x.DeletedCount,
                 InsertedCount = x.InsertedCount,
                 UpdatedCount = x.UpdatedCount,
                 SkippedCount = x.SkippedCount,

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs
@@ -13,6 +13,15 @@ public static class ConfigurationBackupSections
     public static readonly string[] All = [Agents, Endpoints, Assignments, Identity];
 }
 
+public static class ConfigurationRestoreModes
+{
+    public const string Merge = "merge";
+    public const string Replace = "replace";
+    public const string ReplaceConfirmationText = "REPLACE";
+
+    public static readonly string[] All = [Merge, Replace];
+}
+
 public sealed class ConfigurationBackupMetadata
 {
     public const int CurrentFormatVersion = 1;
@@ -234,11 +243,17 @@ public sealed class RestoreConfigurationRequest
 
     [Required]
     public IReadOnlyList<string> SelectedSections { get; init; } = [];
+
+    [Required]
+    public string RestoreMode { get; init; } = ConfigurationRestoreModes.Merge;
+
+    public string? ConfirmationText { get; init; }
 }
 
 public sealed class RestoreSectionResult
 {
     public string Section { get; init; } = string.Empty;
+    public int DeletedCount { get; set; }
     public int InsertedCount { get; set; }
     public int UpdatedCount { get; set; }
     public int SkippedCount { get; set; }
@@ -250,6 +265,7 @@ public sealed class RestoreConfigurationResponse
 {
     public string FileId { get; init; } = string.Empty;
     public string BackupName { get; init; } = string.Empty;
+    public string RestoreMode { get; init; } = ConfigurationRestoreModes.Merge;
     public IReadOnlyList<string> SelectedSections { get; init; } = [];
     public IReadOnlyList<RestoreSectionResult> SectionResults { get; init; } = [];
 }

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs
@@ -8,7 +8,7 @@ namespace PingMonitor.Web.Services.Backups;
 
 public interface IConfigurationRestoreService
 {
-    Task<RestoreConfigurationResponse> RestoreMergeAsync(RestoreConfigurationRequest request, CancellationToken cancellationToken);
+    Task<RestoreConfigurationResponse> RestoreAsync(RestoreConfigurationRequest request, CancellationToken cancellationToken);
 }
 
 public sealed class ConfigurationRestoreService : IConfigurationRestoreService
@@ -27,7 +27,7 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
         _logger = logger;
     }
 
-    public async Task<RestoreConfigurationResponse> RestoreMergeAsync(RestoreConfigurationRequest request, CancellationToken cancellationToken)
+    public async Task<RestoreConfigurationResponse> RestoreAsync(RestoreConfigurationRequest request, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(request.FileId))
         {
@@ -45,49 +45,178 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
             throw new InvalidOperationException("Select at least one restore section.");
         }
 
+        var restoreMode = NormalizeRestoreMode(request.RestoreMode);
+        ValidateConfirmationForMode(restoreMode, request.ConfirmationText);
+        ValidateReplaceSelectionRules(restoreMode, selectedSections);
+
         var backup = await _documentLoader.LoadValidatedDocumentAsync(request.FileId, cancellationToken);
         EnsureSelectedSectionsExist(selectedSections, backup);
 
         _logger.LogInformation(
-            "Starting configuration restore in merge mode for {FileId}. Sections: {Sections}.",
+            "Starting configuration restore in {RestoreMode} mode for {FileId}. Sections: {Sections}.",
+            restoreMode,
             request.FileId,
             string.Join(",", selectedSections));
 
         var sectionResults = new List<RestoreSectionResult>();
         var endpointIdMapping = new Dictionary<string, string>(StringComparer.Ordinal);
         var agentIdMapping = new Dictionary<string, string>(StringComparer.Ordinal);
+        await using var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+        var deletedCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        if (string.Equals(restoreMode, ConfigurationRestoreModes.Replace, StringComparison.Ordinal))
+        {
+            _logger.LogInformation(
+                "Destructive replace restore confirmed for {FileId}. Sections: {Sections}.",
+                request.FileId,
+                string.Join(",", selectedSections));
+
+            await ApplyReplaceDeletesAsync(selectedSections, deletedCounts, cancellationToken);
+        }
 
         if (selectedSections.Contains(ConfigurationBackupSections.Agents, StringComparer.Ordinal))
         {
-            sectionResults.Add(await RestoreAgentsAsync(backup, agentIdMapping, cancellationToken));
+            var section = await RestoreAgentsAsync(backup, agentIdMapping, cancellationToken);
+            section.DeletedCount = GetDeletedCount(deletedCounts, section.Section);
+            sectionResults.Add(section);
         }
 
         if (selectedSections.Contains(ConfigurationBackupSections.Endpoints, StringComparer.Ordinal))
         {
-            sectionResults.Add(await RestoreEndpointsAsync(backup, endpointIdMapping, cancellationToken));
+            var section = await RestoreEndpointsAsync(backup, endpointIdMapping, cancellationToken);
+            section.DeletedCount = GetDeletedCount(deletedCounts, section.Section);
+            sectionResults.Add(section);
         }
 
         if (selectedSections.Contains(ConfigurationBackupSections.Assignments, StringComparer.Ordinal))
         {
-            sectionResults.Add(await RestoreAssignmentsAsync(backup, endpointIdMapping, agentIdMapping, cancellationToken));
+            var section = await RestoreAssignmentsAsync(backup, endpointIdMapping, agentIdMapping, cancellationToken);
+            section.DeletedCount = GetDeletedCount(deletedCounts, section.Section);
+            sectionResults.Add(section);
         }
 
         if (selectedSections.Contains(ConfigurationBackupSections.Identity, StringComparer.Ordinal))
         {
-            sectionResults.Add(await RestoreIdentityAsync(backup, cancellationToken));
+            var section = await RestoreIdentityAsync(backup, cancellationToken);
+            section.DeletedCount = GetDeletedCount(deletedCounts, section.Section);
+            sectionResults.Add(section);
         }
 
+        await transaction.CommitAsync(cancellationToken);
+
         _logger.LogInformation(
-            "Completed configuration restore in merge mode for {FileId}.",
+            "Completed configuration restore in {RestoreMode} mode for {FileId}.",
+            restoreMode,
             request.FileId);
 
         return new RestoreConfigurationResponse
         {
             FileId = request.FileId,
             BackupName = backup.BackupName,
+            RestoreMode = restoreMode,
             SelectedSections = selectedSections,
             SectionResults = sectionResults
         };
+    }
+
+    private static string NormalizeRestoreMode(string? restoreMode)
+    {
+        if (string.IsNullOrWhiteSpace(restoreMode))
+        {
+            return ConfigurationRestoreModes.Merge;
+        }
+
+        var normalized = restoreMode.Trim().ToLowerInvariant();
+        if (!ConfigurationRestoreModes.All.Contains(normalized, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException($"Unsupported restore mode '{restoreMode}'.");
+        }
+
+        return normalized;
+    }
+
+    private void ValidateConfirmationForMode(string restoreMode, string? confirmationText)
+    {
+        if (!string.Equals(restoreMode, ConfigurationRestoreModes.Replace, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        if (!string.Equals(confirmationText, ConfigurationRestoreModes.ReplaceConfirmationText, StringComparison.Ordinal))
+        {
+            _logger.LogWarning("Replace restore confirmation failed due to invalid confirmation text.");
+            throw new InvalidOperationException($"Replace restore requires typed confirmation text '{ConfigurationRestoreModes.ReplaceConfirmationText}'.");
+        }
+
+        _logger.LogInformation("Replace restore confirmation validated.");
+    }
+
+    private static void ValidateReplaceSelectionRules(string restoreMode, IReadOnlyCollection<string> selectedSections)
+    {
+        if (!string.Equals(restoreMode, ConfigurationRestoreModes.Replace, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var includesAgents = selectedSections.Contains(ConfigurationBackupSections.Agents, StringComparer.Ordinal);
+        var includesEndpoints = selectedSections.Contains(ConfigurationBackupSections.Endpoints, StringComparer.Ordinal);
+        var includesAssignments = selectedSections.Contains(ConfigurationBackupSections.Assignments, StringComparer.Ordinal);
+
+        if ((includesAgents || includesEndpoints) && !includesAssignments)
+        {
+            throw new InvalidOperationException("Replace mode for agents/endpoints requires selecting assignments so relationship rows are replaced deterministically.");
+        }
+    }
+
+    private async Task ApplyReplaceDeletesAsync(
+        IReadOnlyCollection<string> selectedSections,
+        IDictionary<string, int> deletedCounts,
+        CancellationToken cancellationToken)
+    {
+        if (selectedSections.Contains(ConfigurationBackupSections.Identity, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException("Replace restore for identity section is not supported in this phase because configuration backups do not contain password hashes.");
+        }
+
+        // Explicit destructive ordering:
+        // 1) MonitorAssignments are deleted before Agents/Endpoints.
+        // 2) EndpointDependencies and endpoint-scoped access/membership rows are deleted before Endpoints.
+        // This keeps referential dependencies deterministic in replace mode.
+        if (selectedSections.Contains(ConfigurationBackupSections.Assignments, StringComparer.Ordinal))
+        {
+            var deletedAssignments = await _dbContext.MonitorAssignments.ExecuteDeleteAsync(cancellationToken);
+            deletedCounts[ConfigurationBackupSections.Assignments] = deletedAssignments;
+            _logger.LogInformation("Replace delete completed for section {Section}. Deleted {DeletedCount} records.", ConfigurationBackupSections.Assignments, deletedAssignments);
+        }
+
+        if (selectedSections.Contains(ConfigurationBackupSections.Endpoints, StringComparer.Ordinal))
+        {
+            var deletedDependencies = await _dbContext.EndpointDependencies.ExecuteDeleteAsync(cancellationToken);
+            var deletedEndpointMemberships = await _dbContext.EndpointGroupMemberships.ExecuteDeleteAsync(cancellationToken);
+            var deletedEndpointAccess = await _dbContext.UserEndpointAccesses.ExecuteDeleteAsync(cancellationToken);
+            var deletedEndpoints = await _dbContext.Endpoints.ExecuteDeleteAsync(cancellationToken);
+
+            deletedCounts[ConfigurationBackupSections.Endpoints] = deletedEndpoints + deletedDependencies + deletedEndpointMemberships + deletedEndpointAccess;
+            _logger.LogInformation(
+                "Replace delete completed for section {Section}. Deleted endpoints {EndpointCount}, dependencies {DependencyCount}, memberships {MembershipCount}, endpoint access {AccessCount}.",
+                ConfigurationBackupSections.Endpoints,
+                deletedEndpoints,
+                deletedDependencies,
+                deletedEndpointMemberships,
+                deletedEndpointAccess);
+        }
+
+        if (selectedSections.Contains(ConfigurationBackupSections.Agents, StringComparer.Ordinal))
+        {
+            var deletedAgents = await _dbContext.Agents.ExecuteDeleteAsync(cancellationToken);
+            deletedCounts[ConfigurationBackupSections.Agents] = deletedAgents;
+            _logger.LogInformation("Replace delete completed for section {Section}. Deleted {DeletedCount} records.", ConfigurationBackupSections.Agents, deletedAgents);
+        }
+    }
+
+    private static int GetDeletedCount(IReadOnlyDictionary<string, int> deletedCounts, string section)
+    {
+        return deletedCounts.TryGetValue(section, out var deletedCount) ? deletedCount : 0;
     }
 
     private static void EnsureSelectedSectionsExist(IReadOnlyCollection<string> selectedSections, ConfigurationBackupDocument backup)
@@ -117,8 +246,6 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
     {
         var result = new RestoreSectionResult { Section = ConfigurationBackupSections.Agents };
         var sourceAgents = backup.Sections.Agents ?? [];
-
-        await using var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
 
         var existingAgents = await _dbContext.Agents.ToListAsync(cancellationToken);
         foreach (var source in sourceAgents)
@@ -163,7 +290,6 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
         }
 
         await _dbContext.SaveChangesAsync(cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
 
         _logger.LogInformation(
             "Restored section {Section}. Inserted {InsertedCount}, updated {UpdatedCount}, skipped {SkippedCount}, errors {ErrorCount}.",
@@ -183,8 +309,6 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
     {
         var result = new RestoreSectionResult { Section = ConfigurationBackupSections.Endpoints };
         var sourceEndpoints = backup.Sections.Endpoints ?? [];
-
-        await using var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
 
         var existingEndpoints = await _dbContext.Endpoints.ToListAsync(cancellationToken);
         var existingDependencies = await _dbContext.EndpointDependencies.ToListAsync(cancellationToken);
@@ -271,7 +395,6 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
         }
 
         await _dbContext.SaveChangesAsync(cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
 
         _logger.LogInformation(
             "Restored section {Section}. Inserted {InsertedCount}, updated {UpdatedCount}, skipped {SkippedCount}, errors {ErrorCount}.",
@@ -292,8 +415,6 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
     {
         var result = new RestoreSectionResult { Section = ConfigurationBackupSections.Assignments };
         var sourceAssignments = backup.Sections.Assignments ?? [];
-
-        await using var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
 
         var existingAssignments = await _dbContext.MonitorAssignments.ToListAsync(cancellationToken);
         var existingAgentIds = await _dbContext.Agents.AsNoTracking().Select(x => x.AgentId).ToListAsync(cancellationToken);
@@ -360,7 +481,6 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
         }
 
         await _dbContext.SaveChangesAsync(cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
 
         _logger.LogInformation(
             "Restored section {Section}. Inserted {InsertedCount}, updated {UpdatedCount}, skipped {SkippedCount}, errors {ErrorCount}.",
@@ -381,8 +501,6 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
         {
             throw new InvalidOperationException("Identity section is missing in selected backup.");
         }
-
-        await using var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
 
         var existingRoles = await _dbContext.Roles.ToListAsync(cancellationToken);
         var existingUsers = await _dbContext.Users.ToListAsync(cancellationToken);
@@ -481,7 +599,6 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
         }
 
         await _dbContext.SaveChangesAsync(cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
 
         _logger.LogInformation(
             "Restored section {Section}. Inserted {InsertedCount}, updated {UpdatedCount}, skipped {SkippedCount}, errors {ErrorCount}.",

--- a/src/WebApp/PingMonitor.Web/ViewModels/Backups/BackupsPageViewModels.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Backups/BackupsPageViewModels.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using PingMonitor.Web.Services.Backups;
 
 namespace PingMonitor.Web.ViewModels.Backups;
 
@@ -70,6 +71,12 @@ public sealed class RestoreApplyForm
 
     [Display(Name = "Restore identity")]
     public bool IncludeIdentity { get; set; }
+
+    [Display(Name = "Restore mode")]
+    public string RestoreMode { get; set; } = ConfigurationRestoreModes.Merge;
+
+    [Display(Name = "Typed confirmation")]
+    public string? ConfirmationText { get; set; }
 }
 
 public sealed class BackupRestorePreviewViewModel
@@ -97,6 +104,7 @@ public sealed class ConfigurationBackupSectionCountViewModel
 public sealed class BackupRestoreSectionResultViewModel
 {
     public string Section { get; init; } = string.Empty;
+    public int DeletedCount { get; init; }
     public int InsertedCount { get; init; }
     public int UpdatedCount { get; init; }
     public int SkippedCount { get; init; }
@@ -108,6 +116,7 @@ public sealed class BackupRestoreSummaryViewModel
 {
     public string FileId { get; init; } = string.Empty;
     public string BackupName { get; init; } = string.Empty;
+    public string RestoreMode { get; init; } = ConfigurationRestoreModes.Merge;
     public IReadOnlyList<string> SelectedSections { get; init; } = [];
     public IReadOnlyList<BackupRestoreSectionResultViewModel> Sections { get; init; } = [];
 }

--- a/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
@@ -55,7 +55,7 @@
     <div class="stack">
         <section class="card">
             <h1>Configuration backups</h1>
-            <p class="muted">Create/download configuration-only JSON backups and restore from server-side files with explicit preview. Restore mode in this phase is <strong>MERGE only</strong> (no deletes, no replace mode).</p>
+            <p class="muted">Create/download configuration-only JSON backups and restore from server-side files with explicit preview. Restore supports <strong>MERGE</strong> (safe default) and <strong>REPLACE</strong> (destructive for selected sections only).</p>
             <div class="button-row">
                 <a class="button-secondary" href="/admin">Back to admin settings</a>
                 <a class="button-secondary" href="/status">Back to status</a>
@@ -103,9 +103,9 @@
         </form>
 
         <section class="card">
-            <h2>Restore (merge mode only)</h2>
+            <h2>Restore</h2>
             <div class="warning">
-                <strong>Mode:</strong> MERGE only in this phase. Existing records are updated and missing records are inserted. No records are deleted.
+                <strong>Mode notes:</strong> MERGE updates/inserts without deletes. REPLACE deletes selected sections first, then restores them from the backup.
             </div>
 
             <form method="post" action="/admin/backups/preview" class="stack" style="margin-top:1rem;">
@@ -163,17 +163,31 @@
                     <form method="post" action="/admin/backups/restore" class="card stack">
                         @Html.AntiForgeryToken()
                         <input type="hidden" asp-for="RestoreApplyForm.SelectedFileId" value="@Model.Preview.FileId" />
-                        <h3>Apply merge restore</h3>
-                        <p class="muted">Select one or more sections. Only selected sections are restored. Replace mode is not available in this phase.</p>
+                        <h3>Apply restore</h3>
+                        <p class="muted">Select one or more sections. Only selected sections are restored. Non-selected sections remain untouched.</p>
                         <div class="check-list">
                             <label class="check-item"><input asp-for="RestoreApplyForm.IncludeAgents" /> Agents</label>
                             <label class="check-item"><input asp-for="RestoreApplyForm.IncludeEndpoints" /> Endpoints (includes endpoint dependency links)</label>
                             <label class="check-item"><input asp-for="RestoreApplyForm.IncludeAssignments" /> Assignments</label>
                             <label class="check-item"><input asp-for="RestoreApplyForm.IncludeIdentity" /> Identity (sensitive and optional)</label>
                         </div>
+                        <div>
+                            <label asp-for="RestoreApplyForm.RestoreMode"></label>
+                            <select asp-for="RestoreApplyForm.RestoreMode">
+                                <option value="merge">Merge (safe default)</option>
+                                <option value="replace">Replace (destructive)</option>
+                            </select>
+                        </div>
+                        <div class="warning">
+                            Replace mode is destructive for selected sections. Type <strong>REPLACE</strong> exactly to confirm.
+                        </div>
+                        <div>
+                            <label asp-for="RestoreApplyForm.ConfirmationText"></label>
+                            <input asp-for="RestoreApplyForm.ConfirmationText" placeholder="Type REPLACE to confirm replace mode" />
+                        </div>
                         <div class="warning">Identity restore is explicit and optional. Password hashes are not restored from configuration backups.</div>
                         <div class="button-row">
-                            <button class="button" type="submit">Run merge restore</button>
+                            <button class="button" type="submit">Run restore</button>
                         </div>
                     </form>
                 </div>
@@ -185,12 +199,14 @@
                     <h3>Restore summary</h3>
                     <p><strong>File restored:</strong> @Model.RestoreSummary.FileId</p>
                     <p><strong>Backup name:</strong> @Model.RestoreSummary.BackupName</p>
+                    <p><strong>Restore mode:</strong> @Model.RestoreSummary.RestoreMode</p>
                     <p><strong>Selected sections:</strong> @string.Join(", ", Model.RestoreSummary.SelectedSections)</p>
                     <div style="overflow-x:auto;">
                         <table>
                             <thead>
                                 <tr>
                                     <th>Section</th>
+                                    <th>Deleted</th>
                                     <th>Inserted</th>
                                     <th>Updated</th>
                                     <th>Skipped</th>
@@ -213,6 +229,7 @@
                                             </ul>
                                         }
                                     </td>
+                                    <td>@(section.DeletedCount)</td>
                                     <td>@(section.InsertedCount)</td>
                                     <td>@(section.UpdatedCount)</td>
                                     <td>@(section.SkippedCount)</td>


### PR DESCRIPTION
### Motivation
- Provide a destructive, operator-confirmed restore path in addition to existing safe `merge` restores so operators can fully replace selected configuration sections from server-side backups.  
- Ensure destructive actions require explicit typed confirmation (`REPLACE`) and are section-scoped to limit blast radius.  
- Keep the workflow preview-first, deterministic, and documented per the backup/restore and platform constraints.

### Description
- Add `ConfigurationRestoreModes` and extend the restore DTOs with `RestoreMode` and `ConfirmationText`, add per-section `DeletedCount`, and return `RestoreMode` in the response (`RestoreConfigurationRequest/Response`, `RestoreSectionResult`).  
- Implement a single `IConfigurationRestoreService.RestoreAsync` entrypoint and validation helpers: `NormalizeRestoreMode`, `ValidateConfirmationForMode`, and `ValidateReplaceSelectionRules`, enforcing exact typed confirmation `REPLACE` for replace mode and rejecting unsafe selections (identity replace blocked).  
- Implement explicit, section-scoped destructive deletes in `ApplyReplaceDeletesAsync` with a deterministic ordering (delete `MonitorAssignments` first, then endpoint-related rows and endpoints, then agents), track deleted counts and run deletes inside a transaction to avoid partial destructive state.  
- Update admin controller, view models, and Razor UI to select restore mode, enter typed confirmation, and display the restore summary with `Deleted/Inserted/Updated/Skipped/Error` counts; merge remains the default mode.  
- Update `docs/config-backup-and-restore.md` and `README.md` to document `merge` vs `replace`, the required confirmation phrase, and the identity-replace restriction.  
- Fixes #128.

### Testing
- Created GitHub issue `#128` to track the work (issue creation succeeded).  
- Performed a project build after installing the .NET 10 SDK and resolving SDK version in `global.json` with: `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, and the build completed successfully.  
- No automated unit tests were added or changed in this change set; UI screenshots/manual validations were not captured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7e1eed678832aa472190cffe29e32)