### PR TITLE
Add event logging, recent events panel, and endpoint/agent history pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ States:
 
 - No silent failures
 - All actions are traceable
+- Status page includes a recent events panel for meaningful endpoint/agent activity
+- Endpoint history is available at `/endpoints/{endpointId}/history`
+- Agent history is available at `/agents/{agentId}/history`
+- Event logging is intentionally focused on meaningful state/activity events (not every raw successful check result)
 
 ### Configuration Backup and Restore
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -409,6 +409,37 @@ Represents a historical state change.
 
 ---
 
+### EventLog
+
+Represents a meaningful endpoint/agent operational event.
+
+#### Purpose
+
+- auditable operational timeline
+- searchable endpoint/agent activity history
+- status-page recent event visibility
+
+#### Key fields
+
+- `eventLogId`
+- `occurredAtUtc`
+- `eventCategory` (endpoint / agent)
+- `eventType`
+- `severity` (info / warning / error)
+- `agentId` (nullable)
+- `endpointId` (nullable)
+- `assignmentId` (nullable)
+- `message`
+- `detailsJson` (nullable)
+
+#### Constraints
+
+- unified single event table (no per-domain split tables)
+- intended for meaningful domain events only (not every successful check)
+- indexed by `occurredAtUtc`, (`endpointId`, `occurredAtUtc`), (`agentId`, `occurredAtUtc`), (`assignmentId`, `occurredAtUtc`)
+
+---
+
 ### AlertEvent
 
 Represents an alert lifecycle.
@@ -461,6 +492,7 @@ Represents an alert lifecycle.
 - MonitorAssignment 1 → many CheckResults  
 - MonitorAssignment 1 → 1 EndpointState  
 - MonitorAssignment 1 → many StateTransitions  
+- MonitorAssignment 1 → many EventLogs  
 - MonitorAssignment 1 → many AlertEvents  
 
 ---

--- a/docs/event-logging.md
+++ b/docs/event-logging.md
@@ -82,25 +82,24 @@ All events are stored in a single table.
 
 ## Event Types (Initial Set)
 
-### Endpoint Events
+### Endpoint Events (initial)
 
 | Event Type                  | Description |
 |----------------------------|------------|
 | endpoint_state_changed     | Endpoint changed state (e.g. UP → DOWN) |
-| endpoint_suppressed        | Monitoring suppressed due to dependency or rule |
-| endpoint_unsuppressed      | Suppression lifted |
+| endpoint_suppression_applied | Monitoring suppression applied due to dependency |
+| endpoint_suppression_cleared | Suppression lifted |
 
 ---
 
-### Agent Events
+### Agent Events (initial)
 
 | Event Type                  | Description |
 |----------------------------|------------|
 | agent_authenticated        | Agent successfully authenticated |
-| agent_heartbeat_received   | Heartbeat received (used sparingly if needed) |
-| agent_became_online        | Agent transitioned to online state |
-| agent_became_stale         | Agent missed expected heartbeat window |
-| agent_became_offline       | Agent considered offline |
+| agent_heartbeat_received   | Heartbeat received (rate-limited for signal) |
+| agent_online               | Agent transitioned to online state |
+| agent_config_fetched       | Agent fetched configuration (reserved for optional use) |
 
 ---
 

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.Agents;
+using PingMonitor.Web.Services.EventLogs;
 using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.ViewModels.Agents;
 
@@ -17,13 +18,16 @@ public sealed class AgentsController : Controller
 
     private readonly IAgentProvisioningService _agentProvisioningService;
     private readonly IAgentManagementQueryService _agentManagementQueryService;
+    private readonly IEventLogQueryService _eventLogQueryService;
 
     public AgentsController(
         IAgentProvisioningService agentProvisioningService,
-        IAgentManagementQueryService agentManagementQueryService)
+        IAgentManagementQueryService agentManagementQueryService,
+        IEventLogQueryService eventLogQueryService)
     {
         _agentProvisioningService = agentProvisioningService;
         _agentManagementQueryService = agentManagementQueryService;
+        _eventLogQueryService = eventLogQueryService;
     }
 
     [HttpGet("")]
@@ -59,6 +63,26 @@ public sealed class AgentsController : Controller
     public IActionResult Deploy()
     {
         return View("Deploy", new DeployAgentPageViewModel());
+    }
+
+    [HttpGet("{id}/history")]
+    public async Task<IActionResult> History(
+        [FromRoute] string id,
+        [FromQuery] string? search,
+        [FromQuery] string? eventType,
+        [FromQuery] DateTimeOffset? dateFromUtc,
+        [FromQuery] DateTimeOffset? dateToUtc,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 50,
+        CancellationToken cancellationToken = default)
+    {
+        var model = await _eventLogQueryService.GetAgentHistoryPageAsync(id, search, eventType, dateFromUtc, dateToUtc, page, pageSize, cancellationToken);
+        if (model is null)
+        {
+            return NotFound();
+        }
+
+        return View("History", model);
     }
 
     [HttpPost("deploy")]

--- a/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
@@ -4,6 +4,7 @@ using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.Endpoints;
 using PingMonitor.Web.Services.Groups;
 using PingMonitor.Web.Services.Identity;
+using PingMonitor.Web.Services.EventLogs;
 using PingMonitor.Web.ViewModels.Endpoints;
 
 namespace PingMonitor.Web.Controllers;
@@ -23,6 +24,7 @@ public sealed class EndpointsController : Controller
     private readonly IGroupManagementService _groupManagementService;
     private readonly IEndpointPerformanceQueryService _endpointPerformanceQueryService;
     private readonly IUserAccessScopeService _userAccessScopeService;
+    private readonly IEventLogQueryService _eventLogQueryService;
 
     public EndpointsController(
         IEndpointCreationQueryService endpointCreationQueryService,
@@ -31,7 +33,8 @@ public sealed class EndpointsController : Controller
         IApplicationSettingsService applicationSettingsService,
         IGroupManagementService groupManagementService,
         IEndpointPerformanceQueryService endpointPerformanceQueryService,
-        IUserAccessScopeService userAccessScopeService)
+        IUserAccessScopeService userAccessScopeService,
+        IEventLogQueryService eventLogQueryService)
     {
         _endpointCreationQueryService = endpointCreationQueryService;
         _endpointManagementQueryService = endpointManagementQueryService;
@@ -40,6 +43,7 @@ public sealed class EndpointsController : Controller
         _groupManagementService = groupManagementService;
         _endpointPerformanceQueryService = endpointPerformanceQueryService;
         _userAccessScopeService = userAccessScopeService;
+        _eventLogQueryService = eventLogQueryService;
     }
 
     [HttpGet("")]
@@ -194,6 +198,26 @@ public sealed class EndpointsController : Controller
         }
 
         return View("Performance", model);
+    }
+
+    [HttpGet("{endpointId}/history")]
+    public async Task<IActionResult> History(
+        [FromRoute] string endpointId,
+        [FromQuery] string? search,
+        [FromQuery] string? eventType,
+        [FromQuery] DateTimeOffset? dateFromUtc,
+        [FromQuery] DateTimeOffset? dateToUtc,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 50,
+        CancellationToken cancellationToken = default)
+    {
+        var model = await _eventLogQueryService.GetEndpointHistoryPageAsync(endpointId, search, eventType, dateFromUtc, dateToUtc, page, pageSize, cancellationToken);
+        if (model is null)
+        {
+            return NotFound();
+        }
+
+        return View("History", model);
     }
 
     [Authorize(Roles = ApplicationRoles.Admin)]

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -29,6 +29,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
     public DbSet<ResultBatch> ResultBatches => Set<ResultBatch>();
     public DbSet<EndpointState> EndpointStates => Set<EndpointState>();
     public DbSet<StateTransition> StateTransitions => Set<StateTransition>();
