### PR TITLE
Add practical filtering and search to admin security auth logs

### DIFF
--- a/docs/security-logging.md
+++ b/docs/security-logging.md
@@ -71,7 +71,7 @@ No bearer tokens, API keys, or secret material are logged.
 
 ---
 
-## Security logs/settings page (phase 1)
+## Security logs/settings page
 
 A read-only admin page exposes recent authentication attempts in two panels:
 
@@ -86,10 +86,16 @@ Each entry shows:
 - success/failure
 - failure reason (if present)
 
-Default behavior is failure-focused:
+Filtering is explicit and server-side for both user and agent auth panels:
+
+- UTC from/to date-time range (`OccurredAtUtc`)
+- text search over practical fields (`SubjectIdentifier`, source IP, failure reason, related user/agent identifiers when available)
+- success/failure visibility controls
+
+Default behavior remains failure-focused:
 
 - successful attempts are hidden by default
-- operator can enable a simple toggle to include successful attempts
+- operators can opt in to show successful attempts when required
 
 
 ## Operator manual enforcement-clear actions

--- a/docs/security-settings.md
+++ b/docs/security-settings.md
@@ -12,6 +12,7 @@ It covers:
 - manual unlock of currently locked-out users from the admin security page
 - automatic enforcement of temporary/permanent IP blocking
 - automatic enforcement of temporary user account lockout
+- operator filtering of user/agent authentication attempt logs by UTC range, search text, and success visibility (successful attempts hidden by default)
 
 ## Authentication settings
 

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminSecurityController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminSecurityController.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
@@ -41,11 +42,36 @@ public sealed class AdminSecurityController : Controller
     }
 
     [HttpGet]
