### PR TITLE
Add automatic auth enforcement: IP blocking and user lockout

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -7,6 +7,9 @@ The platform foundation is in place:
 - startup gate exists for MySQL-backed application startup
 - authenticated agent API endpoints exist for hello/config/heartbeat/results
 - result ingestion and core control-plane/execution-plane wiring exist
+- automatic authentication enforcement exists for security settings:
+  - temporary/permanent IP blocking for agent and user auth paths
+  - temporary user account lockout via Identity lockout timing
 - server-side state engine and alert lifecycle are still pending
 
 ---

--- a/docs/security-logging.md
+++ b/docs/security-logging.md
@@ -1,16 +1,16 @@
-# Security logging (phase 1)
+# Security logging
 
 ## Purpose
 
-Phase 1 adds auditable, persistent authentication-attempt logging for operators.
+Security logging provides auditable, persistent authentication-attempt logging for operators.
 
-This phase covers:
+It covers:
 
 - user authentication attempts
 - agent authentication attempts
 - a read-only admin page for reviewing recent attempts
 
-This phase does **not** add automatic active controls (automatic lockouts, automatic blocking, rate limiting, firewall actions). Manual block management and security setting persistence are covered in `docs/security-settings.md`.
+Automatic active controls for temporary/permanent IP blocking and temporary user lockout are enforced as defined in `docs/security-settings.md`.
 
 ---
 
@@ -44,6 +44,9 @@ Expected failure-reason examples:
 - `account_locked`
 - `login_not_allowed`
 - `two_factor_required`
+- `ip_temporarily_blocked`
+- `ip_permanently_blocked`
+- `account_temporarily_locked`
 
 No passwords or secret material are logged.
 
@@ -61,6 +64,8 @@ Expected failure-reason examples:
 - `disabled_agent`
 - `revoked_key`
 - `invalid_key`
+- `ip_temporarily_blocked`
+- `ip_permanently_blocked`
 
 No bearer tokens, API keys, or secret material are logged.
 
@@ -85,4 +90,3 @@ Default behavior is failure-focused:
 
 - successful attempts are hidden by default
 - operator can enable a simple toggle to include successful attempts
-

--- a/docs/security-settings.md
+++ b/docs/security-settings.md
@@ -1,16 +1,16 @@
-# Security settings (phase 1)
+# Security settings
 
 ## Purpose
 
-This phase adds operator-managed security configuration and blocked IP management for authentication paths.
+Security settings provide operator-managed authentication protection configuration and blocked IP management for authentication paths.
 
 It covers:
 
 - persisted security settings for **agent authentication** and **user authentication**
 - persistent blocked IP records for agent/user auth types
 - manual IP block and unblock from the admin security page
-
-It does **not** yet implement full automatic enforcement of temporary/permanent IP blocks or account lockouts.
+- automatic enforcement of temporary/permanent IP blocking
+- automatic enforcement of temporary user account lockout
 
 ## Authentication settings
 
@@ -35,7 +35,7 @@ Security settings are stored as explicit fields in minutes/counts.
 - **IP block** applies to requests coming from a source IP address for a selected auth type (`User` or `Agent`).
 - **Account lockout** applies to a specific user account and is configured separately from IP block thresholds/duration.
 
-In this phase, account lockout values are configurable and persisted, but lockout policy enforcement remains a follow-up phase.
+Account lockout is enforced through ASP.NET Identity lockout fields (`LockoutEnd`, access-failed counters), not through a separate parallel lockout store.
 
 ## Manual IP block / unblock behaviour
 
@@ -44,17 +44,44 @@ In this phase, account lockout values are configurable and persisted, but lockou
 - Existing active blocks for the same `(AuthType, IpAddress)` are not duplicated.
 - Unblock is implemented as an audited soft-removal (`RemovedAtUtc`, `RemovedByUserId`) rather than hard deletion.
 