+    public DbSet<EventLog> EventLogs => Set<EventLog>();
     public DbSet<AppSchemaInfo> AppSchemaInfos => Set<AppSchemaInfo>();
     public DbSet<ApplicationSettings> ApplicationSettings => Set<ApplicationSettings>();
 
@@ -64,6 +65,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         agent.Property(x => x.Platform).HasMaxLength(50);
         agent.Property(x => x.MachineName).HasMaxLength(255);
         agent.Property(x => x.CreatedAtUtc).IsRequired();
+        agent.Property(x => x.LastHeartbeatEventLoggedAtUtc);
         agent.Property(x => x.ApiKeyCreatedAtUtc).IsRequired();
         agent.Property(x => x.Enabled).HasDefaultValue(true);
         agent.Property(x => x.ApiKeyRevoked).HasDefaultValue(false);
@@ -197,6 +199,24 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         stateTransition.Property(x => x.ReasonCode).HasMaxLength(64);
         stateTransition.Property(x => x.DependencyEndpointId).HasMaxLength(64);
         stateTransition.HasIndex(x => new { x.AssignmentId, x.TransitionAtUtc });
+
+        var eventLog = modelBuilder.Entity<EventLog>();
+        eventLog.ToTable("EventLogs");
+        eventLog.HasKey(x => x.EventLogId);
+        eventLog.Property(x => x.EventLogId).HasMaxLength(64);
+        eventLog.Property(x => x.OccurredAtUtc).IsRequired();
+        eventLog.Property(x => x.EventCategory).HasConversion<string>().HasMaxLength(32).IsRequired();
+        eventLog.Property(x => x.EventType).HasMaxLength(128).IsRequired();
+        eventLog.Property(x => x.Severity).HasConversion<string>().HasMaxLength(16).IsRequired();
+        eventLog.Property(x => x.AgentId).HasMaxLength(64);
+        eventLog.Property(x => x.EndpointId).HasMaxLength(64);
+        eventLog.Property(x => x.AssignmentId).HasMaxLength(64);
+        eventLog.Property(x => x.Message).HasMaxLength(2048).IsRequired();
+        eventLog.Property(x => x.DetailsJson).HasMaxLength(8192);
+        eventLog.HasIndex(x => x.OccurredAtUtc);
+        eventLog.HasIndex(x => new { x.EndpointId, x.OccurredAtUtc });
+        eventLog.HasIndex(x => new { x.AgentId, x.OccurredAtUtc });
+        eventLog.HasIndex(x => new { x.AssignmentId, x.OccurredAtUtc });
 
         var appSettings = modelBuilder.Entity<ApplicationSettings>();
         appSettings.ToTable("ApplicationSettings");

--- a/src/WebApp/PingMonitor.Web/Models/Agent.cs
+++ b/src/WebApp/PingMonitor.Web/Models/Agent.cs
@@ -17,4 +17,5 @@ public sealed class Agent
     public string? Platform { get; set; }
     public string? MachineName { get; set; }
     public DateTimeOffset CreatedAtUtc { get; set; }