-    public async Task<IActionResult> Index([FromQuery] bool includeSuccessfulUsers = false, [FromQuery] bool includeSuccessfulAgents = false, CancellationToken cancellationToken = default)
+    public async Task<IActionResult> Index(
+        [FromQuery] bool includeSuccessfulUsers = false,
+        [FromQuery] bool includeSuccessfulAgents = false,
+        [FromQuery] string? searchText = null,
+        [FromQuery] string? fromUtc = null,
+        [FromQuery] string? toUtc = null,
+        [FromQuery(Name = "LogFilterForm.IncludeSuccessfulUsers")] bool? includeSuccessfulUsersFilter = null,
+        [FromQuery(Name = "LogFilterForm.IncludeSuccessfulAgents")] bool? includeSuccessfulAgentsFilter = null,
+        [FromQuery(Name = "LogFilterForm.SearchText")] string? searchTextFilter = null,
+        [FromQuery(Name = "LogFilterForm.FromUtc")] string? fromUtcFilter = null,
+        [FromQuery(Name = "LogFilterForm.ToUtc")] string? toUtcFilter = null,
+        CancellationToken cancellationToken = default)
     {
+        includeSuccessfulUsers = includeSuccessfulUsersFilter ?? includeSuccessfulUsers;
+        includeSuccessfulAgents = includeSuccessfulAgentsFilter ?? includeSuccessfulAgents;
+        searchText = searchTextFilter ?? searchText;
+        fromUtc = fromUtcFilter ?? fromUtc;
+        toUtc = toUtcFilter ?? toUtc;
+
+        var logFilterForm = new SecurityAuthLogFilterForm
+        {
+            IncludeSuccessfulUsers = includeSuccessfulUsers,
+            IncludeSuccessfulAgents = includeSuccessfulAgents,
+            SearchText = searchText,
+            FromUtc = fromUtc,
+            ToUtc = toUtc
+        };
+
         var viewModel = await BuildViewModelAsync(
-            includeSuccessfulUsers,
-            includeSuccessfulAgents,
+            logFilterForm,
             settingsSaved: false,
             blockSaved: false,
             unblockSaved: false,
@@ -61,15 +87,13 @@ public sealed class AdminSecurityController : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> UpdateSettings(
         [FromForm(Name = "SettingsForm")] SecuritySettingsForm settingsForm,
-        [FromForm] bool includeSuccessfulUsers = false,
-        [FromForm] bool includeSuccessfulAgents = false,
+        [FromForm(Name = "LogFilterForm")] SecurityAuthLogFilterForm logFilterForm,
         CancellationToken cancellationToken = default)
     {
         if (!ModelState.IsValid)
         {
             var invalidViewModel = await BuildViewModelAsync(
-                includeSuccessfulUsers,
-                includeSuccessfulAgents,
+                logFilterForm,
                 settingsSaved: false,
                 blockSaved: false,
                 unblockSaved: false,
@@ -92,15 +116,14 @@ public sealed class AdminSecurityController : Controller
             UserTemporaryAccountLockoutDurationMinutes = settingsForm.UserTemporaryAccountLockoutDurationMinutes
         }, cancellationToken);
 
-        return RedirectToAction(nameof(Index), new { includeSuccessfulUsers, includeSuccessfulAgents, settingsSaved = true });
+        return RedirectToAction(nameof(Index), BuildRouteValues(logFilterForm, settingsSaved: true));
     }
 
     [HttpPost("ip-blocks")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> AddManualIpBlock(
         [FromForm(Name = "ManualIpBlockForm")] ManualIpBlockForm manualIpBlockForm,
-        [FromForm] bool includeSuccessfulUsers = false,
-        [FromForm] bool includeSuccessfulAgents = false,
+        [FromForm(Name = "LogFilterForm")] SecurityAuthLogFilterForm logFilterForm,
         CancellationToken cancellationToken = default)
     {
         if (!manualIpBlockForm.AuthType.HasValue)
@@ -116,8 +139,7 @@ public sealed class AdminSecurityController : Controller
         if (!ModelState.IsValid)
         {
             var invalidViewModel = await BuildViewModelAsync(
-                includeSuccessfulUsers,
-                includeSuccessfulAgents,
+                logFilterForm,
                 settingsSaved: false,
                 blockSaved: false,
                 unblockSaved: false,
@@ -143,8 +165,7 @@ public sealed class AdminSecurityController : Controller
             ModelState.AddModelError($"{nameof(ManualIpBlockForm)}.{nameof(ManualIpBlockForm.IpAddress)}", result.Error ?? "Unable to add IP block.");
 
             var invalidViewModel = await BuildViewModelAsync(
-                includeSuccessfulUsers,
-                includeSuccessfulAgents,
+                logFilterForm,
                 settingsSaved: false,
                 blockSaved: false,
                 unblockSaved: false,
@@ -155,21 +176,31 @@ public sealed class AdminSecurityController : Controller
             return View("Index", invalidViewModel);
         }
 
-        return RedirectToAction(nameof(Index), new { includeSuccessfulUsers, includeSuccessfulAgents, blockSaved = true });
+        return RedirectToAction(nameof(Index), BuildRouteValues(logFilterForm, blockSaved: true));
     }
 
     [HttpGet("ip-blocks/{securityIpBlockId}/remove")]
     public async Task<IActionResult> RemoveIpBlock(
         string securityIpBlockId,
-        [FromQuery] bool includeSuccessfulUsers = false,
-        [FromQuery] bool includeSuccessfulAgents = false,
+        [FromQuery(Name = "LogFilterForm.IncludeSuccessfulUsers")] bool includeSuccessfulUsers = false,
+        [FromQuery(Name = "LogFilterForm.IncludeSuccessfulAgents")] bool includeSuccessfulAgents = false,
+        [FromQuery(Name = "LogFilterForm.SearchText")] string? searchText = null,
+        [FromQuery(Name = "LogFilterForm.FromUtc")] string? fromUtc = null,
+        [FromQuery(Name = "LogFilterForm.ToUtc")] string? toUtc = null,
         CancellationToken cancellationToken = default)
     {
         var details = await _securityOperatorActionService.GetActiveIpBlockAsync(securityIpBlockId, cancellationToken);
         if (details is null)
         {
             TempData["SecurityIpBlockRemoveError"] = "Blocked IP record is not active or no longer exists.";
-            return RedirectToAction(nameof(Index), new { includeSuccessfulUsers, includeSuccessfulAgents });
+            return RedirectToAction(nameof(Index), BuildRouteValues(new SecurityAuthLogFilterForm
+            {
+                IncludeSuccessfulUsers = includeSuccessfulUsers,
+                IncludeSuccessfulAgents = includeSuccessfulAgents,
+                SearchText = searchText,
+                FromUtc = fromUtc,
+                ToUtc = toUtc
+            }));
         }
 
         return View("ConfirmUnblockIp", new ConfirmUnblockIpViewModel
@@ -285,8 +316,7 @@ public sealed class AdminSecurityController : Controller
     }
 
     private async Task<AdminSecurityPageViewModel> BuildViewModelAsync(
-        bool includeSuccessfulUsers,
-        bool includeSuccessfulAgents,
+        SecurityAuthLogFilterForm logFilterForm,
         bool settingsSaved,
         bool blockSaved,
         bool unblockSaved,
@@ -295,11 +325,22 @@ public sealed class AdminSecurityController : Controller
         ManualIpBlockForm? manualIpBlockFormOverride,
         CancellationToken cancellationToken)
     {
+        var fromUtc = ParseUtcValue(logFilterForm.FromUtc, nameof(SecurityAuthLogFilterForm.FromUtc));
+        var toUtc = ParseUtcValue(logFilterForm.ToUtc, nameof(SecurityAuthLogFilterForm.ToUtc));
+
+        if (fromUtc.HasValue && toUtc.HasValue && fromUtc > toUtc)
+        {
+            ModelState.AddModelError("LogFilterForm.ToUtc", "To date/time (UTC) must be greater than or equal to From date/time (UTC).");
+        }
+
         var userAttempts = await _securityAuthLogQueryService.GetRecentAsync(
             new SecurityAuthLogQuery
             {
                 AuthType = SecurityAuthType.User,
-                IncludeSuccessful = includeSuccessfulUsers,
+                IncludeSuccessful = logFilterForm.IncludeSuccessfulUsers,
+                SearchText = logFilterForm.SearchText,
+                FromUtc = fromUtc,
+                ToUtc = toUtc,
                 Limit = DefaultLogLimit
             },
             cancellationToken);
@@ -308,7 +349,10 @@ public sealed class AdminSecurityController : Controller
             new SecurityAuthLogQuery
             {
                 AuthType = SecurityAuthType.Agent,
-                IncludeSuccessful = includeSuccessfulAgents,
+                IncludeSuccessful = logFilterForm.IncludeSuccessfulAgents,
+                SearchText = logFilterForm.SearchText,
+                FromUtc = fromUtc,
+                ToUtc = toUtc,
                 Limit = DefaultLogLimit
             },
             cancellationToken);
@@ -332,8 +376,7 @@ public sealed class AdminSecurityController : Controller
 
         return new AdminSecurityPageViewModel
         {
-            IncludeSuccessfulUserAttempts = includeSuccessfulUsers,
-            IncludeSuccessfulAgentAttempts = includeSuccessfulAgents,
+            LogFilterForm = logFilterForm,
             UserAttempts = userAttempts,
             AgentAttempts = agentAttempts,
             ActiveIpBlocks = activeBlocks,
@@ -355,6 +398,46 @@ public sealed class AdminSecurityController : Controller
                 UpdatedAtUtc = settings.UpdatedAtUtc
             },
             ManualIpBlockForm = manualIpBlockFormOverride ?? new ManualIpBlockForm()
+        };
+    }
+
+    private DateTimeOffset? ParseUtcValue(string? value, string fieldName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsedOffset))
+        {
+            return parsedOffset;
+        }
+
+        if (DateTime.TryParseExact(
+                value,
+                ["yyyy-MM-ddTHH:mm", "yyyy-MM-ddTHH:mm:ss"],
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var parsedDateTime))
+        {
+            return new DateTimeOffset(DateTime.SpecifyKind(parsedDateTime, DateTimeKind.Utc));
+        }
+
+        ModelState.AddModelError($"LogFilterForm.{fieldName}", "Enter a valid UTC date/time value.");
+        return null;
+    }
+
+    private static object BuildRouteValues(SecurityAuthLogFilterForm logFilterForm, bool settingsSaved = false, bool blockSaved = false)
+    {
+        return new
+        {
+            includeSuccessfulUsers = logFilterForm.IncludeSuccessfulUsers,
+            includeSuccessfulAgents = logFilterForm.IncludeSuccessfulAgents,
+            searchText = logFilterForm.SearchText,
+            fromUtc = logFilterForm.FromUtc,
+            toUtc = logFilterForm.ToUtc,
+            settingsSaved,
+            blockSaved
         };
     }
 

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -236,6 +236,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         securityAuthLog.HasIndex(x => x.OccurredAtUtc);
         securityAuthLog.HasIndex(x => new { x.AuthType, x.OccurredAtUtc });
         securityAuthLog.HasIndex(x => new { x.AuthType, x.Success, x.OccurredAtUtc });
+        securityAuthLog.HasIndex(x => new { x.AuthType, x.SourceIpAddress, x.OccurredAtUtc });
 
         var appSettings = modelBuilder.Entity<ApplicationSettings>();
         appSettings.ToTable("ApplicationSettings");

--- a/src/WebApp/PingMonitor.Web/README.md
+++ b/src/WebApp/PingMonitor.Web/README.md
@@ -81,7 +81,7 @@ Per-agent actions include:
 
 Credential rotation replaces the stored API key hash and returns a ZIP with a new `.env` file. The new package must be redeployed to the agent host for continued connectivity.
 
-## Security settings page (phase 1)
+## Security settings page
 
 In normal startup mode, `GET /admin/security` provides:
 
@@ -90,6 +90,8 @@ In normal startup mode, `GET /admin/security` provides:
 - manual block and manual remove operations for active blocked IP entries
 - manual unlock operation for currently locked-out users
 - explicit typed confirmations for unblock/unlock actions (`UNBLOCK` / `UNLOCK`)
-- read-only recent authentication-attempt logs
+- read-only recent authentication-attempt logs with server-side UTC date range, search text, and success visibility filters for both user and agent panels
+
+Authentication log defaults stay failure-focused: successful attempts remain hidden unless the operator explicitly enables "Show successful attempts" controls.
 
 Automatic enforcement of IP block thresholds and user lockout policy is active. Manual unblock/unlock actions are audited through security event logs.

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityAuthLogQueryModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityAuthLogQueryModels.cs
@@ -17,5 +17,8 @@ public sealed class SecurityAuthLogQuery
 {
     public required SecurityAuthType AuthType { get; init; }
     public required bool IncludeSuccessful { get; init; }
+    public string? SearchText { get; init; }
+    public DateTimeOffset? FromUtc { get; init; }
+    public DateTimeOffset? ToUtc { get; init; }
     public required int Limit { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityAuthLogQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityAuthLogQueryService.cs
@@ -15,10 +15,26 @@ internal sealed class SecurityAuthLogQueryService : ISecurityAuthLogQueryService
     public async Task<IReadOnlyList<SecurityAuthLogListItem>> GetRecentAsync(SecurityAuthLogQuery query, CancellationToken cancellationToken)
     {
         var effectiveLimit = Math.Clamp(query.Limit, 1, 200);
+        var searchText = query.SearchText?.Trim();
 
-        var rows = await _dbContext.SecurityAuthLogs
+        var dbQuery = _dbContext.SecurityAuthLogs
             .AsNoTracking()
-            .Where(x => x.AuthType == query.AuthType && (query.IncludeSuccessful || !x.Success))
+            .Where(x => x.AuthType == query.AuthType)
+            .Where(x => query.IncludeSuccessful || !x.Success)
+            .Where(x => !query.FromUtc.HasValue || x.OccurredAtUtc >= query.FromUtc.Value)
+            .Where(x => !query.ToUtc.HasValue || x.OccurredAtUtc <= query.ToUtc.Value);
+
+        if (!string.IsNullOrWhiteSpace(searchText))
+        {
+            dbQuery = dbQuery.Where(x =>
+                x.SubjectIdentifier.Contains(searchText) ||
+                (x.SourceIpAddress != null && x.SourceIpAddress.Contains(searchText)) ||
+                (x.FailureReason != null && x.FailureReason.Contains(searchText)) ||
+                (x.UserId != null && x.UserId.Contains(searchText)) ||
+                (x.AgentId != null && x.AgentId.Contains(searchText)));
+        }
+
+        var rows = await dbQuery
             .OrderByDescending(x => x.OccurredAtUtc)
             .Take(effectiveLimit)
             .Select(x => new SecurityAuthLogListItem

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -294,7 +294,8 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 PRIMARY KEY (`SecurityAuthLogId`),
                 KEY `IX_SecurityAuthLogs_OccurredAtUtc` (`OccurredAtUtc`),
                 KEY `IX_SecurityAuthLogs_AuthType_OccurredAtUtc` (`AuthType`, `OccurredAtUtc`),
-                KEY `IX_SecurityAuthLogs_AuthType_Success_OccurredAtUtc` (`AuthType`, `Success`, `OccurredAtUtc`)
+                KEY `IX_SecurityAuthLogs_AuthType_Success_OccurredAtUtc` (`AuthType`, `Success`, `OccurredAtUtc`),
+                KEY `IX_SecurityAuthLogs_AuthType_SourceIpAddress_OccurredAtUtc` (`AuthType`, `SourceIpAddress`, `OccurredAtUtc`)
             );
             """;
 

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/AdminSecurityPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/AdminSecurityPageViewModel.cs
@@ -6,8 +6,7 @@ namespace PingMonitor.Web.ViewModels.Admin;
 
 public sealed class AdminSecurityPageViewModel
 {
-    public bool IncludeSuccessfulUserAttempts { get; init; }
-    public bool IncludeSuccessfulAgentAttempts { get; init; }
+    public SecurityAuthLogFilterForm LogFilterForm { get; init; } = new();
     public IReadOnlyList<SecurityAuthLogListItem> UserAttempts { get; init; } = [];
     public IReadOnlyList<SecurityAuthLogListItem> AgentAttempts { get; init; } = [];
     public IReadOnlyList<SecurityIpBlockListItem> ActiveIpBlocks { get; init; } = [];
@@ -18,6 +17,26 @@ public sealed class AdminSecurityPageViewModel
     public bool BlockSaved { get; init; }
     public bool UnblockSaved { get; init; }
     public bool UnlockSaved { get; init; }
+}
+
+
+public sealed class SecurityAuthLogFilterForm
+{
+    [Display(Name = "From date/time (UTC)")]
+    public string? FromUtc { get; set; }
+
+    [Display(Name = "To date/time (UTC)")]
+    public string? ToUtc { get; set; }
+
+    [StringLength(128, ErrorMessage = "Search text must be 128 characters or fewer.")]
+    [Display(Name = "Search text")]
+    public string? SearchText { get; set; }
+
+    [Display(Name = "Show successful user attempts")]
+    public bool IncludeSuccessfulUsers { get; set; }
+
+    [Display(Name = "Show successful agent attempts")]
+    public bool IncludeSuccessfulAgents { get; set; }
 }
 
 public sealed class LockedOutUserListItem

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
@@ -95,7 +95,7 @@
                             <td>@(string.IsNullOrWhiteSpace(user.Email) ? "n/a" : user.Email)</td>
                             <td>@user.LockoutEndUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")</td>
                             <td>
-                                <a class="button-secondary" href="/admin/security/users/@user.UserId/unlock?includeSuccessfulUsers=@Model.IncludeSuccessfulUserAttempts.ToString().ToLowerInvariant()&includeSuccessfulAgents=@Model.IncludeSuccessfulAgentAttempts.ToString().ToLowerInvariant()">Unlock user</a>
+                                <a class="button-secondary" href="/admin/security/users/@user.UserId/unlock?includeSuccessfulUsers=@Model.LogFilterForm.IncludeSuccessfulUsers.ToString().ToLowerInvariant()&includeSuccessfulAgents=@Model.LogFilterForm.IncludeSuccessfulAgents.ToString().ToLowerInvariant()">Unlock user</a>
                             </td>
                         </tr>
                     }
@@ -113,8 +113,11 @@
         }
         <form method="post" action="/admin/security/settings">
             @Html.AntiForgeryToken()
-            <input type="hidden" name="includeSuccessfulUsers" value="@Model.IncludeSuccessfulUserAttempts.ToString().ToLowerInvariant()" />
-            <input type="hidden" name="includeSuccessfulAgents" value="@Model.IncludeSuccessfulAgentAttempts.ToString().ToLowerInvariant()" />
+            <input type="hidden" name="LogFilterForm.IncludeSuccessfulUsers" value="@Model.LogFilterForm.IncludeSuccessfulUsers.ToString().ToLowerInvariant()" />
+            <input type="hidden" name="LogFilterForm.IncludeSuccessfulAgents" value="@Model.LogFilterForm.IncludeSuccessfulAgents.ToString().ToLowerInvariant()" />
+            <input type="hidden" name="LogFilterForm.SearchText" value="@Model.LogFilterForm.SearchText" />
+            <input type="hidden" name="LogFilterForm.FromUtc" value="@Model.LogFilterForm.FromUtc" />
+            <input type="hidden" name="LogFilterForm.ToUtc" value="@Model.LogFilterForm.ToUtc" />
 
             <div class="grid-two">
                 <section>
@@ -189,8 +192,11 @@
 
         <form method="post" action="/admin/security/ip-blocks" class="grid-two" style="margin-bottom: 1rem;">
             @Html.AntiForgeryToken()
-            <input type="hidden" name="includeSuccessfulUsers" value="@Model.IncludeSuccessfulUserAttempts.ToString().ToLowerInvariant()" />
-            <input type="hidden" name="includeSuccessfulAgents" value="@Model.IncludeSuccessfulAgentAttempts.ToString().ToLowerInvariant()" />
+            <input type="hidden" name="LogFilterForm.IncludeSuccessfulUsers" value="@Model.LogFilterForm.IncludeSuccessfulUsers.ToString().ToLowerInvariant()" />
+            <input type="hidden" name="LogFilterForm.IncludeSuccessfulAgents" value="@Model.LogFilterForm.IncludeSuccessfulAgents.ToString().ToLowerInvariant()" />
+            <input type="hidden" name="LogFilterForm.SearchText" value="@Model.LogFilterForm.SearchText" />
+            <input type="hidden" name="LogFilterForm.FromUtc" value="@Model.LogFilterForm.FromUtc" />
+            <input type="hidden" name="LogFilterForm.ToUtc" value="@Model.LogFilterForm.ToUtc" />
             <div class="field">
                 <label asp-for="ManualIpBlockForm.AuthType"></label>
                 <select asp-for="ManualIpBlockForm.AuthType">
@@ -247,7 +253,7 @@
                             <td>@(block.ExpiresAtUtc.HasValue ? block.ExpiresAtUtc.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss") : "n/a")</td>
                             <td>@(string.IsNullOrWhiteSpace(block.Reason) ? "n/a" : block.Reason)</td>
                             <td>
-                                <a class="button-secondary" href="/admin/security/ip-blocks/@block.SecurityIpBlockId/remove?includeSuccessfulUsers=@Model.IncludeSuccessfulUserAttempts.ToString().ToLowerInvariant()&includeSuccessfulAgents=@Model.IncludeSuccessfulAgentAttempts.ToString().ToLowerInvariant()">Remove block</a>
+                                <a class="button-secondary" href="/admin/security/ip-blocks/@block.SecurityIpBlockId/remove?LogFilterForm.IncludeSuccessfulUsers=@Model.LogFilterForm.IncludeSuccessfulUsers.ToString().ToLowerInvariant()&LogFilterForm.IncludeSuccessfulAgents=@Model.LogFilterForm.IncludeSuccessfulAgents.ToString().ToLowerInvariant()&LogFilterForm.SearchText=@Model.LogFilterForm.SearchText&LogFilterForm.FromUtc=@Model.LogFilterForm.FromUtc&LogFilterForm.ToUtc=@Model.LogFilterForm.ToUtc">Remove block</a>
                             </td>
                         </tr>
                     }
@@ -258,19 +264,48 @@
     </section>
 
     <section class="card">
-        <h2>User authentication attempts</h2>
-        <form method="get" action="/admin/security" class="button-row" style="margin-bottom: .8rem;">
-            <label>
-                <input type="checkbox" name="includeSuccessfulUsers" value="true" @(Model.IncludeSuccessfulUserAttempts ? "checked" : null) />
-                Show successful user attempts
-            </label>
-            <input type="hidden" name="includeSuccessfulAgents" value="@Model.IncludeSuccessfulAgentAttempts.ToString().ToLowerInvariant()" />
-            <button type="submit">Apply user filter</button>
+        <h2>Authentication log filters</h2>
+        <p class="muted">All log filters use UTC values and apply to both user and agent authentication panels.</p>
+        <form method="get" action="/admin/security" class="grid-two" style="margin-bottom: .8rem;">
+            <div class="field">
+                <label asp-for="LogFilterForm.FromUtc"></label>
+                <input asp-for="LogFilterForm.FromUtc" type="datetime-local" />
+                <div class="field-error"><span asp-validation-for="LogFilterForm.FromUtc"></span></div>
+            </div>
+            <div class="field">
+                <label asp-for="LogFilterForm.ToUtc"></label>
+                <input asp-for="LogFilterForm.ToUtc" type="datetime-local" />
+                <div class="field-error"><span asp-validation-for="LogFilterForm.ToUtc"></span></div>
+            </div>
+            <div class="field" style="grid-column: 1 / -1;">
+                <label asp-for="LogFilterForm.SearchText"></label>
+                <input asp-for="LogFilterForm.SearchText" maxlength="128" placeholder="Search subject, source IP, failure reason, user id, agent id" />
+                <div class="field-error"><span asp-validation-for="LogFilterForm.SearchText"></span></div>
+            </div>
+            <div class="field">
+                <label>
+                    <input asp-for="LogFilterForm.IncludeSuccessfulUsers" type="checkbox" />
+                    Show successful attempts (users)
+                </label>
+            </div>
+            <div class="field">
+                <label>
+                    <input asp-for="LogFilterForm.IncludeSuccessfulAgents" type="checkbox" />
+                    Show successful attempts (agents)
+                </label>
+            </div>
+            <div class="button-row" style="grid-column: 1 / -1;">
+                <button type="submit">Apply log filters</button>
+            </div>
         </form>
+    </section>
+
+    <section class="card">
+        <h2>User authentication attempts</h2>
         <div class="log-box" role="region" aria-label="User authentication attempts">
             @if (!Model.UserAttempts.Any())
             {
-                <div class="empty">No user authentication attempts match the current filter.</div>
+                <div class="empty">No matching authentication attempts found.</div>
             }
             else
             {
@@ -295,18 +330,10 @@
 
     <section class="card">
         <h2>Agent authentication attempts</h2>
-        <form method="get" action="/admin/security" class="button-row" style="margin-bottom: .8rem;">
-            <input type="hidden" name="includeSuccessfulUsers" value="@Model.IncludeSuccessfulUserAttempts.ToString().ToLowerInvariant()" />
-            <label>
-                <input type="checkbox" name="includeSuccessfulAgents" value="true" @(Model.IncludeSuccessfulAgentAttempts ? "checked" : null) />
-                Show successful agent attempts
-            </label>
-            <button type="submit">Apply agent filter</button>
-        </form>
         <div class="log-box" role="region" aria-label="Agent authentication attempts">
             @if (!Model.AgentAttempts.Any())
             {
-                <div class="empty">No agent authentication attempts match the current filter.</div>
+                <div class="empty">No matching authentication attempts found.</div>
             }
             else
             {


### PR DESCRIPTION
### Motivation
- Operators need fast, server-side filtering on the admin security page to narrow user and agent authentication attempts without exposing secrets or loading unbounded result sets.  
- Filters must be explicit, UTC-aware, MySQL-safe, and preserve the existing default failure-focused view.  

### Description
- Added `SearchText`, `FromUtc`, `ToUtc`, and `IncludeSuccessful` fields to the security auth log query model and extended `SecurityAuthLogQueryService` to apply server-side filters for auth type, UTC range, text search (subject, source IP, failure reason, user id, agent id), and include/exclude successful attempts with a bounded `Take` limit; query remains EF-translatable and provider-safe.  
- Updated `AdminSecurityController` to accept shared filter inputs, parse/validate UTC date/time values, and pass deterministic filter parameters for both user and agent panels.  
- Introduced a simple `SecurityAuthLogFilterForm` on the admin page and updated `Index.cshtml` to provide controls for From/To (UTC), Search text, and separate "Show successful attempts" toggles for users and agents while preserving the default (successful attempts hidden).  
- Added an index for `(AuthType, SourceIpAddress, OccurredAtUtc)` in the EF model and startup DDL to support the new lookup patterns, and updated documentation (`docs/security-logging.md`, `docs/security-settings.md`, `src/WebApp/PingMonitor.Web/README.md`) to describe filtering behavior and default failure-focused visibility.  
- Issue linkage: Fixes #174.  

### Testing
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the build succeeded.  
- Ran unit/test targets with `dotnet test src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj --no-build` and the test run completed without failures.  
- Verified the changed query path is server-side and bounded (`SecurityAuthLogQueryService.GetRecentAsync`) and added an index to support the search-by-IP pattern; automated build/tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9474fb50c832aa0e3d206479c8ce4)