+## Automatic enforcement behavior
+
+### Enforcement order
+
+Agent authentication request order:
+
+1. Resolve source IP.
+2. Check for an active IP block for `AuthType = Agent`.
+3. If blocked, reject immediately and write a failed auth log entry.
+4. If not blocked, perform normal credential validation.
+5. On failed auth, evaluate failed-attempt thresholds and create/update block state as needed.
+
+User login request order:
+
+1. Resolve source IP.
+2. Check for an active IP block for `AuthType = User`.
+3. If blocked, reject immediately and write a failed auth log entry.
+4. If not IP-blocked and user can be identified, check user lockout status.
+5. If user is locked, reject and write a failed auth log entry.
+6. If not blocked/locked, perform normal credential validation.
+7. On failed auth, evaluate IP block thresholds and user lockout thresholds.
+
+### Temporary vs permanent IP block decision
+
+- Failed attempts are evaluated in a deterministic rolling lookback window of recent auth log data.
+- If permanent threshold is met or exceeded, create a `Permanent` block (no expiry).
+- Otherwise, if temporary threshold is met or exceeded, create a `Temporary` block with expiry set to `now + configured duration`.
+- Existing active block rows for the same `(AuthType, IpAddress)` are not duplicated.
+- Existing permanent/manual blocks remain authoritative.
+
+### Expiry behavior
+
+- Temporary IP blocks stop enforcing once `ExpiresAtUtc <= now`.
+- Expired temporary IP blocks may remain in history for audit purposes.
+- Active enforcement checks only consider records where `RemovedAtUtc` is null and expiry is still in the future (or no expiry for permanent/manual blocks).
+- User temporary lockout automatically expires when current UTC time passes the stored lockout end value.
+
 ## Auditability
 
-Manual block and unblock actions are persisted as security IP block records and event log entries.
+Manual and automatic block/unblock actions are persisted as security IP block records and event log entries.
 Settings updates are also event logged.
-
-## Phase boundary
-
-This phase intentionally focuses on:
-
-- settings persistence
-- operator UI for settings
-- blocked IP list and manual management
-
-Automatic auth enforcement, automatic expiry handling pipeline behavior, and lockout execution are next-phase work.

--- a/src/WebApp/PingMonitor.Web/Controllers/AccountController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AccountController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Models;
 using PingMonitor.Web.Models.Identity;
 using PingMonitor.Web.Services.Security;
 
@@ -14,15 +15,18 @@ public sealed class AccountController : Controller
     private readonly SignInManager<ApplicationUser> _signInManager;
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly ISecurityAuthLogService _securityAuthLogService;
+    private readonly ISecurityEnforcementService _securityEnforcementService;
 
     public AccountController(
         SignInManager<ApplicationUser> signInManager,
         UserManager<ApplicationUser> userManager,
-        ISecurityAuthLogService securityAuthLogService)
+        ISecurityAuthLogService securityAuthLogService,
+        ISecurityEnforcementService securityEnforcementService)
     {
         _signInManager = signInManager;
         _userManager = userManager;
         _securityAuthLogService = securityAuthLogService;
+        _securityEnforcementService = securityEnforcementService;
     }
 
     [HttpGet("login")]
@@ -45,20 +49,72 @@ public sealed class AccountController : Controller
         var user = await _userManager.FindByNameAsync(normalizedUserName) ??
                    await _userManager.FindByEmailAsync(normalizedUserName);
 
