### PR TITLE
Add backup delete management, automatic backups, and retention controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ States:
 
 ### Configuration Backup and Restore
 
-- Admin backup page supports server-side JSON configuration backups.
-- Admin backup page supports uploading JSON configuration backups.
+- Admin backup page supports server-side JSON configuration backups with source classification (`manual`, `uploaded`, `automatic_scheduled`, `automatic_config_change`).
+- Admin backup page supports uploading JSON configuration backups and server-side delete management (single and bulk delete with typed confirmation for bulk).
 - Accepted uploads are validated, retained on the server, and added to the managed backup list.
+- Automatic configuration backups support a simple daily schedule plus configuration-change coalescing, with retention pruning applied to automatic backups by default.
 - Restore is explicit and preview-first from existing server-side backup files.
 - Restore supports:
   - **merge mode** (insert missing + update matching; no deletes)

--- a/docs/config-backup-and-restore.md
+++ b/docs/config-backup-and-restore.md
@@ -123,3 +123,50 @@ Example:
   - locally created backups
   - accepted uploaded JSON configuration backups
 - Both sources are listed together and use the same preview and restore paths.
+
+
+## Backup source classification
+
+Each managed backup is classified with a source value for operational visibility and retention handling:
+
+- `manual` - created explicitly by an operator from the admin backup page
+- `uploaded` - accepted uploaded JSON backup file
+- `automatic_scheduled` - created by the daily automatic backup schedule
+- `automatic_config_change` - created automatically after configuration changes are coalesced
+
+Source classification is part of managed backup metadata and is shown in the admin backup list.
+
+## Delete management
+
+Managed backups can be deleted from the admin UI with explicit confirmation:
+
+- Single-file delete requires explicit confirmation in the delete form submission
+- Bulk delete requires typed confirmation text: `DELETE`
+- Delete operations are restricted to files in the configured `Backup:StoragePath`
+- Path traversal and arbitrary file delete attempts must be rejected
+
+## Automatic backup behaviour
+
+Automatic backups remain configuration-only and use the existing export pipeline.
+
+### Scheduled backups
+
+- Daily scheduled backups are supported using a simple configured local time
+- Scheduled backups are created with source `automatic_scheduled`
+- Scheduling remains intentionally simple (no cron dependency)
+
+### Configuration-change backups
+
+- Configuration changes in monitored configuration areas can trigger automatic backup creation
+- Config-change backups are created with source `automatic_config_change`
+- Debounce/coalescing is required so bursts of changes result in one backup for the coalescing window
+
+## Retention behaviour
+
+Retention is safe and predictable by default:
+
+- Retention pruning applies to automatic backups by default
+- Manual backups are not silently auto-pruned by default
+- Uploaded backups are not silently auto-pruned by default
+- Pruning may run after automatic backup creation and/or during maintenance passes
+- Max-count pruning for automatic backups is the baseline policy; optional age-based pruning may be added when needed

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminBackupsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminBackupsController.cs
@@ -13,6 +13,7 @@ public sealed class AdminBackupsController : Controller
     private readonly IConfigurationBackupService _backupService;
     private readonly IConfigurationBackupQueryService _backupQueryService;
     private readonly IConfigurationBackupUploadService _backupUploadService;
+    private readonly IConfigurationBackupManagementService _backupManagementService;
     private readonly IConfigurationRestorePreviewService _restorePreviewService;
     private readonly IConfigurationRestoreService _restoreService;
 
@@ -20,20 +21,22 @@ public sealed class AdminBackupsController : Controller
         IConfigurationBackupService backupService,
         IConfigurationBackupQueryService backupQueryService,
         IConfigurationBackupUploadService backupUploadService,
+        IConfigurationBackupManagementService backupManagementService,
         IConfigurationRestorePreviewService restorePreviewService,
         IConfigurationRestoreService restoreService)
     {
         _backupService = backupService;
         _backupQueryService = backupQueryService;
         _backupUploadService = backupUploadService;
+        _backupManagementService = backupManagementService;
         _restorePreviewService = restorePreviewService;
         _restoreService = restoreService;
     }
 
     [HttpGet]
-    public async Task<IActionResult> Index(CancellationToken cancellationToken)
+    public async Task<IActionResult> Index([FromQuery] string? name, [FromQuery] string? source, CancellationToken cancellationToken)
     {
-        var viewModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), new UploadBackupPageForm(), new RestorePreviewForm(), new RestoreApplyForm(), statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
+        var viewModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), new UploadBackupPageForm(), new RestorePreviewForm(), new RestoreApplyForm(), new BackupDeleteSingleForm(), new BackupDeleteBulkForm(), name, source, statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
         return View("Index", viewModel);
     }
 
@@ -49,7 +52,7 @@ public sealed class AdminBackupsController : Controller
 
         if (!ModelState.IsValid)
         {
-            var invalidModel = await BuildPageViewModelAsync(form, new UploadBackupPageForm(), new RestorePreviewForm(), new RestoreApplyForm(), statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
+            var invalidModel = await BuildPageViewModelAsync(form, new UploadBackupPageForm(), new RestorePreviewForm(), new RestoreApplyForm(), new BackupDeleteSingleForm(), new BackupDeleteBulkForm(), null, null, statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
             return View("Index", invalidModel);
         }
 
@@ -61,7 +64,8 @@ public sealed class AdminBackupsController : Controller
                     BackupName = form.BackupName,
                     Notes = form.Notes,
                     SelectedSections = selectedSections,
-                    ExportedBy = User?.Identity?.Name
+                    ExportedBy = User?.Identity?.Name,
+                    BackupSource = ConfigurationBackupSources.Manual
                 },
                 cancellationToken);
 
@@ -70,7 +74,7 @@ public sealed class AdminBackupsController : Controller
         catch (InvalidOperationException ex)
         {
             ModelState.AddModelError(string.Empty, ex.Message);
-            var invalidModel = await BuildPageViewModelAsync(form, new UploadBackupPageForm(), new RestorePreviewForm(), new RestoreApplyForm(), statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
+            var invalidModel = await BuildPageViewModelAsync(form, new UploadBackupPageForm(), new RestorePreviewForm(), new RestoreApplyForm(), new BackupDeleteSingleForm(), new BackupDeleteBulkForm(), null, null, statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
             return View("Index", invalidModel);
         }
     }
@@ -81,7 +85,7 @@ public sealed class AdminBackupsController : Controller
     {
         if (!ModelState.IsValid)
         {
-            var invalidModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), form, new RestorePreviewForm(), new RestoreApplyForm(), statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
+            var invalidModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), form, new RestorePreviewForm(), new RestoreApplyForm(), new BackupDeleteSingleForm(), new BackupDeleteBulkForm(), null, null, statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
             return View("Index", invalidModel);
         }
 
@@ -100,7 +104,7 @@ public sealed class AdminBackupsController : Controller
         catch (InvalidOperationException ex)
         {
             ModelState.AddModelError(string.Empty, ex.Message);
-            var invalidModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), form, new RestorePreviewForm(), new RestoreApplyForm(), statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
+            var invalidModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), form, new RestorePreviewForm(), new RestoreApplyForm(), new BackupDeleteSingleForm(), new BackupDeleteBulkForm(), null, null, statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
             return View("Index", invalidModel);
         }
     }
@@ -111,7 +115,7 @@ public sealed class AdminBackupsController : Controller
     {
         if (!ModelState.IsValid)
         {
-            var invalidModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), new UploadBackupPageForm(), form, new RestoreApplyForm(), statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
+            var invalidModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), new UploadBackupPageForm(), form, new RestoreApplyForm(), new BackupDeleteSingleForm(), new BackupDeleteBulkForm(), null, null, statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
             return View("Index", invalidModel);
         }
 
@@ -129,7 +133,7 @@ public sealed class AdminBackupsController : Controller
                 RestoreMode = ConfigurationRestoreModes.Merge
             };
 
