### PR TITLE
Fix startup-gate cookie filtering nullable dereference warning

### DIFF
--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -151,7 +151,7 @@ builder.Services.AddHostedService(sp => sp.GetRequiredService<ConfigurationAutoB
 var app = builder.Build();
 
 var identityCookieOptionsMonitor = app.Services.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>();
-var identityApplicationCookieName = identityCookieOptionsMonitor.Get(IdentityConstants.ApplicationScheme).Cookie.Name;
+var identityApplicationCookieName = identityCookieOptionsMonitor.Get(IdentityConstants.ApplicationScheme).Cookie?.Name;
 
 app.UseForwardedHeaders();
 app.UseHttpsRedirection();
@@ -175,9 +175,13 @@ app.Use(async (context, next) =>
             context.Request.Headers.TryGetValue("Cookie", out var cookieHeaderValues))
         {
             var filteredCookieHeaders = cookieHeaderValues
-                .Select(cookieHeader => string.Join("; ", cookieHeader
-                    .Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
-                    .Where(cookiePart => !cookiePart.StartsWith($"{identityApplicationCookieName}=", StringComparison.Ordinal))))
+                .Select(cookieHeader =>
+                {
+                    var nonNullCookieHeader = cookieHeader ?? string.Empty;
+                    return string.Join("; ", nonNullCookieHeader
+                        .Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                        .Where(cookiePart => !cookiePart.StartsWith($"{identityApplicationCookieName}=", StringComparison.Ordinal)));
+                })
                 .Where(cookieHeader => !string.IsNullOrWhiteSpace(cookieHeader))
                 .ToArray();
 


### PR DESCRIPTION
### Motivation
- Remove a CS8602 nullable-dereference warning observed during release builds when reading the identity application cookie name in the startup-gate middleware while preserving existing startup-gate behavior.

### Description
- Make the identity application cookie name lookup null-safe by changing `.Cookie.Name` to `.Cookie?.Name` and normalize `cookieHeader` values to `string.Empty` before splitting/filtering so header enumeration is null-safe; change is limited to `src/WebApp/PingMonitor.Web/Program.cs` and preserves current semantics; Fixes #152.

### Testing
- Ran `dotnet build ./src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj --configuration Release` before and after the change, where the pre-change build emitted `CS8602` and the post-change build completed with `0 Warning(s)` and `0 Error(s)`, and `dotnet publish` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9110ccd0c832a8c5fae2b0a9e21d5)