### PR TITLE
Refine event logging signal and recent-events status highlighting

### DIFF
--- a/docs/event-logging.md
+++ b/docs/event-logging.md
@@ -97,8 +97,9 @@ All events are stored in a single table.
 | Event Type                  | Description |
 |----------------------------|------------|
 | agent_authenticated        | Agent successfully authenticated |
-| agent_heartbeat_received   | Heartbeat received (rate-limited for signal) |
-| agent_online               | Agent transitioned to online state |
+| agent_became_online        | Agent transitioned to online state |
+| agent_became_stale         | Agent transitioned to stale (missed heartbeat threshold) |
+| agent_became_offline       | Agent transitioned to offline (extended heartbeat loss) |
 | agent_config_fetched       | Agent fetched configuration (reserved for optional use) |
 
 ---
@@ -114,6 +115,8 @@ Messages must be:
 ### Examples
 
 - `Endpoint "Google DNS" changed state from UP to DOWN`
+- `Endpoint "DNS Server 2" went down.`
+- `Endpoint "DNS Server 2" recovered after 00:09:38 downtime.`
 - `Endpoint "API Server" suppressed due to dependency failure`
 - `Agent "Warton-Node-1" became stale (no heartbeat for 60s)`
 - `Agent "Lab-VM-3" authenticated successfully`
@@ -142,6 +145,7 @@ This field must:
 To prevent noise and database bloat, the following are explicitly excluded:
 
 - Every successful endpoint check
+- Routine successful `agent_heartbeat_received` events
 - Every retry attempt
 - Raw latency/metrics streams
 - Debug-level internal application logs

--- a/src/WebApp/PingMonitor.Web/Models/EventType.cs
+++ b/src/WebApp/PingMonitor.Web/Models/EventType.cs
@@ -6,7 +6,8 @@ public static class EventType
     public const string EndpointSuppressionApplied = "endpoint_suppression_applied";
     public const string EndpointSuppressionCleared = "endpoint_suppression_cleared";
     public const string AgentAuthenticated = "agent_authenticated";
-    public const string AgentHeartbeatReceived = "agent_heartbeat_received";
-    public const string AgentOnline = "agent_online";
+    public const string AgentBecameOnline = "agent_became_online";
+    public const string AgentBecameStale = "agent_became_stale";
+    public const string AgentBecameOffline = "agent_became_offline";
     public const string AgentConfigFetched = "agent_config_fetched";
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -147,6 +147,7 @@ builder.Services.AddScoped<IConfigurationRestoreService, ConfigurationRestoreSer
 builder.Services.AddSingleton<ConfigurationAutoBackupBackgroundService>();
 builder.Services.AddSingleton<IConfigurationChangeBackupSignal>(sp => sp.GetRequiredService<ConfigurationAutoBackupBackgroundService>());
 builder.Services.AddHostedService(sp => sp.GetRequiredService<ConfigurationAutoBackupBackgroundService>());
+builder.Services.AddHostedService<AgentStatusTransitionBackgroundService>();
 
 var app = builder.Build();
 

--- a/src/WebApp/PingMonitor.Web/Services/AgentHeartbeatService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentHeartbeatService.cs
@@ -27,7 +27,6 @@ internal sealed class AgentHeartbeatService : IHeartbeatService
         var currentConfigVersion = await _configurationService.GetCurrentConfigVersionAsync(agent, cancellationToken);
 
         var wasOnline = agent.Status == AgentHealthStatus.Online;
-        var previousHeartbeat = agent.LastHeartbeatUtc;
         agent.LastHeartbeatUtc = now;
         agent.LastSeenUtc = now;
         agent.AgentVersion = request.AgentVersion.Trim();
@@ -48,29 +47,11 @@ internal sealed class AgentHeartbeatService : IHeartbeatService
             {
                 OccurredAtUtc = now,
                 Category = EventCategory.Agent,
-                EventType = EventType.AgentOnline,
+                EventType = EventType.AgentBecameOnline,
                 Severity = EventSeverity.Info,
                 AgentId = agent.AgentId,
-                Message = $"Agent \"{agent.Name ?? agent.InstanceId}\" is now online."
+                Message = $"Agent \"{agent.Name ?? agent.InstanceId}\" became online."
             }, cancellationToken);