-            var model = await BuildPageViewModelAsync(new CreateBackupPageForm(), new UploadBackupPageForm(), form, applyForm, statusMessage: null, preview: previewViewModel, restoreSummary: null, cancellationToken);
+            var model = await BuildPageViewModelAsync(new CreateBackupPageForm(), new UploadBackupPageForm(), form, applyForm, new BackupDeleteSingleForm(), new BackupDeleteBulkForm(), null, null, statusMessage: null, preview: previewViewModel, restoreSummary: null, cancellationToken);
             return View("Index", model);
         }
         catch (FileNotFoundException)
@@ -141,7 +145,7 @@ public sealed class AdminBackupsController : Controller
             ModelState.AddModelError(string.Empty, ex.Message);
         }
 
-        var failedModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), new UploadBackupPageForm(), form, new RestoreApplyForm(), statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
+        var failedModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), new UploadBackupPageForm(), form, new RestoreApplyForm(), new BackupDeleteSingleForm(), new BackupDeleteBulkForm(), null, null, statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
         return View("Index", failedModel);
     }
 
@@ -163,7 +167,7 @@ public sealed class AdminBackupsController : Controller
 
         if (!ModelState.IsValid)
         {
-            var invalidModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), new UploadBackupPageForm(), new RestorePreviewForm { SelectedFileId = form.SelectedFileId }, form, statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
+            var invalidModel = await BuildPageViewModelAsync(new CreateBackupPageForm(), new UploadBackupPageForm(), new RestorePreviewForm { SelectedFileId = form.SelectedFileId }, form, new BackupDeleteSingleForm(), new BackupDeleteBulkForm(), null, null, statusMessage: null, preview: null, restoreSummary: null, cancellationToken);
             return View("Index", invalidModel);
         }
 
@@ -185,6 +189,10 @@ public sealed class AdminBackupsController : Controller
                 new UploadBackupPageForm(),
                 new RestorePreviewForm { SelectedFileId = form.SelectedFileId },
                 form,
+                new BackupDeleteSingleForm(),
+                new BackupDeleteBulkForm(),
+                null,
+                null,
                 statusMessage: $"{response.RestoreMode.ToUpperInvariant()} restore completed.",
                 preview: ToPreviewViewModel(preview),
                 restoreSummary: ToRestoreSummaryViewModel(response),
@@ -205,11 +213,47 @@ public sealed class AdminBackupsController : Controller
             new UploadBackupPageForm(),
             new RestorePreviewForm { SelectedFileId = form.SelectedFileId },
             form,
+            new BackupDeleteSingleForm(),
+            new BackupDeleteBulkForm(),
+            null,
+            null,
             statusMessage: null,
             preview: null,
             restoreSummary: null,
             cancellationToken);
         return View("Index", failedModel);
