### PR TITLE
Add phase-1 security auth logging and admin security logs page

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -440,6 +440,37 @@ Represents a meaningful endpoint/agent operational event.
 
 ---
 
+### SecurityAuthLog
+
+Represents one persisted authentication attempt for user or agent access.
+
+#### Purpose
+
+- auditable authentication timeline
+- operator-facing security visibility
+- supports review of successful and failed auth attempts
+
+#### Key fields
+
+- `securityAuthLogId`
+- `occurredAtUtc`
+- `authType` (`User` / `Agent`)
+- `subjectIdentifier`
+- `sourceIpAddress` (nullable)
+- `success`
+- `failureReason` (nullable)
+- `userId` (nullable)
+- `agentId` (nullable)
+- `detailsJson` (nullable, non-secret metadata only)
+
+#### Constraints
+
+- append-only
+- secrets (passwords, bearer tokens, API keys) must not be stored
+- indexed by `occurredAtUtc`, (`authType`, `occurredAtUtc`), (`authType`, `success`, `occurredAtUtc`)
+
+---
+
 ### AlertEvent
 
 Represents an alert lifecycle.

--- a/docs/security-logging.md
+++ b/docs/security-logging.md
@@ -1,0 +1,88 @@
+# Security logging (phase 1)
+
+## Purpose
+
+Phase 1 adds auditable, persistent authentication-attempt logging for operators.
+
+This phase covers:
+
+- user authentication attempts
+- agent authentication attempts
+- a read-only admin page for reviewing recent attempts
+
+This phase does **not** add active controls (lockouts, blocking, rate limiting, firewall actions).
+
+---
+
+## What is logged
+
+Authentication attempts are persisted as `SecurityAuthLog` rows.
+
+Each row records one authentication attempt with:
+
+- `SecurityAuthLogId`
+- `OccurredAtUtc`
+- `AuthType` (`User` or `Agent`)
+- `SubjectIdentifier` (username/email for users, instance id for agents when available)
+- `SourceIpAddress` (nullable)
+- `Success`
+- `FailureReason` (nullable)
+- `UserId` (nullable)
+- `AgentId` (nullable)
+- `DetailsJson` (nullable, non-secret context only)
+
+---
+
+## User authentication attempt logging
+
+The user login flow records both successful and failed login attempts.
+
+Expected failure-reason examples:
+
+- `unknown_user`
+- `invalid_password`
+- `account_locked`
+- `login_not_allowed`
+- `two_factor_required`
+
+No passwords or secret material are logged.
+
+---
+
+## Agent authentication attempt logging
+
+Agent API authentication records both successful and failed attempts for `/api/v1/agent/*` endpoints.
+
+Expected failure-reason examples:
+
+- `missing_instance_header`
+- `missing_or_invalid_bearer_token`
+- `unknown_instance`
+- `disabled_agent`
+- `revoked_key`
+- `invalid_key`
+
+No bearer tokens, API keys, or secret material are logged.
+
+---
+
+## Security logs/settings page (phase 1)
+
+A read-only admin page exposes recent authentication attempts in two panels:
+
+- user authentication attempts
+- agent authentication attempts
+
+Each entry shows:
+
+- UTC date/time
+- source IP
+- subject identifier
+- success/failure
+- failure reason (if present)
+
+Default behavior is failure-focused:
+
+- successful attempts are hidden by default
+- operator can enable a simple toggle to include successful attempts
+

--- a/src/WebApp/PingMonitor.Web/Controllers/AccountController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AccountController.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Models.Identity;
+using PingMonitor.Web.Services.Security;
 
 namespace PingMonitor.Web.Controllers;
 