-        }
-
-        if (!agent.LastHeartbeatEventLoggedAtUtc.HasValue ||
-            now - agent.LastHeartbeatEventLoggedAtUtc.Value >= TimeSpan.FromMinutes(5) ||
-            (previousHeartbeat.HasValue && now - previousHeartbeat.Value >= TimeSpan.FromMinutes(5)))
-        {
-            await _eventLogService.WriteAsync(new EventLogWriteRequest
-            {
-                OccurredAtUtc = now,
-                Category = EventCategory.Agent,
-                EventType = EventType.AgentHeartbeatReceived,
-                Severity = EventSeverity.Info,
-                AgentId = agent.AgentId,
-                Message = $"Heartbeat received from agent \"{agent.Name ?? agent.InstanceId}\"."
-            }, cancellationToken);
-
-            agent.LastHeartbeatEventLoggedAtUtc = now;
-            await _dbContext.SaveChangesAsync(cancellationToken);
         }
 
         return new AgentHeartbeatResponse(

--- a/src/WebApp/PingMonitor.Web/Services/AgentHelloService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentHelloService.cs
@@ -49,10 +49,10 @@ internal sealed class AgentHelloService : IAgentHelloService
             {
                 OccurredAtUtc = now,
                 Category = EventCategory.Agent,
-                EventType = EventType.AgentOnline,
+                EventType = EventType.AgentBecameOnline,
                 Severity = EventSeverity.Info,
                 AgentId = agent.AgentId,
-                Message = $"Agent \"{agent.Name ?? agent.InstanceId}\" is now online."
+                Message = $"Agent \"{agent.Name ?? agent.InstanceId}\" became online."
             }, cancellationToken);
         }
 

--- a/src/WebApp/PingMonitor.Web/Services/AgentStatusTransitionBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentStatusTransitionBackgroundService.cs
@@ -1,0 +1,99 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.EventLogs;
+
+namespace PingMonitor.Web.Services;
+
+internal sealed class AgentStatusTransitionBackgroundService : BackgroundService
+{
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan StaleThreshold = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan OfflineThreshold = TimeSpan.FromMinutes(5);
+
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly ILogger<AgentStatusTransitionBackgroundService> _logger;
+
+    public AgentStatusTransitionBackgroundService(
+        IServiceScopeFactory serviceScopeFactory,
+        ILogger<AgentStatusTransitionBackgroundService> logger)
+    {
+        _serviceScopeFactory = serviceScopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await EvaluateTransitionsAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Agent status transition evaluation failed.");
+            }
+
+            await Task.Delay(PollInterval, stoppingToken);
+        }
+    }
+
+    private async Task EvaluateTransitionsAsync(CancellationToken cancellationToken)
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<PingMonitorDbContext>();
+        var eventLogService = scope.ServiceProvider.GetRequiredService<IEventLogService>();
+        var now = DateTimeOffset.UtcNow;
+
+        var agents = await dbContext.Agents
+            .Where(x => x.Enabled && !x.ApiKeyRevoked)
+            .ToArrayAsync(cancellationToken);
+
+        foreach (var agent in agents)
+        {
+            if (!agent.LastHeartbeatUtc.HasValue)
+            {
+                continue;
+            }
+
+            var previousStatus = agent.Status;
+            var elapsed = now - agent.LastHeartbeatUtc.Value;
+            var nextStatus = elapsed >= OfflineThreshold
+                ? AgentHealthStatus.Offline
+                : elapsed >= StaleThreshold
+                    ? AgentHealthStatus.Stale
+                    : AgentHealthStatus.Online;
+
+            if (nextStatus == previousStatus)
+            {
+                continue;
+            }
+
+            if (nextStatus == AgentHealthStatus.Online)
+            {
+                continue;
+            }
+
+            agent.Status = nextStatus;
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+            await eventLogService.WriteAsync(
+                new EventLogWriteRequest
+                {
+                    OccurredAtUtc = now,
+                    Category = EventCategory.Agent,
+                    EventType = nextStatus == AgentHealthStatus.Stale ? EventType.AgentBecameStale : EventType.AgentBecameOffline,
+                    Severity = EventSeverity.Warning,
+                    AgentId = agent.AgentId,
+                    Message = nextStatus == AgentHealthStatus.Stale
+                        ? $"Agent \"{agent.Name ?? agent.InstanceId}\" became stale."
+                        : $"Agent \"{agent.Name ?? agent.InstanceId}\" became offline."
+                },
+                cancellationToken);
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/EventLogs/EventLogQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/EventLogs/EventLogQueryService.cs
@@ -32,7 +32,8 @@ internal sealed class EventLogQueryService : IEventLogQueryService
                 EndpointName = x.EndpointName,
                 AgentId = x.AgentId,
                 AgentName = x.AgentName,
-                AssignmentId = x.AssignmentId
+                AssignmentId = x.AssignmentId,
+                RowKind = x.RowKind
             })
             .ToArrayAsync(cancellationToken);
     }