-        var signInIdentifier = user?.UserName ?? normalizedUserName;
-        var result = await _signInManager.PasswordSignInAsync(signInIdentifier, model.Password, isPersistent: false, lockoutOnFailure: true);
-        if (!result.Succeeded)
+        // Enforcement order:
+        // 1) source IP block check
+        // 2) user lockout check (if user identified)
+        // 3) password validation
+        // 4) failed-attempt threshold evaluation for IP and user lockout
+        var sourceIpAddress = HttpContext.Connection.RemoteIpAddress?.ToString();
+        var ipBlockStatus = await _securityEnforcementService.GetIpBlockStatusAsync(SecurityAuthType.User, sourceIpAddress, HttpContext.RequestAborted);
+        if (ipBlockStatus.IsBlocked)
         {
             await _securityAuthLogService.LogUserAttemptAsync(
                 new UserAuthLogWriteRequest
                 {
                     SubjectIdentifier = normalizedUserName,
                     UserId = user?.Id,
-                    SourceIpAddress = HttpContext.Connection.RemoteIpAddress?.ToString(),
+                    SourceIpAddress = sourceIpAddress,
                     Success = false,
-                    FailureReason = BuildFailureReason(result, user)
+                    FailureReason = ipBlockStatus.FailureReason
                 },
                 HttpContext.RequestAborted);
+
+            ModelState.AddModelError(string.Empty, "Authentication attempt denied.");
+            return View("Login", model);
+        }
+
+        if (user is not null)
+        {
+            var lockoutStatus = await _securityEnforcementService.GetUserLockoutStatusAsync(user, HttpContext.RequestAborted);
+            if (lockoutStatus.IsLockedOut)
+            {
+                await _securityAuthLogService.LogUserAttemptAsync(
+                    new UserAuthLogWriteRequest
+                    {
+                        SubjectIdentifier = normalizedUserName,
+                        UserId = user.Id,
+                        SourceIpAddress = sourceIpAddress,
+                        Success = false,
+                        FailureReason = "account_temporarily_locked"
+                    },
+                    HttpContext.RequestAborted);
+
+                ModelState.AddModelError(string.Empty, "Your account is temporarily locked.");
+                return View("Login", model);
+            }
+        }
+
+        var signInIdentifier = user?.UserName ?? normalizedUserName;
+        var result = await _signInManager.PasswordSignInAsync(signInIdentifier, model.Password, isPersistent: false, lockoutOnFailure: false);
+        if (!result.Succeeded)
+        {
+            var failureReason = BuildFailureReason(result, user);
+            await _securityAuthLogService.LogUserAttemptAsync(
+                new UserAuthLogWriteRequest
+                {
+                    SubjectIdentifier = normalizedUserName,
+                    UserId = user?.Id,
+                    SourceIpAddress = sourceIpAddress,
+                    Success = false,
+                    FailureReason = failureReason
+                },
+                HttpContext.RequestAborted);
+
+            await _securityEnforcementService.EvaluateFailedAttemptAsync(SecurityAuthType.User, sourceIpAddress, HttpContext.RequestAborted);
+            if (user is not null)
+            {
+                await _securityEnforcementService.EvaluateFailedUserLockoutAsync(user, HttpContext.RequestAborted);
+            }
 
             ModelState.AddModelError(string.Empty, "Invalid credentials.");
             return View("Login", model);
@@ -69,7 +125,7 @@ public sealed class AccountController : Controller
             {
                 SubjectIdentifier = normalizedUserName,
                 UserId = user?.Id,
-                SourceIpAddress = HttpContext.Connection.RemoteIpAddress?.ToString(),
+                SourceIpAddress = sourceIpAddress,
                 Success = true,
                 FailureReason = null
             },

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminSecurityController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminSecurityController.cs
@@ -1,8 +1,11 @@
 using System.Net;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Models;
+using PingMonitor.Web.Models.Identity;
 using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.Services.Security;
 using PingMonitor.Web.ViewModels.Admin;
@@ -17,15 +20,18 @@ public sealed class AdminSecurityController : Controller
     private readonly ISecurityAuthLogQueryService _securityAuthLogQueryService;
     private readonly ISecuritySettingsService _securitySettingsService;
     private readonly ISecurityIpBlockService _securityIpBlockService;
+    private readonly UserManager<ApplicationUser> _userManager;
 
     public AdminSecurityController(
         ISecurityAuthLogQueryService securityAuthLogQueryService,
         ISecuritySettingsService securitySettingsService,
-        ISecurityIpBlockService securityIpBlockService)
+        ISecurityIpBlockService securityIpBlockService,
+        UserManager<ApplicationUser> userManager)
     {
         _securityAuthLogQueryService = securityAuthLogQueryService;
         _securitySettingsService = securitySettingsService;
         _securityIpBlockService = securityIpBlockService;
+        _userManager = userManager;
     }
 
     [HttpGet]
@@ -195,6 +201,20 @@ public sealed class AdminSecurityController : Controller
 
         var settings = await _securitySettingsService.GetCurrentAsync(cancellationToken);
         var activeBlocks = await _securityIpBlockService.ListActiveAsync(cancellationToken);
