### PR TITLE
Add assignment state-duration display to operational status page

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
@@ -33,6 +33,7 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
         string? search,
         CancellationToken cancellationToken)
     {
+        var nowUtc = DateTimeOffset.UtcNow;
         var normalizedState = Normalize(state);
 
         var principal = _httpContextAccessor.HttpContext?.User;
@@ -67,6 +68,8 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
                 StatusCssClass = GetStatusCssClass(endpointState != null ? endpointState.CurrentState : EndpointStateKind.Unknown),
                 LastCheckUtc = endpointState != null ? endpointState.LastCheckUtc : null,
                 LastStateChangeUtc = endpointState != null ? endpointState.LastStateChangeUtc : null,
+                CurrentStateDuration = endpointState != null ? GetCurrentStateDuration(endpointState.CurrentState, endpointState.LastStateChangeUtc, nowUtc) : null,
+                CurrentStateDurationDisplay = endpointState != null ? FormatCurrentStateDuration(endpointState.CurrentState, endpointState.LastStateChangeUtc, nowUtc) : "—",
                 ConsecutiveFailureCount = endpointState != null ? endpointState.ConsecutiveFailureCount : 0,
                 ConsecutiveSuccessCount = endpointState != null ? endpointState.ConsecutiveSuccessCount : 0,
                 CheckType = assignment.CheckType.ToString(),
@@ -160,6 +163,8 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
                 StatusCssClass = GetStatusCssClass(row.CurrentState),
                 LastCheckUtc = row.LastCheckUtc,
                 LastStateChangeUtc = row.LastStateChangeUtc,
+                CurrentStateDuration = row.CurrentStateDuration,
+                CurrentStateDurationDisplay = row.CurrentStateDurationDisplay,
                 ConsecutiveFailureCount = row.ConsecutiveFailureCount,
                 ConsecutiveSuccessCount = row.ConsecutiveSuccessCount,
                 CheckType = row.CheckType,
@@ -197,6 +202,8 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
                 StatusCssClass = row.StatusCssClass,
                 LastCheckUtc = row.LastCheckUtc,
                 LastStateChangeUtc = row.LastStateChangeUtc,
+                CurrentStateDuration = row.CurrentStateDuration,
+                CurrentStateDurationDisplay = row.CurrentStateDurationDisplay,
                 ConsecutiveFailureCount = row.ConsecutiveFailureCount,
                 ConsecutiveSuccessCount = row.ConsecutiveSuccessCount,
                 CheckType = row.CheckType,
@@ -265,5 +272,61 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
             EndpointStateKind.Suppressed => "status-suppressed",
             _ => "status-unknown"
         };
+    }
+
+    private static TimeSpan? GetCurrentStateDuration(EndpointStateKind state, DateTimeOffset? lastStateChangeUtc, DateTimeOffset nowUtc)
+    {
+        if (!lastStateChangeUtc.HasValue)
+        {
+            return null;
+        }
+
+        if (state == EndpointStateKind.Unknown)
+        {
+            return null;
+        }
+
+        var duration = nowUtc - lastStateChangeUtc.Value;
+        return duration < TimeSpan.Zero ? TimeSpan.Zero : duration;
+    }
+
+    private static string FormatCurrentStateDuration(EndpointStateKind state, DateTimeOffset? lastStateChangeUtc, DateTimeOffset nowUtc)
+    {
+        var duration = GetCurrentStateDuration(state, lastStateChangeUtc, nowUtc);
+        if (!duration.HasValue)
+        {
+            return "—";
+        }
+
+        var prefix = state switch
+        {
+            EndpointStateKind.Up => "Up for",
+            EndpointStateKind.Down => "Down for",
+            EndpointStateKind.Suppressed => "Suppressed for",
+            EndpointStateKind.Degraded => "Degraded for",
+            _ => null
+        };
+
+        if (prefix is null)
+        {
+            return "—";
+        }
+
+        return $"{prefix} {FormatDuration(duration.Value)}";
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        if (duration.TotalDays >= 1d)
+        {
+            return $"{(int)duration.TotalDays}d {duration.Hours:00}h {duration.Minutes:00}m";
+        }
+
+        if (duration.TotalHours >= 1d)
+        {
+            return $"{(int)duration.TotalHours}h {duration.Minutes:00}m";
+        }
+
+        return $"{duration.Minutes:00}m {duration.Seconds:00}s";
     }
 }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Status/EndpointStatusPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Status/EndpointStatusPageViewModel.cs
