### PR TITLE
Make operational status assignments collapsible by default

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -110,9 +110,9 @@
             border: 1px solid var(--border);
             border-left: 4px solid var(--border);
             border-radius: 12px;
-            padding: 1rem;
             background: #fff;
             transition: box-shadow .15s ease, border-color .15s ease;
+            overflow: hidden;
         }
         .status-row:hover {
             box-shadow: 0 2px 8px rgba(16,24,40,.08);
@@ -122,8 +122,25 @@
         .status-row.status-degraded { background: #fff8ec; border-left-color: #dc6803; }
         .status-row.status-unknown { background: #fffdf0; border-left-color: #ca8504; }
         .status-row.status-suppressed { background: #f7f8fa; border-left-color: #667085; }
-        .status-row h2 { margin: 0; font-size: 1.1rem; }
-        .row-header { display: flex; flex-direction: column; gap: .75rem; margin-bottom: .85rem; }
+        .status-row h2 { margin: 0; font-size: 1.05rem; }
+        .row-header { display: grid; grid-template-columns: auto 1fr auto; gap: .65rem; align-items: start; }
+        .row-header-main { min-width: 0; }
+        .row-header-subtitle { font-size: .9rem; color: var(--muted); margin-top: .15rem; word-break: break-word; }
+        .summary-grid-row { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .6rem .8rem; min-width: 0; }
+        .summary-item-compact { min-width: 0; }
+        .summary-item-compact span { display: block; font-size: .74rem; color: var(--muted); text-transform: uppercase; letter-spacing: .03em; }
+        .summary-item-compact strong { font-size: .92rem; }
+        .summary-chevron { width: 1.25rem; text-align: center; color: var(--muted); font-size: 1rem; line-height: 1.2rem; }
+        .status-details > summary {
+            list-style: none;
+            cursor: pointer;
+            padding: .85rem;
+        }
+        .status-details > summary::-webkit-details-marker { display: none; }
+        .status-details > summary:focus-visible { outline: 3px solid var(--accent); outline-offset: -3px; border-radius: 10px; }
+        .status-details[open] .summary-chevron { transform: rotate(90deg); }
+        .status-details-body { padding: 0 .85rem .85rem .85rem; }
+        .row-detail-intro { display: flex; flex-direction: column; gap: .75rem; margin-bottom: .85rem; }
         .row-meta { grid-template-columns: repeat(2, minmax(0, 1fr)); }
         .meta-item { min-width: 0; }
         .meta-item span { display: block; font-size: .85rem; color: var(--muted); margin-bottom: .2rem; }
@@ -140,7 +157,11 @@
         @@media (min-width: 720px) {
             .summary-grid { grid-template-columns: repeat(6, minmax(0, 1fr)); }
             .filter-grid { grid-template-columns: 1fr 220px 220px 220px; align-items: end; }
-            .row-header { flex-direction: row; justify-content: space-between; align-items: start; }
+            .status-details > summary { padding: .95rem 1rem; }
+            .status-details-body { padding: 0 1rem 1rem 1rem; }
+            .row-header { grid-template-columns: auto minmax(340px, 1fr) auto auto; gap: .9rem; }
+            .summary-grid-row { grid-template-columns: repeat(4, minmax(0, 1fr)); gap: .7rem .9rem; }
+            .row-detail-intro { flex-direction: row; justify-content: space-between; align-items: start; }
             .row-meta { grid-template-columns: repeat(4, minmax(0, 1fr)); }
         }
     </style>
@@ -293,38 +314,70 @@
                     @foreach (var row in Model.Rows)
                     {
                         <article class="status-row @row.StatusCssClass">
-                            <div class="row-header">
-                                <div>
-                                    <h2>@EndpointIconCatalog.GetSymbol(row.IconKey) @row.EndpointName</h2>
-                                    <div class="muted">@row.Target</div>
-                                </div>
-                                <div class="badge @StateClass(row.CurrentState)">@row.CurrentState</div>
-                            </div>
+                            <details class="status-details">
+                                <summary>
+                                    <div class="row-header">
+                                        <div class="summary-chevron" aria-hidden="true">▶</div>
+                                        <div class="row-header-main">
+                                            <h2>@EndpointIconCatalog.GetSymbol(row.IconKey) @row.EndpointName</h2>
+                                            <div class="row-header-subtitle">@row.Target</div>
+                                        </div>
+                                        <div class="summary-grid-row">
+                                            <div class="summary-item-compact">
+                                                <span>State duration</span>
+                                                <strong>@row.CurrentStateDurationDisplay</strong>
+                                            </div>
+                                            <div class="summary-item-compact">
+                                                <span>Uptime (24h)</span>
+                                                <strong>@FormatPercent(row.UptimePercent)</strong>
+                                            </div>
+                                            <div class="summary-item-compact">
+                                                <span>Last RTT</span>
+                                                <strong>@FormatRtt(row.LastRttMs)</strong>
+                                            </div>
+                                            <div class="summary-item-compact">
+                                                <span>Agent</span>
+                                                <strong>@row.AgentInstanceId</strong>
+                                            </div>
+                                        </div>
+                                        <div class="badge @StateClass(row.CurrentState)">@row.CurrentState</div>
+                                    </div>
+                                </summary>
+                                <div class="status-details-body">
+                                    <div class="row-detail-intro">
+                                        <div>
+                                            <h2>@EndpointIconCatalog.GetSymbol(row.IconKey) @row.EndpointName</h2>
+                                            <div class="muted">@row.Target</div>
+                                        </div>
+                                        <div class="badge @StateClass(row.CurrentState)">@row.CurrentState</div>
+                                    </div>
 
-                            <div class="row-meta">
-                                <div class="meta-item"><span>Agent / instance</span><div>@row.AgentName <span class="muted">(@row.AgentInstanceId)</span></div></div>
-                                <div class="meta-item"><span>Check type</span><div>@row.CheckType</div></div>
-                                <div class="meta-item"><span>Last check</span><div class="nowrap">@FormatDate(row.LastCheckUtc)</div></div>
-                                <div class="meta-item"><span>Last state change</span><div class="nowrap">@FormatDate(row.LastStateChangeUtc)</div></div>
-                                <div class="meta-item"><span>Current state duration</span><div>@row.CurrentStateDurationDisplay</div></div>
-                                <div class="meta-item"><span>Consecutive failures</span><div>@row.ConsecutiveFailureCount</div></div>
-                                <div class="meta-item"><span>Consecutive successes</span><div>@row.ConsecutiveSuccessCount</div></div>
-                                <div class="meta-item"><span>Endpoint uptime (24h)</span><div>@FormatPercent(row.UptimePercent)</div></div>
-                                <div class="meta-item"><span>Last RTT (24h)</span><div>@FormatRtt(row.LastRttMs)</div></div>
-                                <div class="meta-item"><span>Average RTT (24h)</span><div>@FormatRtt(row.AverageRttMs)</div></div>
-                                <div class="meta-item"><span>Groups</span><div>@(row.GroupNames.Count == 0 ? "None" : string.Join(", ", row.GroupNames))</div></div>
-                                <div class="meta-item"><span>Dependency parents</span><div>@FormatDependencies(row.ParentEndpointIds, row.ParentEndpointNames, "None")</div></div>
-                                <div class="meta-item"><span>Suppressed by</span><div>@FormatDependency(row.SuppressedByEndpointId, row.SuppressedByEndpointName, "Not suppressed")</div></div>
-                                <div class="meta-item"><span>Assignment enabled</span><div>@(row.AssignmentEnabled ? "Enabled" : "Disabled")</div></div>
-                                <div class="meta-item"><span>Endpoint enabled</span><div>@(row.EndpointEnabled ? "Enabled" : "Disabled")</div></div>
-                                <div class="meta-item"><span>Assignment ID</span><div>@row.AssignmentId</div></div>
-                                <div class="meta-item"><span>Endpoint ID</span><div>@row.EndpointId</div></div>
-                            </div>
-                            <div class="inline-actions">
-                                <a class="button-secondary" href="/endpoints/@row.AssignmentId/performance">View performance</a>
-                                <a class="button-secondary" href="/endpoints/@row.EndpointId/history">Endpoint history</a>
-                                <a class="button-secondary" href="/agents/@row.AgentId/history">Agent history</a>
-                            </div>
+                                    <div class="row-meta">
+                                        <div class="meta-item"><span>Agent / instance</span><div>@row.AgentName <span class="muted">(@row.AgentInstanceId)</span></div></div>
+                                        <div class="meta-item"><span>Check type</span><div>@row.CheckType</div></div>
+                                        <div class="meta-item"><span>Last check</span><div class="nowrap">@FormatDate(row.LastCheckUtc)</div></div>
+                                        <div class="meta-item"><span>Last state change</span><div class="nowrap">@FormatDate(row.LastStateChangeUtc)</div></div>
+                                        <div class="meta-item"><span>Current state duration</span><div>@row.CurrentStateDurationDisplay</div></div>
+                                        <div class="meta-item"><span>Consecutive failures</span><div>@row.ConsecutiveFailureCount</div></div>
+                                        <div class="meta-item"><span>Consecutive successes</span><div>@row.ConsecutiveSuccessCount</div></div>
+                                        <div class="meta-item"><span>Endpoint uptime (24h)</span><div>@FormatPercent(row.UptimePercent)</div></div>
+                                        <div class="meta-item"><span>Last RTT (24h)</span><div>@FormatRtt(row.LastRttMs)</div></div>
+                                        <div class="meta-item"><span>Average RTT (24h)</span><div>@FormatRtt(row.AverageRttMs)</div></div>
+                                        <div class="meta-item"><span>Groups</span><div>@(row.GroupNames.Count == 0 ? "None" : string.Join(", ", row.GroupNames))</div></div>
+                                        <div class="meta-item"><span>Dependency parents</span><div>@FormatDependencies(row.ParentEndpointIds, row.ParentEndpointNames, "None")</div></div>
+                                        <div class="meta-item"><span>Suppressed by</span><div>@FormatDependency(row.SuppressedByEndpointId, row.SuppressedByEndpointName, "Not suppressed")</div></div>
+                                        <div class="meta-item"><span>Assignment enabled</span><div>@(row.AssignmentEnabled ? "Enabled" : "Disabled")</div></div>
+                                        <div class="meta-item"><span>Endpoint enabled</span><div>@(row.EndpointEnabled ? "Enabled" : "Disabled")</div></div>
+                                        <div class="meta-item"><span>Assignment ID</span><div>@row.AssignmentId</div></div>
+                                        <div class="meta-item"><span>Endpoint ID</span><div>@row.EndpointId</div></div>
+                                    </div>
+                                    <div class="inline-actions">
+                                        <a class="button-secondary" href="/endpoints/@row.AssignmentId/performance">View performance</a>
+                                        <a class="button-secondary" href="/endpoints/@row.EndpointId/history">Endpoint history</a>
+                                        <a class="button-secondary" href="/agents/@row.AgentId/history">Agent history</a>
+                                    </div>
+                                </div>
+                            </details>
                         </article>
                     }
                 </div>


### PR DESCRIPTION
### Motivation
- Improve scanability and mobile usability of the Operational Status page by collapsing assignment details by default while keeping full details available on demand.
- Surface a compact, at-a-glance summary (assignment name, hostname/IP, current state, state duration, 24h uptime, last RTT) so operators can scan many assignments quickly.
- Keep all state calculation and server-side semantics unchanged and avoid heavy JavaScript by using native HTML semantics.
- Follow repository issue workflow by creating and linking an issue before implementation (see #164).

### Description
- Converted each assignment card into a semantic `<details>/<summary>` block so assignments are collapsed by default and expandable via the header click affordance.
- Added compact collapsed header layout and styling (chevron, compact grid) showing assignment name, target hostname/IP, current state badge, current state duration, uptime (24h), and last RTT, while preserving expanded content (agent, dependency info, counters, last check/time, enabled flags, IDs, and action links).
- Kept status tinting/colouring and responsive/mobile-first layout; introduced small CSS adjustments to support compact summary and rotated chevron when expanded.
- No backend/state-engine changes were made; `LastRttMs` and `UptimePercent` are consumed from the existing metrics projection on the view model and rendered with a graceful fallback when absent.
- Created issue #164 before implementation and linked it from the PR description.

### Testing
- Built the web project with the .NET 10 SDK using `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully (build passed).
- Verified presence of required summary fields in the generated markup and that assignments are collapsed by default by inspecting the view file (collapsed behavior is provided by absence of the `open` attribute on `<details>`).
- Created the tracking GitHub issue via the API (issue #164) as part of the workflow validation.
- Note: no automated UI screenshot tests were executed in this environment; visual verification is recommended in a browser as a follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9304cfe20832aae792383fae8f3f4)