+    public DateTimeOffset? LastHeartbeatEventLoggedAtUtc { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/Models/EventCategory.cs
+++ b/src/WebApp/PingMonitor.Web/Models/EventCategory.cs
@@ -1,0 +1,7 @@
+namespace PingMonitor.Web.Models;
+
+public enum EventCategory
+{
+    Endpoint = 0,
+    Agent = 1
+}

--- a/src/WebApp/PingMonitor.Web/Models/EventLog.cs
+++ b/src/WebApp/PingMonitor.Web/Models/EventLog.cs
@@ -1,0 +1,15 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class EventLog
+{
+    public string EventLogId { get; set; } = $"evt_{Guid.NewGuid():N}";
+    public DateTimeOffset OccurredAtUtc { get; set; }
+    public EventCategory EventCategory { get; set; }
+    public string EventType { get; set; } = string.Empty;
+    public EventSeverity Severity { get; set; }
+    public string? AgentId { get; set; }
+    public string? EndpointId { get; set; }
+    public string? AssignmentId { get; set; }
+    public string Message { get; set; } = string.Empty;
+    public string? DetailsJson { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Models/EventSeverity.cs
+++ b/src/WebApp/PingMonitor.Web/Models/EventSeverity.cs
@@ -1,0 +1,8 @@
+namespace PingMonitor.Web.Models;
+
+public enum EventSeverity
+{
+    Info = 0,
+    Warning = 1,
+    Error = 2
+}

--- a/src/WebApp/PingMonitor.Web/Models/EventType.cs
+++ b/src/WebApp/PingMonitor.Web/Models/EventType.cs
@@ -1,0 +1,12 @@
+namespace PingMonitor.Web.Models;
+
+public static class EventType
+{
+    public const string EndpointStateChanged = "endpoint_state_changed";
+    public const string EndpointSuppressionApplied = "endpoint_suppression_applied";
+    public const string EndpointSuppressionCleared = "endpoint_suppression_cleared";
+    public const string AgentAuthenticated = "agent_authenticated";
+    public const string AgentHeartbeatReceived = "agent_heartbeat_received";
+    public const string AgentOnline = "agent_online";
+    public const string AgentConfigFetched = "agent_config_fetched";
+}

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -14,6 +14,7 @@ using PingMonitor.Web.Services.Backups;
 using PingMonitor.Web.Services.Endpoints;
 using PingMonitor.Web.Services.Groups;
 using PingMonitor.Web.Services.Identity;
+using PingMonitor.Web.Services.EventLogs;
 using PingMonitor.Web.Services.Metrics;
 using PingMonitor.Web.Services.StartupGate;
 using PingMonitor.Web.Services.Status;
@@ -110,6 +111,8 @@ builder.Services.AddScoped<IAgentConfigurationService, AgentConfigurationService
 builder.Services.AddScoped<IResultIngestionService, ResultIngestionService>();
 builder.Services.AddScoped<IHeartbeatService, AgentHeartbeatService>();
 builder.Services.AddScoped<IStateEvaluationService, StateEvaluationService>();
+builder.Services.AddScoped<IEventLogService, EventLogService>();
+builder.Services.AddScoped<IEventLogQueryService, EventLogQueryService>();
 builder.Services.AddScoped<IEndpointStatusQueryService, EndpointStatusQueryService>();
 builder.Services.AddScoped<IStartupGateService, StartupGateService>();
 builder.Services.AddSingleton<IStartupDatabaseConfigurationStore, FileStartupDatabaseConfigurationStore>();

--- a/src/WebApp/PingMonitor.Web/Services/AgentHeartbeatService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentHeartbeatService.cs
@@ -1,6 +1,7 @@
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Contracts.Heartbeat;
 using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.EventLogs;
 
 namespace PingMonitor.Web.Services;
 
@@ -8,13 +9,16 @@ internal sealed class AgentHeartbeatService : IHeartbeatService
 {
     private readonly PingMonitorDbContext _dbContext;
     private readonly IAgentConfigurationService _configurationService;
+    private readonly IEventLogService _eventLogService;
 
     public AgentHeartbeatService(
         PingMonitorDbContext dbContext,
-        IAgentConfigurationService configurationService)
+        IAgentConfigurationService configurationService,
+        IEventLogService eventLogService)
     {
         _dbContext = dbContext;
         _configurationService = configurationService;
+        _eventLogService = eventLogService;
     }
 
     public async Task<AgentHeartbeatResponse> ProcessHeartbeatAsync(Agent agent, AgentHeartbeatRequest request, CancellationToken cancellationToken)
@@ -22,6 +26,8 @@ internal sealed class AgentHeartbeatService : IHeartbeatService
         var now = DateTimeOffset.UtcNow;
         var currentConfigVersion = await _configurationService.GetCurrentConfigVersionAsync(agent, cancellationToken);
 
+        var wasOnline = agent.Status == AgentHealthStatus.Online;
+        var previousHeartbeat = agent.LastHeartbeatUtc;
         agent.LastHeartbeatUtc = now;
         agent.LastSeenUtc = now;
         agent.AgentVersion = request.AgentVersion.Trim();
@@ -35,6 +41,37 @@ internal sealed class AgentHeartbeatService : IHeartbeatService
         });
 
         await _dbContext.SaveChangesAsync(cancellationToken);
+
+        if (!wasOnline)
+        {
+            await _eventLogService.WriteAsync(new EventLogWriteRequest
+            {
+                OccurredAtUtc = now,
+                Category = EventCategory.Agent,
+                EventType = EventType.AgentOnline,
+                Severity = EventSeverity.Info,
+                AgentId = agent.AgentId,
+                Message = $"Agent \"{agent.Name ?? agent.InstanceId}\" is now online."
+            }, cancellationToken);
+        }
+
+        if (!agent.LastHeartbeatEventLoggedAtUtc.HasValue ||
+            now - agent.LastHeartbeatEventLoggedAtUtc.Value >= TimeSpan.FromMinutes(5) ||
+            (previousHeartbeat.HasValue && now - previousHeartbeat.Value >= TimeSpan.FromMinutes(5)))
+        {
+            await _eventLogService.WriteAsync(new EventLogWriteRequest
+            {
+                OccurredAtUtc = now,
+                Category = EventCategory.Agent,
+                EventType = EventType.AgentHeartbeatReceived,
+                Severity = EventSeverity.Info,
+                AgentId = agent.AgentId,
+                Message = $"Heartbeat received from agent \"{agent.Name ?? agent.InstanceId}\"."
+            }, cancellationToken);
+
+            agent.LastHeartbeatEventLoggedAtUtc = now;
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
 
         return new AgentHeartbeatResponse(
             Ok: true,

--- a/src/WebApp/PingMonitor.Web/Services/AgentHelloService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentHelloService.cs
@@ -3,6 +3,7 @@ using PingMonitor.Web.Contracts.Hello;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Options;
+using PingMonitor.Web.Services.EventLogs;
 
 namespace PingMonitor.Web.Services;
 
@@ -10,11 +11,13 @@ internal sealed class AgentHelloService : IAgentHelloService
 {
     private readonly PingMonitorDbContext _dbContext;
     private readonly AgentApiOptions _options;
+    private readonly IEventLogService _eventLogService;
 
-    public AgentHelloService(PingMonitorDbContext dbContext, IOptions<AgentApiOptions> options)
+    public AgentHelloService(PingMonitorDbContext dbContext, IOptions<AgentApiOptions> options, IEventLogService eventLogService)
     {
         _dbContext = dbContext;
         _options = options.Value;
+        _eventLogService = eventLogService;
     }
 
     public async Task<AgentHelloResponse> ProcessHelloAsync(Agent agent, AgentHelloRequest request, CancellationToken cancellationToken)
@@ -26,9 +29,32 @@ internal sealed class AgentHelloService : IAgentHelloService
         agent.AgentVersion = request.AgentVersion.Trim();
         agent.MachineName = request.MachineName.Trim();
         agent.Platform = request.Platform.Trim();
+        var wasOnline = agent.Status == AgentHealthStatus.Online;
         agent.Status = AgentHealthStatus.Online;
 
         await _dbContext.SaveChangesAsync(cancellationToken);
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            OccurredAtUtc = now,
+            Category = EventCategory.Agent,
+            EventType = EventType.AgentAuthenticated,
+            Severity = EventSeverity.Info,
+            AgentId = agent.AgentId,
+            Message = $"Agent \"{agent.Name ?? agent.InstanceId}\" authenticated successfully (hello)."
+        }, cancellationToken);
+
+        if (!wasOnline)
+        {
+            await _eventLogService.WriteAsync(new EventLogWriteRequest
+            {
+                OccurredAtUtc = now,
+                Category = EventCategory.Agent,
+                EventType = EventType.AgentOnline,
+                Severity = EventSeverity.Info,
+                AgentId = agent.AgentId,
+                Message = $"Agent \"{agent.Name ?? agent.InstanceId}\" is now online."
+            }, cancellationToken);
+        }
 
         return new AgentHelloResponse(
             AgentId: agent.AgentId,

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
@@ -106,6 +106,7 @@ internal sealed class EndpointManagementQueryService : IEndpointManagementQueryS
                 LowestRttMs = metricsByAssignmentId.GetValueOrDefault(row.AssignmentId)?.LowestRttMs,
                 JitterMs = metricsByAssignmentId.GetValueOrDefault(row.AssignmentId)?.JitterMs,
                 AssignmentId = row.AssignmentId,
+                EndpointId = row.EndpointId,
                 EndpointName = row.EndpointName,
                 IconKey = EndpointIconCatalog.Normalize(row.IconKey),
                 Target = row.Target,

--- a/src/WebApp/PingMonitor.Web/Services/EventLogs/EventLogQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/EventLogs/EventLogQueryService.cs
@@ -1,0 +1,227 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.ViewModels.EventLogs;
+
+namespace PingMonitor.Web.Services.EventLogs;
+
+internal sealed class EventLogQueryService : IEventLogQueryService
+{
+    private const int MaxPageSize = 100;
+    private readonly PingMonitorDbContext _dbContext;
+
+    public EventLogQueryService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<RecentEventViewModel>> GetRecentEventsAsync(int count, CancellationToken cancellationToken)
+    {
+        var safeCount = Math.Clamp(count, 1, 100);
+        return await BuildProjection(_dbContext.EventLogs.AsNoTracking())
+            .OrderByDescending(x => x.OccurredAtUtc)
+            .ThenByDescending(x => x.EventLogId)
+            .Take(safeCount)
+            .Select(x => new RecentEventViewModel
+            {
+                OccurredAtUtc = x.OccurredAtUtc,
+                Category = x.Category,
+                EventType = x.EventType,
+                Severity = x.Severity,
+                Message = x.Message,
+                EndpointId = x.EndpointId,
+                EndpointName = x.EndpointName,
+                AgentId = x.AgentId,
+                AgentName = x.AgentName,
+                AssignmentId = x.AssignmentId
+            })
+            .ToArrayAsync(cancellationToken);
+    }
+
+    public Task<EventLogHistoryPageViewModel?> GetEndpointHistoryPageAsync(string endpointId, string? search, string? eventType, DateTimeOffset? dateFromUtc, DateTimeOffset? dateToUtc, int page, int pageSize, CancellationToken cancellationToken)
+    {
+        return GetHistoryPageAsync(
+            scopeType: "Endpoint",
+            scopeId: endpointId,
+            baseQuery: _dbContext.EventLogs.AsNoTracking().Where(x => x.EndpointId == endpointId),
+            scopeNameQuery: _dbContext.Endpoints.AsNoTracking().Where(x => x.EndpointId == endpointId).Select(x => x.Name),
+            backLink: "/endpoints",
+            emptyMessage: "No endpoint events match the selected filters.",
+            search,
+            eventType,
+            dateFromUtc,
+            dateToUtc,
+            page,
+            pageSize,
+            cancellationToken);
+    }
+
+    public Task<EventLogHistoryPageViewModel?> GetAgentHistoryPageAsync(string agentId, string? search, string? eventType, DateTimeOffset? dateFromUtc, DateTimeOffset? dateToUtc, int page, int pageSize, CancellationToken cancellationToken)
+    {
+        return GetHistoryPageAsync(
+            scopeType: "Agent",
+            scopeId: agentId,
+            baseQuery: _dbContext.EventLogs.AsNoTracking().Where(x => x.AgentId == agentId),
+            scopeNameQuery: _dbContext.Agents.AsNoTracking().Where(x => x.AgentId == agentId).Select(x => x.Name ?? x.InstanceId),
+            backLink: "/agents",
+            emptyMessage: "No agent events match the selected filters.",
+            search,
+            eventType,
+            dateFromUtc,
+            dateToUtc,
+            page,
+            pageSize,
+            cancellationToken);
+    }
+
+    private async Task<EventLogHistoryPageViewModel?> GetHistoryPageAsync(
+        string scopeType,
+        string scopeId,
+        IQueryable<Models.EventLog> baseQuery,
+        IQueryable<string> scopeNameQuery,
+        string backLink,
+        string emptyMessage,
+        string? search,
+        string? eventType,
+        DateTimeOffset? dateFromUtc,
+        DateTimeOffset? dateToUtc,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken)
+    {
+        var scopeName = await scopeNameQuery.SingleOrDefaultAsync(cancellationToken);
+        if (scopeName is null)
+        {
+            return null;
+        }
+
+        var normalizedSearch = Normalize(search);
+        var normalizedEventType = Normalize(eventType);
+        var safePageSize = Math.Clamp(pageSize, 10, MaxPageSize);
+        var safePage = Math.Max(1, page);
+
+        if (!string.IsNullOrWhiteSpace(normalizedSearch))
+        {
+            baseQuery = baseQuery.Where(x =>
+                EF.Functions.Like(x.Message, $"%{normalizedSearch}%") ||
+                EF.Functions.Like(x.EventType, $"%{normalizedSearch}%") ||
+                (x.DetailsJson != null && EF.Functions.Like(x.DetailsJson, $"%{normalizedSearch}%")));
+        }
+
+        if (!string.IsNullOrWhiteSpace(normalizedEventType))
+        {
+            baseQuery = baseQuery.Where(x => x.EventType == normalizedEventType);
+        }
+
+        if (dateFromUtc.HasValue)
+        {
+            baseQuery = baseQuery.Where(x => x.OccurredAtUtc >= dateFromUtc.Value);
+        }
+
+        if (dateToUtc.HasValue)
+        {
+            baseQuery = baseQuery.Where(x => x.OccurredAtUtc <= dateToUtc.Value);
+        }
+
+        var projected = BuildProjection(baseQuery);
+        var totalCount = await projected.CountAsync(cancellationToken);
+        var totalPages = Math.Max(1, (int)Math.Ceiling(totalCount / (double)safePageSize));
+        safePage = Math.Min(safePage, totalPages);
+
+        var rows = await projected
+            .OrderByDescending(x => x.OccurredAtUtc)
+            .ThenByDescending(x => x.EventLogId)
+            .Skip((safePage - 1) * safePageSize)
+            .Take(safePageSize)
+            .Select(x => new EventLogHistoryRowViewModel
+            {
+                EventLogId = x.EventLogId,
+                OccurredAtUtc = x.OccurredAtUtc,
+                Category = x.Category,
+                EventType = x.EventType,
+                Severity = x.Severity,
+                Message = x.Message,
+                EndpointId = x.EndpointId,
+                EndpointName = x.EndpointName,
+                AgentId = x.AgentId,
+                AgentName = x.AgentName,
+                AssignmentId = x.AssignmentId
+            })
+            .ToArrayAsync(cancellationToken);
+
+        var availableEventTypes = await _dbContext.EventLogs.AsNoTracking()
+            .Where(x => (scopeType == "Endpoint" && x.EndpointId == scopeId) || (scopeType == "Agent" && x.AgentId == scopeId))
+            .Select(x => x.EventType)
+            .Distinct()
+            .OrderBy(x => x)
+            .ToArrayAsync(cancellationToken);
+
+        return new EventLogHistoryPageViewModel
+        {
+            ScopeId = scopeId,
+            ScopeLabel = scopeType,
+            ScopeName = scopeName,
+            BackLink = backLink,
+            EmptyMessage = emptyMessage,
+            Filters = new EventLogHistoryFilterViewModel
+            {
+                Search = normalizedSearch,
+                EventType = normalizedEventType,
+                DateFromUtc = dateFromUtc,
+                DateToUtc = dateToUtc,
+                PageSize = safePageSize,
+                AvailableEventTypes = availableEventTypes
+            },
+            Rows = rows,
+            Pagination = new EventLogHistoryPaginationViewModel
+            {
+                Page = safePage,
+                PageSize = safePageSize,
+                TotalCount = totalCount,
+                TotalPages = totalPages
+            }
+        };
+    }
+
+    private IQueryable<EventProjection> BuildProjection(IQueryable<Models.EventLog> query)
+    {
+        return from eventLog in query
+            join endpoint in _dbContext.Endpoints.AsNoTracking() on eventLog.EndpointId equals endpoint.EndpointId into endpointJoin
+            from endpoint in endpointJoin.DefaultIfEmpty()
+            join agent in _dbContext.Agents.AsNoTracking() on eventLog.AgentId equals agent.AgentId into agentJoin
+            from agent in agentJoin.DefaultIfEmpty()
+            select new EventProjection
+            {
+                EventLogId = eventLog.EventLogId,
+                OccurredAtUtc = eventLog.OccurredAtUtc,
+                Category = eventLog.EventCategory.ToString(),
+                EventType = eventLog.EventType,
+                Severity = eventLog.Severity.ToString(),
+                Message = eventLog.Message,
+                AgentId = eventLog.AgentId,
+                AgentName = agent != null ? (agent.Name ?? agent.InstanceId) : null,
+                EndpointId = eventLog.EndpointId,
+                EndpointName = endpoint != null ? endpoint.Name : null,
+                AssignmentId = eventLog.AssignmentId
+            };
+    }
+
+    private static string? Normalize(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private sealed class EventProjection
+    {
+        public string EventLogId { get; init; } = string.Empty;
+        public DateTimeOffset OccurredAtUtc { get; init; }
+        public string Category { get; init; } = string.Empty;
+        public string EventType { get; init; } = string.Empty;
+        public string Severity { get; init; } = string.Empty;
+        public string Message { get; init; } = string.Empty;
+        public string? AgentId { get; init; }
+        public string? AgentName { get; init; }
+        public string? EndpointId { get; init; }
+        public string? EndpointName { get; init; }
+        public string? AssignmentId { get; init; }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/EventLogs/EventLogService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/EventLogs/EventLogService.cs
@@ -1,0 +1,38 @@
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.EventLogs;
+
+internal sealed class EventLogService : IEventLogService
+{
+    private readonly PingMonitorDbContext _dbContext;
+
+    public EventLogService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task WriteAsync(EventLogWriteRequest request, CancellationToken cancellationToken)
+    {
+        _dbContext.EventLogs.Add(new EventLog
+        {
+            EventLogId = $"evt_{Guid.NewGuid():N}",
+            OccurredAtUtc = request.OccurredAtUtc ?? DateTimeOffset.UtcNow,
+            EventCategory = request.Category,
+            EventType = request.EventType.Trim(),
+            Severity = request.Severity,
+            AgentId = Normalize(request.AgentId),
+            EndpointId = Normalize(request.EndpointId),
+            AssignmentId = Normalize(request.AssignmentId),
+            Message = request.Message.Trim(),
+            DetailsJson = string.IsNullOrWhiteSpace(request.DetailsJson) ? null : request.DetailsJson.Trim()
+        });
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private static string? Normalize(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/EventLogs/EventLogWriteRequest.cs
+++ b/src/WebApp/PingMonitor.Web/Services/EventLogs/EventLogWriteRequest.cs
@@ -1,0 +1,16 @@
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.EventLogs;
+
+public sealed class EventLogWriteRequest
+{
+    public DateTimeOffset? OccurredAtUtc { get; init; }
+    public required EventCategory Category { get; init; }
+    public required string EventType { get; init; }
+    public required EventSeverity Severity { get; init; }
+    public string? AgentId { get; init; }
+    public string? EndpointId { get; init; }
+    public string? AssignmentId { get; init; }
+    public required string Message { get; init; }
+    public string? DetailsJson { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/EventLogs/IEventLogQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/EventLogs/IEventLogQueryService.cs
@@ -1,0 +1,10 @@
+using PingMonitor.Web.ViewModels.EventLogs;
+
+namespace PingMonitor.Web.Services.EventLogs;
+
+public interface IEventLogQueryService
+{
+    Task<IReadOnlyList<RecentEventViewModel>> GetRecentEventsAsync(int count, CancellationToken cancellationToken);
+    Task<EventLogHistoryPageViewModel?> GetEndpointHistoryPageAsync(string endpointId, string? search, string? eventType, DateTimeOffset? dateFromUtc, DateTimeOffset? dateToUtc, int page, int pageSize, CancellationToken cancellationToken);
+    Task<EventLogHistoryPageViewModel?> GetAgentHistoryPageAsync(string agentId, string? search, string? eventType, DateTimeOffset? dateFromUtc, DateTimeOffset? dateToUtc, int page, int pageSize, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/EventLogs/IEventLogService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/EventLogs/IEventLogService.cs
@@ -1,0 +1,6 @@
+namespace PingMonitor.Web.Services.EventLogs;
+
+public interface IEventLogService
+{
+    Task WriteAsync(EventLogWriteRequest request, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -28,6 +28,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "ResultBatches",
         "EndpointStates",
         "StateTransitions",
+        "EventLogs",
         "ApplicationSettings"
     ];
     private static readonly string[] RequiredEndpointDependencyColumns =
@@ -221,6 +222,25 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 PRIMARY KEY (`ApplicationSettingsId`)
             );
             """;
+        const string createEventLogsSql = """
+            CREATE TABLE IF NOT EXISTS `EventLogs` (
+                `EventLogId` varchar(64) NOT NULL,
+                `OccurredAtUtc` datetime(6) NOT NULL,
+                `EventCategory` varchar(32) NOT NULL,
+                `EventType` varchar(128) NOT NULL,
+                `Severity` varchar(16) NOT NULL,
+                `AgentId` varchar(64) NULL,
+                `EndpointId` varchar(64) NULL,
+                `AssignmentId` varchar(64) NULL,
+                `Message` varchar(2048) NOT NULL,
+                `DetailsJson` varchar(8192) NULL,
+                PRIMARY KEY (`EventLogId`),
+                KEY `IX_EventLogs_OccurredAtUtc` (`OccurredAtUtc`),
+                KEY `IX_EventLogs_EndpointId_OccurredAtUtc` (`EndpointId`, `OccurredAtUtc`),
+                KEY `IX_EventLogs_AgentId_OccurredAtUtc` (`AgentId`, `OccurredAtUtc`),
+                KEY `IX_EventLogs_AssignmentId_OccurredAtUtc` (`AssignmentId`, `OccurredAtUtc`)
+            );
+            """;
 
         const string createEndpointDependenciesSql = """
             CREATE TABLE IF NOT EXISTS `EndpointDependencies` (
@@ -290,6 +310,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
 
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointStatesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createStateTransitionsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createEventLogsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createApplicationSettingsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointDependenciesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createAgentHeartbeatHistorySql, cancellationToken);
@@ -299,6 +320,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await dbContext.Database.ExecuteSqlRawAsync(createUserEndpointAccessesSql, cancellationToken);
         await EnsureEndpointDependenciesColumnsAsync(dbContext, cancellationToken);
         await EnsureEndpointColumnsAsync(dbContext, cancellationToken);
+        await EnsureAgentColumnsAsync(dbContext, cancellationToken);
         await MigrateLegacyEndpointDependenciesAsync(dbContext, cancellationToken);
     }
 
@@ -464,6 +486,25 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         }
     }
 
+    private static async Task EnsureAgentColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
+    {
+        await using var connection = dbContext.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        if (!await HasAgentColumnAsync(connection, "LastHeartbeatEventLoggedAtUtc", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `Agents`
+                ADD COLUMN `LastHeartbeatEventLoggedAtUtc` datetime(6) NULL;
+                """,
+                cancellationToken);
+        }
+    }
+
     private static async Task EnsureEndpointColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
     {
         await using var connection = dbContext.Database.GetDbConnection();
@@ -524,6 +565,24 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             FROM information_schema.columns
             WHERE table_schema = DATABASE()
               AND table_name = 'EndpointDependencies'
+              AND column_name = @columnName;
+            """;
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "@columnName";
+        parameter.Value = columnName;
+        command.Parameters.Add(parameter);
+
+        return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
+    }
+
+    private static async Task<bool> HasAgentColumnAsync(System.Data.Common.DbConnection connection, string columnName, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'Agents'
               AND column_name = @columnName;
             """;
         var parameter = command.CreateParameter();

--- a/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.EventLogs;
+using System.Text.Json;
 
 namespace PingMonitor.Web.Services;
 
@@ -8,13 +10,16 @@ internal sealed class StateEvaluationService : IStateEvaluationService
 {
     private readonly PingMonitorDbContext _dbContext;
     private readonly ILogger<StateEvaluationService> _logger;
+    private readonly IEventLogService _eventLogService;
 
     public StateEvaluationService(
         PingMonitorDbContext dbContext,
-        ILogger<StateEvaluationService> logger)
+        ILogger<StateEvaluationService> logger,
+        IEventLogService eventLogService)
     {
         _dbContext = dbContext;
         _logger = logger;
+        _eventLogService = eventLogService;
     }
 
     public async Task EvaluateAssignmentsAsync(IEnumerable<string> assignmentIds, CancellationToken cancellationToken)
@@ -124,6 +129,7 @@ internal sealed class StateEvaluationService : IStateEvaluationService
         if (previousState != nextState)
         {
             state.LastStateChangeUtc = DateTimeOffset.UtcNow;
+            var transitionAtUtc = state.LastStateChangeUtc.Value;
             _dbContext.StateTransitions.Add(new StateTransition
             {
                 TransitionId = Guid.NewGuid().ToString(),
@@ -132,7 +138,7 @@ internal sealed class StateEvaluationService : IStateEvaluationService
                 EndpointId = assignment.EndpointId,
                 PreviousState = previousState,
                 NewState = nextState,
-                TransitionAtUtc = state.LastStateChangeUtc.Value,
+                TransitionAtUtc = transitionAtUtc,
                 ReasonCode = reasonCode,
                 DependencyEndpointId = nextState == EndpointStateKind.Suppressed ? parentContext.ParentEndpointId : null
             });
@@ -143,6 +149,40 @@ internal sealed class StateEvaluationService : IStateEvaluationService
                 previousState,
                 nextState,
                 reasonCode ?? "(none)");
+
+            var eventType = EventType.EndpointStateChanged;
+            if (previousState != EndpointStateKind.Suppressed && nextState == EndpointStateKind.Suppressed)
+            {
+                eventType = EventType.EndpointSuppressionApplied;
+            }
+            else if (previousState == EndpointStateKind.Suppressed && nextState != EndpointStateKind.Suppressed)
+            {
+                eventType = EventType.EndpointSuppressionCleared;
+            }
+
+            await _eventLogService.WriteAsync(
+                new EventLogWriteRequest
+                {
+                    OccurredAtUtc = transitionAtUtc,
+                    Category = EventCategory.Endpoint,
+                    EventType = eventType,
+                    Severity = nextState == EndpointStateKind.Down ? EventSeverity.Warning : EventSeverity.Info,
+                    AgentId = assignment.AgentId,
+                    EndpointId = assignment.EndpointId,
+                    AssignmentId = assignment.AssignmentId,
+                    Message = $"Endpoint \"{endpoint.Name}\" state changed from {previousState} to {nextState}.",
+                    DetailsJson = JsonSerializer.Serialize(new
+                    {
+                        assignment.AssignmentId,
+                        assignment.AgentId,
+                        assignment.EndpointId,
+                        previousState = previousState.ToString(),
+                        newState = nextState.ToString(),
+                        reasonCode,
+                        dependencyEndpointId = state.SuppressedByEndpointId
+                    })
+                },
+                cancellationToken);
         }
 
         await _dbContext.SaveChangesAsync(cancellationToken);

--- a/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
@@ -4,6 +4,7 @@ using PingMonitor.Web.Models;
 using PingMonitor.Web.Services.Endpoints;
 using PingMonitor.Web.Services.Metrics;
 using PingMonitor.Web.Services.Identity;
+using PingMonitor.Web.Services.EventLogs;
 using PingMonitor.Web.ViewModels.Status;
 
 namespace PingMonitor.Web.Services.Status;
@@ -14,13 +15,15 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
     private readonly IEndpointMetricsService _endpointMetricsService;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IUserAccessScopeService _userAccessScopeService;
+    private readonly IEventLogQueryService _eventLogQueryService;
 
-    public EndpointStatusQueryService(PingMonitorDbContext dbContext, IEndpointMetricsService endpointMetricsService, IHttpContextAccessor httpContextAccessor, IUserAccessScopeService userAccessScopeService)
+    public EndpointStatusQueryService(PingMonitorDbContext dbContext, IEndpointMetricsService endpointMetricsService, IHttpContextAccessor httpContextAccessor, IUserAccessScopeService userAccessScopeService, IEventLogQueryService eventLogQueryService)
     {
         _dbContext = dbContext;
         _endpointMetricsService = endpointMetricsService;
         _httpContextAccessor = httpContextAccessor;
         _userAccessScopeService = userAccessScopeService;
+        _eventLogQueryService = eventLogQueryService;
     }
 
     public async Task<EndpointStatusPageViewModel> GetStatusPageAsync(
@@ -227,7 +230,8 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
                 AvailableAgents = availableAgents,
                 AvailableGroups = availableGroups
             },
-            Rows = rowsWithMetrics
+            Rows = rowsWithMetrics,
+            RecentEvents = await _eventLogQueryService.GetRecentEventsAsync(50, cancellationToken)
         };
     }
 

--- a/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/ManageEndpointsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/ManageEndpointsPageViewModel.cs
@@ -15,6 +15,7 @@ public sealed class ManageEndpointsPageViewModel
 public sealed class ManageEndpointRowViewModel
 {
     public string AssignmentId { get; init; } = string.Empty;
+    public string EndpointId { get; init; } = string.Empty;
     public string EndpointName { get; init; } = string.Empty;
     public string IconKey { get; init; } = "generic";
     public string Target { get; init; } = string.Empty;

--- a/src/WebApp/PingMonitor.Web/ViewModels/EventLogs/EventLogHistoryPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/EventLogs/EventLogHistoryPageViewModel.cs
@@ -1,0 +1,62 @@
+namespace PingMonitor.Web.ViewModels.EventLogs;
+
+public sealed class EventLogHistoryPageViewModel
+{
+    public required string ScopeId { get; init; }
+    public required string ScopeLabel { get; init; }
+    public required string ScopeName { get; init; }
+    public required string BackLink { get; init; }
+    public required string EmptyMessage { get; init; }
+    public EventLogHistoryFilterViewModel Filters { get; init; } = new();
+    public IReadOnlyList<EventLogHistoryRowViewModel> Rows { get; init; } = [];
+    public EventLogHistoryPaginationViewModel Pagination { get; init; } = new();
+}
+
+public sealed class EventLogHistoryFilterViewModel
+{
+    public string? Search { get; init; }
+    public string? EventType { get; init; }
+    public DateTimeOffset? DateFromUtc { get; init; }
+    public DateTimeOffset? DateToUtc { get; init; }
+    public int PageSize { get; init; }
+    public IReadOnlyList<string> AvailableEventTypes { get; init; } = [];
+}
+
+public sealed class EventLogHistoryRowViewModel
+{
+    public string EventLogId { get; init; } = string.Empty;
+    public DateTimeOffset OccurredAtUtc { get; init; }
+    public string Category { get; init; } = string.Empty;
+    public string EventType { get; init; } = string.Empty;
+    public string Severity { get; init; } = string.Empty;
+    public string Message { get; init; } = string.Empty;
+    public string? EndpointId { get; init; }
+    public string? EndpointName { get; init; }
+    public string? AgentId { get; init; }
+    public string? AgentName { get; init; }
+    public string? AssignmentId { get; init; }
+}
+
+public sealed class EventLogHistoryPaginationViewModel
+{
+    public int Page { get; init; } = 1;
+    public int PageSize { get; init; } = 50;
+    public int TotalCount { get; init; }
+    public int TotalPages { get; init; }
+    public bool HasPreviousPage => Page > 1;
+    public bool HasNextPage => Page < TotalPages;
+}
+
+public sealed class RecentEventViewModel
+{
+    public DateTimeOffset OccurredAtUtc { get; init; }
+    public string Category { get; init; } = string.Empty;
+    public string EventType { get; init; } = string.Empty;
+    public string Severity { get; init; } = string.Empty;
+    public string Message { get; init; } = string.Empty;
+    public string? EndpointId { get; init; }
+    public string? EndpointName { get; init; }
+    public string? AgentId { get; init; }
+    public string? AgentName { get; init; }
+    public string? AssignmentId { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/Status/EndpointStatusPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Status/EndpointStatusPageViewModel.cs
@@ -1,4 +1,5 @@
 using PingMonitor.Web.Models;
+using PingMonitor.Web.ViewModels.EventLogs;
 
 namespace PingMonitor.Web.ViewModels.Status;
 
@@ -7,6 +8,7 @@ public sealed class EndpointStatusPageViewModel
     public EndpointStatusSummaryViewModel Summary { get; init; } = new();
     public EndpointStatusFiltersViewModel Filters { get; init; } = new();
     public IReadOnlyList<EndpointStatusRowViewModel> Rows { get; init; } = [];
+    public IReadOnlyList<RecentEventViewModel> RecentEvents { get; init; } = [];
 }
 
 public sealed class EndpointStatusSummaryViewModel

--- a/src/WebApp/PingMonitor.Web/Views/Agents/History.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/History.cshtml
@@ -1,0 +1,153 @@
+@model PingMonitor.Web.ViewModels.EventLogs.EventLogHistoryPageViewModel
+@{
+    static string FormatDate(DateTimeOffset value) => value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'");
+    static string FormatRelated(string? endpointId, string? endpointName, string? agentId, string? agentName)
+    {
+        var parts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(endpointId))
+        {
+            parts.Add($"Endpoint: {(string.IsNullOrWhiteSpace(endpointName) ? endpointId : endpointName)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(agentId))
+        {
+            parts.Add($"Agent: {(string.IsNullOrWhiteSpace(agentName) ? agentId : agentName)}");
+        }
+
+        return parts.Count == 0 ? "None" : string.Join(" | ", parts);
+    }
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>@Model.ScopeLabel history</title>
+    <style>
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; }
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 1180px; margin: 0 auto; padding: 1rem; }
+        .stack { display: grid; gap: 1rem; }
+        .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
+        .table-wrap { overflow-x: auto; }
+        table { width: 100%; border-collapse: collapse; min-width: 900px; }
+        th, td { text-align: left; padding: .65rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+        th { font-size: .85rem; color: var(--muted); }
+        input, select { width: 100%; padding: .65rem; border: 1px solid var(--border); border-radius: 10px; font-size: .95rem; }
+        .filter-grid { display: grid; gap: .75rem; }
+        .button-row { display: flex; gap: .75rem; flex-wrap: wrap; margin-top:.75rem; }
+        .button, .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: .7rem .95rem; border-radius: 10px; font-weight: 600; text-decoration: none; }
+        .button { border: 0; background: var(--accent); color: #fff; }
+        .button-secondary { border: 1px solid var(--border); color: var(--text); background: #fff; }
+        .muted { color: var(--muted); }
+        @@media (min-width: 880px) { .filter-grid { grid-template-columns: 1fr 220px 200px 200px 120px; align-items:end; } }
+    </style>
+</head>
+<body>
+<main>
+    <div class="stack">
+        <section class="card">
+            <h1>@Model.ScopeLabel event history</h1>
+            <p class="muted"><strong>@Model.ScopeName</strong> (@Model.ScopeId)</p>
+            <div class="button-row">
+                <a class="button-secondary" href="@Model.BackLink">Back</a>
+            </div>
+        </section>
+
+        <section class="card">
+            <h2>Filters</h2>
+            <form method="get">
+                <div class="filter-grid">
+                    <div>
+                        <label for="search">Text search</label>
+                        <input id="search" name="search" value="@Model.Filters.Search" />
+                    </div>
+                    <div>
+                        <label for="eventType">Event type</label>
+                        <select id="eventType" name="eventType">
+                            <option value="">All event types</option>
+                            @foreach (var type in Model.Filters.AvailableEventTypes)
+                            {
+                                <option value="@type" selected="@(string.Equals(Model.Filters.EventType, type, StringComparison.Ordinal))">@type</option>
+                            }
+                        </select>
+                    </div>
+                    <div>
+                        <label for="dateFromUtc">Date from (UTC)</label>
+                        <input id="dateFromUtc" type="datetime-local" name="dateFromUtc" value="@Model.Filters.DateFromUtc?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm")" />
+                    </div>
+                    <div>
+                        <label for="dateToUtc">Date to (UTC)</label>
+                        <input id="dateToUtc" type="datetime-local" name="dateToUtc" value="@Model.Filters.DateToUtc?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm")" />
+                    </div>
+                    <div>
+                        <label for="pageSize">Page size</label>
+                        <select id="pageSize" name="pageSize">
+                            @foreach (var size in new[] { 25, 50, 100 })
+                            {
+                                <option value="@size" selected="@(Model.Filters.PageSize == size)">@size</option>
+                            }
+                        </select>
+                    </div>
+                </div>
+                <div class="button-row">
+                    <button class="button" type="submit">Apply filters</button>
+                    <a class="button-secondary" href="?pageSize=@Model.Filters.PageSize">Clear filters</a>
+                </div>
+            </form>
+        </section>
+
+        <section class="card">
+            <h2>Events (@Model.Pagination.TotalCount)</h2>
+            @if (Model.Rows.Count == 0)
+            {
+                <p class="muted">@Model.EmptyMessage</p>
+            }
+            else
+            {
+                <div class="table-wrap">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Time</th>
+                                <th>Type</th>
+                                <th>Category</th>
+                                <th>Severity</th>
+                                <th>Message</th>
+                                <th>Related</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var row in Model.Rows)
+                            {
+                                <tr>
+                                    <td>@FormatDate(row.OccurredAtUtc)</td>
+                                    <td>@row.EventType</td>
+                                    <td>@row.Category</td>
+                                    <td>@row.Severity</td>
+                                    <td>@row.Message</td>
+                                    <td>@FormatRelated(row.EndpointId, row.EndpointName, row.AgentId, row.AgentName)</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+
+                <div class="button-row">
+                    @if (Model.Pagination.HasPreviousPage)
+                    {
+                        <a class="button-secondary" href="?search=@Model.Filters.Search&eventType=@Model.Filters.EventType&dateFromUtc=@Model.Filters.DateFromUtc?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm")&dateToUtc=@Model.Filters.DateToUtc?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm")&pageSize=@Model.Pagination.PageSize&page=@(Model.Pagination.Page - 1)">Previous</a>
+                    }
+                    @if (Model.Pagination.HasNextPage)
+                    {
+                        <a class="button-secondary" href="?search=@Model.Filters.Search&eventType=@Model.Filters.EventType&dateFromUtc=@Model.Filters.DateFromUtc?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm")&dateToUtc=@Model.Filters.DateToUtc?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm")&pageSize=@Model.Pagination.PageSize&page=@(Model.Pagination.Page + 1)">Next</a>
+                    }
+                    <span class="muted">Page @Model.Pagination.Page of @Model.Pagination.TotalPages</span>
+                </div>
+            }
+        </section>
+    </div>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
@@ -116,6 +116,7 @@
                             </div>
 
                             <div class="action-row" style="margin-top:.9rem;">
+                                <a class="button-secondary" href="/agents/@agent.AgentId/history">View history</a>
                                 @if (agent.Enabled)
                                 {
                                     <form method="post" action="/agents/@agent.AgentId/disable">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/History.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/History.cshtml
@@ -1,0 +1,153 @@
+@model PingMonitor.Web.ViewModels.EventLogs.EventLogHistoryPageViewModel
+@{
+    static string FormatDate(DateTimeOffset value) => value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'");
+    static string FormatRelated(string? endpointId, string? endpointName, string? agentId, string? agentName)
+    {
+        var parts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(endpointId))
+        {
+            parts.Add($"Endpoint: {(string.IsNullOrWhiteSpace(endpointName) ? endpointId : endpointName)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(agentId))
+        {
+            parts.Add($"Agent: {(string.IsNullOrWhiteSpace(agentName) ? agentId : agentName)}");
+        }
+
+        return parts.Count == 0 ? "None" : string.Join(" | ", parts);
+    }
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>@Model.ScopeLabel history</title>
+    <style>
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; }
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 1180px; margin: 0 auto; padding: 1rem; }
+        .stack { display: grid; gap: 1rem; }
+        .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
+        .table-wrap { overflow-x: auto; }
+        table { width: 100%; border-collapse: collapse; min-width: 900px; }
+        th, td { text-align: left; padding: .65rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+        th { font-size: .85rem; color: var(--muted); }
+        input, select { width: 100%; padding: .65rem; border: 1px solid var(--border); border-radius: 10px; font-size: .95rem; }
+        .filter-grid { display: grid; gap: .75rem; }
+        .button-row { display: flex; gap: .75rem; flex-wrap: wrap; margin-top:.75rem; }
+        .button, .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: .7rem .95rem; border-radius: 10px; font-weight: 600; text-decoration: none; }
+        .button { border: 0; background: var(--accent); color: #fff; }
+        .button-secondary { border: 1px solid var(--border); color: var(--text); background: #fff; }
+        .muted { color: var(--muted); }
+        @@media (min-width: 880px) { .filter-grid { grid-template-columns: 1fr 220px 200px 200px 120px; align-items:end; } }
+    </style>
+</head>
+<body>
+<main>
+    <div class="stack">
+        <section class="card">
+            <h1>@Model.ScopeLabel event history</h1>
+            <p class="muted"><strong>@Model.ScopeName</strong> (@Model.ScopeId)</p>
+            <div class="button-row">
+                <a class="button-secondary" href="@Model.BackLink">Back</a>
+            </div>
+        </section>
+
+        <section class="card">
+            <h2>Filters</h2>
+            <form method="get">
+                <div class="filter-grid">
+                    <div>
+                        <label for="search">Text search</label>
+                        <input id="search" name="search" value="@Model.Filters.Search" />
+                    </div>
+                    <div>
+                        <label for="eventType">Event type</label>
+                        <select id="eventType" name="eventType">
+                            <option value="">All event types</option>
+                            @foreach (var type in Model.Filters.AvailableEventTypes)
+                            {
+                                <option value="@type" selected="@(string.Equals(Model.Filters.EventType, type, StringComparison.Ordinal))">@type</option>
+                            }
+                        </select>
+                    </div>
+                    <div>
+                        <label for="dateFromUtc">Date from (UTC)</label>
+                        <input id="dateFromUtc" type="datetime-local" name="dateFromUtc" value="@Model.Filters.DateFromUtc?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm")" />
+                    </div>
+                    <div>
+                        <label for="dateToUtc">Date to (UTC)</label>
+                        <input id="dateToUtc" type="datetime-local" name="dateToUtc" value="@Model.Filters.DateToUtc?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm")" />
+                    </div>
+                    <div>
+                        <label for="pageSize">Page size</label>
+                        <select id="pageSize" name="pageSize">
+                            @foreach (var size in new[] { 25, 50, 100 })
+                            {
+                                <option value="@size" selected="@(Model.Filters.PageSize == size)">@size</option>
+                            }
+                        </select>
+                    </div>
+                </div>
+                <div class="button-row">
+                    <button class="button" type="submit">Apply filters</button>
+                    <a class="button-secondary" href="?pageSize=@Model.Filters.PageSize">Clear filters</a>
+                </div>
+            </form>
+        </section>
+
+        <section class="card">
+            <h2>Events (@Model.Pagination.TotalCount)</h2>
+            @if (Model.Rows.Count == 0)
+            {
+                <p class="muted">@Model.EmptyMessage</p>
+            }
+            else
+            {
+                <div class="table-wrap">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Time</th>
+                                <th>Type</th>
+                                <th>Category</th>
+                                <th>Severity</th>
+                                <th>Message</th>
+                                <th>Related</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var row in Model.Rows)
+                            {
+                                <tr>
+                                    <td>@FormatDate(row.OccurredAtUtc)</td>
+                                    <td>@row.EventType</td>
+                                    <td>@row.Category</td>
+                                    <td>@row.Severity</td>
+                                    <td>@row.Message</td>
+                                    <td>@FormatRelated(row.EndpointId, row.EndpointName, row.AgentId, row.AgentName)</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+
+                <div class="button-row">
+                    @if (Model.Pagination.HasPreviousPage)
+                    {
+                        <a class="button-secondary" href="?search=@Model.Filters.Search&eventType=@Model.Filters.EventType&dateFromUtc=@Model.Filters.DateFromUtc?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm")&dateToUtc=@Model.Filters.DateToUtc?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm")&pageSize=@Model.Pagination.PageSize&page=@(Model.Pagination.Page - 1)">Previous</a>
+                    }
+                    @if (Model.Pagination.HasNextPage)
+                    {
+                        <a class="button-secondary" href="?search=@Model.Filters.Search&eventType=@Model.Filters.EventType&dateFromUtc=@Model.Filters.DateFromUtc?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm")&dateToUtc=@Model.Filters.DateToUtc?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm")&pageSize=@Model.Pagination.PageSize&page=@(Model.Pagination.Page + 1)">Next</a>
+                    }
+                    <span class="muted">Page @Model.Pagination.Page of @Model.Pagination.TotalPages</span>
+                </div>
+            }
+        </section>
+    </div>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
@@ -133,6 +133,7 @@
                             </div>
                             <div class="button-row" style="margin-top:.85rem;">
                                 <a class="button-secondary" href="/endpoints/@row.AssignmentId/performance">View performance</a>
+                                <a class="button-secondary" href="/endpoints/@row.EndpointId/history">View history</a>
                                 @if (User.IsInRole("Admin"))
                                 {
                                     <a class="button-secondary" href="/endpoints/@row.AssignmentId/edit">Edit assignment</a>

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -73,6 +73,9 @@
         .meta-item span { display: block; font-size: .85rem; color: var(--muted); margin-bottom: .2rem; }
         .empty { text-align: center; padding: 1rem; border: 1px dashed var(--border); border-radius: 12px; }
         .inline-actions { margin-top: .85rem; }
+        .recent-events { max-height: 360px; overflow-y: auto; border: 1px solid var(--border); border-radius: 12px; }
+        .event-row { padding: .7rem; border-bottom: 1px solid var(--border); }
+        .event-row:last-child { border-bottom: 0; }
         .nowrap { white-space: nowrap; }
         @@media (min-width: 720px) {
             .summary-grid { grid-template-columns: repeat(6, minmax(0, 1fr)); }
@@ -100,6 +103,36 @@
                     <a class="button-secondary" href="/users">Manage users</a>
                 }
             </div>
+        </section>
+
+        <section class="card">
+            <h2>Recent events</h2>
+            @if (Model.RecentEvents.Count == 0)
+            {
+                <p class="muted">No events recorded yet.</p>
+            }
+            else
+            {
+                <div class="recent-events">
+                    @foreach (var recentEvent in Model.RecentEvents)
+                    {
+                        <div class="event-row">
+                            <div><strong>@recentEvent.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</strong> · @recentEvent.EventType (@recentEvent.Category)</div>
+                            <div>@recentEvent.Message</div>
+                            <div class="muted">
+                                @if (!string.IsNullOrWhiteSpace(recentEvent.EndpointId))
+                                {
+                                    <span>Endpoint: @(string.IsNullOrWhiteSpace(recentEvent.EndpointName) ? recentEvent.EndpointId : recentEvent.EndpointName)</span>
+                                }
+                                @if (!string.IsNullOrWhiteSpace(recentEvent.AgentId))
+                                {
+                                    <span> · Agent: @(string.IsNullOrWhiteSpace(recentEvent.AgentName) ? recentEvent.AgentId : recentEvent.AgentName)</span>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+            }
         </section>
 
         <section class="card">
@@ -203,6 +236,8 @@
                             </div>
                             <div class="inline-actions">
                                 <a class="button-secondary" href="/endpoints/@row.AssignmentId/performance">View performance</a>
+                                <a class="button-secondary" href="/endpoints/@row.EndpointId/history">Endpoint history</a>
+                                <a class="button-secondary" href="/agents/@row.AgentId/history">Agent history</a>
                             </div>
                         </article>
                     }


### PR DESCRIPTION
### Motivation
- Provide a focused, persistent, searchable event stream for meaningful operational events (endpoint state & agent lifecycle) without logging every raw check result.
- Surface recent operational events on the main status page and give operators full searchable, filterable history per-endpoint and per-agent for audit and troubleshooting.
- Keep the implementation explicit, MySQL-compatible, and aligned with the existing data model and startup/schema guardrails.

### Description
- Add a unified `EventLog` entity and supporting enums (`EventCategory`, `EventSeverity`, `EventType`) with EF Core mapping and MySQL-oriented indexes, and extend the startup/schema apply checks to create the `EventLogs` table and required agent column. (Fixes #150)
- Implement `IEventLogService`/`EventLogService` for writes and `IEventLogQueryService`/`EventLogQueryService` for reads, supporting recent-event queries and paginated endpoint/agent history with text/type/date filters.
- Wire event creation into key places only: endpoint state transitions (including suppression applied/cleared), agent hello (authenticated + online transition), and agent heartbeat (rate-limited heartbeat events to avoid spam).
- Add UI: a recent events panel on `/status`, an endpoint history page at `/endpoints/{endpointId}/history`, an agent history page at `/agents/{agentId}/history`, and links from status/endpoints/agents lists to their history pages; also update `docs/event-logging.md`, `docs/data-model.md`, and README to document scope and types.

### Testing
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`; the build completed successfully (one pre-existing nullable warning in `Program.cs`) and produced the web DLL.
- No unit tests were added in this change-set; manual code inspection and local build verified compilation and DI registrations for the new services.
- Startup-gate schema apply logic was updated to create the `EventLogs` table and agent column, but end-to-end DB migration and runtime validation on a MySQL instance should be run in integration environments before production rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c827c7b960832ab55e605bfe14c1b1)