+        var now = DateTimeOffset.UtcNow;
+        var lockedOutUsers = await _userManager.Users
+            .AsNoTracking()
+            .Where(x => x.LockoutEnd != null && x.LockoutEnd > now)
+            .OrderBy(x => x.LockoutEnd)
+            .Take(100)
+            .Select(x => new LockedOutUserListItem
+            {
+                UserId = x.Id,
+                UserName = x.UserName ?? string.Empty,
+                Email = x.Email ?? string.Empty,
+                LockoutEndUtc = x.LockoutEnd!.Value
+            })
+            .ToListAsync(cancellationToken);
 
         return new AdminSecurityPageViewModel
         {
@@ -203,6 +223,7 @@ public sealed class AdminSecurityController : Controller
             UserAttempts = userAttempts,
             AgentAttempts = agentAttempts,
             ActiveIpBlocks = activeBlocks,
+            LockedOutUsers = lockedOutUsers,
             SettingsSaved = settingsSaved || string.Equals(Request.Query["settingsSaved"], "true", StringComparison.OrdinalIgnoreCase),
             BlockSaved = blockSaved || string.Equals(Request.Query["blockSaved"], "true", StringComparison.OrdinalIgnoreCase),
             UnblockSaved = unblockSaved || string.Equals(Request.Query["unblockSaved"], "true", StringComparison.OrdinalIgnoreCase),

--- a/src/WebApp/PingMonitor.Web/Models/EventType.cs
+++ b/src/WebApp/PingMonitor.Web/Models/EventType.cs
@@ -13,4 +13,7 @@ public static class EventType
     public const string SecuritySettingsUpdated = "security_settings_updated";
     public const string SecurityManualIpBlockAdded = "security_manual_ip_block_added";
     public const string SecurityIpBlockRemoved = "security_ip_block_removed";
+    public const string SecurityAutomaticTemporaryIpBlockAdded = "security_automatic_temporary_ip_block_added";
+    public const string SecurityAutomaticPermanentIpBlockAdded = "security_automatic_permanent_ip_block_added";
+    public const string SecurityAutomaticUserLockoutApplied = "security_automatic_user_lockout_applied";
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -118,6 +118,7 @@ builder.Services.AddScoped<ISecurityAuthLogService, SecurityAuthLogService>();
 builder.Services.AddScoped<ISecurityAuthLogQueryService, SecurityAuthLogQueryService>();
 builder.Services.AddScoped<ISecuritySettingsService, SecuritySettingsService>();
 builder.Services.AddScoped<ISecurityIpBlockService, SecurityIpBlockService>();
+builder.Services.AddScoped<ISecurityEnforcementService, SecurityEnforcementService>();
 builder.Services.AddScoped<IEndpointStatusQueryService, EndpointStatusQueryService>();
 builder.Services.AddScoped<IStartupGateService, StartupGateService>();
 builder.Services.AddSingleton<IStartupDatabaseConfigurationStore, FileStartupDatabaseConfigurationStore>();

--- a/src/WebApp/PingMonitor.Web/Services/AgentAuthenticationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentAuthenticationService.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
 using PingMonitor.Web.Services.Security;
 
 namespace PingMonitor.Web.Services;
@@ -10,23 +11,41 @@ internal sealed class AgentAuthenticationService : IAgentAuthenticationService
     private readonly PingMonitorDbContext _dbContext;
     private readonly IAgentApiKeyHasher _apiKeyHasher;
     private readonly ISecurityAuthLogService _securityAuthLogService;
+    private readonly ISecurityEnforcementService _securityEnforcementService;
 
     public AgentAuthenticationService(
         PingMonitorDbContext dbContext,
         IAgentApiKeyHasher apiKeyHasher,
-        ISecurityAuthLogService securityAuthLogService)
+        ISecurityAuthLogService securityAuthLogService,
+        ISecurityEnforcementService securityEnforcementService)
     {
         _dbContext = dbContext;
         _apiKeyHasher = apiKeyHasher;
         _securityAuthLogService = securityAuthLogService;
+        _securityEnforcementService = securityEnforcementService;
     }
 
     public async Task<AgentAuthenticationResult> AuthenticateAsync(HttpRequest request, CancellationToken cancellationToken)
     {
+        // Enforcement order:
+        // 1) resolve source IP
+        // 2) check active agent-auth IP block
+        // 3) if blocked, reject and log once
+        // 4) continue normal auth checks
+        // 5) after failed auth, evaluate automatic blocking thresholds
+        var sourceIpAddress = request.HttpContext.Connection.RemoteIpAddress?.ToString();
+        var ipBlockStatus = await _securityEnforcementService.GetIpBlockStatusAsync(SecurityAuthType.Agent, sourceIpAddress, cancellationToken);
+        if (ipBlockStatus.IsBlocked)
+        {
+            await LogAttemptAsync(request, success: false, subjectIdentifier: "blocked_agent", agentId: null, failureReason: ipBlockStatus.FailureReason, cancellationToken);
+            return AgentAuthenticationResult.Forbidden("Authentication attempt denied.");
+        }
+
         var instanceId = request.Headers[InstanceIdHeaderName].ToString().Trim();
         if (string.IsNullOrWhiteSpace(instanceId))
         {
             await LogAttemptAsync(request, success: false, subjectIdentifier: "unknown_instance", agentId: null, failureReason: "missing_instance_header", cancellationToken);
+            await _securityEnforcementService.EvaluateFailedAttemptAsync(SecurityAuthType.Agent, sourceIpAddress, cancellationToken);
             return AgentAuthenticationResult.Unauthorized($"Missing required header '{InstanceIdHeaderName}'.");
         }
 
@@ -34,6 +53,7 @@ internal sealed class AgentAuthenticationService : IAgentAuthenticationService
         if (!TryReadBearerToken(authorizationHeader, out var apiKey))
         {
             await LogAttemptAsync(request, success: false, subjectIdentifier: instanceId, agentId: null, failureReason: "missing_or_invalid_bearer_token", cancellationToken);
+            await _securityEnforcementService.EvaluateFailedAttemptAsync(SecurityAuthType.Agent, sourceIpAddress, cancellationToken);
             return AgentAuthenticationResult.Unauthorized("Missing or invalid bearer token.");
         }
 
@@ -41,24 +61,28 @@ internal sealed class AgentAuthenticationService : IAgentAuthenticationService
         if (agent is null)
         {
             await LogAttemptAsync(request, success: false, subjectIdentifier: instanceId, agentId: null, failureReason: "unknown_instance", cancellationToken);
+            await _securityEnforcementService.EvaluateFailedAttemptAsync(SecurityAuthType.Agent, sourceIpAddress, cancellationToken);
             return AgentAuthenticationResult.Unauthorized("The supplied agent credentials are invalid.");
         }
 
         if (!agent.Enabled)
         {
             await LogAttemptAsync(request, success: false, subjectIdentifier: instanceId, agentId: agent.AgentId, failureReason: "disabled_agent", cancellationToken);
+            await _securityEnforcementService.EvaluateFailedAttemptAsync(SecurityAuthType.Agent, sourceIpAddress, cancellationToken);
             return AgentAuthenticationResult.Forbidden("The agent is disabled.");
         }
 
         if (agent.ApiKeyRevoked)
         {
             await LogAttemptAsync(request, success: false, subjectIdentifier: instanceId, agentId: agent.AgentId, failureReason: "revoked_key", cancellationToken);
+            await _securityEnforcementService.EvaluateFailedAttemptAsync(SecurityAuthType.Agent, sourceIpAddress, cancellationToken);
             return AgentAuthenticationResult.Forbidden("The agent API key has been revoked.");
         }
 
         if (string.IsNullOrWhiteSpace(agent.ApiKeyHash) || !_apiKeyHasher.Verify(agent, apiKey!))
         {
             await LogAttemptAsync(request, success: false, subjectIdentifier: instanceId, agentId: agent.AgentId, failureReason: "invalid_key", cancellationToken);
+            await _securityEnforcementService.EvaluateFailedAttemptAsync(SecurityAuthType.Agent, sourceIpAddress, cancellationToken);
             return AgentAuthenticationResult.Unauthorized("The supplied agent credentials are invalid.");
         }
 

--- a/src/WebApp/PingMonitor.Web/Services/Security/ISecurityEnforcementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/ISecurityEnforcementService.cs
@@ -1,0 +1,12 @@
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Models.Identity;
+
+namespace PingMonitor.Web.Services.Security;
+
+public interface ISecurityEnforcementService
+{
+    Task<SecurityIpBlockStatus> GetIpBlockStatusAsync(SecurityAuthType authType, string? sourceIpAddress, CancellationToken cancellationToken);
+    Task<UserLockoutStatus> GetUserLockoutStatusAsync(ApplicationUser user, CancellationToken cancellationToken);
+    Task EvaluateFailedAttemptAsync(SecurityAuthType authType, string? sourceIpAddress, CancellationToken cancellationToken);
+    Task EvaluateFailedUserLockoutAsync(ApplicationUser user, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityEnforcementModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityEnforcementModels.cs
@@ -1,0 +1,43 @@
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.Security;
+
+public sealed class SecurityIpBlockStatus
+{
+    public bool IsBlocked { get; init; }
+    public SecurityIpBlockType? BlockType { get; init; }
+    public DateTimeOffset? ExpiresAtUtc { get; init; }
+    public string FailureReason { get; init; } = string.Empty;
+
+    public static SecurityIpBlockStatus NotBlocked() => new()
+    {
+        IsBlocked = false,
+        FailureReason = string.Empty
+    };
+
+    public static SecurityIpBlockStatus Blocked(SecurityIpBlockType blockType, DateTimeOffset? expiresAtUtc) => new()
+    {
+        IsBlocked = true,
+        BlockType = blockType,
+        ExpiresAtUtc = expiresAtUtc,
+        FailureReason = blockType == SecurityIpBlockType.Temporary ? "ip_temporarily_blocked" : "ip_permanently_blocked"
+    };
+}
+
+public sealed class UserLockoutStatus
+{
+    public bool IsLockedOut { get; init; }
+    public DateTimeOffset? LockoutEndUtc { get; init; }
+
+    public static UserLockoutStatus NotLockedOut() => new()
+    {
+        IsLockedOut = false,
+        LockoutEndUtc = null
+    };
+
+    public static UserLockoutStatus Locked(DateTimeOffset lockoutEndUtc) => new()
+    {
+        IsLockedOut = true,
+        LockoutEndUtc = lockoutEndUtc
+    };
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityEnforcementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityEnforcementService.cs
@@ -1,0 +1,263 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Models.Identity;
+using PingMonitor.Web.Services.EventLogs;
+
+namespace PingMonitor.Web.Services.Security;
+
+internal sealed class SecurityEnforcementService : ISecurityEnforcementService
+{
+    private const int FailedAttemptLookbackHours = 24;
+
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IEventLogService _eventLogService;
+    private readonly ILogger<SecurityEnforcementService> _logger;
+
+    public SecurityEnforcementService(
+        PingMonitorDbContext dbContext,
+        UserManager<ApplicationUser> userManager,
+        IEventLogService eventLogService,
+        ILogger<SecurityEnforcementService> logger)
+    {
+        _dbContext = dbContext;
+        _userManager = userManager;
+        _eventLogService = eventLogService;
+        _logger = logger;
+    }
+
+    public async Task<SecurityIpBlockStatus> GetIpBlockStatusAsync(SecurityAuthType authType, string? sourceIpAddress, CancellationToken cancellationToken)
+    {
+        var normalizedIp = NormalizeIpAddress(sourceIpAddress);
+        if (normalizedIp is null)
+        {
+            return SecurityIpBlockStatus.NotBlocked();
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var activeBlock = await _dbContext.SecurityIpBlocks
+            .AsNoTracking()
+            .Where(x => x.AuthType == authType)
+            .Where(x => x.IpAddress == normalizedIp)
+            .Where(x => x.RemovedAtUtc == null)
+            .Where(x => x.ExpiresAtUtc == null || x.ExpiresAtUtc > now)
+            .OrderByDescending(x => x.BlockType == SecurityIpBlockType.Permanent || x.BlockType == SecurityIpBlockType.Manual)
+            .ThenByDescending(x => x.BlockedAtUtc)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (activeBlock is null)
+        {
+            return SecurityIpBlockStatus.NotBlocked();
+        }
+
+        return SecurityIpBlockStatus.Blocked(activeBlock.BlockType, activeBlock.ExpiresAtUtc);
+    }
+
+    public Task<UserLockoutStatus> GetUserLockoutStatusAsync(ApplicationUser user, CancellationToken cancellationToken)
+    {
+        if (user.LockoutEnd.HasValue && user.LockoutEnd.Value > DateTimeOffset.UtcNow)
+        {
+            return Task.FromResult(UserLockoutStatus.Locked(user.LockoutEnd.Value));
+        }
+
+        return Task.FromResult(UserLockoutStatus.NotLockedOut());
+    }
+
+    public async Task EvaluateFailedAttemptAsync(SecurityAuthType authType, string? sourceIpAddress, CancellationToken cancellationToken)
+    {
+        var normalizedIp = NormalizeIpAddress(sourceIpAddress);
+        if (normalizedIp is null)
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var settings = await GetSecuritySettingsAsync(cancellationToken);
+        var lookbackStartUtc = now.AddHours(-FailedAttemptLookbackHours);
+
+        var failedAttempts = await _dbContext.SecurityAuthLogs
+            .AsNoTracking()
+            .Where(x => x.AuthType == authType)
+            .Where(x => x.SourceIpAddress == normalizedIp)
+            .Where(x => !x.Success)
+            .Where(x => x.OccurredAtUtc >= lookbackStartUtc)
+            .CountAsync(cancellationToken);
+
+        var permanentThreshold = authType == SecurityAuthType.Agent
+            ? settings.AgentFailedAttemptsBeforePermanentIpBlock
+            : settings.UserFailedAttemptsBeforePermanentIpBlock;
+
+        var temporaryThreshold = authType == SecurityAuthType.Agent
+            ? settings.AgentFailedAttemptsBeforeTemporaryIpBlock
+            : settings.UserFailedAttemptsBeforeTemporaryIpBlock;
+
+        if (failedAttempts >= permanentThreshold)
+        {
+            await EnsureIpBlockAsync(authType, normalizedIp, SecurityIpBlockType.Permanent, now, expiresAtUtc: null, cancellationToken);
+            return;
+        }
+
+        if (failedAttempts >= temporaryThreshold)
+        {
+            var durationMinutes = authType == SecurityAuthType.Agent
+                ? settings.AgentTemporaryIpBlockDurationMinutes
+                : settings.UserTemporaryIpBlockDurationMinutes;
+            var expiresAtUtc = now.AddMinutes(durationMinutes);
+            await EnsureIpBlockAsync(authType, normalizedIp, SecurityIpBlockType.Temporary, now, expiresAtUtc, cancellationToken);
+        }
+    }
+
+    public async Task EvaluateFailedUserLockoutAsync(ApplicationUser user, CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        if (user.LockoutEnd.HasValue && user.LockoutEnd.Value > now)
+        {
+            return;
+        }
+
+        var settings = await GetSecuritySettingsAsync(cancellationToken);
+        var lookbackStartUtc = now.AddHours(-FailedAttemptLookbackHours);
+
+        var failedAttempts = await _dbContext.SecurityAuthLogs
+            .AsNoTracking()
+            .Where(x => x.AuthType == SecurityAuthType.User)
+            .Where(x => x.UserId == user.Id)
+            .Where(x => !x.Success)
+            .Where(x => x.OccurredAtUtc >= lookbackStartUtc)
+            .CountAsync(cancellationToken);
+
+        if (failedAttempts < settings.UserFailedAttemptsBeforeTemporaryAccountLockout)
+        {
+            return;
+        }
+
+        var lockoutEndUtc = now.AddMinutes(settings.UserTemporaryAccountLockoutDurationMinutes);
+
+        if (!user.LockoutEnabled)
+        {
+            user.LockoutEnabled = true;
+            await _userManager.UpdateAsync(user);
+        }
+
+        await _userManager.SetLockoutEndDateAsync(user, lockoutEndUtc);
+
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.Security,
+            EventType = EventType.SecurityAutomaticUserLockoutApplied,
+            Severity = EventSeverity.Warning,
+            Message = "Automatic temporary account lockout applied after failed user authentication attempts.",
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                userId = user.Id,
+                lockoutEndUtc,
+                lookbackWindowHours = FailedAttemptLookbackHours,
+                threshold = settings.UserFailedAttemptsBeforeTemporaryAccountLockout,
+                failedAttempts
+            })
+        }, cancellationToken);
+    }
+
+    private async Task EnsureIpBlockAsync(
+        SecurityAuthType authType,
+        string sourceIpAddress,
+        SecurityIpBlockType blockType,
+        DateTimeOffset now,
+        DateTimeOffset? expiresAtUtc,
+        CancellationToken cancellationToken)
+    {
+        var activeBlock = await _dbContext.SecurityIpBlocks
+            .Where(x => x.AuthType == authType)
+            .Where(x => x.IpAddress == sourceIpAddress)
+            .Where(x => x.RemovedAtUtc == null)
+            .Where(x => x.ExpiresAtUtc == null || x.ExpiresAtUtc > now)
+            .OrderByDescending(x => x.BlockedAtUtc)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (activeBlock is not null)
+        {
+            if (activeBlock.BlockType == SecurityIpBlockType.Permanent || activeBlock.BlockType == SecurityIpBlockType.Manual)
+            {
+                return;
+            }
+
+            if (blockType == SecurityIpBlockType.Temporary)
+            {
+                return;
+            }
+
+            activeBlock.RemovedAtUtc = now;
+            activeBlock.RemovedByUserId = null;
+        }
+
+        var entity = new SecurityIpBlock
+        {
+            AuthType = authType,
+            IpAddress = sourceIpAddress,
+            BlockType = blockType,
+            BlockedAtUtc = now,
+            ExpiresAtUtc = expiresAtUtc,
+            Reason = blockType == SecurityIpBlockType.Temporary
+                ? "Automatic temporary block after failed authentication attempts."
+                : "Automatic permanent block after failed authentication attempts.",
+            CreatedByUserId = null
+        };
+
+        _dbContext.SecurityIpBlocks.Add(entity);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.Security,
+            EventType = blockType == SecurityIpBlockType.Temporary
+                ? EventType.SecurityAutomaticTemporaryIpBlockAdded
+                : EventType.SecurityAutomaticPermanentIpBlockAdded,
+            Severity = EventSeverity.Warning,
+            Message = blockType == SecurityIpBlockType.Temporary
+                ? "Automatic temporary IP block added after failed authentication attempts."
+                : "Automatic permanent IP block added after failed authentication attempts.",
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                entity.SecurityIpBlockId,
+                entity.AuthType,
+                entity.IpAddress,
+                entity.BlockType,
+                entity.BlockedAtUtc,
+                entity.ExpiresAtUtc,
+                lookbackWindowHours = FailedAttemptLookbackHours
+            })
+        }, cancellationToken);
+
+        _logger.LogWarning("Automatic {BlockType} IP block applied for {AuthType} auth on {IpAddress}.", blockType, authType, sourceIpAddress);
+    }
+
+    private async Task<SecuritySettings> GetSecuritySettingsAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _dbContext.SecuritySettings
+            .SingleOrDefaultAsync(x => x.SecuritySettingsId == SecuritySettings.SingletonId, cancellationToken);
+
+        if (settings is not null)
+        {
+            return settings;
+        }
+
+        settings = new SecuritySettings
+        {
+            SecuritySettingsId = SecuritySettings.SingletonId,
+            UpdatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        _dbContext.SecuritySettings.Add(settings);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return settings;
+    }
+
+    private static string? NormalizeIpAddress(string? sourceIpAddress)
+    {
+        var value = sourceIpAddress?.Trim();
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/AdminSecurityPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/AdminSecurityPageViewModel.cs
@@ -11,11 +11,20 @@ public sealed class AdminSecurityPageViewModel
     public IReadOnlyList<SecurityAuthLogListItem> UserAttempts { get; init; } = [];
     public IReadOnlyList<SecurityAuthLogListItem> AgentAttempts { get; init; } = [];
     public IReadOnlyList<SecurityIpBlockListItem> ActiveIpBlocks { get; init; } = [];
+    public IReadOnlyList<LockedOutUserListItem> LockedOutUsers { get; init; } = [];
     public SecuritySettingsForm SettingsForm { get; init; } = new();
     public ManualIpBlockForm ManualIpBlockForm { get; init; } = new();
     public bool SettingsSaved { get; init; }
     public bool BlockSaved { get; init; }
     public bool UnblockSaved { get; init; }
+}
+
+public sealed class LockedOutUserListItem
+{
+    public string UserId { get; init; } = string.Empty;
+    public string UserName { get; init; } = string.Empty;
+    public string Email { get; init; } = string.Empty;
+    public DateTimeOffset LockoutEndUtc { get; init; }
 }
 
 public sealed class SecuritySettingsForm

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
@@ -51,10 +51,45 @@
 <main>
     <section class="card">
         <h1>Security logs and settings</h1>
