### PR TITLE
docs: add official .NET 10 and MySQL 8 references to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,12 @@ Correctness, safety, and predictability take priority over elegance.
   - an explicit new issue, and
   - a corresponding update to `docs/PLATFORM_CONSTRAINTS.md`.
 
+## Implementation references (authoritative when unsure)
+
+- .NET 10 documentation: https://learn.microsoft.com/dotnet/core/whats-new/dotnet-10/overview
+- MySQL 8.0 documentation: https://dev.mysql.com/doc/refman/8.0/en/
+- Whenever you are unsure how to properly implement behavior, consult these official references first and align implementation decisions with them.
+
 ---
 
 ## Core Principles


### PR DESCRIPTION
### Motivation
- Provide canonical implementation references to reduce ambiguity and ensure implementation decisions align with supported platform runtimes and storage engines.

### Description
- Add an `Implementation references (authoritative when unsure)` section to `AGENTS.md` that links to the official .NET 10 overview and the MySQL 8.0 manual and instructs contributors to consult them when unsure; Closes #139.

### Testing
- Ran automated repository checks including creating/listing the issue via `curl` to the GitHub API, verifying the change with `git diff -- AGENTS.md`, and printing the updated file head with `nl -ba AGENTS.md | sed -n '1,60p'`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7f3e0b10c832a836f3927fa1d24b9)