### PR TITLE
Run startup gate middleware before authentication

### DIFF
--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -139,8 +139,6 @@ var app = builder.Build();
 
 app.UseForwardedHeaders();
 app.UseHttpsRedirection();
-app.UseAuthentication();
-app.UseAuthorization();
 app.UseStaticFiles();
 
 app.Use(async (context, next) =>
@@ -170,6 +168,9 @@ app.Use(async (context, next) =>
     context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
     await context.Response.WriteAsync("Startup gate is active. Use local loopback access to complete setup.");
 });
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapControllers();
 app.MapControllerRoute(


### PR DESCRIPTION
### Motivation
- Requests can hit ASP.NET Identity cookie validation before the startup-gate runs, causing database access with placeholder/invalid MySQL credentials and throwing unhandled `MySqlException` errors. 
- The startup-gate must be able to short-circuit requests when the app is in setup mode so Identity never attempts DB queries during initial configuration.

### Description
- Reordered middleware in `Program.cs` so the startup-gate middleware runs before `UseAuthentication()` and `UseAuthorization()` to prevent early DB access. 
- `UseStaticFiles()` remains before the startup-gate so assets are served as before and routing is unchanged. 
- Added traceability by creating an issue for this change: `#130`. 
- Fixes #130

### Testing
- Installed required tooling and SDKs (`powershell`, `.NET 10`) and confirmed `pwsh -v` and `dotnet --version` executed successfully. 
- Ran `dotnet build src/WebApp/PingMonitor.WebApp.slnx` and the solution built successfully with `0 Warning(s)` and `0 Error(s)`. 
- No automated test failures were observed during the build step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7e6b3cbcc832a8ee66eba40427f4d)