-        <p class="muted">Configure user/agent authentication thresholds, manage manual blocked IPs, and review authentication attempts.</p>
+        <p class="muted">Configure user/agent authentication thresholds, manage blocked IPs, and review authentication attempts. IP blocking and temporary account lockout settings are enforced automatically.</p>
         <div class="button-row">
             <a class="button-secondary" href="/admin">Back to admin settings</a>
             <a class="button-secondary" href="/status">Back to status</a>
+        </div>
+    </section>
+
+    <section class="card">
+        <h2>Currently locked-out user accounts</h2>
+        <p class="muted">User temporary lockout is enforced through ASP.NET Identity lockout timing.</p>
+        <div class="table-wrap">
+            <table>
+                <thead>
+                <tr>
+                    <th>User name</th>
+                    <th>Email</th>
+                    <th>Lockout ends (UTC)</th>
+                </tr>
+                </thead>
+                <tbody>
+                @if (!Model.LockedOutUsers.Any())
+                {
+                    <tr>
+                        <td colspan="3" class="muted">No users are currently locked out.</td>
+                    </tr>
+                }
+                else
+                {
+                    @foreach (var user in Model.LockedOutUsers)
+                    {
+                        <tr>
+                            <td>@user.UserName</td>
+                            <td>@(string.IsNullOrWhiteSpace(user.Email) ? "n/a" : user.Email)</td>
+                            <td>@user.LockoutEndUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")</td>
+                        </tr>
+                    }
+                }
+                </tbody>
+            </table>
         </div>
     </section>
 