@@ -53,6 +53,8 @@ public sealed class EndpointStatusRowViewModel
     public string StatusCssClass { get; init; } = "status-unknown";
     public DateTimeOffset? LastCheckUtc { get; init; }
     public DateTimeOffset? LastStateChangeUtc { get; init; }
+    public TimeSpan? CurrentStateDuration { get; init; }
+    public string CurrentStateDurationDisplay { get; init; } = "—";
     public int ConsecutiveFailureCount { get; init; }
     public int ConsecutiveSuccessCount { get; init; }
     public string CheckType { get; init; } = string.Empty;

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -306,6 +306,7 @@
                                 <div class="meta-item"><span>Check type</span><div>@row.CheckType</div></div>
                                 <div class="meta-item"><span>Last check</span><div class="nowrap">@FormatDate(row.LastCheckUtc)</div></div>
                                 <div class="meta-item"><span>Last state change</span><div class="nowrap">@FormatDate(row.LastStateChangeUtc)</div></div>
+                                <div class="meta-item"><span>Current state duration</span><div>@row.CurrentStateDurationDisplay</div></div>
                                 <div class="meta-item"><span>Consecutive failures</span><div>@row.ConsecutiveFailureCount</div></div>
                                 <div class="meta-item"><span>Consecutive successes</span><div>@row.ConsecutiveSuccessCount</div></div>
                                 <div class="meta-item"><span>Endpoint uptime (24h)</span><div>@FormatPercent(row.UptimePercent)</div></div>


### PR DESCRIPTION
### Motivation
- Operators need to see how long an assignment has been in its current meaningful state beside the existing uptime percentage so incidents can be triaged faster.
- The duration must be deterministic, server-derived, and based on the authoritative transition timestamp (`lastStateChangeUtc`) rather than any agent-supplied values.

### Description
- Added two fields to the status page row view-model: `CurrentStateDuration` (`TimeSpan?`) and `CurrentStateDurationDisplay` (`string`) with a `—` fallback in `EndpointStatusRowViewModel` in `EndpointStatusPageViewModel.cs`.
- Computed duration server-side in `EndpointStatusQueryService.GetStatusPageAsync` using a single `nowUtc = DateTimeOffset.UtcNow` snapshot and `duration = nowUtc - lastStateChangeUtc`, clamping negative durations to zero and returning `null` when `lastStateChangeUtc` is unavailable or state is `UNKNOWN`.
- Added helper formatting that emits human-friendly strings and labels per state (e.g. `Up for X`, `Down for X`, `Suppressed for X`, `Degraded for X`, and `—` when unavailable) in `EndpointStatusQueryService.cs` and populated the row with both raw and display-ready values.
- Rendered the new display in the UI by adding a `Current state duration` meta field to the operational status page view `Views/Status/Index.cshtml` and kept the existing 24h uptime percentage unchanged.
- Files changed: `src/WebApp/PingMonitor.Web/ViewModels/Status/EndpointStatusPageViewModel.cs`, `src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs`, `src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml`.
- Issue linkage: created GitHub issue `#162` and linked it from this change (`Fixes #162`).

### Testing
- Built the web project with the .NET 10 SDK using `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully (build passed).
- Verified the toolchain in the environment (`dotnet --version` => `10.0.104`, `pwsh --version` => `7.6.0`).
- No automated unit tests were added for the new formatter in this change; build validation passed and the change is read-side only so runtime behavior and alerting logic were not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c92ae52cdc832a96efd63aae2c04eb)