### PR TITLE
Add assignment status tinting on operational status page

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
@@ -64,6 +64,7 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
                 AgentInstanceId = assignmentAgent.InstanceId,
                 AgentName = assignmentAgent.Name ?? assignmentAgent.InstanceId,
                 CurrentState = endpointState != null ? endpointState.CurrentState : EndpointStateKind.Unknown,
+                StatusCssClass = GetStatusCssClass(endpointState != null ? endpointState.CurrentState : EndpointStateKind.Unknown),
                 LastCheckUtc = endpointState != null ? endpointState.LastCheckUtc : null,
                 LastStateChangeUtc = endpointState != null ? endpointState.LastStateChangeUtc : null,
                 ConsecutiveFailureCount = endpointState != null ? endpointState.ConsecutiveFailureCount : 0,
@@ -156,6 +157,7 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
                 AgentInstanceId = row.AgentInstanceId,
                 AgentName = row.AgentName,
                 CurrentState = row.CurrentState,
+                StatusCssClass = GetStatusCssClass(row.CurrentState),
                 LastCheckUtc = row.LastCheckUtc,
                 LastStateChangeUtc = row.LastStateChangeUtc,
                 ConsecutiveFailureCount = row.ConsecutiveFailureCount,
@@ -192,6 +194,7 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
                 AgentInstanceId = row.AgentInstanceId,
                 AgentName = row.AgentName,
                 CurrentState = row.CurrentState,
+                StatusCssClass = row.StatusCssClass,
                 LastCheckUtc = row.LastCheckUtc,
                 LastStateChangeUtc = row.LastStateChangeUtc,
                 ConsecutiveFailureCount = row.ConsecutiveFailureCount,
@@ -250,5 +253,17 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
         return Enum.TryParse<EndpointStateKind>(value, ignoreCase: true, out var parsedValue)
             ? parsedValue
             : null;
+    }
+
+    private static string GetStatusCssClass(EndpointStateKind state)
+    {
+        return state switch
+        {
+            EndpointStateKind.Up => "status-up",
+            EndpointStateKind.Down => "status-down",
+            EndpointStateKind.Degraded => "status-degraded",
+            EndpointStateKind.Suppressed => "status-suppressed",
+            _ => "status-unknown"
+        };
     }
 }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Status/EndpointStatusPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Status/EndpointStatusPageViewModel.cs
@@ -50,6 +50,7 @@ public sealed class EndpointStatusRowViewModel
     public string AgentInstanceId { get; init; } = string.Empty;
     public string AgentName { get; init; } = string.Empty;
     public EndpointStateKind CurrentState { get; init; } = EndpointStateKind.Unknown;
+    public string StatusCssClass { get; init; } = "status-unknown";
     public DateTimeOffset? LastCheckUtc { get; init; }
     public DateTimeOffset? LastStateChangeUtc { get; init; }
     public int ConsecutiveFailureCount { get; init; }

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -106,7 +106,22 @@
         .state-degraded { color: var(--degraded); background: #fff7e6; }
         .muted { color: var(--muted); }
         .row-list { display: grid; gap: .9rem; }
-        .status-row { border: 1px solid var(--border); border-radius: 12px; padding: 1rem; }
+        .status-row {
+            border: 1px solid var(--border);
+            border-left: 4px solid var(--border);
+            border-radius: 12px;
+            padding: 1rem;
+            background: #fff;
+            transition: box-shadow .15s ease, border-color .15s ease;
+        }
+        .status-row:hover {
+            box-shadow: 0 2px 8px rgba(16,24,40,.08);
+        }
+        .status-row.status-up { background: #f1fbf4; border-left-color: #1f8f4b; }
+        .status-row.status-down { background: #fff3f2; border-left-color: #d92d20; }
+        .status-row.status-degraded { background: #fff8ec; border-left-color: #dc6803; }
+        .status-row.status-unknown { background: #fffdf0; border-left-color: #ca8504; }
+        .status-row.status-suppressed { background: #f7f8fa; border-left-color: #667085; }
         .status-row h2 { margin: 0; font-size: 1.1rem; }
         .row-header { display: flex; flex-direction: column; gap: .75rem; margin-bottom: .85rem; }
         .row-meta { grid-template-columns: repeat(2, minmax(0, 1fr)); }
@@ -277,7 +292,7 @@
                 <div class="row-list">
                     @foreach (var row in Model.Rows)
                     {
-                        <article class="status-row">
+                        <article class="status-row @row.StatusCssClass">
                             <div class="row-header">
                                 <div>
                                     <h2>@EndpointIconCatalog.GetSymbol(row.IconKey) @row.EndpointName</h2>


### PR DESCRIPTION
### Motivation
- Improve operator scanability of the operational status page by applying subtle per-assignment background tints and an accent to reflect the assignment's current state without changing server-side state logic. 

### Description
- Exposed an explicit CSS class on each assignment row by adding `StatusCssClass` to `EndpointStatusRowViewModel` and populating it in `EndpointStatusQueryService` via a centralized `GetStatusCssClass` switch so state-to-style mapping is deterministic and maintainable. 
- Mapping implemented: `UP -> status-up`, `DOWN -> status-down`, `DEGRADED -> status-degraded`, `UNKNOWN -> status-unknown`, `SUPPRESSED -> status-suppressed` (class names kept explicit). 
- Applied the CSS class at the assignment container level in the status view by adding `@row.StatusCssClass` to the `article.status-row` element so colouring is per-assignment only. 
- Added light background tints plus a stronger left-border accent and a hover shadow to keep contrast and interactivity; existing state badge and layout were preserved so there are no behavior or layout rewrites. 
- Files changed: `src/WebApp/PingMonitor.Web/ViewModels/Status/EndpointStatusPageViewModel.cs`, `src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs`, `src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml`. 
- Issue linkage: Fixes #160. 

### Testing
- Created issue on GitHub successfully for traceability (`Issue #160`). 
- Built the web project to verify compilation on .NET 10 using `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, and the build succeeded. 
- No automated UI screenshot tool was available in this environment, so visual verification should be performed in a reviewer browser; unit/state-engine behaviour was not changed so state tests were not required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c920c49be4832a9dd09195d967d369)