+    }
+
+    [HttpPost("delete")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteSingle([FromForm, Bind(Prefix = "DeleteSingleForm")] BackupDeleteSingleForm form, CancellationToken cancellationToken)
+    {
+        var result = await _backupManagementService.DeleteAsync(
+            new DeleteConfigurationBackupRequest
+            {
+                FileId = form.FileId,
+                ConfirmSingleDelete = form.ConfirmDelete
+            },
+            cancellationToken);
+
+        var status = result.Deleted ? "Backup deleted successfully." : result.Message;
+        return RedirectToAction(nameof(Index), new { status });
+    }
+
+    [HttpPost("delete-bulk")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteBulk([FromForm, Bind(Prefix = "DeleteBulkForm")] BackupDeleteBulkForm form, CancellationToken cancellationToken)
+    {
+        var result = await _backupManagementService.BulkDeleteAsync(
+            new BulkDeleteConfigurationBackupsRequest
+            {
+                FileIds = form.SelectedFileIds,
+                ConfirmationText = form.ConfirmationText
+            },
+            cancellationToken);
+
+        var status = $"Bulk delete complete. Requested={result.RequestedCount}, Deleted={result.DeletedCount}, Failed={result.FailedCount}.";
+        return RedirectToAction(nameof(Index), new { status });
     }
 
     [HttpGet("download")]
@@ -232,18 +276,36 @@ public sealed class AdminBackupsController : Controller
         UploadBackupPageForm uploadForm,
         RestorePreviewForm restorePreviewForm,
         RestoreApplyForm restoreApplyForm,
+        BackupDeleteSingleForm deleteSingleForm,
+        BackupDeleteBulkForm deleteBulkForm,
+        string? nameFilter,
+        string? sourceFilter,
         string? statusMessage,
         BackupRestorePreviewViewModel? preview,
         BackupRestoreSummaryViewModel? restoreSummary,
         CancellationToken cancellationToken)
     {
         var backups = await _backupQueryService.ListBackupsAsync(cancellationToken);
+        if (!string.IsNullOrWhiteSpace(nameFilter))
+        {
+            backups = backups.Where(x => (x.BackupName ?? x.FileName).Contains(nameFilter, StringComparison.OrdinalIgnoreCase)).ToArray();
+        }
+
+        if (!string.IsNullOrWhiteSpace(sourceFilter))
+        {
+            backups = backups.Where(x => string.Equals(x.BackupSource, sourceFilter, StringComparison.Ordinal)).ToArray();
+        }
+
         return new AdminBackupsPageViewModel
         {
             Form = form,
             UploadForm = uploadForm,
             RestorePreviewForm = restorePreviewForm,
             RestoreApplyForm = restoreApplyForm,
+            DeleteSingleForm = deleteSingleForm,
+            DeleteBulkForm = deleteBulkForm,
+            NameFilter = nameFilter?.Trim() ?? string.Empty,
+            SourceFilter = sourceFilter?.Trim() ?? string.Empty,
             Preview = preview,
             RestoreSummary = restoreSummary,
             StatusMessage = statusMessage ?? Request.Query["status"],
@@ -254,8 +316,10 @@ public sealed class AdminBackupsController : Controller
                     FileId = item.FileId,
                     BackupName = string.IsNullOrWhiteSpace(item.BackupName) ? "(unknown)" : item.BackupName,
                     AppVersion = item.AppVersion,
+                    BackupSource = item.BackupSource,
                     ExportedAtUtc = item.ExportedAtUtc,
                     FileCreatedAtUtc = item.FileCreatedAtUtc,
+                    FileSizeBytes = item.FileSizeBytes,
                     IncludedSectionsDisplay = item.IncludedSections.Count == 0
                         ? "(not detected)"
                         : string.Join(", ", item.IncludedSections.Select(ToDisplaySectionName)),

--- a/src/WebApp/PingMonitor.Web/Options/BackupOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/BackupOptions.cs
@@ -6,4 +6,23 @@ public sealed class BackupOptions
 
     public string StoragePath { get; set; } = "App_Data/Backups";
     public long MaxUploadSizeBytes { get; set; } = 5 * 1024 * 1024;
+    public BackupRetentionOptions Retention { get; set; } = new();
+    public AutoBackupOptions AutoBackup { get; set; } = new();
+}
+
+public sealed class BackupRetentionOptions
+{
+    public bool Enabled { get; set; } = true;
+    public int AutomaticBackupMaxCount { get; set; } = 30;
+    public int? AutomaticBackupMaxAgeDays { get; set; }
+}
+
+public sealed class AutoBackupOptions
+{
+    public bool Enabled { get; set; } = true;
+    public bool OnConfigChangeEnabled { get; set; } = true;
+    public bool ScheduledEnabled { get; set; } = true;
+    public string ScheduledTimeLocal { get; set; } = "02:00";
+    public bool IncludeIdentityByDefault { get; set; }
+    public int ConfigChangeCoalescingSeconds { get; set; } = 180;
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -133,11 +133,17 @@ builder.Services.AddScoped<IUserManagementService, UserManagementService>();
 builder.Services.AddScoped<IConfigurationBackupFileNameGenerator, ConfigurationBackupFileNameGenerator>();
 builder.Services.AddScoped<IConfigurationBackupService, ConfigurationBackupService>();
 builder.Services.AddScoped<IConfigurationBackupDocumentValidator, ConfigurationBackupDocumentValidator>();
+builder.Services.AddSingleton<IConfigurationBackupCatalogService, ConfigurationBackupCatalogService>();
 builder.Services.AddScoped<IConfigurationBackupDocumentLoader, ConfigurationBackupDocumentLoader>();
 builder.Services.AddScoped<IConfigurationBackupQueryService, ConfigurationBackupQueryService>();
 builder.Services.AddScoped<IConfigurationBackupUploadService, ConfigurationBackupUploadService>();
+builder.Services.AddScoped<IConfigurationBackupManagementService, ConfigurationBackupManagementService>();
+builder.Services.AddScoped<IConfigurationBackupRetentionService, ConfigurationBackupRetentionService>();
 builder.Services.AddScoped<IConfigurationRestorePreviewService, ConfigurationRestorePreviewService>();
 builder.Services.AddScoped<IConfigurationRestoreService, ConfigurationRestoreService>();
+builder.Services.AddSingleton<ConfigurationAutoBackupBackgroundService>();
+builder.Services.AddSingleton<IConfigurationChangeBackupSignal>(sp => sp.GetRequiredService<ConfigurationAutoBackupBackgroundService>());
+builder.Services.AddHostedService(sp => sp.GetRequiredService<ConfigurationAutoBackupBackgroundService>());
 
 var app = builder.Build();
 

--- a/src/WebApp/PingMonitor.Web/Services/AgentProvisioningService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentProvisioningService.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.Backups;
 
 namespace PingMonitor.Web.Services;
 
@@ -12,6 +13,7 @@ internal sealed class AgentProvisioningService : IAgentProvisioningService
     private readonly IAgentApiKeyHasher _apiKeyHasher;
     private readonly IAgentPackageBuilder _agentPackageBuilder;
     private readonly IApplicationSettingsService _applicationSettingsService;
+    private readonly IConfigurationChangeBackupSignal _configurationChangeBackupSignal;
     private readonly ILogger<AgentProvisioningService> _logger;
 
     public AgentProvisioningService(
@@ -19,12 +21,14 @@ internal sealed class AgentProvisioningService : IAgentProvisioningService
         IAgentApiKeyHasher apiKeyHasher,
         IAgentPackageBuilder agentPackageBuilder,
         IApplicationSettingsService applicationSettingsService,
+        IConfigurationChangeBackupSignal configurationChangeBackupSignal,
         ILogger<AgentProvisioningService> logger)
     {
         _dbContext = dbContext;
         _apiKeyHasher = apiKeyHasher;
         _agentPackageBuilder = agentPackageBuilder;
         _applicationSettingsService = applicationSettingsService;
+        _configurationChangeBackupSignal = configurationChangeBackupSignal;
         _logger = logger;
     }
 
@@ -72,6 +76,7 @@ internal sealed class AgentProvisioningService : IAgentProvisioningService
             var packageBytes = await _agentPackageBuilder.BuildAsync(serverUrl, instanceId, plainTextApiKey, cancellationToken);
 
             await transaction.CommitAsync(cancellationToken);
+            _configurationChangeBackupSignal.NotifyConfigurationChanged("agent-provisioned");
             _logger.LogInformation("Provisioned agent {AgentId} with instance {InstanceId}", agent.AgentId, agent.InstanceId);
 
             return BuildResult(agent.AgentId, agent.InstanceId, normalizedName, packageBytes);
@@ -99,6 +104,7 @@ internal sealed class AgentProvisioningService : IAgentProvisioningService
 
         agent.Enabled = enabled;
         await _dbContext.SaveChangesAsync(cancellationToken);
+        _configurationChangeBackupSignal.NotifyConfigurationChanged("agent-enabled-state-changed");
         _logger.LogInformation("Set enabled={Enabled} for agent {AgentId}", enabled, agent.AgentId);
         return true;
     }
@@ -147,6 +153,7 @@ internal sealed class AgentProvisioningService : IAgentProvisioningService
         }
 
         await _dbContext.SaveChangesAsync(cancellationToken);
+        _configurationChangeBackupSignal.NotifyConfigurationChanged("agent-removed");
         _logger.LogInformation("Removed agent {AgentId}. Agent disabled, API key revoked, and active assignments disabled.", agent.AgentId);
         return true;
     }

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationAutoBackupBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationAutoBackupBackgroundService.cs
@@ -1,0 +1,169 @@
+using Microsoft.Extensions.Options;
+using PingMonitor.Web.Options;
+
+namespace PingMonitor.Web.Services.Backups;
+
+public interface IConfigurationChangeBackupSignal
+{
+    void NotifyConfigurationChanged(string reason);
+}
+
+public sealed class ConfigurationAutoBackupBackgroundService : BackgroundService, IConfigurationChangeBackupSignal
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly BackupOptions _options;
+    private readonly ILogger<ConfigurationAutoBackupBackgroundService> _logger;
+
+    private readonly object _sync = new();
+    private DateTimeOffset? _lastConfigChangeSignalUtc;
+
+    public ConfigurationAutoBackupBackgroundService(
+        IServiceScopeFactory scopeFactory,
+        IOptions<BackupOptions> options,
+        ILogger<ConfigurationAutoBackupBackgroundService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public void NotifyConfigurationChanged(string reason)
+    {
+        if (!_options.AutoBackup.Enabled || !_options.AutoBackup.OnConfigChangeEnabled)
+        {
+            return;
+        }
+
+        lock (_sync)
+        {
+            _lastConfigChangeSignalUtc = DateTimeOffset.UtcNow;
+        }
+
+        _logger.LogInformation("Configuration change signal queued for automatic backup. Reason: {Reason}.", reason);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Configuration auto-backup background service started.");
+        var nextScheduledRunUtc = GetNextScheduledRunUtc(DateTimeOffset.Now);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (_options.AutoBackup.Enabled && _options.AutoBackup.ScheduledEnabled && DateTimeOffset.Now >= nextScheduledRunUtc)
+                {
+                    await CreateAutomaticBackupAsync(ConfigurationBackupSources.AutomaticScheduled, "Automatic scheduled configuration backup", stoppingToken);
+                    nextScheduledRunUtc = GetNextScheduledRunUtc(DateTimeOffset.Now.AddSeconds(1));
+                }
+
+                var pendingSignalUtc = GetPendingSignalUtc();
+                if (_options.AutoBackup.Enabled && _options.AutoBackup.OnConfigChangeEnabled && pendingSignalUtc.HasValue)
+                {
+                    var coalesceFor = TimeSpan.FromSeconds(Math.Max(30, _options.AutoBackup.ConfigChangeCoalescingSeconds));
+                    var dueAtUtc = pendingSignalUtc.Value + coalesceFor;
+                    if (DateTimeOffset.UtcNow >= dueAtUtc)
+                    {
+                        ClearPendingSignal();
+                        _logger.LogInformation("Configuration change backup coalescing window elapsed. Creating single backup for queued changes.");
+                        await CreateAutomaticBackupAsync(ConfigurationBackupSources.AutomaticConfigChange, "Automatic backup created after configuration changes", stoppingToken);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Automatic backup background loop failure.");
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(15), stoppingToken);
+        }
+    }
+
+    private async Task CreateAutomaticBackupAsync(string source, string notes, CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var backupService = scope.ServiceProvider.GetRequiredService<IConfigurationBackupService>();
+        var retentionService = scope.ServiceProvider.GetRequiredService<IConfigurationBackupRetentionService>();
+
+        try
+        {
+            _logger.LogInformation("Automatic configuration backup started. Source: {Source}.", source);
+            await backupService.CreateBackupAsync(
+                new CreateConfigurationBackupRequest
+                {
+                    BackupName = source == ConfigurationBackupSources.AutomaticScheduled ? "auto-scheduled" : "auto-config-change",
+                    Notes = notes,
+                    BackupSource = source,
+                    SelectedSections = GetDefaultSections()
+                },
+                cancellationToken);
+
+            var prune = await retentionService.PruneAutomaticBackupsAsync(cancellationToken);
+            _logger.LogInformation(
+                "Automatic configuration backup completed. Source: {Source}. Retention prune requested={RequestedCount}, deleted={DeletedCount}, failed={FailedCount}.",
+                source,
+                prune.RequestedCount,
+                prune.DeletedCount,
+                prune.FailedCount);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Automatic configuration backup failed. Source: {Source}.", source);
+        }
+    }
+
+    private IReadOnlyList<string> GetDefaultSections()
+    {
+        var sections = new List<string>
+        {
+            ConfigurationBackupSections.Agents,
+            ConfigurationBackupSections.Endpoints,
+            ConfigurationBackupSections.Assignments
+        };
+
+        if (_options.AutoBackup.IncludeIdentityByDefault)
+        {
+            sections.Add(ConfigurationBackupSections.Identity);
+        }
+
+        return sections;
+    }
+
+    private DateTimeOffset GetNextScheduledRunUtc(DateTimeOffset nowLocal)
+    {
+        var scheduledLocal = ParseScheduledTimeLocal(_options.AutoBackup.ScheduledTimeLocal);
+        var nextLocal = new DateTimeOffset(nowLocal.Year, nowLocal.Month, nowLocal.Day, scheduledLocal.Hours, scheduledLocal.Minutes, 0, nowLocal.Offset);
+        if (nextLocal <= nowLocal)
+        {
+            nextLocal = nextLocal.AddDays(1);
+        }
+
+        return nextLocal.ToUniversalTime();
+    }
+
+    private static TimeSpan ParseScheduledTimeLocal(string value)
+    {
+        if (TimeSpan.TryParse(value, out var parsed))
+        {
+            return parsed;
+        }
+
+        return new TimeSpan(2, 0, 0);
+    }
+
+    private DateTimeOffset? GetPendingSignalUtc()
+    {
+        lock (_sync)
+        {
+            return _lastConfigChangeSignalUtc;
+        }
+    }
+
+    private void ClearPendingSignal()
+    {
+        lock (_sync)
+        {
+            _lastConfigChangeSignalUtc = null;
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupCatalogService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupCatalogService.cs
@@ -1,0 +1,160 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Options;
+using PingMonitor.Web.Options;
+
+namespace PingMonitor.Web.Services.Backups;
+
+public interface IConfigurationBackupCatalogService
+{
+    Task<IReadOnlyDictionary<string, string>> GetSourcesAsync(CancellationToken cancellationToken);
+    Task UpsertSourceAsync(string fileId, string source, CancellationToken cancellationToken);
+    Task RemoveAsync(string fileId, CancellationToken cancellationToken);
+}
+
+public sealed class ConfigurationBackupCatalogService : IConfigurationBackupCatalogService
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
+    private static readonly SemaphoreSlim FileLock = new(1, 1);
+
+    private readonly IWebHostEnvironment _environment;
+    private readonly BackupOptions _options;
+
+    public ConfigurationBackupCatalogService(IWebHostEnvironment environment, IOptions<BackupOptions> options)
+    {
+        _environment = environment;
+        _options = options.Value;
+    }
+
+    public async Task<IReadOnlyDictionary<string, string>> GetSourcesAsync(CancellationToken cancellationToken)
+    {
+        var catalog = await LoadCatalogAsync(cancellationToken);
+        return catalog.Entries.ToDictionary(x => x.FileId, x => x.Source, StringComparer.Ordinal);
+    }
+
+    public async Task UpsertSourceAsync(string fileId, string source, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(fileId))
+        {
+            return;
+        }
+
+        var normalizedSource = NormalizeSource(source);
+
+        await FileLock.WaitAsync(cancellationToken);
+        try
+        {
+            var catalog = await LoadCatalogCoreAsync(cancellationToken);
+            var existing = catalog.Entries.SingleOrDefault(x => string.Equals(x.FileId, fileId, StringComparison.Ordinal));
+            if (existing is null)
+            {
+                catalog.Entries.Add(new BackupCatalogEntry
+                {
+                    FileId = fileId,
+                    Source = normalizedSource,
+                    UpdatedAtUtc = DateTimeOffset.UtcNow
+                });
+            }
+            else
+            {
+                existing.Source = normalizedSource;
+                existing.UpdatedAtUtc = DateTimeOffset.UtcNow;
+            }
+
+            await SaveCatalogCoreAsync(catalog, cancellationToken);
+        }
+        finally
+        {
+            FileLock.Release();
+        }
+    }
+
+    public async Task RemoveAsync(string fileId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(fileId))
+        {
+            return;
+        }
+
+        await FileLock.WaitAsync(cancellationToken);
+        try
+        {
+            var catalog = await LoadCatalogCoreAsync(cancellationToken);
+            catalog.Entries.RemoveAll(x => string.Equals(x.FileId, fileId, StringComparison.Ordinal));
+            await SaveCatalogCoreAsync(catalog, cancellationToken);
+        }
+        finally
+        {
+            FileLock.Release();
+        }
+    }
+
+    private async Task<BackupCatalogDocument> LoadCatalogAsync(CancellationToken cancellationToken)
+    {
+        await FileLock.WaitAsync(cancellationToken);
+        try
+        {
+            return await LoadCatalogCoreAsync(cancellationToken);
+        }
+        finally
+        {
+            FileLock.Release();
+        }
+    }
+
+    private async Task<BackupCatalogDocument> LoadCatalogCoreAsync(CancellationToken cancellationToken)
+    {
+        var fullPath = ResolveCatalogPath();
+        if (!File.Exists(fullPath))
+        {
+            return new BackupCatalogDocument();
+        }
+
+        await using var stream = File.OpenRead(fullPath);
+        var document = await JsonSerializer.DeserializeAsync<BackupCatalogDocument>(stream, cancellationToken: cancellationToken);
+        return document ?? new BackupCatalogDocument();
+    }
+
+    private async Task SaveCatalogCoreAsync(BackupCatalogDocument document, CancellationToken cancellationToken)
+    {
+        var fullPath = ResolveCatalogPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+
+        var json = JsonSerializer.Serialize(document, SerializerOptions);
+        await File.WriteAllTextAsync(fullPath, json, cancellationToken);
+    }
+
+    private string ResolveCatalogPath()
+    {
+        var storagePath = Path.IsPathRooted(_options.StoragePath)
+            ? _options.StoragePath
+            : Path.Combine(_environment.ContentRootPath, _options.StoragePath);
+
+        return Path.Combine(storagePath, "backup-catalog.json");
+    }
+
+    private static string NormalizeSource(string? source)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            return ConfigurationBackupSources.Manual;
+        }
+
+        var normalized = source.Trim().ToLowerInvariant();
+        return ConfigurationBackupSources.All.Contains(normalized, StringComparer.Ordinal)
+            ? normalized
+            : ConfigurationBackupSources.Manual;
+    }
+
+    private sealed class BackupCatalogDocument
+    {
+        public List<BackupCatalogEntry> Entries { get; init; } = [];
+    }
+
+    private sealed class BackupCatalogEntry
+    {
+        public string FileId { get; init; } = string.Empty;
+        public string Source { get; set; } = ConfigurationBackupSources.Manual;
+        public DateTimeOffset UpdatedAtUtc { get; set; }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentLoader.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentLoader.cs
@@ -17,17 +17,20 @@ public sealed class ConfigurationBackupDocumentLoader : IConfigurationBackupDocu
     private readonly IWebHostEnvironment _environment;
     private readonly BackupOptions _options;
     private readonly IConfigurationBackupDocumentValidator _documentValidator;
+    private readonly IConfigurationBackupCatalogService _catalogService;
     private readonly ILogger<ConfigurationBackupDocumentLoader> _logger;
 
     public ConfigurationBackupDocumentLoader(
         IWebHostEnvironment environment,
         IOptions<BackupOptions> options,
         IConfigurationBackupDocumentValidator documentValidator,
+        IConfigurationBackupCatalogService catalogService,
         ILogger<ConfigurationBackupDocumentLoader> logger)
     {
         _environment = environment;
         _options = options.Value;
         _documentValidator = documentValidator;
+        _catalogService = catalogService;
         _logger = logger;
     }
 
@@ -44,6 +47,7 @@ public sealed class ConfigurationBackupDocumentLoader : IConfigurationBackupDocu
             .ToArray();
 
         var rows = new List<BackupFileListItem>(files.Length);
+        var sourceCatalog = await _catalogService.GetSourcesAsync(cancellationToken);
         foreach (var fullPath in files)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -59,8 +63,10 @@ public sealed class ConfigurationBackupDocumentLoader : IConfigurationBackupDocu
                 ExportedAtUtc = metadata.ExportedAtUtc,
                 BackupName = metadata.BackupName,
                 AppVersion = metadata.AppVersion,
+                BackupSource = ResolveSource(fileInfo.Name, metadata.BackupSource, sourceCatalog),
                 IncludedSections = metadata.IncludedSections,
-                NotesSummary = metadata.NotesSummary
+                NotesSummary = metadata.NotesSummary,
+                FileSizeBytes = fileInfo.Length
             });
         }
 