@@ -144,7 +145,8 @@ internal sealed class EventLogQueryService : IEventLogQueryService
                 EndpointName = x.EndpointName,
                 AgentId = x.AgentId,
                 AgentName = x.AgentName,
-                AssignmentId = x.AssignmentId
+                AssignmentId = x.AssignmentId,
+                RowKind = x.RowKind
             })
             .ToArrayAsync(cancellationToken);
 
@@ -201,7 +203,16 @@ internal sealed class EventLogQueryService : IEventLogQueryService
                 AgentName = agent != null ? (agent.Name ?? agent.InstanceId) : null,
                 EndpointId = eventLog.EndpointId,
                 EndpointName = endpoint != null ? endpoint.Name : null,
-                AssignmentId = eventLog.AssignmentId
+                AssignmentId = eventLog.AssignmentId,
+                RowKind = eventLog.EventCategory == Models.EventCategory.Endpoint &&
+                          eventLog.EventType == Models.EventType.EndpointStateChanged &&
+                          EF.Functions.Like(eventLog.Message, "Endpoint \"%\" went down.%")
+                    ? RecentEventRowKind.EndpointDown
+                    : eventLog.EventCategory == Models.EventCategory.Endpoint &&
+                      eventLog.EventType == Models.EventType.EndpointStateChanged &&
+                      EF.Functions.Like(eventLog.Message, "Endpoint \"%\" recovered%")
+                        ? RecentEventRowKind.EndpointRecovery
+                        : RecentEventRowKind.Default
             };
     }
 
@@ -223,5 +234,6 @@ internal sealed class EventLogQueryService : IEventLogQueryService
         public string? EndpointId { get; init; }
         public string? EndpointName { get; init; }
         public string? AssignmentId { get; init; }
+        public RecentEventRowKind RowKind { get; init; }
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Contracts.Results;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.EventLogs;
 using PingMonitor.Web.Support;
 
 namespace PingMonitor.Web.Services;
