### PR TITLE
Add security settings and manual blocked IP management (phase 1)

### DIFF
--- a/docs/security-logging.md
+++ b/docs/security-logging.md
@@ -10,7 +10,7 @@ This phase covers:
 - agent authentication attempts
 - a read-only admin page for reviewing recent attempts
 
-This phase does **not** add active controls (lockouts, blocking, rate limiting, firewall actions).
+This phase does **not** add automatic active controls (automatic lockouts, automatic blocking, rate limiting, firewall actions). Manual block management and security setting persistence are covered in `docs/security-settings.md`.
 
 ---
 

--- a/docs/security-settings.md
+++ b/docs/security-settings.md
@@ -1,0 +1,60 @@
+# Security settings (phase 1)
+
+## Purpose
+
+This phase adds operator-managed security configuration and blocked IP management for authentication paths.
+
+It covers:
+
+- persisted security settings for **agent authentication** and **user authentication**
+- persistent blocked IP records for agent/user auth types
+- manual IP block and unblock from the admin security page
+
+It does **not** yet implement full automatic enforcement of temporary/permanent IP blocks or account lockouts.
+
+## Authentication settings
+
+Security settings are stored as explicit fields in minutes/counts.
+
+### Agent authentication settings
+
+- `AgentFailedAttemptsBeforeTemporaryIpBlock`
+- `AgentTemporaryIpBlockDurationMinutes`
+- `AgentFailedAttemptsBeforePermanentIpBlock`
+
+### User authentication settings
+
+- `UserFailedAttemptsBeforeTemporaryIpBlock`
+- `UserTemporaryIpBlockDurationMinutes`
+- `UserFailedAttemptsBeforePermanentIpBlock`
+- `UserFailedAttemptsBeforeTemporaryAccountLockout`
+- `UserTemporaryAccountLockoutDurationMinutes`
+
+## IP block vs account lockout
+
+- **IP block** applies to requests coming from a source IP address for a selected auth type (`User` or `Agent`).
+- **Account lockout** applies to a specific user account and is configured separately from IP block thresholds/duration.
+
+In this phase, account lockout values are configurable and persisted, but lockout policy enforcement remains a follow-up phase.
+
+## Manual IP block / unblock behaviour
+
+- Operators can manually add a block for a valid IP address and selected auth type.
+- Block type for manual blocks is recorded as `Manual`.
+- Existing active blocks for the same `(AuthType, IpAddress)` are not duplicated.
+- Unblock is implemented as an audited soft-removal (`RemovedAtUtc`, `RemovedByUserId`) rather than hard deletion.
+
+## Auditability
+
+Manual block and unblock actions are persisted as security IP block records and event log entries.
+Settings updates are also event logged.
+
+## Phase boundary
+
+This phase intentionally focuses on:
+
+- settings persistence
+- operator UI for settings
+- blocked IP list and manual management
+
+Automatic auth enforcement, automatic expiry handling pipeline behavior, and lockout execution are next-phase work.

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminSecurityController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminSecurityController.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Models;
@@ -13,14 +15,165 @@ public sealed class AdminSecurityController : Controller
 {
     private const int DefaultLogLimit = 100;
     private readonly ISecurityAuthLogQueryService _securityAuthLogQueryService;
+    private readonly ISecuritySettingsService _securitySettingsService;
+    private readonly ISecurityIpBlockService _securityIpBlockService;
 
-    public AdminSecurityController(ISecurityAuthLogQueryService securityAuthLogQueryService)
+    public AdminSecurityController(
+        ISecurityAuthLogQueryService securityAuthLogQueryService,
+        ISecuritySettingsService securitySettingsService,
+        ISecurityIpBlockService securityIpBlockService)
     {
         _securityAuthLogQueryService = securityAuthLogQueryService;
+        _securitySettingsService = securitySettingsService;
+        _securityIpBlockService = securityIpBlockService;
     }
 
     [HttpGet]
     public async Task<IActionResult> Index([FromQuery] bool includeSuccessfulUsers = false, [FromQuery] bool includeSuccessfulAgents = false, CancellationToken cancellationToken = default)
+    {
+        var viewModel = await BuildViewModelAsync(
+            includeSuccessfulUsers,
+            includeSuccessfulAgents,
+            settingsSaved: false,
+            blockSaved: false,
+            unblockSaved: false,
+            settingsFormOverride: null,
+            manualIpBlockFormOverride: null,
+            cancellationToken: cancellationToken);
+
+        return View("Index", viewModel);
+    }
+
+    [HttpPost("settings")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UpdateSettings(
+        [FromForm(Name = "SettingsForm")] SecuritySettingsForm settingsForm,
+        [FromForm] bool includeSuccessfulUsers = false,
+        [FromForm] bool includeSuccessfulAgents = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (!ModelState.IsValid)
+        {
+            var invalidViewModel = await BuildViewModelAsync(
+                includeSuccessfulUsers,
+                includeSuccessfulAgents,
+                settingsSaved: false,
+                blockSaved: false,
+                unblockSaved: false,
+                settingsFormOverride: settingsForm,
+                manualIpBlockFormOverride: null,
+                cancellationToken);
+            return View("Index", invalidViewModel);
+        }
+
+        await _securitySettingsService.UpdateAsync(new UpdateSecuritySettingsCommand
+        {
+            AgentFailedAttemptsBeforeTemporaryIpBlock = settingsForm.AgentFailedAttemptsBeforeTemporaryIpBlock,
+            AgentTemporaryIpBlockDurationMinutes = settingsForm.AgentTemporaryIpBlockDurationMinutes,
+            AgentFailedAttemptsBeforePermanentIpBlock = settingsForm.AgentFailedAttemptsBeforePermanentIpBlock,
+            UserFailedAttemptsBeforeTemporaryIpBlock = settingsForm.UserFailedAttemptsBeforeTemporaryIpBlock,
+            UserTemporaryIpBlockDurationMinutes = settingsForm.UserTemporaryIpBlockDurationMinutes,
+            UserFailedAttemptsBeforePermanentIpBlock = settingsForm.UserFailedAttemptsBeforePermanentIpBlock,
+            UserFailedAttemptsBeforeTemporaryAccountLockout = settingsForm.UserFailedAttemptsBeforeTemporaryAccountLockout,
+            UserTemporaryAccountLockoutDurationMinutes = settingsForm.UserTemporaryAccountLockoutDurationMinutes
+        }, cancellationToken);
+
+        return RedirectToAction(nameof(Index), new { includeSuccessfulUsers, includeSuccessfulAgents, settingsSaved = true });
+    }
+
+    [HttpPost("ip-blocks")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> AddManualIpBlock(
+        [FromForm(Name = "ManualIpBlockForm")] ManualIpBlockForm manualIpBlockForm,
+        [FromForm] bool includeSuccessfulUsers = false,
+        [FromForm] bool includeSuccessfulAgents = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (!manualIpBlockForm.AuthType.HasValue)
+        {
+            ModelState.AddModelError($"{nameof(ManualIpBlockForm)}.{nameof(ManualIpBlockForm.AuthType)}", "Auth type is required.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(manualIpBlockForm.IpAddress) && !IPAddress.TryParse(manualIpBlockForm.IpAddress.Trim(), out _))
+        {
+            ModelState.AddModelError($"{nameof(ManualIpBlockForm)}.{nameof(ManualIpBlockForm.IpAddress)}", "IP address must be valid.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            var invalidViewModel = await BuildViewModelAsync(
+                includeSuccessfulUsers,
+                includeSuccessfulAgents,
+                settingsSaved: false,
+                blockSaved: false,
+                unblockSaved: false,
+                settingsFormOverride: null,
+                manualIpBlockFormOverride: manualIpBlockForm,
+                cancellationToken);
+            return View("Index", invalidViewModel);
+        }
+
+        var result = await _securityIpBlockService.AddManualBlockAsync(
+            new ManualSecurityIpBlockRequest
+            {
+                AuthType = manualIpBlockForm.AuthType!.Value,
+                IpAddress = manualIpBlockForm.IpAddress,
+                Reason = manualIpBlockForm.Reason,
+                CreatedByUserId = User.FindFirstValue(ClaimTypes.NameIdentifier)
+            },
+            cancellationToken);
+
+        if (!result.Succeeded)
+        {
+            ModelState.AddModelError($"{nameof(ManualIpBlockForm)}.{nameof(ManualIpBlockForm.IpAddress)}", result.Error ?? "Unable to add IP block.");
+
+            var invalidViewModel = await BuildViewModelAsync(
+                includeSuccessfulUsers,
+                includeSuccessfulAgents,
+                settingsSaved: false,
+                blockSaved: false,
+                unblockSaved: false,
+                settingsFormOverride: null,
+                manualIpBlockFormOverride: manualIpBlockForm,
+                cancellationToken);
+            return View("Index", invalidViewModel);
+        }
+
+        return RedirectToAction(nameof(Index), new { includeSuccessfulUsers, includeSuccessfulAgents, blockSaved = true });
+    }
+
+    [HttpPost("ip-blocks/{securityIpBlockId}/remove")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RemoveIpBlock(
+        string securityIpBlockId,
+        [FromForm] bool includeSuccessfulUsers = false,
+        [FromForm] bool includeSuccessfulAgents = false,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _securityIpBlockService.RemoveAsync(new RemoveSecurityIpBlockRequest
+        {
+            SecurityIpBlockId = securityIpBlockId,
+            RemovedByUserId = User.FindFirstValue(ClaimTypes.NameIdentifier)
+        }, cancellationToken);
+
+        if (!result.Succeeded)
+        {
+            TempData["SecurityIpBlockRemoveError"] = result.Error ?? "Unable to remove blocked IP.";
+            return RedirectToAction(nameof(Index), new { includeSuccessfulUsers, includeSuccessfulAgents });
+        }
+
+        return RedirectToAction(nameof(Index), new { includeSuccessfulUsers, includeSuccessfulAgents, unblockSaved = true });
+    }
+
+    private async Task<AdminSecurityPageViewModel> BuildViewModelAsync(
+        bool includeSuccessfulUsers,
+        bool includeSuccessfulAgents,
+        bool settingsSaved,
+        bool blockSaved,
+        bool unblockSaved,
+        SecuritySettingsForm? settingsFormOverride,
+        ManualIpBlockForm? manualIpBlockFormOverride,
+        CancellationToken cancellationToken)
     {
         var userAttempts = await _securityAuthLogQueryService.GetRecentAsync(
             new SecurityAuthLogQuery
@@ -40,12 +193,32 @@ public sealed class AdminSecurityController : Controller
             },
             cancellationToken);
 
-        return View("Index", new AdminSecurityPageViewModel
+        var settings = await _securitySettingsService.GetCurrentAsync(cancellationToken);
+        var activeBlocks = await _securityIpBlockService.ListActiveAsync(cancellationToken);
+
+        return new AdminSecurityPageViewModel
         {
             IncludeSuccessfulUserAttempts = includeSuccessfulUsers,
             IncludeSuccessfulAgentAttempts = includeSuccessfulAgents,
             UserAttempts = userAttempts,
-            AgentAttempts = agentAttempts
-        });
+            AgentAttempts = agentAttempts,
+            ActiveIpBlocks = activeBlocks,
+            SettingsSaved = settingsSaved || string.Equals(Request.Query["settingsSaved"], "true", StringComparison.OrdinalIgnoreCase),
+            BlockSaved = blockSaved || string.Equals(Request.Query["blockSaved"], "true", StringComparison.OrdinalIgnoreCase),
+            UnblockSaved = unblockSaved || string.Equals(Request.Query["unblockSaved"], "true", StringComparison.OrdinalIgnoreCase),
+            SettingsForm = settingsFormOverride ?? new SecuritySettingsForm
+            {
+                AgentFailedAttemptsBeforeTemporaryIpBlock = settings.AgentFailedAttemptsBeforeTemporaryIpBlock,
+                AgentTemporaryIpBlockDurationMinutes = settings.AgentTemporaryIpBlockDurationMinutes,
+                AgentFailedAttemptsBeforePermanentIpBlock = settings.AgentFailedAttemptsBeforePermanentIpBlock,
+                UserFailedAttemptsBeforeTemporaryIpBlock = settings.UserFailedAttemptsBeforeTemporaryIpBlock,
+                UserTemporaryIpBlockDurationMinutes = settings.UserTemporaryIpBlockDurationMinutes,
+                UserFailedAttemptsBeforePermanentIpBlock = settings.UserFailedAttemptsBeforePermanentIpBlock,
+                UserFailedAttemptsBeforeTemporaryAccountLockout = settings.UserFailedAttemptsBeforeTemporaryAccountLockout,
+                UserTemporaryAccountLockoutDurationMinutes = settings.UserTemporaryAccountLockoutDurationMinutes,
+                UpdatedAtUtc = settings.UpdatedAtUtc
+            },
+            ManualIpBlockForm = manualIpBlockFormOverride ?? new ManualIpBlockForm()
+        };
     }
 }

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -33,6 +33,8 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
     public DbSet<SecurityAuthLog> SecurityAuthLogs => Set<SecurityAuthLog>();
     public DbSet<AppSchemaInfo> AppSchemaInfos => Set<AppSchemaInfo>();
     public DbSet<ApplicationSettings> ApplicationSettings => Set<ApplicationSettings>();
+    public DbSet<SecuritySettings> SecuritySettings => Set<SecuritySettings>();
+    public DbSet<SecurityIpBlock> SecurityIpBlocks => Set<SecurityIpBlock>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -246,5 +248,34 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         appSettings.Property(x => x.DefaultFailureThreshold).IsRequired();
         appSettings.Property(x => x.DefaultRecoveryThreshold).IsRequired();
         appSettings.Property(x => x.UpdatedAtUtc).IsRequired();
+
+        var securitySettings = modelBuilder.Entity<SecuritySettings>();
+        securitySettings.ToTable("SecuritySettings");
+        securitySettings.HasKey(x => x.SecuritySettingsId);
+        securitySettings.Property(x => x.SecuritySettingsId).ValueGeneratedNever();
+        securitySettings.Property(x => x.AgentFailedAttemptsBeforeTemporaryIpBlock).IsRequired();
+        securitySettings.Property(x => x.AgentTemporaryIpBlockDurationMinutes).IsRequired();
+        securitySettings.Property(x => x.AgentFailedAttemptsBeforePermanentIpBlock).IsRequired();
+        securitySettings.Property(x => x.UserFailedAttemptsBeforeTemporaryIpBlock).IsRequired();
+        securitySettings.Property(x => x.UserTemporaryIpBlockDurationMinutes).IsRequired();
+        securitySettings.Property(x => x.UserFailedAttemptsBeforePermanentIpBlock).IsRequired();
+        securitySettings.Property(x => x.UserFailedAttemptsBeforeTemporaryAccountLockout).IsRequired();
+        securitySettings.Property(x => x.UserTemporaryAccountLockoutDurationMinutes).IsRequired();
+        securitySettings.Property(x => x.UpdatedAtUtc).IsRequired();
+
+        var securityIpBlock = modelBuilder.Entity<SecurityIpBlock>();
+        securityIpBlock.ToTable("SecurityIpBlocks");
+        securityIpBlock.HasKey(x => x.SecurityIpBlockId);
+        securityIpBlock.Property(x => x.SecurityIpBlockId).HasMaxLength(64);
+        securityIpBlock.Property(x => x.AuthType).HasConversion<string>().HasMaxLength(16).IsRequired();
+        securityIpBlock.Property(x => x.IpAddress).HasMaxLength(64).IsRequired();
+        securityIpBlock.Property(x => x.BlockType).HasConversion<string>().HasMaxLength(16).IsRequired();
+        securityIpBlock.Property(x => x.BlockedAtUtc).IsRequired();
+        securityIpBlock.Property(x => x.Reason).HasMaxLength(512);
+        securityIpBlock.Property(x => x.CreatedByUserId).HasMaxLength(255);
+        securityIpBlock.Property(x => x.RemovedByUserId).HasMaxLength(255);
+        securityIpBlock.HasIndex(x => new { x.AuthType, x.IpAddress, x.RemovedAtUtc });
+        securityIpBlock.HasIndex(x => x.BlockedAtUtc);
+
     }
 }

--- a/src/WebApp/PingMonitor.Web/Models/EventCategory.cs
+++ b/src/WebApp/PingMonitor.Web/Models/EventCategory.cs
@@ -3,5 +3,6 @@ namespace PingMonitor.Web.Models;
 public enum EventCategory
 {
     Endpoint = 0,
-    Agent = 1
+    Agent = 1,
+    Security = 2
 }

--- a/src/WebApp/PingMonitor.Web/Models/EventType.cs
+++ b/src/WebApp/PingMonitor.Web/Models/EventType.cs
@@ -10,4 +10,7 @@ public static class EventType
     public const string AgentBecameStale = "agent_became_stale";
     public const string AgentBecameOffline = "agent_became_offline";
     public const string AgentConfigFetched = "agent_config_fetched";
+    public const string SecuritySettingsUpdated = "security_settings_updated";
+    public const string SecurityManualIpBlockAdded = "security_manual_ip_block_added";
+    public const string SecurityIpBlockRemoved = "security_ip_block_removed";
 }