@@ -172,6 +178,7 @@ public sealed class ConfigurationBackupDocumentLoader : IConfigurationBackupDocu
                 ExportedAtUtc = exportedAtUtc,
                 BackupName = TryReadString(root, "backupName"),
                 AppVersion = TryReadString(root, "appVersion"),
+                BackupSource = TryReadString(root, "backupSource"),
                 IncludedSections = includedSections,
                 NotesSummary = ToNotesSummary(notes)
             };
@@ -217,7 +224,25 @@ public sealed class ConfigurationBackupDocumentLoader : IConfigurationBackupDocu
         public DateTimeOffset? ExportedAtUtc { get; init; }
         public string? BackupName { get; init; }
         public string? AppVersion { get; init; }
+        public string? BackupSource { get; init; }
         public IReadOnlyList<string> IncludedSections { get; init; } = [];
         public string? NotesSummary { get; init; }
+    }
+
+    private static string ResolveSource(string fileId, string? documentSource, IReadOnlyDictionary<string, string> catalog)
+    {
+        if (catalog.TryGetValue(fileId, out var catalogSource)
+            && ConfigurationBackupSources.All.Contains(catalogSource, StringComparer.Ordinal))
+        {
+            return catalogSource;
+        }
+
+        if (!string.IsNullOrWhiteSpace(documentSource)
+            && ConfigurationBackupSources.All.Contains(documentSource, StringComparer.Ordinal))
+        {
+            return documentSource;
+        }
+
+        return ConfigurationBackupSources.Manual;
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentValidator.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentValidator.cs
@@ -23,6 +23,12 @@ public sealed class ConfigurationBackupDocumentValidator : IConfigurationBackupD
             throw new InvalidOperationException("Backup metadata is incomplete.");
         }
 