@@ -11,10 +12,17 @@ namespace PingMonitor.Web.Controllers;
 public sealed class AccountController : Controller
 {
     private readonly SignInManager<ApplicationUser> _signInManager;
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly ISecurityAuthLogService _securityAuthLogService;
 
-    public AccountController(SignInManager<ApplicationUser> signInManager)
+    public AccountController(
+        SignInManager<ApplicationUser> signInManager,
+        UserManager<ApplicationUser> userManager,
+        ISecurityAuthLogService securityAuthLogService)
     {
         _signInManager = signInManager;
+        _userManager = userManager;
+        _securityAuthLogService = securityAuthLogService;
     }
 
     [HttpGet("login")]
@@ -27,19 +35,72 @@ public sealed class AccountController : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Login([FromForm] LoginViewModel model)
     {
+        var normalizedUserName = model.UserName?.Trim() ?? string.Empty;
+
         if (!ModelState.IsValid)
         {
             return View("Login", model);
         }
 
-        var result = await _signInManager.PasswordSignInAsync(model.UserName, model.Password, isPersistent: false, lockoutOnFailure: true);
+        var user = await _userManager.FindByNameAsync(normalizedUserName) ??
+                   await _userManager.FindByEmailAsync(normalizedUserName);
+
+        var signInIdentifier = user?.UserName ?? normalizedUserName;
+        var result = await _signInManager.PasswordSignInAsync(signInIdentifier, model.Password, isPersistent: false, lockoutOnFailure: true);
         if (!result.Succeeded)
         {
+            await _securityAuthLogService.LogUserAttemptAsync(
+                new UserAuthLogWriteRequest
+                {
+                    SubjectIdentifier = normalizedUserName,
+                    UserId = user?.Id,
+                    SourceIpAddress = HttpContext.Connection.RemoteIpAddress?.ToString(),
+                    Success = false,
+                    FailureReason = BuildFailureReason(result, user)
+                },
+                HttpContext.RequestAborted);
+
             ModelState.AddModelError(string.Empty, "Invalid credentials.");
             return View("Login", model);
         }
 
+        await _securityAuthLogService.LogUserAttemptAsync(
+            new UserAuthLogWriteRequest
+            {
+                SubjectIdentifier = normalizedUserName,
+                UserId = user?.Id,
+                SourceIpAddress = HttpContext.Connection.RemoteIpAddress?.ToString(),
+                Success = true,
+                FailureReason = null
+            },
+            HttpContext.RequestAborted);
+
         return LocalRedirect(string.IsNullOrWhiteSpace(model.ReturnUrl) ? "/status" : model.ReturnUrl);
+    }
+
+    private static string BuildFailureReason(Microsoft.AspNetCore.Identity.SignInResult result, ApplicationUser? user)
+    {
+        if (result.IsLockedOut)
+        {
+            return "account_locked";
+        }
+
+        if (result.IsNotAllowed)
+        {
+            return "login_not_allowed";
+        }
+
+        if (result.RequiresTwoFactor)
+        {
+            return "two_factor_required";
+        }
+
+        if (user is null)
+        {
+            return "unknown_user";
+        }
+
+        return "invalid_password";
     }
 
     [HttpPost("logout")]

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminSecurityController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminSecurityController.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.Identity;
+using PingMonitor.Web.Services.Security;
+using PingMonitor.Web.ViewModels.Admin;
+
+namespace PingMonitor.Web.Controllers;
+
+[Authorize(Roles = ApplicationRoles.Admin)]
+[Route("admin/security")]
+public sealed class AdminSecurityController : Controller
+{
+    private const int DefaultLogLimit = 100;
+    private readonly ISecurityAuthLogQueryService _securityAuthLogQueryService;
+
+    public AdminSecurityController(ISecurityAuthLogQueryService securityAuthLogQueryService)
+    {
+        _securityAuthLogQueryService = securityAuthLogQueryService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Index([FromQuery] bool includeSuccessfulUsers = false, [FromQuery] bool includeSuccessfulAgents = false, CancellationToken cancellationToken = default)
+    {
+        var userAttempts = await _securityAuthLogQueryService.GetRecentAsync(
+            new SecurityAuthLogQuery
+            {
+                AuthType = SecurityAuthType.User,
+                IncludeSuccessful = includeSuccessfulUsers,
+                Limit = DefaultLogLimit
+            },
+            cancellationToken);
+
+        var agentAttempts = await _securityAuthLogQueryService.GetRecentAsync(
+            new SecurityAuthLogQuery
+            {
+                AuthType = SecurityAuthType.Agent,
+                IncludeSuccessful = includeSuccessfulAgents,
+                Limit = DefaultLogLimit
+            },
+            cancellationToken);
+
+        return View("Index", new AdminSecurityPageViewModel
+        {
+            IncludeSuccessfulUserAttempts = includeSuccessfulUsers,
+            IncludeSuccessfulAgentAttempts = includeSuccessfulAgents,
+            UserAttempts = userAttempts,
+            AgentAttempts = agentAttempts
+        });
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -30,6 +30,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
     public DbSet<EndpointState> EndpointStates => Set<EndpointState>();
     public DbSet<StateTransition> StateTransitions => Set<StateTransition>();
     public DbSet<EventLog> EventLogs => Set<EventLog>();
+    public DbSet<SecurityAuthLog> SecurityAuthLogs => Set<SecurityAuthLog>();
     public DbSet<AppSchemaInfo> AppSchemaInfos => Set<AppSchemaInfo>();
     public DbSet<ApplicationSettings> ApplicationSettings => Set<ApplicationSettings>();
 
@@ -217,6 +218,22 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         eventLog.HasIndex(x => new { x.EndpointId, x.OccurredAtUtc });
         eventLog.HasIndex(x => new { x.AgentId, x.OccurredAtUtc });
         eventLog.HasIndex(x => new { x.AssignmentId, x.OccurredAtUtc });
+
+        var securityAuthLog = modelBuilder.Entity<SecurityAuthLog>();
+        securityAuthLog.ToTable("SecurityAuthLogs");
+        securityAuthLog.HasKey(x => x.SecurityAuthLogId);
+        securityAuthLog.Property(x => x.SecurityAuthLogId).HasMaxLength(64);
+        securityAuthLog.Property(x => x.OccurredAtUtc).IsRequired();
+        securityAuthLog.Property(x => x.AuthType).HasConversion<string>().HasMaxLength(16).IsRequired();
+        securityAuthLog.Property(x => x.SubjectIdentifier).HasMaxLength(255).IsRequired();
+        securityAuthLog.Property(x => x.SourceIpAddress).HasMaxLength(64);
+        securityAuthLog.Property(x => x.FailureReason).HasMaxLength(128);
+        securityAuthLog.Property(x => x.UserId).HasMaxLength(255);
+        securityAuthLog.Property(x => x.AgentId).HasMaxLength(64);
+        securityAuthLog.Property(x => x.DetailsJson).HasMaxLength(4096);
+        securityAuthLog.HasIndex(x => x.OccurredAtUtc);
+        securityAuthLog.HasIndex(x => new { x.AuthType, x.OccurredAtUtc });
+        securityAuthLog.HasIndex(x => new { x.AuthType, x.Success, x.OccurredAtUtc });
 
         var appSettings = modelBuilder.Entity<ApplicationSettings>();
         appSettings.ToTable("ApplicationSettings");

--- a/src/WebApp/PingMonitor.Web/Models/SecurityAuthLog.cs
+++ b/src/WebApp/PingMonitor.Web/Models/SecurityAuthLog.cs
@@ -1,0 +1,15 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class SecurityAuthLog
+{
+    public string SecurityAuthLogId { get; set; } = $"sal_{Guid.NewGuid():N}";
+    public DateTimeOffset OccurredAtUtc { get; set; }
+    public SecurityAuthType AuthType { get; set; }
+    public string SubjectIdentifier { get; set; } = string.Empty;
+    public string? SourceIpAddress { get; set; }
+    public bool Success { get; set; }
+    public string? FailureReason { get; set; }
+    public string? UserId { get; set; }
+    public string? AgentId { get; set; }
+    public string? DetailsJson { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Models/SecurityAuthType.cs
+++ b/src/WebApp/PingMonitor.Web/Models/SecurityAuthType.cs
@@ -1,0 +1,7 @@
+namespace PingMonitor.Web.Models;
+
+public enum SecurityAuthType
+{
+    User = 1,
+    Agent = 2
+}

--- a/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
@@ -5,6 +5,6 @@ public sealed class StartupGateOptions
     public const string SectionName = "StartupGate";
 
     public string StorageDirectory { get; set; } = "App_Data/StartupGate";
-    public int RequiredSchemaVersion { get; set; } = 5;
+    public int RequiredSchemaVersion { get; set; } = 6;
     public int DefaultMySqlPort { get; set; } = 3306;
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -18,6 +18,7 @@ using PingMonitor.Web.Services.EventLogs;
 using PingMonitor.Web.Services.Metrics;
 using PingMonitor.Web.Services.StartupGate;
 using PingMonitor.Web.Services.Status;
+using PingMonitor.Web.Services.Security;
 using PingMonitor.Web.Support;
 using Microsoft.Extensions.Options;
 
@@ -113,6 +114,8 @@ builder.Services.AddScoped<IHeartbeatService, AgentHeartbeatService>();
 builder.Services.AddScoped<IStateEvaluationService, StateEvaluationService>();
 builder.Services.AddScoped<IEventLogService, EventLogService>();
 builder.Services.AddScoped<IEventLogQueryService, EventLogQueryService>();
+builder.Services.AddScoped<ISecurityAuthLogService, SecurityAuthLogService>();
+builder.Services.AddScoped<ISecurityAuthLogQueryService, SecurityAuthLogQueryService>();
 builder.Services.AddScoped<IEndpointStatusQueryService, EndpointStatusQueryService>();
 builder.Services.AddScoped<IStartupGateService, StartupGateService>();
 builder.Services.AddSingleton<IStartupDatabaseConfigurationStore, FileStartupDatabaseConfigurationStore>();

--- a/src/WebApp/PingMonitor.Web/Services/AgentAuthenticationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentAuthenticationService.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
+using PingMonitor.Web.Services.Security;
 
 namespace PingMonitor.Web.Services;
 
@@ -8,11 +9,16 @@ internal sealed class AgentAuthenticationService : IAgentAuthenticationService
     private const string InstanceIdHeaderName = "X-Instance-Id";
     private readonly PingMonitorDbContext _dbContext;
     private readonly IAgentApiKeyHasher _apiKeyHasher;
+    private readonly ISecurityAuthLogService _securityAuthLogService;
 
-    public AgentAuthenticationService(PingMonitorDbContext dbContext, IAgentApiKeyHasher apiKeyHasher)
+    public AgentAuthenticationService(
+        PingMonitorDbContext dbContext,
+        IAgentApiKeyHasher apiKeyHasher,
+        ISecurityAuthLogService securityAuthLogService)
     {
         _dbContext = dbContext;
         _apiKeyHasher = apiKeyHasher;
+        _securityAuthLogService = securityAuthLogService;
     }
 
     public async Task<AgentAuthenticationResult> AuthenticateAsync(HttpRequest request, CancellationToken cancellationToken)
@@ -20,37 +26,65 @@ internal sealed class AgentAuthenticationService : IAgentAuthenticationService
         var instanceId = request.Headers[InstanceIdHeaderName].ToString().Trim();
         if (string.IsNullOrWhiteSpace(instanceId))
         {
+            await LogAttemptAsync(request, success: false, subjectIdentifier: "unknown_instance", agentId: null, failureReason: "missing_instance_header", cancellationToken);
             return AgentAuthenticationResult.Unauthorized($"Missing required header '{InstanceIdHeaderName}'.");
         }
 
         var authorizationHeader = request.Headers.Authorization.ToString();
         if (!TryReadBearerToken(authorizationHeader, out var apiKey))
         {
+            await LogAttemptAsync(request, success: false, subjectIdentifier: instanceId, agentId: null, failureReason: "missing_or_invalid_bearer_token", cancellationToken);
             return AgentAuthenticationResult.Unauthorized("Missing or invalid bearer token.");
         }
 
         var agent = await _dbContext.Agents.SingleOrDefaultAsync(x => x.InstanceId == instanceId, cancellationToken);
         if (agent is null)
         {
+            await LogAttemptAsync(request, success: false, subjectIdentifier: instanceId, agentId: null, failureReason: "unknown_instance", cancellationToken);
             return AgentAuthenticationResult.Unauthorized("The supplied agent credentials are invalid.");
         }
 
         if (!agent.Enabled)
         {
+            await LogAttemptAsync(request, success: false, subjectIdentifier: instanceId, agentId: agent.AgentId, failureReason: "disabled_agent", cancellationToken);
             return AgentAuthenticationResult.Forbidden("The agent is disabled.");
         }
 
         if (agent.ApiKeyRevoked)
         {
+            await LogAttemptAsync(request, success: false, subjectIdentifier: instanceId, agentId: agent.AgentId, failureReason: "revoked_key", cancellationToken);
             return AgentAuthenticationResult.Forbidden("The agent API key has been revoked.");
         }
 
         if (string.IsNullOrWhiteSpace(agent.ApiKeyHash) || !_apiKeyHasher.Verify(agent, apiKey!))
         {
+            await LogAttemptAsync(request, success: false, subjectIdentifier: instanceId, agentId: agent.AgentId, failureReason: "invalid_key", cancellationToken);
             return AgentAuthenticationResult.Unauthorized("The supplied agent credentials are invalid.");
         }
 
+        await LogAttemptAsync(request, success: true, subjectIdentifier: instanceId, agentId: agent.AgentId, failureReason: null, cancellationToken);
         return AgentAuthenticationResult.Success(agent);
+    }
+
+    private Task LogAttemptAsync(
+        HttpRequest request,
+        bool success,
+        string subjectIdentifier,
+        string? agentId,
+        string? failureReason,
+        CancellationToken cancellationToken)
+    {
+        return _securityAuthLogService.LogAgentAttemptAsync(
+            new AgentAuthLogWriteRequest
+            {
+                SubjectIdentifier = subjectIdentifier,
+                AgentId = agentId,
+                SourceIpAddress = request.HttpContext.Connection.RemoteIpAddress?.ToString(),
+                Success = success,
+                FailureReason = failureReason,
+                RequestPath = request.Path.Value
+            },
+            cancellationToken);
     }
 
     private static bool TryReadBearerToken(string? authorizationHeader, out string? apiKey)

--- a/src/WebApp/PingMonitor.Web/Services/Security/ISecurityAuthLogQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/ISecurityAuthLogQueryService.cs
@@ -1,0 +1,6 @@
+namespace PingMonitor.Web.Services.Security;
+
+public interface ISecurityAuthLogQueryService
+{
+    Task<IReadOnlyList<SecurityAuthLogListItem>> GetRecentAsync(SecurityAuthLogQuery query, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/ISecurityAuthLogService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/ISecurityAuthLogService.cs
@@ -1,0 +1,7 @@
+namespace PingMonitor.Web.Services.Security;
+
+public interface ISecurityAuthLogService
+{
+    Task LogUserAttemptAsync(UserAuthLogWriteRequest request, CancellationToken cancellationToken);
+    Task LogAgentAttemptAsync(AgentAuthLogWriteRequest request, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityAuthLogQueryModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityAuthLogQueryModels.cs
@@ -1,0 +1,21 @@
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.Security;
+
+public sealed class SecurityAuthLogListItem
+{
+    public required DateTimeOffset OccurredAtUtc { get; init; }
+    public required string SubjectIdentifier { get; init; }
+    public string? SourceIpAddress { get; init; }
+    public required bool Success { get; init; }
+    public string? FailureReason { get; init; }
+    public string? UserId { get; init; }
+    public string? AgentId { get; init; }
+}
+
+public sealed class SecurityAuthLogQuery
+{
+    public required SecurityAuthType AuthType { get; init; }
+    public required bool IncludeSuccessful { get; init; }
+    public required int Limit { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityAuthLogQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityAuthLogQueryService.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+
+namespace PingMonitor.Web.Services.Security;
+
+internal sealed class SecurityAuthLogQueryService : ISecurityAuthLogQueryService
+{
+    private readonly PingMonitorDbContext _dbContext;
+
+    public SecurityAuthLogQueryService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<SecurityAuthLogListItem>> GetRecentAsync(SecurityAuthLogQuery query, CancellationToken cancellationToken)
+    {
+        var effectiveLimit = Math.Clamp(query.Limit, 1, 200);
+
+        var rows = await _dbContext.SecurityAuthLogs
+            .AsNoTracking()
+            .Where(x => x.AuthType == query.AuthType && (query.IncludeSuccessful || !x.Success))
+            .OrderByDescending(x => x.OccurredAtUtc)
+            .Take(effectiveLimit)
+            .Select(x => new SecurityAuthLogListItem
+            {
+                OccurredAtUtc = x.OccurredAtUtc,
+                SubjectIdentifier = x.SubjectIdentifier,
+                SourceIpAddress = x.SourceIpAddress,
+                Success = x.Success,
+                FailureReason = x.FailureReason,
+                UserId = x.UserId,
+                AgentId = x.AgentId
+            })
+            .ToListAsync(cancellationToken);
+
+        return rows;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityAuthLogService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityAuthLogService.cs
@@ -1,0 +1,63 @@
+using System.Text.Json;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.Security;
+
+internal sealed class SecurityAuthLogService : ISecurityAuthLogService
+{
+    private readonly PingMonitorDbContext _dbContext;
+
+    public SecurityAuthLogService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task LogUserAttemptAsync(UserAuthLogWriteRequest request, CancellationToken cancellationToken)
+    {
+        var log = new SecurityAuthLog
+        {
+            OccurredAtUtc = DateTimeOffset.UtcNow,
+            AuthType = SecurityAuthType.User,
+            SubjectIdentifier = Normalize(request.SubjectIdentifier, fallback: "unknown_user"),
+            SourceIpAddress = Normalize(request.SourceIpAddress),
+            Success = request.Success,
+            FailureReason = Normalize(request.FailureReason),
+            UserId = Normalize(request.UserId),
+            AgentId = null,
+            DetailsJson = null
+        };
+
+        _dbContext.SecurityAuthLogs.Add(log);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task LogAgentAttemptAsync(AgentAuthLogWriteRequest request, CancellationToken cancellationToken)
+    {
+        var details = string.IsNullOrWhiteSpace(request.RequestPath)
+            ? null
+            : JsonSerializer.Serialize(new { requestPath = request.RequestPath });
+
+        var log = new SecurityAuthLog
+        {
+            OccurredAtUtc = DateTimeOffset.UtcNow,
+            AuthType = SecurityAuthType.Agent,
+            SubjectIdentifier = Normalize(request.SubjectIdentifier, fallback: "unknown_agent"),
+            SourceIpAddress = Normalize(request.SourceIpAddress),
+            Success = request.Success,
+            FailureReason = Normalize(request.FailureReason),
+            UserId = null,
+            AgentId = Normalize(request.AgentId),
+            DetailsJson = details
+        };
+
+        _dbContext.SecurityAuthLogs.Add(log);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private static string Normalize(string? value, string fallback = "unknown")
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? fallback : normalized;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityAuthLogWriteModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityAuthLogWriteModels.cs
@@ -1,0 +1,20 @@
+namespace PingMonitor.Web.Services.Security;
+
+public sealed class UserAuthLogWriteRequest
+{
+    public required string SubjectIdentifier { get; init; }
+    public string? UserId { get; init; }
+    public string? SourceIpAddress { get; init; }
+    public bool Success { get; init; }
+    public string? FailureReason { get; init; }
+}
+
+public sealed class AgentAuthLogWriteRequest
+{
+    public required string SubjectIdentifier { get; init; }
+    public string? AgentId { get; init; }
+    public string? SourceIpAddress { get; init; }
+    public bool Success { get; init; }
+    public string? FailureReason { get; init; }
+    public string? RequestPath { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -29,6 +29,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "EndpointStates",
         "StateTransitions",
         "EventLogs",
+        "SecurityAuthLogs",
         "ApplicationSettings"
     ];
     private static readonly string[] RequiredEndpointDependencyColumns =
@@ -241,6 +242,24 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 KEY `IX_EventLogs_AssignmentId_OccurredAtUtc` (`AssignmentId`, `OccurredAtUtc`)
             );
             """;
+        const string createSecurityAuthLogsSql = """
+            CREATE TABLE IF NOT EXISTS `SecurityAuthLogs` (
+                `SecurityAuthLogId` varchar(64) NOT NULL,
+                `OccurredAtUtc` datetime(6) NOT NULL,
+                `AuthType` varchar(16) NOT NULL,
+                `SubjectIdentifier` varchar(255) NOT NULL,
+                `SourceIpAddress` varchar(64) NULL,
+                `Success` tinyint(1) NOT NULL,
+                `FailureReason` varchar(128) NULL,
+                `UserId` varchar(255) NULL,
+                `AgentId` varchar(64) NULL,
+                `DetailsJson` varchar(4096) NULL,
+                PRIMARY KEY (`SecurityAuthLogId`),
+                KEY `IX_SecurityAuthLogs_OccurredAtUtc` (`OccurredAtUtc`),
+                KEY `IX_SecurityAuthLogs_AuthType_OccurredAtUtc` (`AuthType`, `OccurredAtUtc`),
+                KEY `IX_SecurityAuthLogs_AuthType_Success_OccurredAtUtc` (`AuthType`, `Success`, `OccurredAtUtc`)
+            );
+            """;
 
         const string createEndpointDependenciesSql = """
             CREATE TABLE IF NOT EXISTS `EndpointDependencies` (
@@ -311,6 +330,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointStatesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createStateTransitionsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createEventLogsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createSecurityAuthLogsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createApplicationSettingsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointDependenciesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createAgentHeartbeatHistorySql, cancellationToken);

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/AdminSecurityPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/AdminSecurityPageViewModel.cs
@@ -1,0 +1,11 @@
+using PingMonitor.Web.Services.Security;
+
+namespace PingMonitor.Web.ViewModels.Admin;
+
+public sealed class AdminSecurityPageViewModel
+{
+    public bool IncludeSuccessfulUserAttempts { get; init; }
+    public bool IncludeSuccessfulAgentAttempts { get; init; }
+    public IReadOnlyList<SecurityAuthLogListItem> UserAttempts { get; init; } = [];
+    public IReadOnlyList<SecurityAuthLogListItem> AgentAttempts { get; init; } = [];
+}

--- a/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
@@ -48,6 +48,7 @@
             <div class="button-row">
                 <a class="button-secondary" href="/status">Back to status</a>
                 <a class="button-secondary" href="/admin/backups">Configuration backups</a>
+                <a class="button-secondary" href="/admin/security">Security logs and settings</a>
             </div>
         </section>
 

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
@@ -1,0 +1,123 @@
+@model PingMonitor.Web.ViewModels.Admin.AdminSecurityPageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Security logs and settings</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #f3f6f8;
+            --card: #ffffff;
+            --text: #102a43;
+            --muted: #52606d;
+            --border: #d9e2ec;
+            --ok: #166534;
+            --bad: #b42318;
+        }
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 980px; margin: 0 auto; padding: 1rem; display: grid; gap: 1rem; }
+        .card { background: var(--card); border-radius: 12px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
+        .muted { color: var(--muted); }
+        .button-row { display: flex; gap: .6rem; flex-wrap: wrap; }
+        .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: .7rem .95rem; border: 1px solid var(--border); border-radius: 10px; background: white; color: var(--text); text-decoration: none; }
+        .filter-row { display: grid; gap: .6rem; margin-bottom: .8rem; }
+        .log-box { border: 1px solid var(--border); border-radius: 10px; max-height: 360px; overflow-y: auto; background: #fbfdff; }
+        .log-item { padding: .7rem; border-bottom: 1px solid var(--border); font-size: .95rem; }
+        .log-item:last-child { border-bottom: 0; }
+        .status-ok { color: var(--ok); font-weight: 700; }
+        .status-bad { color: var(--bad); font-weight: 700; }
+        .entry-meta { display: grid; gap: .25rem; }
+        .empty { padding: 1rem; color: var(--muted); }
+        label { display: inline-flex; align-items: center; gap: .5rem; min-height: 44px; }
+        input[type="checkbox"] { width: 20px; height: 20px; }
+        button { min-height: 44px; padding: .6rem .9rem; border-radius: 10px; border: 1px solid var(--border); background: white; }
+    </style>
+</head>
+<body>
+<main>
+    <section class="card">
+        <h1>Security logs and settings</h1>
+        <p class="muted">Read-only authentication-attempt logs for operator review. This phase is visibility only and does not enforce lockouts or blocking.</p>
+        <div class="button-row">
+            <a class="button-secondary" href="/admin">Back to admin settings</a>
+            <a class="button-secondary" href="/status">Back to status</a>
+        </div>
+    </section>
+
+    <section class="card">
+        <h2>User authentication attempts</h2>
+        <form method="get" action="/admin/security" class="filter-row">
+            <label>
+                <input type="checkbox" name="includeSuccessfulUsers" value="true" @(Model.IncludeSuccessfulUserAttempts ? "checked" : null) />
+                Show successful user attempts
+            </label>
+            <input type="hidden" name="includeSuccessfulAgents" value="@Model.IncludeSuccessfulAgentAttempts.ToString().ToLowerInvariant()" />
+            <button type="submit">Apply user filter</button>
+        </form>
+        <div class="log-box" role="region" aria-label="User authentication attempts">
+            @if (!Model.UserAttempts.Any())
+            {
+                <div class="empty">No user authentication attempts match the current filter.</div>
+            }
+            else
+            {
+                @foreach (var entry in Model.UserAttempts)
+                {
+                    <div class="log-item">
+                        <div class="entry-meta">
+                            <div><strong>@entry.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</strong></div>
+                            <div>Subject: @entry.SubjectIdentifier</div>
+                            <div>Source IP: @(string.IsNullOrWhiteSpace(entry.SourceIpAddress) ? "n/a" : entry.SourceIpAddress)</div>
+                            <div>Status: <span class="@(entry.Success ? "status-ok" : "status-bad")">@(entry.Success ? "SUCCESS" : "FAILED")</span></div>
+                            @if (!string.IsNullOrWhiteSpace(entry.FailureReason))
+                            {
+                                <div>Failure reason: @entry.FailureReason</div>
+                            }
+                        </div>
+                    </div>
+                }
+            }
+        </div>
+    </section>
+
+    <section class="card">
+        <h2>Agent authentication attempts</h2>
+        <form method="get" action="/admin/security" class="filter-row">
+            <input type="hidden" name="includeSuccessfulUsers" value="@Model.IncludeSuccessfulUserAttempts.ToString().ToLowerInvariant()" />
+            <label>
+                <input type="checkbox" name="includeSuccessfulAgents" value="true" @(Model.IncludeSuccessfulAgentAttempts ? "checked" : null) />
+                Show successful agent attempts
+            </label>
+            <button type="submit">Apply agent filter</button>
+        </form>
+        <div class="log-box" role="region" aria-label="Agent authentication attempts">
+            @if (!Model.AgentAttempts.Any())
+            {
+                <div class="empty">No agent authentication attempts match the current filter.</div>
+            }
+            else
+            {
+                @foreach (var entry in Model.AgentAttempts)
+                {
+                    <div class="log-item">
+                        <div class="entry-meta">
+                            <div><strong>@entry.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</strong></div>
+                            <div>Subject: @entry.SubjectIdentifier</div>
+                            <div>Source IP: @(string.IsNullOrWhiteSpace(entry.SourceIpAddress) ? "n/a" : entry.SourceIpAddress)</div>
+                            <div>Status: <span class="@(entry.Success ? "status-ok" : "status-bad")">@(entry.Success ? "SUCCESS" : "FAILED")</span></div>
+                            @if (!string.IsNullOrWhiteSpace(entry.FailureReason))
+                            {
+                                <div>Failure reason: @entry.FailureReason</div>
+                            }
+                        </div>
+                    </div>
+                }
+            }
+        </div>
+    </section>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 5,
+    "RequiredSchemaVersion": 6,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 5,
+    "RequiredSchemaVersion": 6,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
### Motivation

- Provide auditable, operator-friendly logging of both user and agent authentication attempts without adding active controls in this phase.
- Surface recent auth attempts in the control-plane UI so operators can review successes and failures with clear failure reasons.
- Keep the implementation explicit, minimal, and MySQL-compatible and follow the repository issue/workflow requirements.

### Description

- Documented Phase 1 behavior in `docs/security-logging.md` and extended `docs/data-model.md` with a `SecurityAuthLog` entry describing required fields and constraints. 
- Added a persistent model `SecurityAuthLog` and enum `SecurityAuthType`, wired into EF Core via `PingMonitorDbContext` with explicit indexes and a `SecurityAuthLogs` table creation SQL path in `StartupSchemaService`. 
- Implemented write and read services: `ISecurityAuthLogService` / `SecurityAuthLogService` for logging, and `ISecurityAuthLogQueryService` / `SecurityAuthLogQueryService` for fetching recent entries, and registered them in DI (`Program.cs`).
- Integrated logging into authentication paths: agent attempts are logged once per request in `AgentAuthenticationService` with clear failure reasons and source IP; user login attempts are logged in `AccountController` with failure reasons and source IP, ensuring no secrets are recorded. 
- Added an admin-only read-only page at `/admin/security` (`AdminSecurityController`, `AdminSecurityPageViewModel`, and `Views/AdminSecurity/Index.cshtml`) showing two scrollable panels (user and agent attempts) that default to hiding successful attempts and provide independent toggles to include successes; added a navigation link from Admin Settings. 
- Bumped the startup-required schema version and ensured the startup schema apply path creates `SecurityAuthLogs`; linked this work to the tracked issue with `Fixes #166`.

### Testing

- Created and linked tracking issue `#166` before implementation using the GitHub API (succeeded). 
- Installed the required .NET 10 SDK versions using the official `dotnet-install.sh` script and built the web project with `/root/.dotnet/dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which ultimately succeeded after ensuring the SDK version matched `global.json`. 
- Verified the solution builds cleanly after changes with `dotnet build` (succeeded). 
- Performed static repository scans (file searches/greps) to confirm auth paths were updated and DI registrations were added (informational checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c937981928832abbe889af60daaf68)