### PR DESCRIPTION
### Motivation

- Introduce deterministic, auditable enforcement of security settings so failed authentication attempts can automatically cause temporary/permanent IP blocks and temporary user account lockouts.
- Follow existing security logging/settings models and ASP.NET Identity lockout semantics to avoid duplicating state and to keep enforcement explicit and MySQL-compatible.
- Provide operator visibility of active enforcement state on the admin security page and ensure enforcement order is explicit in the auth flows.

### Description

- Added a new enforcement service interface `ISecurityEnforcementService` and implementation `SecurityEnforcementService` that evaluates active IP blocks, creates automatic temporary or permanent IP blocks, and applies temporary user lockout via Identity `LockoutEnd` fields using a deterministic 24-hour lookback window.
- Integrated enforcement into agent authentication by checking IP blocks before credential validation and invoking failed-attempt evaluation after failed agent auth attempts, and added explicit enforcement-order comments to the flow.
- Integrated enforcement into user login by checking IP blocks first, checking user lockout next (when user is identifiable), disabling Identity automatic lockout-on-failure and instead evaluating IP block and account lockout thresholds after a failed sign-in, and logging clear failure reasons (`ip_temporarily_blocked`, `ip_permanently_blocked`, `account_temporarily_locked`).
- Extended data/UI/docs: added enforcement models and examples to `docs/security-settings.md` and `docs/security-logging.md`, added new event types for automatic temporary/permanent IP blocks and automatic user lockout, registered the enforcement service in DI, and surfaced currently locked-out users on the admin security page.

### Testing

- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which completed successfully with zero errors and produced the build artifact.
- Ran `dotnet test src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj --no-build` which exited successfully in this environment (project contains no runnable unit tests here).
- Created a tracked GitHub issue for this work (Issue #170) before implementation to satisfy repository traceability requirements.

Note: build and compile validations passed, but live enforcement behavior (blocked IPs, lockout expiry) should be validated in a MySQL-backed deployment for end-to-end verification; no runtime integration tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c940c37560832ab98b2b15bc45593c)