+        if (!string.IsNullOrWhiteSpace(document.BackupSource)
+            && !ConfigurationBackupSources.All.Contains(document.BackupSource, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException("Backup source metadata is not supported.");
+        }
+
         if (document.Sections is null)
         {
             throw new InvalidOperationException("Backup sections are missing.");

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupManagementService.cs
@@ -1,0 +1,108 @@
+namespace PingMonitor.Web.Services.Backups;
+
+public interface IConfigurationBackupManagementService
+{
+    Task<DeleteConfigurationBackupResponse> DeleteAsync(DeleteConfigurationBackupRequest request, CancellationToken cancellationToken);
+    Task<BulkDeleteConfigurationBackupsResponse> BulkDeleteAsync(BulkDeleteConfigurationBackupsRequest request, CancellationToken cancellationToken);
+}
+
+public sealed class ConfigurationBackupManagementService : IConfigurationBackupManagementService
+{
+    private readonly IConfigurationBackupDocumentLoader _documentLoader;
+    private readonly IConfigurationBackupCatalogService _catalogService;
+    private readonly ILogger<ConfigurationBackupManagementService> _logger;
+
+    public ConfigurationBackupManagementService(
+        IConfigurationBackupDocumentLoader documentLoader,
+        IConfigurationBackupCatalogService catalogService,
+        ILogger<ConfigurationBackupManagementService> logger)
+    {
+        _documentLoader = documentLoader;
+        _catalogService = catalogService;
+        _logger = logger;
+    }
+
+    public async Task<DeleteConfigurationBackupResponse> DeleteAsync(DeleteConfigurationBackupRequest request, CancellationToken cancellationToken)
+    {
+        if (!request.ConfirmSingleDelete)
+        {
+            return new DeleteConfigurationBackupResponse
+            {
+                FileId = request.FileId,
+                Deleted = false,
+                Message = "Single delete requires explicit confirmation."
+            };
+        }
+
+        try
+        {
+            var fullPath = _documentLoader.ResolveBackupPath(request.FileId);
+            File.Delete(fullPath);
+            await _catalogService.RemoveAsync(request.FileId, cancellationToken);
+            _logger.LogInformation("Deleted configuration backup file {FileId}.", request.FileId);
+            return new DeleteConfigurationBackupResponse { FileId = request.FileId, Deleted = true, Message = "Backup deleted." };
+        }
+        catch (FileNotFoundException)
+        {
+            _logger.LogWarning("Delete request for backup file {FileId} could not be completed because file was not found.", request.FileId);
+            return new DeleteConfigurationBackupResponse { FileId = request.FileId, Deleted = false, Message = "Backup file was not found." };
+        }
+    }
+
+    public async Task<BulkDeleteConfigurationBackupsResponse> BulkDeleteAsync(BulkDeleteConfigurationBackupsRequest request, CancellationToken cancellationToken)
+    {
+        var fileIds = request.FileIds
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        if (fileIds.Length == 0)
+        {
+            return new BulkDeleteConfigurationBackupsResponse { RequestedCount = 0, Messages = ["Select at least one backup file for bulk delete."] };
+        }
+
+        if (!string.Equals(request.ConfirmationText?.Trim(), BackupDeleteModes.BulkConfirmationText, StringComparison.Ordinal))
+        {
+            return new BulkDeleteConfigurationBackupsResponse
+            {
+                RequestedCount = fileIds.Length,
+                FailedCount = fileIds.Length,
+                Messages = [$"Bulk delete requires typed confirmation '{BackupDeleteModes.BulkConfirmationText}'."]
+            };
+        }
+
+        var messages = new List<string>();
+        var deleted = 0;
+        var failed = 0;
+
+        foreach (var fileId in fileIds)
+        {
+            var result = await DeleteAsync(new DeleteConfigurationBackupRequest { FileId = fileId, ConfirmSingleDelete = true }, cancellationToken);
+            if (result.Deleted)
+            {
+                deleted++;
+            }
+            else
+            {
+                failed++;
+            }
+
+            messages.Add($"{fileId}: {result.Message}");
+        }
+
+        _logger.LogInformation(
+            "Bulk delete completed for configuration backups. Requested: {RequestedCount}, Deleted: {DeletedCount}, Failed: {FailedCount}.",
+            fileIds.Length,
+            deleted,
+            failed);
+
+        return new BulkDeleteConfigurationBackupsResponse
+        {
+            RequestedCount = fileIds.Length,
+            DeletedCount = deleted,
+            FailedCount = failed,
+            Messages = messages
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs
@@ -23,6 +23,29 @@ public static class ConfigurationRestoreModes
     public static readonly string[] All = [Merge, Replace];
 }
 
+public static class ConfigurationBackupSources
+{
+    public const string Manual = "manual";
+    public const string Uploaded = "uploaded";
+    public const string AutomaticScheduled = "automatic_scheduled";
+    public const string AutomaticConfigChange = "automatic_config_change";
+
+    public static readonly string[] All = [Manual, Uploaded, AutomaticScheduled, AutomaticConfigChange];
+
+    public static bool IsAutomatic(string source)
+    {
+        return string.Equals(source, AutomaticScheduled, StringComparison.Ordinal)
+            || string.Equals(source, AutomaticConfigChange, StringComparison.Ordinal);
+    }
+}
+
+public static class BackupDeleteModes
+{
+    public const string Single = "single";
+    public const string Bulk = "bulk";
+    public const string BulkConfirmationText = "DELETE";
+}
+
 public sealed class ConfigurationBackupMetadata
 {
     public const int CurrentFormatVersion = 1;
@@ -34,6 +57,7 @@ public sealed class ConfigurationBackupMetadata
     public DateTimeOffset ExportedAtUtc { get; init; }
     public string? ExportedBy { get; init; }
     public string MachineName { get; init; } = string.Empty;
+    public string BackupSource { get; init; } = ConfigurationBackupSources.Manual;
 }
 
 public sealed class ConfigurationBackupDocument
@@ -67,6 +91,10 @@ public sealed class ConfigurationBackupDocument
     public string MachineName { get; init; } = string.Empty;
 
     [JsonPropertyOrder(8)]
+    [JsonPropertyName("backupSource")]
+    public string BackupSource { get; init; } = ConfigurationBackupSources.Manual;
+
+    [JsonPropertyOrder(9)]
     [JsonPropertyName("sections")]
     public ConfigurationBackupSectionData Sections { get; init; } = new();
 
@@ -81,6 +109,7 @@ public sealed class ConfigurationBackupDocument
             ExportedAtUtc = metadata.ExportedAtUtc,
             ExportedBy = metadata.ExportedBy,
             MachineName = metadata.MachineName,
+            BackupSource = metadata.BackupSource,
             Sections = sections
         };
     }
@@ -184,8 +213,10 @@ public sealed class BackupFileListItem
     public DateTimeOffset? ExportedAtUtc { get; init; }
     public string? BackupName { get; init; }
     public string? AppVersion { get; init; }
+    public string BackupSource { get; init; } = ConfigurationBackupSources.Manual;
     public IReadOnlyList<string> IncludedSections { get; init; } = [];
     public string? NotesSummary { get; init; }
+    public long FileSizeBytes { get; init; }
 }
 
 public sealed class CreateConfigurationBackupRequest
@@ -198,6 +229,36 @@ public sealed class CreateConfigurationBackupRequest
     public required IReadOnlyList<string> SelectedSections { get; init; }
 
     public string? ExportedBy { get; init; }
+    public string BackupSource { get; init; } = ConfigurationBackupSources.Manual;
+}
+
+public sealed class DeleteConfigurationBackupRequest
+{
+    [Required]
+    public string FileId { get; init; } = string.Empty;
+
+    public bool ConfirmSingleDelete { get; init; }
+}
+
+public sealed class BulkDeleteConfigurationBackupsRequest
+{
+    public IReadOnlyList<string> FileIds { get; init; } = [];
+    public string? ConfirmationText { get; init; }
+}
+
+public sealed class DeleteConfigurationBackupResponse
+{
+    public string FileId { get; init; } = string.Empty;
+    public bool Deleted { get; init; }
+    public string Message { get; init; } = string.Empty;
+}
+
+public sealed class BulkDeleteConfigurationBackupsResponse
+{
+    public int RequestedCount { get; init; }
+    public int DeletedCount { get; init; }
+    public int FailedCount { get; init; }
+    public IReadOnlyList<string> Messages { get; init; } = [];
 }
 
 public sealed class CreateConfigurationBackupResponse

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupRetentionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupRetentionService.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.Options;
+using PingMonitor.Web.Options;
+
+namespace PingMonitor.Web.Services.Backups;
+
+public interface IConfigurationBackupRetentionService
+{
+    Task<BulkDeleteConfigurationBackupsResponse> PruneAutomaticBackupsAsync(CancellationToken cancellationToken);
+}
+
+public sealed class ConfigurationBackupRetentionService : IConfigurationBackupRetentionService
+{
+    private readonly IConfigurationBackupQueryService _backupQueryService;
+    private readonly IConfigurationBackupManagementService _backupManagementService;
+    private readonly BackupOptions _options;
+    private readonly ILogger<ConfigurationBackupRetentionService> _logger;
+
+    public ConfigurationBackupRetentionService(
+        IConfigurationBackupQueryService backupQueryService,
+        IConfigurationBackupManagementService backupManagementService,
+        IOptions<BackupOptions> options,
+        ILogger<ConfigurationBackupRetentionService> logger)
+    {
+        _backupQueryService = backupQueryService;
+        _backupManagementService = backupManagementService;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<BulkDeleteConfigurationBackupsResponse> PruneAutomaticBackupsAsync(CancellationToken cancellationToken)
+    {
+        if (!_options.Retention.Enabled || _options.Retention.AutomaticBackupMaxCount <= 0)
+        {
+            return new BulkDeleteConfigurationBackupsResponse { Messages = ["Automatic backup retention is disabled."] };
+        }
+
+        var allBackups = await _backupQueryService.ListBackupsAsync(cancellationToken);
+        var automaticBackups = allBackups
+            .Where(x => ConfigurationBackupSources.IsAutomatic(x.BackupSource))
+            .OrderByDescending(x => x.ExportedAtUtc ?? x.FileCreatedAtUtc)
+            .ToList();
+
+        var fileIdsToDelete = new List<string>();
+        if (automaticBackups.Count > _options.Retention.AutomaticBackupMaxCount)
+        {
+            fileIdsToDelete.AddRange(automaticBackups
+                .Skip(_options.Retention.AutomaticBackupMaxCount)
+                .Select(x => x.FileId));
+        }
+
+        if (_options.Retention.AutomaticBackupMaxAgeDays.HasValue && _options.Retention.AutomaticBackupMaxAgeDays.Value > 0)
+        {
+            var cutoff = DateTimeOffset.UtcNow.AddDays(-_options.Retention.AutomaticBackupMaxAgeDays.Value);
+            fileIdsToDelete.AddRange(automaticBackups
+                .Where(x => (x.ExportedAtUtc ?? x.FileCreatedAtUtc) < cutoff)
+                .Select(x => x.FileId));
+        }
+
+        var distinctFileIds = fileIdsToDelete.Distinct(StringComparer.Ordinal).ToArray();
+        if (distinctFileIds.Length == 0)
+        {
+            return new BulkDeleteConfigurationBackupsResponse { RequestedCount = 0, Messages = ["No automatic backups required pruning."] };
+        }
+
+        _logger.LogInformation("Automatic backup retention pruning started. Files selected: {Count}.", distinctFileIds.Length);
+        return await _backupManagementService.BulkDeleteAsync(
+            new BulkDeleteConfigurationBackupsRequest
+            {
+                FileIds = distinctFileIds,
+                ConfirmationText = BackupDeleteModes.BulkConfirmationText
+            },
+            cancellationToken);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupService.cs
@@ -24,17 +24,20 @@ public sealed class ConfigurationBackupService : IConfigurationBackupService
     private readonly IWebHostEnvironment _environment;
     private readonly BackupOptions _options;
     private readonly IConfigurationBackupFileNameGenerator _fileNameGenerator;
+    private readonly IConfigurationBackupCatalogService _catalogService;
 
     public ConfigurationBackupService(
         PingMonitorDbContext dbContext,
         IWebHostEnvironment environment,
         IOptions<BackupOptions> options,
-        IConfigurationBackupFileNameGenerator fileNameGenerator)
+        IConfigurationBackupFileNameGenerator fileNameGenerator,
+        IConfigurationBackupCatalogService catalogService)
     {
         _dbContext = dbContext;
         _environment = environment;
         _options = options.Value;
         _fileNameGenerator = fileNameGenerator;
+        _catalogService = catalogService;
     }
 
     public async Task<CreateConfigurationBackupResponse> CreateBackupAsync(CreateConfigurationBackupRequest request, CancellationToken cancellationToken)
@@ -69,7 +72,8 @@ public sealed class ConfigurationBackupService : IConfigurationBackupService
             Notes = string.IsNullOrWhiteSpace(request.Notes) ? null : request.Notes.Trim(),
             ExportedAtUtc = exportedAtUtc,
             ExportedBy = request.ExportedBy,
-            MachineName = Environment.MachineName
+            MachineName = Environment.MachineName,
+            BackupSource = NormalizeSource(request.BackupSource)
         };
 
         var sections = new ConfigurationBackupSectionData
@@ -98,6 +102,7 @@ public sealed class ConfigurationBackupService : IConfigurationBackupService
 
         var json = JsonSerializer.Serialize(document, SerializerOptions);
         await File.WriteAllTextAsync(fullPath, json, cancellationToken);
+        await _catalogService.UpsertSourceAsync(fileName, metadata.BackupSource, cancellationToken);
 
         return new CreateConfigurationBackupResponse
         {
@@ -107,6 +112,19 @@ public sealed class ConfigurationBackupService : IConfigurationBackupService
             ExportedAtUtc = metadata.ExportedAtUtc,
             IncludedSections = selectedSections
         };
+    }
+
+    private static string NormalizeSource(string? source)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            return ConfigurationBackupSources.Manual;
+        }
+
+        var trimmed = source.Trim().ToLowerInvariant();
+        return ConfigurationBackupSources.All.Contains(trimmed, StringComparer.Ordinal)
+            ? trimmed
+            : ConfigurationBackupSources.Manual;
     }
 
     private string ResolveStoragePath()

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupUploadService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupUploadService.cs
@@ -16,6 +16,7 @@ public sealed class ConfigurationBackupUploadService : IConfigurationBackupUploa
     private readonly BackupOptions _options;
     private readonly IConfigurationBackupDocumentValidator _documentValidator;
     private readonly IConfigurationBackupFileNameGenerator _fileNameGenerator;
