### PR TITLE
Refine manual unblock/unlock workflows with explicit confirmation and audit logging

### DIFF
--- a/docs/security-logging.md
+++ b/docs/security-logging.md
@@ -90,3 +90,18 @@ Default behavior is failure-focused:
 
 - successful attempts are hidden by default
 - operator can enable a simple toggle to include successful attempts
+
+
+## Operator manual enforcement-clear actions
+
+Manual unblock and manual unlock workflows must generate auditable security records.
+
+At minimum, event records include:
+
+- timestamp (event log occurrence time)
+- operator identity when available
+- action type (`manual_ip_unblock`, `manual_user_unlock`)
+- target identifier (IP block id/IP address or user id/user name)
+- success/failure outcome and failure reason for rejected requests
+
+These records are written without secrets and are intended for operator audit trails and incident review.

--- a/docs/security-settings.md
+++ b/docs/security-settings.md
@@ -9,6 +9,7 @@ It covers:
 - persisted security settings for **agent authentication** and **user authentication**
 - persistent blocked IP records for agent/user auth types
 - manual IP block and unblock from the admin security page
+- manual unlock of currently locked-out users from the admin security page
 - automatic enforcement of temporary/permanent IP blocking
 - automatic enforcement of temporary user account lockout
 
@@ -42,7 +43,16 @@ Account lockout is enforced through ASP.NET Identity lockout fields (`LockoutEnd
 - Operators can manually add a block for a valid IP address and selected auth type.
 - Block type for manual blocks is recorded as `Manual`.
 - Existing active blocks for the same `(AuthType, IpAddress)` are not duplicated.
+- Manual unblock is allowed only for currently active blocks (not already removed and not expired).
 - Unblock is implemented as an audited soft-removal (`RemovedAtUtc`, `RemovedByUserId`) rather than hard deletion.
+- Manual unblock requires explicit typed confirmation (`UNBLOCK`) before mutation.
+
+## Manual user unlock behaviour
+
+- Manual unlock is allowed only for users currently in an active lockout state (`LockoutEnd > now`).
+- Unlock uses ASP.NET Identity lockout fields directly (`SetLockoutEndDateAsync(..., null)`).
+- Access-failed count is reset after a successful manual unlock to avoid immediate re-lock from stale counters.
+- Manual unlock requires explicit typed confirmation (`UNLOCK`) before mutation.
 
 ## Automatic enforcement behavior
 
@@ -84,4 +94,5 @@ User login request order:
 ## Auditability
 
 Manual and automatic block/unblock actions are persisted as security IP block records and event log entries.
+Manual user unlock actions (success and rejected attempts) are event logged with operator identity context when available.
 Settings updates are also event logged.

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminSecurityController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminSecurityController.cs
@@ -17,20 +17,26 @@ namespace PingMonitor.Web.Controllers;
 public sealed class AdminSecurityController : Controller
 {
     private const int DefaultLogLimit = 100;
+    private const string UnblockConfirmationKeyword = "UNBLOCK";
+    private const string UnlockConfirmationKeyword = "UNLOCK";
+
     private readonly ISecurityAuthLogQueryService _securityAuthLogQueryService;
     private readonly ISecuritySettingsService _securitySettingsService;
     private readonly ISecurityIpBlockService _securityIpBlockService;
+    private readonly ISecurityOperatorActionService _securityOperatorActionService;
     private readonly UserManager<ApplicationUser> _userManager;
 
     public AdminSecurityController(
         ISecurityAuthLogQueryService securityAuthLogQueryService,
         ISecuritySettingsService securitySettingsService,
         ISecurityIpBlockService securityIpBlockService,
+        ISecurityOperatorActionService securityOperatorActionService,
         UserManager<ApplicationUser> userManager)
     {
         _securityAuthLogQueryService = securityAuthLogQueryService;
         _securitySettingsService = securitySettingsService;
         _securityIpBlockService = securityIpBlockService;
+        _securityOperatorActionService = securityOperatorActionService;
         _userManager = userManager;
     }
 
@@ -43,6 +49,7 @@ public sealed class AdminSecurityController : Controller
             settingsSaved: false,
             blockSaved: false,
             unblockSaved: false,
+            unlockSaved: false,
             settingsFormOverride: null,
             manualIpBlockFormOverride: null,
             cancellationToken: cancellationToken);
@@ -66,6 +73,7 @@ public sealed class AdminSecurityController : Controller
                 settingsSaved: false,
                 blockSaved: false,
                 unblockSaved: false,
+                unlockSaved: false,
                 settingsFormOverride: settingsForm,
                 manualIpBlockFormOverride: null,
                 cancellationToken);
@@ -113,6 +121,7 @@ public sealed class AdminSecurityController : Controller
                 settingsSaved: false,
                 blockSaved: false,
                 unblockSaved: false,
+                unlockSaved: false,
                 settingsFormOverride: null,
                 manualIpBlockFormOverride: manualIpBlockForm,
                 cancellationToken);
@@ -139,6 +148,7 @@ public sealed class AdminSecurityController : Controller
                 settingsSaved: false,
                 blockSaved: false,
                 unblockSaved: false,
+                unlockSaved: false,
                 settingsFormOverride: null,
                 manualIpBlockFormOverride: manualIpBlockForm,
                 cancellationToken);
@@ -148,15 +158,56 @@ public sealed class AdminSecurityController : Controller
         return RedirectToAction(nameof(Index), new { includeSuccessfulUsers, includeSuccessfulAgents, blockSaved = true });
     }
 
-    [HttpPost("ip-blocks/{securityIpBlockId}/remove")]
-    [ValidateAntiForgeryToken]
+    [HttpGet("ip-blocks/{securityIpBlockId}/remove")]
     public async Task<IActionResult> RemoveIpBlock(
         string securityIpBlockId,
-        [FromForm] bool includeSuccessfulUsers = false,
-        [FromForm] bool includeSuccessfulAgents = false,
+        [FromQuery] bool includeSuccessfulUsers = false,
+        [FromQuery] bool includeSuccessfulAgents = false,
         CancellationToken cancellationToken = default)
     {
-        var result = await _securityIpBlockService.RemoveAsync(new RemoveSecurityIpBlockRequest
+        var details = await _securityOperatorActionService.GetActiveIpBlockAsync(securityIpBlockId, cancellationToken);
+        if (details is null)
+        {
+            TempData["SecurityIpBlockRemoveError"] = "Blocked IP record is not active or no longer exists.";
+            return RedirectToAction(nameof(Index), new { includeSuccessfulUsers, includeSuccessfulAgents });
+        }
+
+        return View("ConfirmUnblockIp", new ConfirmUnblockIpViewModel
+        {
+            IncludeSuccessfulUsers = includeSuccessfulUsers,
+            IncludeSuccessfulAgents = includeSuccessfulAgents,
+            SecurityIpBlockId = details.SecurityIpBlockId,
+            AuthType = details.AuthType,
+            IpAddress = details.IpAddress,
+            BlockType = details.BlockType,
+            BlockedAtUtc = details.BlockedAtUtc,
+            ExpiresAtUtc = details.ExpiresAtUtc,
+            RequiredConfirmationText = UnblockConfirmationKeyword
+        });
+    }
+
+    [HttpPost("ip-blocks/{securityIpBlockId}/remove")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RemoveIpBlockConfirmed(
+        string securityIpBlockId,
+        [FromForm] ConfirmUnblockIpViewModel model,
+        CancellationToken cancellationToken = default)
+    {
+        var details = await _securityOperatorActionService.GetActiveIpBlockAsync(securityIpBlockId, cancellationToken);
+        if (details is null)
+        {
+            TempData["SecurityIpBlockRemoveError"] = "Blocked IP record is not active or no longer exists.";
+            return RedirectToAction(nameof(Index), new { model.IncludeSuccessfulUsers, model.IncludeSuccessfulAgents });
+        }
+
+        var viewModel = BuildConfirmUnblockViewModel(details, model.IncludeSuccessfulUsers, model.IncludeSuccessfulAgents, model.ConfirmationText);
+        if (!string.Equals(model.ConfirmationText?.Trim(), UnblockConfirmationKeyword, StringComparison.Ordinal))
+        {
+            viewModel.ErrorMessage = $"Type {UnblockConfirmationKeyword} to confirm removing this active block.";
+            return View("ConfirmUnblockIp", viewModel);
+        }
+
+        var result = await _securityOperatorActionService.RemoveIpBlockAsync(new RemoveSecurityIpBlockRequest
         {
             SecurityIpBlockId = securityIpBlockId,
             RemovedByUserId = User.FindFirstValue(ClaimTypes.NameIdentifier)
@@ -165,10 +216,72 @@ public sealed class AdminSecurityController : Controller
         if (!result.Succeeded)
         {
             TempData["SecurityIpBlockRemoveError"] = result.Error ?? "Unable to remove blocked IP.";
+            return RedirectToAction(nameof(Index), new { model.IncludeSuccessfulUsers, model.IncludeSuccessfulAgents });
+        }
+
+        return RedirectToAction(nameof(Index), new { model.IncludeSuccessfulUsers, model.IncludeSuccessfulAgents, unblockSaved = true });
+    }
+
+    [HttpGet("users/{userId}/unlock")]
+    public async Task<IActionResult> UnlockUser(
+        string userId,
+        [FromQuery] bool includeSuccessfulUsers = false,
+        [FromQuery] bool includeSuccessfulAgents = false,
+        CancellationToken cancellationToken = default)
+    {
+        var details = await _securityOperatorActionService.GetLockedOutUserAsync(userId, cancellationToken);
+        if (details is null)
+        {
+            TempData["SecurityUserUnlockError"] = "User is not currently locked out or no longer exists.";
             return RedirectToAction(nameof(Index), new { includeSuccessfulUsers, includeSuccessfulAgents });
         }
 
-        return RedirectToAction(nameof(Index), new { includeSuccessfulUsers, includeSuccessfulAgents, unblockSaved = true });
+        return View("ConfirmUnlockUser", new ConfirmUnlockUserViewModel
+        {
+            IncludeSuccessfulUsers = includeSuccessfulUsers,
+            IncludeSuccessfulAgents = includeSuccessfulAgents,
+            UserId = details.UserId,
+            UserName = details.UserName,
+            Email = details.Email,
+            LockoutEndUtc = details.LockoutEndUtc,
+            RequiredConfirmationText = UnlockConfirmationKeyword
+        });
+    }
+
+    [HttpPost("users/{userId}/unlock")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UnlockUserConfirmed(
+        string userId,
+        [FromForm] ConfirmUnlockUserViewModel model,
+        CancellationToken cancellationToken = default)
+    {
+        var details = await _securityOperatorActionService.GetLockedOutUserAsync(userId, cancellationToken);
+        if (details is null)
+        {
+            TempData["SecurityUserUnlockError"] = "User is not currently locked out or no longer exists.";
+            return RedirectToAction(nameof(Index), new { model.IncludeSuccessfulUsers, model.IncludeSuccessfulAgents });
+        }
+
+        var viewModel = BuildConfirmUnlockViewModel(details, model.IncludeSuccessfulUsers, model.IncludeSuccessfulAgents, model.ConfirmationText);
+        if (!string.Equals(model.ConfirmationText?.Trim(), UnlockConfirmationKeyword, StringComparison.Ordinal))
+        {
+            viewModel.ErrorMessage = $"Type {UnlockConfirmationKeyword} to confirm unlocking this user.";
+            return View("ConfirmUnlockUser", viewModel);
+        }
+
+        var result = await _securityOperatorActionService.UnlockUserAsync(new UnlockSecurityUserRequest
+        {
+            UserId = userId,
+            OperatorUserId = User.FindFirstValue(ClaimTypes.NameIdentifier)
+        }, cancellationToken);
+
+        if (!result.Succeeded)
+        {
+            TempData["SecurityUserUnlockError"] = result.Error ?? "Unable to unlock user.";
+            return RedirectToAction(nameof(Index), new { model.IncludeSuccessfulUsers, model.IncludeSuccessfulAgents });
+        }
+
+        return RedirectToAction(nameof(Index), new { model.IncludeSuccessfulUsers, model.IncludeSuccessfulAgents, unlockSaved = true });
     }
 
     private async Task<AdminSecurityPageViewModel> BuildViewModelAsync(
@@ -177,6 +290,7 @@ public sealed class AdminSecurityController : Controller
         bool settingsSaved,
         bool blockSaved,
         bool unblockSaved,
+        bool unlockSaved,
         SecuritySettingsForm? settingsFormOverride,
         ManualIpBlockForm? manualIpBlockFormOverride,
         CancellationToken cancellationToken)
@@ -227,6 +341,7 @@ public sealed class AdminSecurityController : Controller
             SettingsSaved = settingsSaved || string.Equals(Request.Query["settingsSaved"], "true", StringComparison.OrdinalIgnoreCase),
             BlockSaved = blockSaved || string.Equals(Request.Query["blockSaved"], "true", StringComparison.OrdinalIgnoreCase),
             UnblockSaved = unblockSaved || string.Equals(Request.Query["unblockSaved"], "true", StringComparison.OrdinalIgnoreCase),
+            UnlockSaved = unlockSaved || string.Equals(Request.Query["unlockSaved"], "true", StringComparison.OrdinalIgnoreCase),
             SettingsForm = settingsFormOverride ?? new SecuritySettingsForm
             {
                 AgentFailedAttemptsBeforeTemporaryIpBlock = settings.AgentFailedAttemptsBeforeTemporaryIpBlock,
@@ -240,6 +355,38 @@ public sealed class AdminSecurityController : Controller
                 UpdatedAtUtc = settings.UpdatedAtUtc
             },
             ManualIpBlockForm = manualIpBlockFormOverride ?? new ManualIpBlockForm()
+        };
+    }
+
+    private static ConfirmUnblockIpViewModel BuildConfirmUnblockViewModel(ActiveSecurityIpBlockDetails details, bool includeSuccessfulUsers, bool includeSuccessfulAgents, string? confirmationText = null)
+    {
+        return new ConfirmUnblockIpViewModel
+        {
+            IncludeSuccessfulUsers = includeSuccessfulUsers,
+            IncludeSuccessfulAgents = includeSuccessfulAgents,
+            SecurityIpBlockId = details.SecurityIpBlockId,
+            AuthType = details.AuthType,
+            IpAddress = details.IpAddress,
+            BlockType = details.BlockType,
+            BlockedAtUtc = details.BlockedAtUtc,
+            ExpiresAtUtc = details.ExpiresAtUtc,
+            ConfirmationText = confirmationText,
+            RequiredConfirmationText = UnblockConfirmationKeyword
+        };
+    }
+
+    private static ConfirmUnlockUserViewModel BuildConfirmUnlockViewModel(LockedOutUserDetails details, bool includeSuccessfulUsers, bool includeSuccessfulAgents, string? confirmationText = null)
+    {
+        return new ConfirmUnlockUserViewModel
+        {
+            IncludeSuccessfulUsers = includeSuccessfulUsers,
+            IncludeSuccessfulAgents = includeSuccessfulAgents,
+            UserId = details.UserId,
+            UserName = details.UserName,
+            Email = details.Email,
+            LockoutEndUtc = details.LockoutEndUtc,
+            ConfirmationText = confirmationText,
+            RequiredConfirmationText = UnlockConfirmationKeyword
         };
     }
 }

--- a/src/WebApp/PingMonitor.Web/Models/EventType.cs
+++ b/src/WebApp/PingMonitor.Web/Models/EventType.cs
@@ -16,4 +16,7 @@ public static class EventType
     public const string SecurityAutomaticTemporaryIpBlockAdded = "security_automatic_temporary_ip_block_added";
     public const string SecurityAutomaticPermanentIpBlockAdded = "security_automatic_permanent_ip_block_added";
     public const string SecurityAutomaticUserLockoutApplied = "security_automatic_user_lockout_applied";
+    public const string SecurityManualIpBlockRemoveRejected = "security_manual_ip_block_remove_rejected";
+    public const string SecurityManualUserUnlockApplied = "security_manual_user_unlock_applied";
+    public const string SecurityManualUserUnlockRejected = "security_manual_user_unlock_rejected";
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -118,6 +118,7 @@ builder.Services.AddScoped<ISecurityAuthLogService, SecurityAuthLogService>();
 builder.Services.AddScoped<ISecurityAuthLogQueryService, SecurityAuthLogQueryService>();
 builder.Services.AddScoped<ISecuritySettingsService, SecuritySettingsService>();
 builder.Services.AddScoped<ISecurityIpBlockService, SecurityIpBlockService>();
+builder.Services.AddScoped<ISecurityOperatorActionService, SecurityOperatorActionService>();
 builder.Services.AddScoped<ISecurityEnforcementService, SecurityEnforcementService>();
 builder.Services.AddScoped<IEndpointStatusQueryService, EndpointStatusQueryService>();
 builder.Services.AddScoped<IStartupGateService, StartupGateService>();

--- a/src/WebApp/PingMonitor.Web/README.md
+++ b/src/WebApp/PingMonitor.Web/README.md
@@ -87,7 +87,9 @@ In normal startup mode, `GET /admin/security` provides:
 
 - persisted agent auth and user auth threshold/duration settings
 - active blocked IP list for `User` and `Agent` auth types
-- manual block and manual remove operations for blocked IP entries
+- manual block and manual remove operations for active blocked IP entries
+- manual unlock operation for currently locked-out users
+- explicit typed confirmations for unblock/unlock actions (`UNBLOCK` / `UNLOCK`)
 - read-only recent authentication-attempt logs
 
-In this phase, settings and blocked-IP management are persisted and operator-facing. Automatic enforcement of IP block thresholds and user lockout policy remains a follow-up phase.
+Automatic enforcement of IP block thresholds and user lockout policy is active. Manual unblock/unlock actions are audited through security event logs.

--- a/src/WebApp/PingMonitor.Web/Services/Security/ISecurityOperatorActionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/ISecurityOperatorActionService.cs
@@ -1,0 +1,9 @@
+namespace PingMonitor.Web.Services.Security;
+
+public interface ISecurityOperatorActionService
+{
+    Task<ActiveSecurityIpBlockDetails?> GetActiveIpBlockAsync(string securityIpBlockId, CancellationToken cancellationToken);
+    Task<LockedOutUserDetails?> GetLockedOutUserAsync(string userId, CancellationToken cancellationToken);
+    Task<SecurityIpBlockOperationResult> RemoveIpBlockAsync(RemoveSecurityIpBlockRequest request, CancellationToken cancellationToken);
+    Task<SecurityUserUnlockOperationResult> UnlockUserAsync(UnlockSecurityUserRequest request, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityOperatorActionModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityOperatorActionModels.cs
@@ -1,0 +1,36 @@
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.Security;
+
+public sealed class ActiveSecurityIpBlockDetails
+{
+    public string SecurityIpBlockId { get; init; } = string.Empty;
+    public SecurityAuthType AuthType { get; init; }
+    public string IpAddress { get; init; } = string.Empty;
+    public SecurityIpBlockType BlockType { get; init; }
+    public DateTimeOffset BlockedAtUtc { get; init; }
+    public DateTimeOffset? ExpiresAtUtc { get; init; }
+}
+
+public sealed class LockedOutUserDetails
+{
+    public string UserId { get; init; } = string.Empty;
+    public string UserName { get; init; } = string.Empty;
+    public string Email { get; init; } = string.Empty;
+    public DateTimeOffset LockoutEndUtc { get; init; }
+}
+
+public sealed class UnlockSecurityUserRequest
+{
+    public required string UserId { get; init; }
+    public string? OperatorUserId { get; init; }
+}
+
+public sealed class SecurityUserUnlockOperationResult
+{
+    public bool Succeeded { get; init; }
+    public string? Error { get; init; }
+
+    public static SecurityUserUnlockOperationResult Success() => new() { Succeeded = true };
+    public static SecurityUserUnlockOperationResult Failure(string error) => new() { Succeeded = false, Error = error };
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityOperatorActionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityOperatorActionService.cs
@@ -1,0 +1,266 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Models.Identity;
+using PingMonitor.Web.Services.EventLogs;
+
+namespace PingMonitor.Web.Services.Security;
+
+internal sealed class SecurityOperatorActionService : ISecurityOperatorActionService
+{
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IEventLogService _eventLogService;
+    private readonly ILogger<SecurityOperatorActionService> _logger;
+
+    public SecurityOperatorActionService(
+        PingMonitorDbContext dbContext,
+        UserManager<ApplicationUser> userManager,
+        IEventLogService eventLogService,
+        ILogger<SecurityOperatorActionService> logger)
+    {
+        _dbContext = dbContext;
+        _userManager = userManager;
+        _eventLogService = eventLogService;
+        _logger = logger;
+    }
+
+    public async Task<ActiveSecurityIpBlockDetails?> GetActiveIpBlockAsync(string securityIpBlockId, CancellationToken cancellationToken)
+    {
+        var blockId = securityIpBlockId.Trim();
+        if (string.IsNullOrWhiteSpace(blockId))
+        {
+            return null;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        return await _dbContext.SecurityIpBlocks
+            .AsNoTracking()
+            .Where(x => x.SecurityIpBlockId == blockId)
+            .Where(x => x.RemovedAtUtc == null)
+            .Where(x => x.ExpiresAtUtc == null || x.ExpiresAtUtc > now)
+            .Select(x => new ActiveSecurityIpBlockDetails
+            {
+                SecurityIpBlockId = x.SecurityIpBlockId,
+                AuthType = x.AuthType,
+                IpAddress = x.IpAddress,
+                BlockType = x.BlockType,
+                BlockedAtUtc = x.BlockedAtUtc,
+                ExpiresAtUtc = x.ExpiresAtUtc
+            })
+            .SingleOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<LockedOutUserDetails?> GetLockedOutUserAsync(string userId, CancellationToken cancellationToken)
+    {
+        var normalizedUserId = userId.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedUserId))
+        {
+            return null;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        return await _userManager.Users
+            .AsNoTracking()
+            .Where(x => x.Id == normalizedUserId)
+            .Where(x => x.LockoutEnd != null && x.LockoutEnd > now)
+            .Select(x => new LockedOutUserDetails
+            {
+                UserId = x.Id,
+                UserName = x.UserName ?? string.Empty,
+                Email = x.Email ?? string.Empty,
+                LockoutEndUtc = x.LockoutEnd!.Value
+            })
+            .SingleOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<SecurityIpBlockOperationResult> RemoveIpBlockAsync(RemoveSecurityIpBlockRequest request, CancellationToken cancellationToken)
+    {
+        var blockId = request.SecurityIpBlockId.Trim();
+        if (string.IsNullOrWhiteSpace(blockId))
+        {
+            return SecurityIpBlockOperationResult.Failure("Blocked IP record id is required.");
+        }
+
+        var entity = await _dbContext.SecurityIpBlocks
+            .SingleOrDefaultAsync(x => x.SecurityIpBlockId == blockId, cancellationToken);
+
+        if (entity is null)
+        {
+            await WriteRemoveIpBlockAuditAsync(blockId, request.RemovedByUserId, success: false, "not_found", cancellationToken);
+            return SecurityIpBlockOperationResult.Failure("Blocked IP record was not found.");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        if (entity.RemovedAtUtc is not null || (entity.ExpiresAtUtc.HasValue && entity.ExpiresAtUtc <= now))
+        {
+            await WriteRemoveIpBlockAuditAsync(entity.SecurityIpBlockId, request.RemovedByUserId, success: false, "not_active", cancellationToken, entity.AuthType, entity.IpAddress);
+            return SecurityIpBlockOperationResult.Failure("Blocked IP record is no longer active.");
+        }
+
+        entity.RemovedAtUtc = now;
+        entity.RemovedByUserId = string.IsNullOrWhiteSpace(request.RemovedByUserId) ? null : request.RemovedByUserId.Trim();
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.Security,
+            EventType = EventType.SecurityIpBlockRemoved,
+            Severity = EventSeverity.Info,
+            Message = $"Security IP block manually removed for {entity.AuthType} auth.",
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                success = true,
+                action = "manual_ip_unblock",
+                entity.SecurityIpBlockId,
+                entity.AuthType,
+                entity.IpAddress,
+                entity.BlockType,
+                entity.BlockedAtUtc,
+                entity.RemovedAtUtc,
+                operatorUserId = entity.RemovedByUserId
+            })
+        }, cancellationToken);
+
+        _logger.LogInformation(
+            "Manual IP unblock succeeded. SecurityIpBlockId={SecurityIpBlockId} AuthType={AuthType} IpAddress={IpAddress} OperatorUserId={OperatorUserId}",
+            entity.SecurityIpBlockId,
+            entity.AuthType,
+            entity.IpAddress,
+            entity.RemovedByUserId ?? "n/a");
+
+        return SecurityIpBlockOperationResult.Success();
+    }
+
+    public async Task<SecurityUserUnlockOperationResult> UnlockUserAsync(UnlockSecurityUserRequest request, CancellationToken cancellationToken)
+    {
+        var userId = request.UserId.Trim();
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return SecurityUserUnlockOperationResult.Failure("User id is required.");
+        }
+
+        var user = await _userManager.FindByIdAsync(userId);
+        if (user is null)
+        {
+            await WriteUnlockAuditAsync(userId, null, request.OperatorUserId, success: false, "not_found", cancellationToken);
+            return SecurityUserUnlockOperationResult.Failure("User was not found.");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        if (user.LockoutEnd is null || user.LockoutEnd <= now)
+        {
+            await WriteUnlockAuditAsync(user.Id, user.UserName, request.OperatorUserId, success: false, "not_locked", cancellationToken);
+            return SecurityUserUnlockOperationResult.Failure("User is not currently locked out.");
+        }
+
+        var unlockResult = await _userManager.SetLockoutEndDateAsync(user, null);
+        if (!unlockResult.Succeeded)
+        {
+            await WriteUnlockAuditAsync(user.Id, user.UserName, request.OperatorUserId, success: false, "unlock_failed", cancellationToken);
+            return SecurityUserUnlockOperationResult.Failure("Unable to update lockout state.");
+        }
+
+        var resetResult = await _userManager.ResetAccessFailedCountAsync(user);
+        if (!resetResult.Succeeded)
+        {
+            await WriteUnlockAuditAsync(user.Id, user.UserName, request.OperatorUserId, success: false, "reset_failed_count_failed", cancellationToken);
+            return SecurityUserUnlockOperationResult.Failure("User unlock was applied, but failed-count reset failed.");
+        }
+
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.Security,
+            EventType = EventType.SecurityManualUserUnlockApplied,
+            Severity = EventSeverity.Info,
+            Message = "User lockout was manually cleared by an operator.",
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                success = true,
+                action = "manual_user_unlock",
+                userId = user.Id,
+                userName = user.UserName,
+                operatorUserId = string.IsNullOrWhiteSpace(request.OperatorUserId) ? null : request.OperatorUserId.Trim(),
+                unlockedAtUtc = DateTimeOffset.UtcNow,
+                accessFailedCountReset = true
+            })
+        }, cancellationToken);
+
+        _logger.LogInformation(
+            "Manual user unlock succeeded. UserId={UserId} UserName={UserName} OperatorUserId={OperatorUserId}",
+            user.Id,
+            user.UserName ?? "n/a",
+            string.IsNullOrWhiteSpace(request.OperatorUserId) ? "n/a" : request.OperatorUserId.Trim());
+
+        return SecurityUserUnlockOperationResult.Success();
+    }
+
+    private async Task WriteRemoveIpBlockAuditAsync(
+        string securityIpBlockId,
+        string? operatorUserId,
+        bool success,
+        string failureReason,
+        CancellationToken cancellationToken,
+        SecurityAuthType? authType = null,
+        string? ipAddress = null)
+    {
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.Security,
+            EventType = EventType.SecurityManualIpBlockRemoveRejected,
+            Severity = EventSeverity.Warning,
+            Message = "Manual IP unblock request was rejected.",
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                success,
+                action = "manual_ip_unblock",
+                failureReason,
+                securityIpBlockId,
+                authType,
+                ipAddress,
+                operatorUserId = string.IsNullOrWhiteSpace(operatorUserId) ? null : operatorUserId.Trim()
+            })
+        }, cancellationToken);
+
+        _logger.LogWarning(
+            "Manual IP unblock rejected. SecurityIpBlockId={SecurityIpBlockId} Reason={FailureReason} OperatorUserId={OperatorUserId}",
+            securityIpBlockId,
+            failureReason,
+            string.IsNullOrWhiteSpace(operatorUserId) ? "n/a" : operatorUserId.Trim());
+    }
+
+    private async Task WriteUnlockAuditAsync(
+        string userId,
+        string? userName,
+        string? operatorUserId,
+        bool success,
+        string failureReason,
+        CancellationToken cancellationToken)
+    {
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.Security,
+            EventType = EventType.SecurityManualUserUnlockRejected,
+            Severity = EventSeverity.Warning,
+            Message = "Manual user unlock request was rejected.",
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                success,
+                action = "manual_user_unlock",
+                failureReason,
+                userId,
+                userName,
+                operatorUserId = string.IsNullOrWhiteSpace(operatorUserId) ? null : operatorUserId.Trim()
+            })
+        }, cancellationToken);
+
+        _logger.LogWarning(
+            "Manual user unlock rejected. UserId={UserId} UserName={UserName} Reason={FailureReason} OperatorUserId={OperatorUserId}",
+            userId,
+            string.IsNullOrWhiteSpace(userName) ? "n/a" : userName,
+            failureReason,
+            string.IsNullOrWhiteSpace(operatorUserId) ? "n/a" : operatorUserId.Trim());
+    }
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/AdminSecurityPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/AdminSecurityPageViewModel.cs
@@ -17,6 +17,7 @@ public sealed class AdminSecurityPageViewModel
     public bool SettingsSaved { get; init; }
     public bool BlockSaved { get; init; }
     public bool UnblockSaved { get; init; }
+    public bool UnlockSaved { get; init; }
 }
 
 public sealed class LockedOutUserListItem

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/SecurityActionConfirmViewModels.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/SecurityActionConfirmViewModels.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.ViewModels.Admin;
+
+public sealed class ConfirmUnblockIpViewModel
+{
+    public bool IncludeSuccessfulUsers { get; set; }
+    public bool IncludeSuccessfulAgents { get; set; }
+    public string SecurityIpBlockId { get; set; } = string.Empty;
+    public SecurityAuthType AuthType { get; set; }
+    public string IpAddress { get; set; } = string.Empty;
+    public SecurityIpBlockType BlockType { get; set; }
+    public DateTimeOffset BlockedAtUtc { get; set; }
+    public DateTimeOffset? ExpiresAtUtc { get; set; }
+
+    [Display(Name = "Type confirmation text")]
+    public string? ConfirmationText { get; set; }
+
+    public string RequiredConfirmationText { get; set; } = string.Empty;
+    public string? ErrorMessage { get; set; }
+}
+
+public sealed class ConfirmUnlockUserViewModel
+{
+    public bool IncludeSuccessfulUsers { get; set; }
+    public bool IncludeSuccessfulAgents { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public string UserName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public DateTimeOffset LockoutEndUtc { get; set; }
+
+    [Display(Name = "Type confirmation text")]
+    public string? ConfirmationText { get; set; }
+
+    public string RequiredConfirmationText { get; set; } = string.Empty;
+    public string? ErrorMessage { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnblockIp.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnblockIp.cshtml
@@ -1,0 +1,40 @@
+@model PingMonitor.Web.ViewModels.Admin.ConfirmUnblockIpViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Confirm unblock IP</title>
+</head>
+<body>
+<main style="max-width:700px;margin:1rem auto;padding:1rem;font-family:Arial,sans-serif;">
+    <h1>Confirm active IP block removal</h1>
+    <p>This action clears an active enforcement block immediately and is audited.</p>
+
+    @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
+    {
+        <div style="border:1px solid #fda29b;background:#fee4e2;color:#b42318;padding:.75rem;border-radius:10px;margin-bottom:.75rem;">@Model.ErrorMessage</div>
+    }
+
+    <dl>
+        <dt>Auth type</dt><dd>@Model.AuthType</dd>
+        <dt>IP address</dt><dd>@Model.IpAddress</dd>
+        <dt>Block type</dt><dd>@Model.BlockType</dd>
+        <dt>Blocked at (UTC)</dt><dd>@Model.BlockedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")</dd>
+        <dt>Expires at (UTC)</dt><dd>@(Model.ExpiresAtUtc.HasValue ? Model.ExpiresAtUtc.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss") : "n/a")</dd>
+    </dl>
+
+    <form method="post" action="/admin/security/ip-blocks/@Model.SecurityIpBlockId/remove" style="display:grid;gap:.6rem;">
+        @Html.AntiForgeryToken()
+        <input type="hidden" name="IncludeSuccessfulUsers" value="@Model.IncludeSuccessfulUsers.ToString().ToLowerInvariant()" />
+        <input type="hidden" name="IncludeSuccessfulAgents" value="@Model.IncludeSuccessfulAgents.ToString().ToLowerInvariant()" />
+        <label asp-for="ConfirmationText">Type <strong>@Model.RequiredConfirmationText</strong> to confirm.</label>
+        <input asp-for="ConfirmationText" autocomplete="off" style="min-height:44px;padding:.5rem;" />
+        <div style="display:flex;gap:.6rem;flex-wrap:wrap;">
+            <button type="submit" style="min-height:44px;padding:.6rem 1rem;">Confirm remove block</button>
+            <a href="/admin/security?includeSuccessfulUsers=@Model.IncludeSuccessfulUsers.ToString().ToLowerInvariant()&includeSuccessfulAgents=@Model.IncludeSuccessfulAgents.ToString().ToLowerInvariant()" style="min-height:44px;display:inline-flex;align-items:center;">Cancel</a>
+        </div>
+    </form>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnlockUser.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnlockUser.cshtml
@@ -1,0 +1,38 @@
+@model PingMonitor.Web.ViewModels.Admin.ConfirmUnlockUserViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Confirm unlock user</title>
+</head>
+<body>
+<main style="max-width:700px;margin:1rem auto;padding:1rem;font-family:Arial,sans-serif;">
+    <h1>Confirm manual user unlock</h1>
+    <p>This action clears an active Identity lockout immediately and is audited.</p>
+
+    @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
+    {
+        <div style="border:1px solid #fda29b;background:#fee4e2;color:#b42318;padding:.75rem;border-radius:10px;margin-bottom:.75rem;">@Model.ErrorMessage</div>
+    }
+
+    <dl>
+        <dt>User name</dt><dd>@Model.UserName</dd>
+        <dt>Email</dt><dd>@(string.IsNullOrWhiteSpace(Model.Email) ? "n/a" : Model.Email)</dd>
+        <dt>Lockout ends (UTC)</dt><dd>@Model.LockoutEndUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")</dd>
+    </dl>
+
+    <form method="post" action="/admin/security/users/@Model.UserId/unlock" style="display:grid;gap:.6rem;">
+        @Html.AntiForgeryToken()
+        <input type="hidden" name="IncludeSuccessfulUsers" value="@Model.IncludeSuccessfulUsers.ToString().ToLowerInvariant()" />
+        <input type="hidden" name="IncludeSuccessfulAgents" value="@Model.IncludeSuccessfulAgents.ToString().ToLowerInvariant()" />
+        <label asp-for="ConfirmationText">Type <strong>@Model.RequiredConfirmationText</strong> to confirm.</label>
+        <input asp-for="ConfirmationText" autocomplete="off" style="min-height:44px;padding:.5rem;" />
+        <div style="display:flex;gap:.6rem;flex-wrap:wrap;">
+            <button type="submit" style="min-height:44px;padding:.6rem 1rem;">Confirm unlock user</button>
+            <a href="/admin/security?includeSuccessfulUsers=@Model.IncludeSuccessfulUsers.ToString().ToLowerInvariant()&includeSuccessfulAgents=@Model.IncludeSuccessfulAgents.ToString().ToLowerInvariant()" style="min-height:44px;display:inline-flex;align-items:center;">Cancel</a>
+        </div>
+    </form>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
@@ -60,7 +60,15 @@
 
     <section class="card">
         <h2>Currently locked-out user accounts</h2>
-        <p class="muted">User temporary lockout is enforced through ASP.NET Identity lockout timing.</p>
+        <p class="muted">User temporary lockout is enforced through ASP.NET Identity lockout timing. Unlock requires explicit typed confirmation.</p>
+        @if (Model.UnlockSaved)
+        {
+            <div class="saved" role="status">User unlocked successfully.</div>
+        }
+        @if (TempData["SecurityUserUnlockError"] is string unlockError && !string.IsNullOrWhiteSpace(unlockError))
+        {
+            <div class="errors" role="alert">@unlockError</div>
+        }
         <div class="table-wrap">
             <table>
                 <thead>
@@ -68,13 +76,14 @@
                     <th>User name</th>
                     <th>Email</th>
                     <th>Lockout ends (UTC)</th>
+                    <th>Action</th>
                 </tr>
                 </thead>
                 <tbody>
                 @if (!Model.LockedOutUsers.Any())
                 {
                     <tr>
-                        <td colspan="3" class="muted">No users are currently locked out.</td>
+                        <td colspan="4" class="muted">No users are currently locked out.</td>
                     </tr>
                 }
                 else
@@ -85,6 +94,9 @@
                             <td>@user.UserName</td>
                             <td>@(string.IsNullOrWhiteSpace(user.Email) ? "n/a" : user.Email)</td>
                             <td>@user.LockoutEndUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")</td>
+                            <td>
+                                <a class="button-secondary" href="/admin/security/users/@user.UserId/unlock?includeSuccessfulUsers=@Model.IncludeSuccessfulUserAttempts.ToString().ToLowerInvariant()&includeSuccessfulAgents=@Model.IncludeSuccessfulAgentAttempts.ToString().ToLowerInvariant()">Unlock user</a>
+                            </td>
                         </tr>
                     }
                 }
@@ -235,12 +247,7 @@
                             <td>@(block.ExpiresAtUtc.HasValue ? block.ExpiresAtUtc.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss") : "n/a")</td>
                             <td>@(string.IsNullOrWhiteSpace(block.Reason) ? "n/a" : block.Reason)</td>
                             <td>
-                                <form method="post" action="/admin/security/ip-blocks/@block.SecurityIpBlockId/remove">
-                                    @Html.AntiForgeryToken()
-                                    <input type="hidden" name="includeSuccessfulUsers" value="@Model.IncludeSuccessfulUserAttempts.ToString().ToLowerInvariant()" />
-                                    <input type="hidden" name="includeSuccessfulAgents" value="@Model.IncludeSuccessfulAgentAttempts.ToString().ToLowerInvariant()" />
-                                    <button type="submit">Remove</button>
-                                </form>
+                                <a class="button-secondary" href="/admin/security/ip-blocks/@block.SecurityIpBlockId/remove?includeSuccessfulUsers=@Model.IncludeSuccessfulUserAttempts.ToString().ToLowerInvariant()&includeSuccessfulAgents=@Model.IncludeSuccessfulAgentAttempts.ToString().ToLowerInvariant()">Remove block</a>
                             </td>
                         </tr>
                     }


### PR DESCRIPTION
### Motivation

- Operators need a safe, explicit, and auditable way to clear active enforcement state for blocked IPs and locked-out users without changing enforcement policies.  
- Confirmation must be enforced server-side and UI flows must be clear and mobile-friendly to avoid accidental operator actions.  
- All changes must remain minimal, use existing Identity fields for user unlocks, be auditable via event logs, and comply with .NET 10 + MySQL platform constraints. 

### Description

- Added a focused operator service `ISecurityOperatorActionService` and implementation with methods `GetActiveIpBlockAsync`, `RemoveIpBlockAsync`, `GetLockedOutUserAsync`, and `UnlockUserAsync` that validate state before mutation and emit event-log audit records.  
- Controller flow updated to require typed confirmations (`UNBLOCK` / `UNLOCK`) with dedicated confirmation pages and server-side enforcement, and thin handlers that call the new operator service.  
- Implemented safe mutations: IP unblock performs audited soft-removal (`RemovedAtUtc` / `RemovedByUserId`) only for currently active blocks, and user unlock uses ASP.NET Identity `SetLockoutEndDateAsync(..., null)` plus `ResetAccessFailedCountAsync` when appropriate; all outcomes are recorded in event logs and app logs.  
- UI updates on the security admin page expose clear actions (`Remove block`, `Unlock user`), surface success/failure feedback, and the active lists remain accurate because they query active-only state; DI registration and new event type constants were added and documentation was updated to reflect behavior and audit requirements. 

### Testing

- Created and linked issue: Fixes #172 (issue created before implementation).  
- Built the web project successfully with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -v minimal` (succeeded).  
- Ran project tests with `dotnet test src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -v minimal` (no failures / succeeded).  
- Verified local static checks and that new DI registration compiles; UI screenshot capture was not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c944c8ac48832ab22e0a967ba55fe1)