### PR TITLE
Fix startup-gate crash when identity cookie validates against placeholder DB credentials

### DIFF
--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Primitives;
 using Microsoft.EntityFrameworkCore;
 using MySql.EntityFrameworkCore.Extensions;
 using PingMonitor.Web.Data;
@@ -167,6 +168,29 @@ app.Use(async (context, next) =>
 
     context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
     await context.Response.WriteAsync("Startup gate is active. Use local loopback access to complete setup.");
+});
+
+app.Use(async (context, next) =>
+{
+    if (!context.Request.Path.StartsWithSegments("/startup-gate", StringComparison.OrdinalIgnoreCase))
+    {
+        await next();
+        return;
+    }
+
+    var startupGateStatus = context.Items[typeof(StartupGateStatus).FullName!] as StartupGateStatus;
+    if (startupGateStatus is null || startupGateStatus.Mode == StartupMode.Normal)
+    {
+        await next();
+        return;
+    }
+
+    if (context.Request.Headers.ContainsKey("Cookie"))
+    {
+        context.Request.Headers["Cookie"] = StringValues.Empty;
+    }
+
+    await next();
 });
 
 app.UseAuthentication();


### PR DESCRIPTION
### Motivation
- While the app is in startup/setup mode and placeholder MySQL credentials are configured, an existing identity cookie can trigger security-stamp validation which attempts a DB connection and throws, preventing setup endpoints from being reached. 
- The change ensures the `/startup-gate` setup flow remains reachable and stable when startup mode is active and placeholder credentials are present.

### Description
- Add a small middleware (executed before `UseAuthentication()`) that, for requests to `/startup-gate` when startup mode is not `Normal`, clears the incoming `Cookie` header to prevent cookie-based authentication from running during setup. 
- Import `Microsoft.Extensions.Primitives` to safely mutate the `Cookie` header. 
- The middleware is conditional and preserves normal authentication behavior once startup mode is `Normal`. 
- Fixes #132

### Testing
- Ran `dotnet test src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and observed no failing tests. 
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -c Release` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7e8eeb568832a801b8ba6e19b4108)