+    private readonly IConfigurationBackupCatalogService _catalogService;
     private readonly ILogger<ConfigurationBackupUploadService> _logger;
 
     public ConfigurationBackupUploadService(
@@ -23,12 +24,14 @@ public sealed class ConfigurationBackupUploadService : IConfigurationBackupUploa
         IOptions<BackupOptions> options,
         IConfigurationBackupDocumentValidator documentValidator,
         IConfigurationBackupFileNameGenerator fileNameGenerator,
+        IConfigurationBackupCatalogService catalogService,
         ILogger<ConfigurationBackupUploadService> logger)
     {
         _environment = environment;
         _options = options.Value;
         _documentValidator = documentValidator;
         _fileNameGenerator = fileNameGenerator;
+        _catalogService = catalogService;
         _logger = logger;
     }
 
@@ -73,6 +76,8 @@ public sealed class ConfigurationBackupUploadService : IConfigurationBackupUploa
         {
             await outputStream.WriteAsync(fileContent, cancellationToken);
         }
+
+        await _catalogService.UpsertSourceAsync(storedFileName, ConfigurationBackupSources.Uploaded, cancellationToken);
 
         _logger.LogInformation(
             "Configuration backup upload accepted. StoredFile: {StoredFile}, BackupName: {BackupName}, ExportedAtUtc: {ExportedAtUtc:O}.",

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementService.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.Backups;
 using EndpointModel = PingMonitor.Web.Models.Endpoint;
 
 namespace PingMonitor.Web.Services.Endpoints;
@@ -8,10 +9,12 @@ namespace PingMonitor.Web.Services.Endpoints;
 internal sealed class EndpointManagementService : IEndpointManagementService
 {
     private readonly PingMonitorDbContext _dbContext;
+    private readonly IConfigurationChangeBackupSignal _configurationChangeBackupSignal;
 
-    public EndpointManagementService(PingMonitorDbContext dbContext)
+    public EndpointManagementService(PingMonitorDbContext dbContext, IConfigurationChangeBackupSignal configurationChangeBackupSignal)
     {
         _dbContext = dbContext;
+        _configurationChangeBackupSignal = configurationChangeBackupSignal;
     }
 
     public async Task<CreateEndpointResult> CreateEndpointWithAssignmentAsync(CreateEndpointCommand command, CancellationToken cancellationToken)
@@ -78,6 +81,7 @@ internal sealed class EndpointManagementService : IEndpointManagementService
         }
 
         await _dbContext.SaveChangesAsync(cancellationToken);
+        _configurationChangeBackupSignal.NotifyConfigurationChanged("endpoint-create-with-assignment");
 
         return CreateEndpointResult.Succeeded(endpointId, assignmentId);
     }