@@ -10,15 +11,18 @@ internal sealed class ResultIngestionService : IResultIngestionService
 {
     private readonly PingMonitorDbContext _dbContext;
     private readonly IStateEvaluationService _stateEvaluationService;
+    private readonly IEventLogService _eventLogService;
     private readonly ILogger<ResultIngestionService> _logger;
 
     public ResultIngestionService(
         PingMonitorDbContext dbContext,
         IStateEvaluationService stateEvaluationService,
+        IEventLogService eventLogService,
         ILogger<ResultIngestionService> logger)
     {
         _dbContext = dbContext;
         _stateEvaluationService = stateEvaluationService;
+        _eventLogService = eventLogService;
         _logger = logger;
     }
 
@@ -129,11 +133,25 @@ internal sealed class ResultIngestionService : IResultIngestionService
             _dbContext.CheckResults.AddRange(storedResults);
             _dbContext.ResultBatches.Add(batch);
 
+            var wasOnline = agent.Status == AgentHealthStatus.Online;
             agent.LastSeenUtc = receivedAtUtc;
             agent.Status = AgentHealthStatus.Online;
 
             await _dbContext.SaveChangesAsync(cancellationToken);
             await transaction.CommitAsync(cancellationToken);
+
+            if (!wasOnline)
+            {
+                await _eventLogService.WriteAsync(new EventLogWriteRequest
+                {
+                    OccurredAtUtc = receivedAtUtc,
+                    Category = EventCategory.Agent,
+                    EventType = EventType.AgentBecameOnline,
+                    Severity = EventSeverity.Info,
+                    AgentId = agent.AgentId,
+                    Message = $"Agent \"{agent.Name ?? agent.InstanceId}\" became online."
+                }, cancellationToken);
+            }
 
             var affectedAssignmentIds = storedResults
                 .Select(x => x.AssignmentId)

--- a/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
@@ -170,7 +170,13 @@ internal sealed class StateEvaluationService : IStateEvaluationService
                     AgentId = assignment.AgentId,
                     EndpointId = assignment.EndpointId,
                     AssignmentId = assignment.AssignmentId,
-                    Message = $"Endpoint \"{endpoint.Name}\" state changed from {previousState} to {nextState}.",
+                    Message = await BuildStateChangeMessageAsync(
+                        assignment.AssignmentId,
+                        endpoint.Name,
+                        previousState,
+                        nextState,
+                        transitionAtUtc,
+                        cancellationToken),
                     DetailsJson = JsonSerializer.Serialize(new
                     {
                         assignment.AssignmentId,
@@ -355,6 +361,46 @@ internal sealed class StateEvaluationService : IStateEvaluationService
         var previousWasDown = previousState == EndpointStateKind.Down;
         var newIsDown = newState == EndpointStateKind.Down;
         return previousWasDown != newIsDown;
+    }
+
+    private async Task<string> BuildStateChangeMessageAsync(
+        string assignmentId,
+        string endpointName,
+        EndpointStateKind previousState,
+        EndpointStateKind nextState,
+        DateTimeOffset transitionAtUtc,
+        CancellationToken cancellationToken)
+    {
+        if (nextState == EndpointStateKind.Down)
+        {
+            return $"Endpoint \"{endpointName}\" went down.";
+        }
+
+        if (previousState == EndpointStateKind.Down && nextState == EndpointStateKind.Up)
+        {
+            var downTransitionAtUtc = await _dbContext.StateTransitions.AsNoTracking()
+                .Where(x => x.AssignmentId == assignmentId && x.NewState == EndpointStateKind.Down)
+                .OrderByDescending(x => x.TransitionAtUtc)
+                .Select(x => (DateTimeOffset?)x.TransitionAtUtc)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (downTransitionAtUtc.HasValue && transitionAtUtc >= downTransitionAtUtc.Value)
+            {
+                var downtime = transitionAtUtc - downTransitionAtUtc.Value;
+                return $"Endpoint \"{endpointName}\" recovered after {FormatDuration(downtime)} downtime.";
+            }
+
+            return $"Endpoint \"{endpointName}\" recovered.";
+        }
+
+        return $"Endpoint \"{endpointName}\" state changed from {previousState} to {nextState}.";
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        var safeDuration = duration < TimeSpan.Zero ? TimeSpan.Zero : duration;
+        var hours = (int)safeDuration.TotalHours;
+        return $"{hours:D2}:{safeDuration.Minutes:D2}:{safeDuration.Seconds:D2}";
     }
 
     private readonly record struct ParentStateContext(string? ParentEndpointId, bool DependencyDown)

--- a/src/WebApp/PingMonitor.Web/ViewModels/EventLogs/EventLogHistoryPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/EventLogs/EventLogHistoryPageViewModel.cs
@@ -35,6 +35,7 @@ public sealed class EventLogHistoryRowViewModel
     public string? AgentId { get; init; }
     public string? AgentName { get; init; }
     public string? AssignmentId { get; init; }
+    public RecentEventRowKind RowKind { get; init; } = RecentEventRowKind.Default;
 }
 
 public sealed class EventLogHistoryPaginationViewModel
@@ -59,4 +60,12 @@ public sealed class RecentEventViewModel
     public string? AgentId { get; init; }
     public string? AgentName { get; init; }
     public string? AssignmentId { get; init; }
+    public RecentEventRowKind RowKind { get; init; } = RecentEventRowKind.Default;
+}
+
+public enum RecentEventRowKind
+{
+    Default,
+    EndpointDown,
+    EndpointRecovery
 }

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -11,6 +11,12 @@
     static string FormatDependency(string? endpointId, string? endpointName, string emptyText) => string.IsNullOrWhiteSpace(endpointId) ? emptyText : string.IsNullOrWhiteSpace(endpointName) ? $"{endpointId} (name unavailable)" : endpointName;
     static string FormatPercent(double? value) => value.HasValue ? $"{value.Value:F1}%" : "Unknown";
     static string FormatRtt(double? value) => value.HasValue ? $"{value.Value:F1} ms" : "No data";