--- a/src/WebApp/PingMonitor.Web/Models/SecurityIpBlock.cs
+++ b/src/WebApp/PingMonitor.Web/Models/SecurityIpBlock.cs
@@ -1,0 +1,15 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class SecurityIpBlock
+{
+    public string SecurityIpBlockId { get; set; } = $"sib_{Guid.NewGuid():N}";
+    public SecurityAuthType AuthType { get; set; }
+    public string IpAddress { get; set; } = string.Empty;
+    public SecurityIpBlockType BlockType { get; set; }
+    public DateTimeOffset BlockedAtUtc { get; set; }
+    public DateTimeOffset? ExpiresAtUtc { get; set; }
+    public string? Reason { get; set; }
+    public string? CreatedByUserId { get; set; }
+    public DateTimeOffset? RemovedAtUtc { get; set; }
+    public string? RemovedByUserId { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Models/SecurityIpBlockType.cs
+++ b/src/WebApp/PingMonitor.Web/Models/SecurityIpBlockType.cs
@@ -1,0 +1,8 @@
+namespace PingMonitor.Web.Models;
+
+public enum SecurityIpBlockType
+{
+    Temporary = 0,
+    Permanent = 1,
+    Manual = 2
+}

--- a/src/WebApp/PingMonitor.Web/Models/SecuritySettings.cs
+++ b/src/WebApp/PingMonitor.Web/Models/SecuritySettings.cs
@@ -1,0 +1,20 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class SecuritySettings
+{
+    public const int SingletonId = 1;
+
+    public int SecuritySettingsId { get; set; } = SingletonId;
+
+    public int AgentFailedAttemptsBeforeTemporaryIpBlock { get; set; } = 5;
+    public int AgentTemporaryIpBlockDurationMinutes { get; set; } = 15;
+    public int AgentFailedAttemptsBeforePermanentIpBlock { get; set; } = 20;
+
+    public int UserFailedAttemptsBeforeTemporaryIpBlock { get; set; } = 5;
+    public int UserTemporaryIpBlockDurationMinutes { get; set; } = 15;
+    public int UserFailedAttemptsBeforePermanentIpBlock { get; set; } = 20;
+    public int UserFailedAttemptsBeforeTemporaryAccountLockout { get; set; } = 5;
+    public int UserTemporaryAccountLockoutDurationMinutes { get; set; } = 15;
+
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -116,6 +116,8 @@ builder.Services.AddScoped<IEventLogService, EventLogService>();
 builder.Services.AddScoped<IEventLogQueryService, EventLogQueryService>();
 builder.Services.AddScoped<ISecurityAuthLogService, SecurityAuthLogService>();
 builder.Services.AddScoped<ISecurityAuthLogQueryService, SecurityAuthLogQueryService>();
+builder.Services.AddScoped<ISecuritySettingsService, SecuritySettingsService>();
+builder.Services.AddScoped<ISecurityIpBlockService, SecurityIpBlockService>();
 builder.Services.AddScoped<IEndpointStatusQueryService, EndpointStatusQueryService>();
 builder.Services.AddScoped<IStartupGateService, StartupGateService>();
 builder.Services.AddSingleton<IStartupDatabaseConfigurationStore, FileStartupDatabaseConfigurationStore>();

--- a/src/WebApp/PingMonitor.Web/README.md
+++ b/src/WebApp/PingMonitor.Web/README.md
@@ -80,3 +80,14 @@ Per-agent actions include:
 - `POST /agents/{id}/rotate-package` to rotate the agent API credential and download a fresh package
 
 Credential rotation replaces the stored API key hash and returns a ZIP with a new `.env` file. The new package must be redeployed to the agent host for continued connectivity.
+
+## Security settings page (phase 1)
+
+In normal startup mode, `GET /admin/security` provides:
+
+- persisted agent auth and user auth threshold/duration settings
+- active blocked IP list for `User` and `Agent` auth types
+- manual block and manual remove operations for blocked IP entries
+- read-only recent authentication-attempt logs
+
+In this phase, settings and blocked-IP management are persisted and operator-facing. Automatic enforcement of IP block thresholds and user lockout policy remains a follow-up phase.

--- a/src/WebApp/PingMonitor.Web/Services/Security/ISecurityIpBlockService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/ISecurityIpBlockService.cs
@@ -1,0 +1,8 @@
+namespace PingMonitor.Web.Services.Security;
+
+public interface ISecurityIpBlockService
+{
+    Task<IReadOnlyList<SecurityIpBlockListItem>> ListActiveAsync(CancellationToken cancellationToken);
+    Task<SecurityIpBlockOperationResult> AddManualBlockAsync(ManualSecurityIpBlockRequest request, CancellationToken cancellationToken);
+    Task<SecurityIpBlockOperationResult> RemoveAsync(RemoveSecurityIpBlockRequest request, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/ISecuritySettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/ISecuritySettingsService.cs
@@ -1,0 +1,7 @@
+namespace PingMonitor.Web.Services.Security;
+
+public interface ISecuritySettingsService
+{
+    Task<SecuritySettingsDto> GetCurrentAsync(CancellationToken cancellationToken);
+    Task<SecuritySettingsDto> UpdateAsync(UpdateSecuritySettingsCommand command, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityIpBlockModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityIpBlockModels.cs
@@ -1,0 +1,37 @@
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.Security;
+
+public sealed class SecurityIpBlockListItem
+{
+    public string SecurityIpBlockId { get; init; } = string.Empty;
+    public SecurityAuthType AuthType { get; init; }
+    public string IpAddress { get; init; } = string.Empty;
+    public SecurityIpBlockType BlockType { get; init; }
+    public DateTimeOffset BlockedAtUtc { get; init; }
+    public DateTimeOffset? ExpiresAtUtc { get; init; }
+    public string? Reason { get; init; }
+}
+
+public sealed class ManualSecurityIpBlockRequest
+{
+    public required SecurityAuthType AuthType { get; init; }
+    public required string IpAddress { get; init; }
+    public string? Reason { get; init; }
+    public string? CreatedByUserId { get; init; }
+}
+
+public sealed class RemoveSecurityIpBlockRequest
+{
+    public required string SecurityIpBlockId { get; init; }
+    public string? RemovedByUserId { get; init; }
+}
+
+public sealed class SecurityIpBlockOperationResult
+{
+    public bool Succeeded { get; init; }
+    public string? Error { get; init; }
+
+    public static SecurityIpBlockOperationResult Success() => new() { Succeeded = true };
+    public static SecurityIpBlockOperationResult Failure(string error) => new() { Succeeded = false, Error = error };
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityIpBlockService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityIpBlockService.cs
@@ -1,0 +1,140 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.EventLogs;
+
+namespace PingMonitor.Web.Services.Security;
+
+internal sealed class SecurityIpBlockService : ISecurityIpBlockService
+{
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly IEventLogService _eventLogService;
+
+    public SecurityIpBlockService(PingMonitorDbContext dbContext, IEventLogService eventLogService)
+    {
+        _dbContext = dbContext;
+        _eventLogService = eventLogService;
+    }
+
+    public async Task<IReadOnlyList<SecurityIpBlockListItem>> ListActiveAsync(CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return await _dbContext.SecurityIpBlocks
+            .AsNoTracking()
+            .Where(x => x.RemovedAtUtc == null)
+            .Where(x => x.ExpiresAtUtc == null || x.ExpiresAtUtc > now)
+            .OrderByDescending(x => x.BlockedAtUtc)
+            .Select(x => new SecurityIpBlockListItem
+            {
+                SecurityIpBlockId = x.SecurityIpBlockId,
+                AuthType = x.AuthType,
+                IpAddress = x.IpAddress,
+                BlockType = x.BlockType,
+                BlockedAtUtc = x.BlockedAtUtc,
+                ExpiresAtUtc = x.ExpiresAtUtc,
+                Reason = x.Reason
+            })
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<SecurityIpBlockOperationResult> AddManualBlockAsync(ManualSecurityIpBlockRequest request, CancellationToken cancellationToken)
+    {
+        var ipAddress = request.IpAddress.Trim();
+        if (!IPAddress.TryParse(ipAddress, out _))
+        {
+            return SecurityIpBlockOperationResult.Failure("IP address is not valid.");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var duplicateExists = await _dbContext.SecurityIpBlocks
+            .AnyAsync(x => x.AuthType == request.AuthType
+                        && x.IpAddress == ipAddress
+                        && x.RemovedAtUtc == null
+                        && (x.ExpiresAtUtc == null || x.ExpiresAtUtc > now), cancellationToken);
+
+        if (duplicateExists)
+        {
+            return SecurityIpBlockOperationResult.Failure("An active block already exists for this auth type and IP address.");
+        }
+
+        var entity = new SecurityIpBlock
+        {
+            AuthType = request.AuthType,
+            IpAddress = ipAddress,
+            BlockType = SecurityIpBlockType.Manual,
+            BlockedAtUtc = now,
+            ExpiresAtUtc = null,
+            Reason = string.IsNullOrWhiteSpace(request.Reason) ? "Manual operator block" : request.Reason.Trim(),
+            CreatedByUserId = string.IsNullOrWhiteSpace(request.CreatedByUserId) ? null : request.CreatedByUserId.Trim()
+        };
+
+        _dbContext.SecurityIpBlocks.Add(entity);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.Security,
+            EventType = EventType.SecurityManualIpBlockAdded,
+            Severity = EventSeverity.Warning,
+            Message = $"Manual security IP block added for {entity.AuthType} auth.",
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                entity.SecurityIpBlockId,
+                entity.AuthType,
+                entity.IpAddress,
+                entity.BlockType,
+                entity.BlockedAtUtc
+            })
+        }, cancellationToken);
+
+        return SecurityIpBlockOperationResult.Success();
+    }
+
+    public async Task<SecurityIpBlockOperationResult> RemoveAsync(RemoveSecurityIpBlockRequest request, CancellationToken cancellationToken)
+    {
+        var blockId = request.SecurityIpBlockId.Trim();
+        if (string.IsNullOrWhiteSpace(blockId))
+        {
+            return SecurityIpBlockOperationResult.Failure("Blocked IP record id is required.");
+        }
+
+        var entity = await _dbContext.SecurityIpBlocks
+            .SingleOrDefaultAsync(x => x.SecurityIpBlockId == blockId, cancellationToken);
+
+        if (entity is null)
+        {
+            return SecurityIpBlockOperationResult.Failure("Blocked IP record was not found.");
+        }
+
+        if (entity.RemovedAtUtc is not null)
+        {
+            return SecurityIpBlockOperationResult.Failure("Blocked IP record is already removed.");
+        }
+
+        entity.RemovedAtUtc = DateTimeOffset.UtcNow;
+        entity.RemovedByUserId = string.IsNullOrWhiteSpace(request.RemovedByUserId) ? null : request.RemovedByUserId.Trim();
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.Security,
+            EventType = EventType.SecurityIpBlockRemoved,
+            Severity = EventSeverity.Info,
+            Message = $"Security IP block removed for {entity.AuthType} auth.",
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                entity.SecurityIpBlockId,
+                entity.AuthType,
+                entity.IpAddress,
+                entity.BlockType,
+                entity.BlockedAtUtc,
+                entity.RemovedAtUtc
+            })
+        }, cancellationToken);
+
+        return SecurityIpBlockOperationResult.Success();
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecuritySettingsModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecuritySettingsModels.cs
@@ -1,0 +1,29 @@
+namespace PingMonitor.Web.Services.Security;
+
+public sealed class SecuritySettingsDto
+{
+    public int AgentFailedAttemptsBeforeTemporaryIpBlock { get; init; }
+    public int AgentTemporaryIpBlockDurationMinutes { get; init; }
+    public int AgentFailedAttemptsBeforePermanentIpBlock { get; init; }
+
+    public int UserFailedAttemptsBeforeTemporaryIpBlock { get; init; }
+    public int UserTemporaryIpBlockDurationMinutes { get; init; }
+    public int UserFailedAttemptsBeforePermanentIpBlock { get; init; }
+    public int UserFailedAttemptsBeforeTemporaryAccountLockout { get; init; }
+    public int UserTemporaryAccountLockoutDurationMinutes { get; init; }
+
+    public DateTimeOffset UpdatedAtUtc { get; init; }
+}
+
+public sealed class UpdateSecuritySettingsCommand
+{
+    public int AgentFailedAttemptsBeforeTemporaryIpBlock { get; init; }
+    public int AgentTemporaryIpBlockDurationMinutes { get; init; }
+    public int AgentFailedAttemptsBeforePermanentIpBlock { get; init; }
+
+    public int UserFailedAttemptsBeforeTemporaryIpBlock { get; init; }
+    public int UserTemporaryIpBlockDurationMinutes { get; init; }
+    public int UserFailedAttemptsBeforePermanentIpBlock { get; init; }
+    public int UserFailedAttemptsBeforeTemporaryAccountLockout { get; init; }
+    public int UserTemporaryAccountLockoutDurationMinutes { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecuritySettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecuritySettingsService.cs
@@ -1,0 +1,109 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.EventLogs;
+
+namespace PingMonitor.Web.Services.Security;
+
+internal sealed class SecuritySettingsService : ISecuritySettingsService
+{
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly IEventLogService _eventLogService;
+
+    public SecuritySettingsService(PingMonitorDbContext dbContext, IEventLogService eventLogService)
+    {
+        _dbContext = dbContext;
+        _eventLogService = eventLogService;
+    }
+
+    public async Task<SecuritySettingsDto> GetCurrentAsync(CancellationToken cancellationToken)
+    {
+        var settings = await GetOrCreateEntityAsync(cancellationToken);
+        return ToDto(settings);
+    }
+
+    public async Task<SecuritySettingsDto> UpdateAsync(UpdateSecuritySettingsCommand command, CancellationToken cancellationToken)
+    {
+        Validate(command);
+
+        var settings = await GetOrCreateEntityAsync(cancellationToken);
+        settings.AgentFailedAttemptsBeforeTemporaryIpBlock = command.AgentFailedAttemptsBeforeTemporaryIpBlock;
+        settings.AgentTemporaryIpBlockDurationMinutes = command.AgentTemporaryIpBlockDurationMinutes;
+        settings.AgentFailedAttemptsBeforePermanentIpBlock = command.AgentFailedAttemptsBeforePermanentIpBlock;
+        settings.UserFailedAttemptsBeforeTemporaryIpBlock = command.UserFailedAttemptsBeforeTemporaryIpBlock;
+        settings.UserTemporaryIpBlockDurationMinutes = command.UserTemporaryIpBlockDurationMinutes;
+        settings.UserFailedAttemptsBeforePermanentIpBlock = command.UserFailedAttemptsBeforePermanentIpBlock;
+        settings.UserFailedAttemptsBeforeTemporaryAccountLockout = command.UserFailedAttemptsBeforeTemporaryAccountLockout;
+        settings.UserTemporaryAccountLockoutDurationMinutes = command.UserTemporaryAccountLockoutDurationMinutes;
+        settings.UpdatedAtUtc = DateTimeOffset.UtcNow;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.Security,
+            EventType = EventType.SecuritySettingsUpdated,
+            Severity = EventSeverity.Info,
+            Message = "Security settings were updated.",
+            DetailsJson = $"{{\"updatedAtUtc\":\"{settings.UpdatedAtUtc:O}\"}}"
+        }, cancellationToken);
+
+        return ToDto(settings);
+    }
+
+    private async Task<SecuritySettings> GetOrCreateEntityAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _dbContext.SecuritySettings
+            .SingleOrDefaultAsync(x => x.SecuritySettingsId == SecuritySettings.SingletonId, cancellationToken);
+
+        if (settings is not null)
+        {
+            return settings;
+        }
+
+        settings = new SecuritySettings
+        {
+            SecuritySettingsId = SecuritySettings.SingletonId,
+            UpdatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        _dbContext.SecuritySettings.Add(settings);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return settings;
+    }
+
+    private static void Validate(UpdateSecuritySettingsCommand command)
+    {
+        EnsurePositive(command.AgentFailedAttemptsBeforeTemporaryIpBlock, nameof(command.AgentFailedAttemptsBeforeTemporaryIpBlock));
+        EnsurePositive(command.AgentTemporaryIpBlockDurationMinutes, nameof(command.AgentTemporaryIpBlockDurationMinutes));
+        EnsurePositive(command.AgentFailedAttemptsBeforePermanentIpBlock, nameof(command.AgentFailedAttemptsBeforePermanentIpBlock));
+        EnsurePositive(command.UserFailedAttemptsBeforeTemporaryIpBlock, nameof(command.UserFailedAttemptsBeforeTemporaryIpBlock));
+        EnsurePositive(command.UserTemporaryIpBlockDurationMinutes, nameof(command.UserTemporaryIpBlockDurationMinutes));
+        EnsurePositive(command.UserFailedAttemptsBeforePermanentIpBlock, nameof(command.UserFailedAttemptsBeforePermanentIpBlock));
+        EnsurePositive(command.UserFailedAttemptsBeforeTemporaryAccountLockout, nameof(command.UserFailedAttemptsBeforeTemporaryAccountLockout));
+        EnsurePositive(command.UserTemporaryAccountLockoutDurationMinutes, nameof(command.UserTemporaryAccountLockoutDurationMinutes));
+    }
+
+    private static void EnsurePositive(int value, string name)
+    {
+        if (value < 1)
+        {
+            throw new ArgumentOutOfRangeException(name, "Value must be at least 1.");
+        }
+    }
+
+    private static SecuritySettingsDto ToDto(SecuritySettings settings)
+    {
+        return new SecuritySettingsDto
+        {
+            AgentFailedAttemptsBeforeTemporaryIpBlock = settings.AgentFailedAttemptsBeforeTemporaryIpBlock,
+            AgentTemporaryIpBlockDurationMinutes = settings.AgentTemporaryIpBlockDurationMinutes,
+            AgentFailedAttemptsBeforePermanentIpBlock = settings.AgentFailedAttemptsBeforePermanentIpBlock,
+            UserFailedAttemptsBeforeTemporaryIpBlock = settings.UserFailedAttemptsBeforeTemporaryIpBlock,
+            UserTemporaryIpBlockDurationMinutes = settings.UserTemporaryIpBlockDurationMinutes,
+            UserFailedAttemptsBeforePermanentIpBlock = settings.UserFailedAttemptsBeforePermanentIpBlock,
+            UserFailedAttemptsBeforeTemporaryAccountLockout = settings.UserFailedAttemptsBeforeTemporaryAccountLockout,
+            UserTemporaryAccountLockoutDurationMinutes = settings.UserTemporaryAccountLockoutDurationMinutes,
+            UpdatedAtUtc = settings.UpdatedAtUtc
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -30,7 +30,9 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "StateTransitions",
         "EventLogs",
         "SecurityAuthLogs",
-        "ApplicationSettings"
+        "ApplicationSettings",
+        "SecuritySettings",
+        "SecurityIpBlocks"
     ];
     private static readonly string[] RequiredEndpointDependencyColumns =
     [
@@ -223,6 +225,41 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 PRIMARY KEY (`ApplicationSettingsId`)
             );
             """;
+
+        const string createSecuritySettingsSql = """
+            CREATE TABLE IF NOT EXISTS `SecuritySettings` (
+                `SecuritySettingsId` int NOT NULL,
+                `AgentFailedAttemptsBeforeTemporaryIpBlock` int NOT NULL,
+                `AgentTemporaryIpBlockDurationMinutes` int NOT NULL,
+                `AgentFailedAttemptsBeforePermanentIpBlock` int NOT NULL,
+                `UserFailedAttemptsBeforeTemporaryIpBlock` int NOT NULL,
+                `UserTemporaryIpBlockDurationMinutes` int NOT NULL,
+                `UserFailedAttemptsBeforePermanentIpBlock` int NOT NULL,
+                `UserFailedAttemptsBeforeTemporaryAccountLockout` int NOT NULL,
+                `UserTemporaryAccountLockoutDurationMinutes` int NOT NULL,
+                `UpdatedAtUtc` datetime(6) NOT NULL,
+                PRIMARY KEY (`SecuritySettingsId`)
+            );
+            """;
+
+        const string createSecurityIpBlocksSql = """
+            CREATE TABLE IF NOT EXISTS `SecurityIpBlocks` (
+                `SecurityIpBlockId` varchar(64) NOT NULL,
+                `AuthType` varchar(16) NOT NULL,
+                `IpAddress` varchar(64) NOT NULL,
+                `BlockType` varchar(16) NOT NULL,
+                `BlockedAtUtc` datetime(6) NOT NULL,
+                `ExpiresAtUtc` datetime(6) NULL,
+                `Reason` varchar(512) NULL,
+                `CreatedByUserId` varchar(255) NULL,
+                `RemovedAtUtc` datetime(6) NULL,
+                `RemovedByUserId` varchar(255) NULL,
+                PRIMARY KEY (`SecurityIpBlockId`),
+                KEY `IX_SecurityIpBlocks_AuthType_IpAddress_RemovedAtUtc` (`AuthType`, `IpAddress`, `RemovedAtUtc`),
+                KEY `IX_SecurityIpBlocks_BlockedAtUtc` (`BlockedAtUtc`)
+            );
+            """;
+
         const string createEventLogsSql = """
             CREATE TABLE IF NOT EXISTS `EventLogs` (
                 `EventLogId` varchar(64) NOT NULL,
@@ -332,6 +369,8 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await dbContext.Database.ExecuteSqlRawAsync(createEventLogsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createSecurityAuthLogsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createApplicationSettingsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createSecuritySettingsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createSecurityIpBlocksSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointDependenciesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createAgentHeartbeatHistorySql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createGroupsSql, cancellationToken);

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/AdminSecurityPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/AdminSecurityPageViewModel.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+using PingMonitor.Web.Models;
 using PingMonitor.Web.Services.Security;
 
 namespace PingMonitor.Web.ViewModels.Admin;
@@ -8,4 +10,62 @@ public sealed class AdminSecurityPageViewModel
     public bool IncludeSuccessfulAgentAttempts { get; init; }
     public IReadOnlyList<SecurityAuthLogListItem> UserAttempts { get; init; } = [];
     public IReadOnlyList<SecurityAuthLogListItem> AgentAttempts { get; init; } = [];
+    public IReadOnlyList<SecurityIpBlockListItem> ActiveIpBlocks { get; init; } = [];
+    public SecuritySettingsForm SettingsForm { get; init; } = new();
+    public ManualIpBlockForm ManualIpBlockForm { get; init; } = new();
+    public bool SettingsSaved { get; init; }
+    public bool BlockSaved { get; init; }
+    public bool UnblockSaved { get; init; }
+}
+
+public sealed class SecuritySettingsForm
+{
+    [Range(1, int.MaxValue, ErrorMessage = "Agent failed attempts before temporary IP block must be at least 1.")]
+    [Display(Name = "Failed attempts before temporary IP block")]
+    public int AgentFailedAttemptsBeforeTemporaryIpBlock { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Agent temporary IP block duration must be greater than 0 minutes.")]
+    [Display(Name = "Temporary IP block duration (minutes)")]
+    public int AgentTemporaryIpBlockDurationMinutes { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Agent failed attempts before permanent IP block must be at least 1.")]
+    [Display(Name = "Failed attempts before permanent IP block")]
+    public int AgentFailedAttemptsBeforePermanentIpBlock { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "User failed attempts before temporary IP block must be at least 1.")]
+    [Display(Name = "Failed attempts before temporary IP block")]
+    public int UserFailedAttemptsBeforeTemporaryIpBlock { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "User temporary IP block duration must be greater than 0 minutes.")]
+    [Display(Name = "Temporary IP block duration (minutes)")]
+    public int UserTemporaryIpBlockDurationMinutes { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "User failed attempts before permanent IP block must be at least 1.")]
+    [Display(Name = "Failed attempts before permanent IP block")]
+    public int UserFailedAttemptsBeforePermanentIpBlock { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "User failed attempts before temporary account lockout must be at least 1.")]
+    [Display(Name = "Failed attempts before temporary account lockout")]
+    public int UserFailedAttemptsBeforeTemporaryAccountLockout { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "User temporary account lockout duration must be greater than 0 minutes.")]
+    [Display(Name = "Temporary account lockout duration (minutes)")]
+    public int UserTemporaryAccountLockoutDurationMinutes { get; set; }
+
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+}
+
+public sealed class ManualIpBlockForm
+{
+    [Required(ErrorMessage = "Auth type is required.")]
+    [Display(Name = "Auth type")]
+    public SecurityAuthType? AuthType { get; set; }
+
+    [Required(ErrorMessage = "IP address is required.")]
+    [Display(Name = "IP address")]
+    public string IpAddress { get; set; } = string.Empty;
+
+    [StringLength(512, ErrorMessage = "Reason must be 512 characters or fewer.")]
+    [Display(Name = "Reason")]
+    public string? Reason { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
@@ -15,32 +15,43 @@
             --border: #d9e2ec;
             --ok: #166534;
             --bad: #b42318;
+            --warn: #9a3412;
         }
         * { box-sizing: border-box; }
         body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
-        main { max-width: 980px; margin: 0 auto; padding: 1rem; display: grid; gap: 1rem; }
+        main { max-width: 1080px; margin: 0 auto; padding: 1rem; display: grid; gap: 1rem; }
         .card { background: var(--card); border-radius: 12px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
         .muted { color: var(--muted); }
         .button-row { display: flex; gap: .6rem; flex-wrap: wrap; }
-        .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: .7rem .95rem; border: 1px solid var(--border); border-radius: 10px; background: white; color: var(--text); text-decoration: none; }
-        .filter-row { display: grid; gap: .6rem; margin-bottom: .8rem; }
-        .log-box { border: 1px solid var(--border); border-radius: 10px; max-height: 360px; overflow-y: auto; background: #fbfdff; }
+        .button-secondary, button { display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: .7rem .95rem; border: 1px solid var(--border); border-radius: 10px; background: white; color: var(--text); text-decoration: none; }
+        .button-primary { background: #0f62fe; color: white; border: 0; }
+        .grid-two { display: grid; gap: .75rem; }
+        .field { display: grid; gap: .25rem; }
+        label { font-weight: 600; }
+        input, select { width: 100%; min-height: 44px; border: 1px solid var(--border); border-radius: 10px; padding: .65rem; }
+        .field-error { color: var(--bad); font-size: .88rem; }
+        .saved { border: 1px solid #c2f0c2; background: #ebffee; color: var(--ok); border-radius: 10px; padding: .7rem; margin-bottom: .6rem; }
+        .errors { border: 1px solid #fda29b; background: #fee4e2; color: var(--bad); border-radius: 10px; padding: .7rem; margin-bottom: .6rem; }
+        .table-wrap { overflow-x: auto; }
+        table { width: 100%; border-collapse: collapse; min-width: 740px; }
+        th, td { border-bottom: 1px solid var(--border); text-align: left; padding: .6rem; vertical-align: top; }
+        .log-box { border: 1px solid var(--border); border-radius: 10px; max-height: 320px; overflow-y: auto; background: #fbfdff; }
         .log-item { padding: .7rem; border-bottom: 1px solid var(--border); font-size: .95rem; }
         .log-item:last-child { border-bottom: 0; }
         .status-ok { color: var(--ok); font-weight: 700; }
         .status-bad { color: var(--bad); font-weight: 700; }
         .entry-meta { display: grid; gap: .25rem; }
         .empty { padding: 1rem; color: var(--muted); }
-        label { display: inline-flex; align-items: center; gap: .5rem; min-height: 44px; }
-        input[type="checkbox"] { width: 20px; height: 20px; }
-        button { min-height: 44px; padding: .6rem .9rem; border-radius: 10px; border: 1px solid var(--border); background: white; }
+        @@media (min-width: 840px) {
+            .grid-two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        }
     </style>
 </head>
 <body>
 <main>
     <section class="card">
         <h1>Security logs and settings</h1>
-        <p class="muted">Read-only authentication-attempt logs for operator review. This phase is visibility only and does not enforce lockouts or blocking.</p>
+        <p class="muted">Configure user/agent authentication thresholds, manage manual blocked IPs, and review authentication attempts.</p>
         <div class="button-row">
             <a class="button-secondary" href="/admin">Back to admin settings</a>
             <a class="button-secondary" href="/status">Back to status</a>
@@ -48,8 +59,165 @@
     </section>
 
     <section class="card">
+        <h2>Authentication protection settings</h2>
+        @if (Model.SettingsSaved)
+        {
+            <div class="saved" role="status">Security settings saved successfully.</div>
+        }
+        <form method="post" action="/admin/security/settings">
+            @Html.AntiForgeryToken()
+            <input type="hidden" name="includeSuccessfulUsers" value="@Model.IncludeSuccessfulUserAttempts.ToString().ToLowerInvariant()" />
+            <input type="hidden" name="includeSuccessfulAgents" value="@Model.IncludeSuccessfulAgentAttempts.ToString().ToLowerInvariant()" />
+
+            <div class="grid-two">
+                <section>
+                    <h3>Agent authentication</h3>
+                    <div class="field">
+                        <label asp-for="SettingsForm.AgentFailedAttemptsBeforeTemporaryIpBlock"></label>
+                        <input asp-for="SettingsForm.AgentFailedAttemptsBeforeTemporaryIpBlock" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="SettingsForm.AgentFailedAttemptsBeforeTemporaryIpBlock"></span></div>
+                    </div>
+                    <div class="field">
+                        <label asp-for="SettingsForm.AgentTemporaryIpBlockDurationMinutes"></label>
+                        <input asp-for="SettingsForm.AgentTemporaryIpBlockDurationMinutes" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="SettingsForm.AgentTemporaryIpBlockDurationMinutes"></span></div>
+                    </div>
+                    <div class="field">
+                        <label asp-for="SettingsForm.AgentFailedAttemptsBeforePermanentIpBlock"></label>
+                        <input asp-for="SettingsForm.AgentFailedAttemptsBeforePermanentIpBlock" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="SettingsForm.AgentFailedAttemptsBeforePermanentIpBlock"></span></div>
+                    </div>
+                </section>
+
+                <section>
+                    <h3>User authentication</h3>
+                    <div class="field">
+                        <label asp-for="SettingsForm.UserFailedAttemptsBeforeTemporaryIpBlock"></label>
+                        <input asp-for="SettingsForm.UserFailedAttemptsBeforeTemporaryIpBlock" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="SettingsForm.UserFailedAttemptsBeforeTemporaryIpBlock"></span></div>
+                    </div>
+                    <div class="field">
+                        <label asp-for="SettingsForm.UserTemporaryIpBlockDurationMinutes"></label>
+                        <input asp-for="SettingsForm.UserTemporaryIpBlockDurationMinutes" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="SettingsForm.UserTemporaryIpBlockDurationMinutes"></span></div>
+                    </div>
+                    <div class="field">
+                        <label asp-for="SettingsForm.UserFailedAttemptsBeforePermanentIpBlock"></label>
+                        <input asp-for="SettingsForm.UserFailedAttemptsBeforePermanentIpBlock" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="SettingsForm.UserFailedAttemptsBeforePermanentIpBlock"></span></div>
+                    </div>
+                    <div class="field">
+                        <label asp-for="SettingsForm.UserFailedAttemptsBeforeTemporaryAccountLockout"></label>
+                        <input asp-for="SettingsForm.UserFailedAttemptsBeforeTemporaryAccountLockout" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="SettingsForm.UserFailedAttemptsBeforeTemporaryAccountLockout"></span></div>
+                    </div>
+                    <div class="field">
+                        <label asp-for="SettingsForm.UserTemporaryAccountLockoutDurationMinutes"></label>
+                        <input asp-for="SettingsForm.UserTemporaryAccountLockoutDurationMinutes" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="SettingsForm.UserTemporaryAccountLockoutDurationMinutes"></span></div>
+                    </div>
+                </section>
+            </div>
+            <p class="muted">Last updated: @Model.SettingsForm.UpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</p>
+            <div class="button-row">
+                <button class="button-primary" type="submit">Save security settings</button>
+            </div>
+        </form>
+    </section>
+
+    <section class="card">
+        <h2>Blocked IP management</h2>
+        @if (Model.BlockSaved)
+        {
+            <div class="saved" role="status">Blocked IP added successfully.</div>
+        }
+        @if (Model.UnblockSaved)
+        {
+            <div class="saved" role="status">Blocked IP removed successfully.</div>
+        }
+        @if (TempData["SecurityIpBlockRemoveError"] is string removeError && !string.IsNullOrWhiteSpace(removeError))
+        {
+            <div class="errors" role="alert">@removeError</div>
+        }
+
+        <form method="post" action="/admin/security/ip-blocks" class="grid-two" style="margin-bottom: 1rem;">
+            @Html.AntiForgeryToken()
+            <input type="hidden" name="includeSuccessfulUsers" value="@Model.IncludeSuccessfulUserAttempts.ToString().ToLowerInvariant()" />
+            <input type="hidden" name="includeSuccessfulAgents" value="@Model.IncludeSuccessfulAgentAttempts.ToString().ToLowerInvariant()" />
+            <div class="field">
+                <label asp-for="ManualIpBlockForm.AuthType"></label>
+                <select asp-for="ManualIpBlockForm.AuthType">
+                    <option value="">Select auth type</option>
+                    <option value="User">User</option>
+                    <option value="Agent">Agent</option>
+                </select>
+                <div class="field-error"><span asp-validation-for="ManualIpBlockForm.AuthType"></span></div>
+            </div>
+            <div class="field">
+                <label asp-for="ManualIpBlockForm.IpAddress"></label>
+                <input asp-for="ManualIpBlockForm.IpAddress" placeholder="e.g. 203.0.113.10" />
+                <div class="field-error"><span asp-validation-for="ManualIpBlockForm.IpAddress"></span></div>
+            </div>
+            <div class="field" style="grid-column: 1 / -1;">
+                <label asp-for="ManualIpBlockForm.Reason"></label>
+                <input asp-for="ManualIpBlockForm.Reason" maxlength="512" />
+                <div class="field-error"><span asp-validation-for="ManualIpBlockForm.Reason"></span></div>
+            </div>
+            <div class="button-row" style="grid-column: 1 / -1;">
+                <button class="button-primary" type="submit">Add manual IP block</button>
+            </div>
+        </form>
+
+        <div class="table-wrap">
+            <table>
+                <thead>
+                <tr>
+                    <th>Auth type</th>
+                    <th>IP address</th>
+                    <th>Block type</th>
+                    <th>Blocked at (UTC)</th>
+                    <th>Expires at (UTC)</th>
+                    <th>Reason</th>
+                    <th>Action</th>
+                </tr>
+                </thead>
+                <tbody>
+                @if (!Model.ActiveIpBlocks.Any())
+                {
+                    <tr>
+                        <td colspan="7" class="muted">No active blocked IP entries.</td>
+                    </tr>
+                }
+                else
+                {
+                    @foreach (var block in Model.ActiveIpBlocks)
+                    {
+                        <tr>
+                            <td>@block.AuthType</td>
+                            <td>@block.IpAddress</td>
+                            <td>@block.BlockType</td>
+                            <td>@block.BlockedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")</td>
+                            <td>@(block.ExpiresAtUtc.HasValue ? block.ExpiresAtUtc.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss") : "n/a")</td>
+                            <td>@(string.IsNullOrWhiteSpace(block.Reason) ? "n/a" : block.Reason)</td>
+                            <td>
+                                <form method="post" action="/admin/security/ip-blocks/@block.SecurityIpBlockId/remove">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="includeSuccessfulUsers" value="@Model.IncludeSuccessfulUserAttempts.ToString().ToLowerInvariant()" />
+                                    <input type="hidden" name="includeSuccessfulAgents" value="@Model.IncludeSuccessfulAgentAttempts.ToString().ToLowerInvariant()" />
+                                    <button type="submit">Remove</button>
+                                </form>
+                            </td>
+                        </tr>
+                    }
+                }
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <section class="card">
         <h2>User authentication attempts</h2>
-        <form method="get" action="/admin/security" class="filter-row">
+        <form method="get" action="/admin/security" class="button-row" style="margin-bottom: .8rem;">
             <label>
                 <input type="checkbox" name="includeSuccessfulUsers" value="true" @(Model.IncludeSuccessfulUserAttempts ? "checked" : null) />
                 Show successful user attempts
@@ -85,7 +253,7 @@
 
     <section class="card">
         <h2>Agent authentication attempts</h2>
-        <form method="get" action="/admin/security" class="filter-row">
+        <form method="get" action="/admin/security" class="button-row" style="margin-bottom: .8rem;">
             <input type="hidden" name="includeSuccessfulUsers" value="@Model.IncludeSuccessfulUserAttempts.ToString().ToLowerInvariant()" />
             <label>
                 <input type="checkbox" name="includeSuccessfulAgents" value="true" @(Model.IncludeSuccessfulAgentAttempts ? "checked" : null) />


### PR DESCRIPTION
### Motivation
- Provide operator-managed, persistent security settings and manual blocked-IP management as the first phase of authentication protection while deferring automatic enforcement to a follow-up phase.
- Keep implementation explicit, auditable, and MySQL-first, with simple validation and no secret exposure or agent-side trust changes.
- Track work with a linked issue created before implementation (`Fixes #168`).

### Description
- Added documentation `docs/security-settings.md` and updated `docs/security-logging.md` to clarify phase boundaries and operator behaviour for manual blocks and settings persistence.
- Introduced persistent models `SecuritySettings` and `SecurityIpBlock` (and enum `SecurityIpBlockType`) with EF Core mappings, DbSet registration, and startup SQL in `StartupSchemaService` to ensure MySQL schema creation for both tables.
- Implemented `ISecuritySettingsService` / `SecuritySettingsService` to load/create defaults, validate inputs (`>= 1`), persist updates, and write an event log entry for changes; added DTOs/command models for explicit fields.
- Implemented `ISecurityIpBlockService` / `SecurityIpBlockService` to list active blocks, add manual blocks with IP-format validation and duplicate-active-block prevention, and remove blocks via auditable soft-remove; actions log operator-friendly events without logging secrets.
- Extended admin UI and controller with a consolidated security page to edit agent/user settings, list active blocked IPs, add manual blocks, and remove blocks, including server-side validation and mobile-friendly, operational UI elements.
- Registered new services in DI and added event category/type constants for security-related events; updated README admin notes to document the new page and phase constraints.

### Testing
- Created a tracking GitHub issue before implementation and linked the work as `Fixes #168` using `gh issue create` which completed successfully.
- Verified the project builds with `dotnet build src/WebApp/PingMonitor.WebApp.slnx` and resolved initial compile issues, with final build succeeding.
- Ran automated tests with `dotnet test src/WebApp/PingMonitor.WebApp.slnx --no-build` which completed successfully (no failing tests reported).
- Performed basic functional checks in this environment to ensure settings persist, blocked-IP add/remove flows exercise validation paths, and invalid IPs are rejected (manual verification during development).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c93b58c8d4832aacbebf00fad24c30)