@@ -230,6 +234,7 @@ internal sealed class EndpointManagementService : IEndpointManagementService
         }
 
         await _dbContext.SaveChangesAsync(cancellationToken);
+        _configurationChangeBackupSignal.NotifyConfigurationChanged("endpoint-update-with-assignment");
 
         return UpdateEndpointResult.Succeeded();
     }
@@ -280,6 +285,7 @@ internal sealed class EndpointManagementService : IEndpointManagementService
         if (changed)
         {
             await _dbContext.SaveChangesAsync(cancellationToken);
+            _configurationChangeBackupSignal.NotifyConfigurationChanged("endpoint-remove-disable");
         }
 
         return RemoveEndpointResult.Completed(changed);

--- a/src/WebApp/PingMonitor.Web/ViewModels/Backups/BackupsPageViewModels.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Backups/BackupsPageViewModels.cs
@@ -32,8 +32,10 @@ public sealed class BackupRowViewModel
     public required string FileId { get; init; }
     public string BackupName { get; init; } = "(unknown)";
     public string? AppVersion { get; init; }
+    public string BackupSource { get; init; } = ConfigurationBackupSources.Manual;
     public DateTimeOffset? ExportedAtUtc { get; init; }
     public DateTimeOffset FileCreatedAtUtc { get; init; }
+    public long FileSizeBytes { get; init; }
     public string IncludedSectionsDisplay { get; init; } = string.Empty;
     public string? NotesSummary { get; init; }
 }
@@ -46,8 +48,27 @@ public sealed class AdminBackupsPageViewModel
     public string? StatusMessage { get; init; }
     public RestorePreviewForm RestorePreviewForm { get; init; } = new();
     public RestoreApplyForm RestoreApplyForm { get; init; } = new();
+    public BackupDeleteSingleForm DeleteSingleForm { get; init; } = new();
+    public BackupDeleteBulkForm DeleteBulkForm { get; init; } = new();
+    public string NameFilter { get; init; } = string.Empty;
+    public string SourceFilter { get; init; } = string.Empty;
     public BackupRestorePreviewViewModel? Preview { get; init; }
     public BackupRestoreSummaryViewModel? RestoreSummary { get; init; }
+}
+
+public sealed class BackupDeleteSingleForm
+{
+    [Required]
+    public string FileId { get; set; } = string.Empty;
+
+    public bool ConfirmDelete { get; set; }
+}
+
+public sealed class BackupDeleteBulkForm
+{
+    public List<string> SelectedFileIds { get; set; } = [];
+
+    public string? ConfirmationText { get; set; }
 }
 
 public sealed class UploadBackupPageForm

--- a/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
@@ -45,6 +45,9 @@
         th, td { text-align: left; vertical-align: top; padding: .6rem .4rem; border-bottom: 1px solid var(--border); }
         .field-error { color: var(--error-text); font-size: .9rem; margin-top: .25rem; }
         .split { display: grid; gap: 1rem; }