+    static string EventRowClass(PingMonitor.Web.ViewModels.EventLogs.RecentEventRowKind rowKind) => rowKind switch
+    {
+        PingMonitor.Web.ViewModels.EventLogs.RecentEventRowKind.EndpointDown => "event-row event-row-down",
+        PingMonitor.Web.ViewModels.EventLogs.RecentEventRowKind.EndpointRecovery => "event-row event-row-recovery",
+        _ => "event-row"
+    };
     static string StateClass(EndpointStateKind state) => state switch
     {
         EndpointStateKind.Up => "state-up",
@@ -76,6 +82,8 @@
         .recent-events { max-height: 360px; overflow-y: auto; border: 1px solid var(--border); border-radius: 12px; }
         .event-row { padding: .7rem; border-bottom: 1px solid var(--border); }
         .event-row:last-child { border-bottom: 0; }
+        .event-row-down { background: #fdecec; }
+        .event-row-recovery { background: #e8f6ec; }
         .nowrap { white-space: nowrap; }
         @@media (min-width: 720px) {
             .summary-grid { grid-template-columns: repeat(6, minmax(0, 1fr)); }
@@ -116,7 +124,7 @@
                 <div class="recent-events">
                     @foreach (var recentEvent in Model.RecentEvents)
                     {
-                        <div class="event-row">
+                        <div class="@EventRowClass(recentEvent.RowKind)">
                             <div><strong>@recentEvent.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</strong> · @recentEvent.EventType (@recentEvent.Category)</div>
                             <div>@recentEvent.Message</div>
                             <div class="muted">


### PR DESCRIPTION
### Motivation

- Reduce noise in the event log by stopping routine heartbeat events and only surfacing meaningful agent lifecycle transitions. 
- Make recent events more operationally useful by surfacing clear, human-readable endpoint down/recovery messages and highlighting them in the status UI. 
- Keep behavior deterministic and MySQL-safe while following the platform constraints and event-logging guidance.

### Description

- Stop writing `agent_heartbeat_received` events from heartbeat processing and standardize agent lifecycle event types to `agent_became_online`, `agent_became_stale`, and `agent_became_offline`. (`src/WebApp/PingMonitor.Web/Services/AgentHeartbeatService.cs`, `src/WebApp/PingMonitor.Web/Models/EventType.cs`)
- Add a small background evaluator `AgentStatusTransitionBackgroundService` that updates agent `Status` to `Stale`/`Offline` based on heartbeat age and emits a single transition event when the status changes (thresholds: stale = 2m, offline = 5m). (`src/WebApp/PingMonitor.Web/Services/AgentStatusTransitionBackgroundService.cs`, registered in `Program.cs`)
- Ensure agents becoming online are logged at meaningful transitions from the `hello` and `results` code paths (`agent_became_online`). (`src/WebApp/PingMonitor.Web/Services/AgentHelloService.cs`, `src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs`)
- Improve endpoint state-change messages generated by state evaluation so new events read as operators expect: down messages now use `Endpoint "<name>" went down.` and recovery messages include downtime when deterministically calculable as `Endpoint "<name>" recovered after HH:mm:ss downtime.`; fallback to a plain recovery message if no prior DOWN transition exists. Implementation computes downtime from the most recent assignment-scoped `DOWN` StateTransition. (`src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs`)
- Add explicit recent-event row classification (`Default`, `EndpointDown`, `EndpointRecovery`) in the event projection and view models so the UI can style rows without embedding presentation logic in persistence. (`src/WebApp/PingMonitor.Web/Services/EventLogs/EventLogQueryService.cs`, `src/WebApp/PingMonitor.Web/ViewModels/EventLogs/EventLogHistoryPageViewModel.cs`)
- Apply subtle, accessible styling to the Recent Events panel to visually distinguish endpoint DOWN rows (subtle red) and recovery/UP rows (subtle green) while leaving other events unchanged. (`src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml`)
- Update `docs/event-logging.md` to reflect the new behavior: routine heartbeat events are not logged, lifecycle transitions are logged, and recovery messages include downtime where available. (`docs/event-logging.md`)
- Created and linked tracking issue for this work: `Fixes #154`.

### Testing

- Built the web app: `dotnet build src/WebApp/PingMonitor.WebApp.slnx` completed successfully using .NET SDK `10.0.104` (build succeeded with one unrelated nullable warning). (succeeded)
- Verified via code search that no runtime writes of `agent_heartbeat_received` remain in code paths (only the docs reference remains). (succeeded)
- Confirmed the event query projection and view model compile and include the new `RowKind` classification, and the status view compiles with the new CSS classes. (succeeded)

Note: No unit tests were added in this change; the primary validation performed was a successful application build and static verification of the changed event-write paths and UI projection wiring. Follow-up work could parameterize stale/offline thresholds and add regression/unit tests around downtime-message generation and the agent lifecycle evaluator.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9176f760c832ab6fee7f8320a07b6)