+        .inline-form { display:inline; }
+        .danger { background:#b42318; color:white; border:0; }
+        .pill { display:inline-block; padding:.2rem .45rem; border-radius:999px; background:#eef2ff; color:#1e3a8a; font-size:.82rem; }
         @@media (min-width: 780px) {
             .split { grid-template-columns: 1fr 1fr; }
         }
@@ -263,51 +266,105 @@
 
         <section class="card">
             <h2>Stored backups</h2>
+            <form method="get" action="/admin/backups" class="stack" style="margin-bottom:1rem;">
+                <div class="split">
+                    <div>
+                        <label for="name">Filter by name</label>
+                        <input id="name" name="name" value="@Model.NameFilter" placeholder="backup name contains..." />
+                    </div>
+                    <div>
+                        <label for="source">Filter by source</label>
+                        <select id="source" name="source">
+                            <option value="">All sources</option>
+                            <option value="manual" selected="@(Model.SourceFilter == "manual")">manual</option>
+                            <option value="uploaded" selected="@(Model.SourceFilter == "uploaded")">uploaded</option>
+                            <option value="automatic_scheduled" selected="@(Model.SourceFilter == "automatic_scheduled")">automatic_scheduled</option>
+                            <option value="automatic_config_change" selected="@(Model.SourceFilter == "automatic_config_change")">automatic_config_change</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="button-row">
+                    <button class="button-secondary" type="submit">Apply filters</button>
+                    <a class="button-secondary" href="/admin/backups">Reset filters</a>
+                </div>
+            </form>
             @if (Model.Backups.Count == 0)
             {
                 <p class="muted">No backups found in the configured storage folder.</p>
             }
             else
             {
-                <div style="overflow-x:auto;">
-                    <table>
-                        <thead>
-                        <tr>
-                            <th>Backup</th>
-                            <th>Exported</th>
-                            <th>App version</th>
-                            <th>Sections</th>
-                            <th>Notes</th>
-                            <th></th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        @foreach (var backup in Model.Backups)
-                        {
+                <form id="bulkDeleteForm" method="post" action="/admin/backups/delete-bulk">
+                    @Html.AntiForgeryToken()
+                    <div class="warning" style="margin-bottom:.75rem;">Bulk delete requires typed confirmation <strong>DELETE</strong>. Manual and uploaded backups are never auto-pruned by default.</div>
+                    <div class="split">
+                        <div>
+                            <label asp-for="DeleteBulkForm.ConfirmationText">Bulk delete confirmation</label>
+                            <input asp-for="DeleteBulkForm.ConfirmationText" placeholder="Type DELETE" />
+                        </div>
+                        <div class="button-row" style="align-items:end;">
+                            <button class="button danger" type="submit">Bulk delete selected</button>
+                        </div>
+                    </div>
+                </form>
+                <div style="overflow-x:auto; margin-top: .75rem;">
+                        <table>
+                            <thead>
                             <tr>
-                                <td>
-                                    <strong>@backup.BackupName</strong>
-                                    <div class="muted">@backup.FileName</div>
-                                </td>
-                                <td>
-                                    @if (backup.ExportedAtUtc.HasValue)
-                                    {
-                                        @backup.ExportedAtUtc.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")
-                                    }
-                                    else
-                                    {
-                                        @backup.FileCreatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")
-                                    }
-                                </td>
-                                <td>@(backup.AppVersion ?? "(unknown)")</td>
-                                <td>@backup.IncludedSectionsDisplay</td>
-                                <td>@(backup.NotesSummary ?? "")</td>
-                                <td><a class="button-secondary" href="/admin/backups/download?id=@Uri.EscapeDataString(backup.FileId)">Download</a></td>
+                                <th>Select</th>
+                                <th>Backup</th>
+                                <th>Source</th>
+                                <th>Exported</th>
+                                <th>App version</th>
+                                <th>Size</th>
+                                <th>Sections</th>
+                                <th>Notes</th>
+                                <th>Actions</th>
                             </tr>
-                        }
-                        </tbody>
-                    </table>
-                </div>
+                            </thead>
+                            <tbody>
+                            @foreach (var backup in Model.Backups)
+                            {
+                                <tr>
+                                    <td><input type="checkbox" form="bulkDeleteForm" name="DeleteBulkForm.SelectedFileIds" value="@backup.FileId" style="width:24px;height:24px;" /></td>
+                                    <td>
+                                        <strong>@backup.BackupName</strong>
+                                        <div class="muted">@backup.FileName</div>
+                                    </td>
+                                    <td><span class="pill">@backup.BackupSource</span></td>
+                                    <td>
+                                        @if (backup.ExportedAtUtc.HasValue)
+                                        {
+                                            @backup.ExportedAtUtc.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")
+                                        }
+                                        else
+                                        {
+                                            @backup.FileCreatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")
+                                        }
+                                    </td>
+                                    <td>@(backup.AppVersion ?? "(unknown)")</td>
+                                    <td>@((backup.FileSizeBytes / 1024.0).ToString("0.0")) KB</td>
+                                    <td>@backup.IncludedSectionsDisplay</td>
+                                    <td>@(backup.NotesSummary ?? "")</td>
+                                    <td>
+                                        <form method="post" action="/admin/backups/preview" class="inline-form">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="RestorePreviewForm.SelectedFileId" value="@backup.FileId" />
+                                            <button class="button-secondary" type="submit">Preview/Restore</button>
+                                        </form>
+                                        <a class="button-secondary" href="/admin/backups/download?id=@Uri.EscapeDataString(backup.FileId)">Download</a>
+                                        <form method="post" action="/admin/backups/delete" class="inline-form">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="DeleteSingleForm.FileId" value="@backup.FileId" />
+                                            <input type="hidden" name="DeleteSingleForm.ConfirmDelete" value="true" />
+                                            <button class="button-secondary danger" type="submit" onclick="return confirm('Delete backup @backup.BackupName? This cannot be undone.');">Delete</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            }
+                            </tbody>
+                        </table>
+                    </div>
             }
         </section>
     </div>

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -32,6 +32,19 @@
   },
   "Backup": {
     "StoragePath": "App_Data/Backups.Development",
-    "MaxUploadSizeBytes": 5242880
+    "MaxUploadSizeBytes": 5242880,
+    "Retention": {
+      "Enabled": true,
+      "AutomaticBackupMaxCount": 30,
+      "AutomaticBackupMaxAgeDays": null
+    },
+    "AutoBackup": {
+      "Enabled": true,
+      "OnConfigChangeEnabled": true,
+      "ScheduledEnabled": true,
+      "ScheduledTimeLocal": "02:00",
+      "IncludeIdentityByDefault": false,
+      "ConfigChangeCoalescingSeconds": 180
+    }
   }
 }

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -33,6 +33,19 @@
   },
   "Backup": {
     "StoragePath": "App_Data/Backups",
-    "MaxUploadSizeBytes": 5242880
+    "MaxUploadSizeBytes": 5242880,
+    "Retention": {
+      "Enabled": true,
+      "AutomaticBackupMaxCount": 30,
+      "AutomaticBackupMaxAgeDays": null
+    },
+    "AutoBackup": {
+      "Enabled": true,
+      "OnConfigChangeEnabled": true,
+      "ScheduledEnabled": true,
+      "ScheduledTimeLocal": "02:00",
+      "IncludeIdentityByDefault": false,
+      "ConfigChangeCoalescingSeconds": 180
+    }
   }
 }


### PR DESCRIPTION
### Motivation

- Provide safe, operational backup management for configuration-only backups including explicit delete controls and clear source classification for visibility and retention decisions. 
- Add low-risk automatic backup flows (daily schedule and coalesced config-change backups) so configuration is regularly captured without spamming backups during bursts of changes. 
- Ensure retention is predictable and only applies to automatic backups by default so manual/uploaded backups are preserved unless explicitly removed. 

### Description

- Adds backup source classification and metadata support and persists per-file source in a simple managed catalog (`backup-catalog.json`) with source values `manual`, `uploaded`, `automatic_scheduled`, and `automatic_config_change`. (models, loader, catalog service). 
- Implements server-side delete management with `IConfigurationBackupManagementService` supporting single-file delete (requires explicit confirmation) and bulk delete (requires typed `DELETE` confirmation), and enforces safe path resolution to prevent traversal/arbitrary deletes. 
- Extends admin backup UI and controller: shows source and file size, adds per-row preview/download/delete actions, multi-select bulk delete, and simple name/source filters; server-side delete endpoints added and confirmations enforced. 
- Adds automatic backup runtime: `ConfigurationAutoBackupBackgroundService` creates daily scheduled backups and coalesced config-change backups, marks their source appropriately, and invokes retention pruning after automatic backups. 
- Adds retention service that prunes automatic backups by count (configurable) with optional age-based pruning, and new `Backup` configuration options plus appsettings updates; registers new services and background worker in DI. 
- Documentation updated first to define sources, delete rules, auto-backup behaviour, coalescing, and retention; this work is linked to the created issue (Fixes #146). 

### Testing

- Installed .NET 10 (SDK 10.0.104) in the environment and ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully with a single nullable warning. 
- No automated unit tests were added for this change (behavioral/integration checks recommended during review and staging). 
- Static validation and basic runtime wiring were exercised by building the web project and verifying service registrations and controller endpoints compile.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7fefe4bc0832aa494595cf2e52245)