### PR TITLE
Add security auth log retention settings and manual prune workflow

### DIFF
--- a/docs/security-logging.md
+++ b/docs/security-logging.md
@@ -12,6 +12,8 @@ It covers:
 
 Automatic active controls for temporary/permanent IP blocking and temporary user lockout are enforced as defined in `docs/security-settings.md`.
 
+Security auth log retention/pruning is configurable and applies **only** to authentication-attempt logs (`SecurityAuthLog` rows).
+
 ---
 
 ## What is logged
@@ -111,3 +113,38 @@ At minimum, event records include:
 - success/failure outcome and failure reason for rejected requests
 
 These records are written without secrets and are intended for operator audit trails and incident review.
+
+## Security auth log retention and pruning
+
+Security auth log retention is controlled by security settings:
+
+- `SecurityLogRetentionEnabled`
+- `SecurityLogRetentionDays`
+- `SecurityLogAutoPruneEnabled` (setting exists; automatic execution may be disabled/deferred by implementation)
+
+### Prune eligibility (in scope)
+
+Rows are eligible for prune when all are true:
+
+- row is from `SecurityAuthLogs`
+- row type is an authentication attempt log (user or agent auth)
+- `OccurredAtUtc` is older than `UTC now - SecurityLogRetentionDays`
+- retention is enabled and settings are valid
+
+### Not eligible (out of scope)
+
+Pruning must **not** touch:
+
+- active blocked IP records (`SecurityIpBlocks`)
+- user lockout enforcement state (ASP.NET Identity lockout fields)
+- event logs
+- monitoring results/state/history
+- backup files
+
+### Manual prune behavior
+
+- Admin security page shows the current prune cutoff and eligible row count preview.
+- Manual prune requires explicit typed confirmation: `PRUNE`.
+- Confirmation is enforced server-side.
+- Manual prune is destructive and irreversible.
+- Manual prune writes auditable security events (request + completion) including cutoff and deleted row count.

--- a/docs/security-settings.md
+++ b/docs/security-settings.md
@@ -32,6 +32,14 @@ Security settings are stored as explicit fields in minutes/counts.
 - `UserFailedAttemptsBeforeTemporaryAccountLockout`
 - `UserTemporaryAccountLockoutDurationMinutes`
 
+### Security auth log retention settings
+
+- `SecurityLogRetentionEnabled`
+- `SecurityLogRetentionDays`
+- `SecurityLogAutoPruneEnabled`
+
+Retention settings apply only to authentication-attempt logs (`SecurityAuthLogs`) and must not change active enforcement state.
+
 ## IP block vs account lockout
 
 - **IP block** applies to requests coming from a source IP address for a selected auth type (`User` or `Agent`).
@@ -97,3 +105,12 @@ User login request order:
 Manual and automatic block/unblock actions are persisted as security IP block records and event log entries.
 Manual user unlock actions (success and rejected attempts) are event logged with operator identity context when available.
 Settings updates are also event logged.
+
+## Security auth log prune controls
+
+- Security page exposes current retention values, computed cutoff, and current eligible auth-log count.
+- Manual prune requires typed confirmation (`PRUNE`) before deletion.
+- Manual prune deletes only `SecurityAuthLogs` rows older than cutoff.
+- Pruning is destructive and irreversible.
+- Pruning does not remove active IP block rows and does not unlock users.
+- If `SecurityLogAutoPruneEnabled` is present but not wired to automatic execution in the current release, operators must use manual prune.

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminSecurityController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminSecurityController.cs
@@ -20,11 +20,13 @@ public sealed class AdminSecurityController : Controller
     private const int DefaultLogLimit = 100;
     private const string UnblockConfirmationKeyword = "UNBLOCK";
     private const string UnlockConfirmationKeyword = "UNLOCK";
+    private const string PruneConfirmationKeyword = SecurityLogRetentionService.ManualPruneConfirmationKeyword;
 
     private readonly ISecurityAuthLogQueryService _securityAuthLogQueryService;
     private readonly ISecuritySettingsService _securitySettingsService;
     private readonly ISecurityIpBlockService _securityIpBlockService;
     private readonly ISecurityOperatorActionService _securityOperatorActionService;
+    private readonly ISecurityLogRetentionService _securityLogRetentionService;
     private readonly UserManager<ApplicationUser> _userManager;
 
     public AdminSecurityController(
@@ -32,12 +34,14 @@ public sealed class AdminSecurityController : Controller
         ISecuritySettingsService securitySettingsService,
         ISecurityIpBlockService securityIpBlockService,
         ISecurityOperatorActionService securityOperatorActionService,
+        ISecurityLogRetentionService securityLogRetentionService,
         UserManager<ApplicationUser> userManager)
     {
         _securityAuthLogQueryService = securityAuthLogQueryService;
         _securitySettingsService = securitySettingsService;
         _securityIpBlockService = securityIpBlockService;
         _securityOperatorActionService = securityOperatorActionService;
+        _securityLogRetentionService = securityLogRetentionService;
         _userManager = userManager;
     }
 
@@ -76,8 +80,11 @@ public sealed class AdminSecurityController : Controller
             blockSaved: false,
             unblockSaved: false,
             unlockSaved: false,
+            pruneSaved: false,
+            pruneError: null,
             settingsFormOverride: null,
             manualIpBlockFormOverride: null,
+            pruneFormOverride: null,
             cancellationToken: cancellationToken);
 
         return View("Index", viewModel);
@@ -98,8 +105,11 @@ public sealed class AdminSecurityController : Controller
                 blockSaved: false,
                 unblockSaved: false,
                 unlockSaved: false,
+                pruneSaved: false,
+                pruneError: null,
                 settingsFormOverride: settingsForm,
                 manualIpBlockFormOverride: null,
+                pruneFormOverride: null,
                 cancellationToken);
             return View("Index", invalidViewModel);
         }
@@ -113,7 +123,10 @@ public sealed class AdminSecurityController : Controller
             UserTemporaryIpBlockDurationMinutes = settingsForm.UserTemporaryIpBlockDurationMinutes,
             UserFailedAttemptsBeforePermanentIpBlock = settingsForm.UserFailedAttemptsBeforePermanentIpBlock,
             UserFailedAttemptsBeforeTemporaryAccountLockout = settingsForm.UserFailedAttemptsBeforeTemporaryAccountLockout,
-            UserTemporaryAccountLockoutDurationMinutes = settingsForm.UserTemporaryAccountLockoutDurationMinutes
+            UserTemporaryAccountLockoutDurationMinutes = settingsForm.UserTemporaryAccountLockoutDurationMinutes,
+            SecurityLogRetentionEnabled = settingsForm.SecurityLogRetentionEnabled,
+            SecurityLogRetentionDays = settingsForm.SecurityLogRetentionDays,
+            SecurityLogAutoPruneEnabled = settingsForm.SecurityLogAutoPruneEnabled
         }, cancellationToken);
 
         return RedirectToAction(nameof(Index), BuildRouteValues(logFilterForm, settingsSaved: true));
@@ -144,8 +157,11 @@ public sealed class AdminSecurityController : Controller
                 blockSaved: false,
                 unblockSaved: false,
                 unlockSaved: false,
+                pruneSaved: false,
+                pruneError: null,
                 settingsFormOverride: null,
                 manualIpBlockFormOverride: manualIpBlockForm,
+                pruneFormOverride: null,
                 cancellationToken);
             return View("Index", invalidViewModel);
         }
@@ -170,8 +186,11 @@ public sealed class AdminSecurityController : Controller
                 blockSaved: false,
                 unblockSaved: false,
                 unlockSaved: false,
+                pruneSaved: false,
+                pruneError: null,
                 settingsFormOverride: null,
                 manualIpBlockFormOverride: manualIpBlockForm,
+                pruneFormOverride: null,
                 cancellationToken);
             return View("Index", invalidViewModel);
         }
@@ -315,14 +334,57 @@ public sealed class AdminSecurityController : Controller
         return RedirectToAction(nameof(Index), new { model.IncludeSuccessfulUsers, model.IncludeSuccessfulAgents, unlockSaved = true });
     }
 
+    [HttpPost("logs/prune")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> PruneSecurityLogs(
+        [FromForm(Name = "PruneForm")] SecurityLogPruneForm pruneForm,
+        [FromForm(Name = "LogFilterForm")] SecurityAuthLogFilterForm logFilterForm,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _securityLogRetentionService.PruneAsync(new SecurityLogPruneRequest
+        {
+            ConfirmationText = pruneForm.ConfirmationText ?? string.Empty,
+            RequestedByUserId = User.FindFirstValue(ClaimTypes.NameIdentifier),
+            IsManual = true
+        }, cancellationToken);
+
+        if (!result.Succeeded)
+        {
+            if (!string.Equals(pruneForm.ConfirmationText?.Trim(), PruneConfirmationKeyword, StringComparison.Ordinal))
+            {
+                ModelState.AddModelError($"{nameof(SecurityLogPruneForm)}.{nameof(SecurityLogPruneForm.ConfirmationText)}", $"Type {PruneConfirmationKeyword} to confirm pruning security auth logs.");
+            }
+
+            var invalidViewModel = await BuildViewModelAsync(
+                logFilterForm,
+                settingsSaved: false,
+                blockSaved: false,
+                unblockSaved: false,
+                unlockSaved: false,
+                pruneSaved: false,
+                pruneError: result.Error ?? "Security auth log prune failed.",
+                settingsFormOverride: null,
+                manualIpBlockFormOverride: null,
+                pruneFormOverride: pruneForm,
+                cancellationToken: cancellationToken);
+            return View("Index", invalidViewModel);
+        }
+
+        TempData["SecurityLogPruneSummary"] = $"Manual prune completed. Deleted {result.RowsDeleted} security auth log records older than cutoff.";
+        return RedirectToAction(nameof(Index), BuildRouteValues(logFilterForm, pruneSaved: true));
+    }
+
     private async Task<AdminSecurityPageViewModel> BuildViewModelAsync(
         SecurityAuthLogFilterForm logFilterForm,
         bool settingsSaved,
         bool blockSaved,
         bool unblockSaved,
         bool unlockSaved,
+        bool pruneSaved,
+        string? pruneError,
         SecuritySettingsForm? settingsFormOverride,
         ManualIpBlockForm? manualIpBlockFormOverride,
+        SecurityLogPruneForm? pruneFormOverride,
         CancellationToken cancellationToken)
     {
         var fromUtc = ParseUtcValue(logFilterForm.FromUtc, nameof(SecurityAuthLogFilterForm.FromUtc));
@@ -358,6 +420,7 @@ public sealed class AdminSecurityController : Controller
             cancellationToken);
 
         var settings = await _securitySettingsService.GetCurrentAsync(cancellationToken);
+        var retentionPreview = await _securityLogRetentionService.GetPreviewAsync(cancellationToken);
         var activeBlocks = await _securityIpBlockService.ListActiveAsync(cancellationToken);
         var now = DateTimeOffset.UtcNow;
         var lockedOutUsers = await _userManager.Users
@@ -385,6 +448,9 @@ public sealed class AdminSecurityController : Controller
             BlockSaved = blockSaved || string.Equals(Request.Query["blockSaved"], "true", StringComparison.OrdinalIgnoreCase),
             UnblockSaved = unblockSaved || string.Equals(Request.Query["unblockSaved"], "true", StringComparison.OrdinalIgnoreCase),
             UnlockSaved = unlockSaved || string.Equals(Request.Query["unlockSaved"], "true", StringComparison.OrdinalIgnoreCase),
+            PruneSaved = pruneSaved || string.Equals(Request.Query["pruneSaved"], "true", StringComparison.OrdinalIgnoreCase),
+            PruneError = pruneError,
+            RetentionPreview = retentionPreview,
             SettingsForm = settingsFormOverride ?? new SecuritySettingsForm
             {
                 AgentFailedAttemptsBeforeTemporaryIpBlock = settings.AgentFailedAttemptsBeforeTemporaryIpBlock,
@@ -395,9 +461,13 @@ public sealed class AdminSecurityController : Controller
                 UserFailedAttemptsBeforePermanentIpBlock = settings.UserFailedAttemptsBeforePermanentIpBlock,
                 UserFailedAttemptsBeforeTemporaryAccountLockout = settings.UserFailedAttemptsBeforeTemporaryAccountLockout,
                 UserTemporaryAccountLockoutDurationMinutes = settings.UserTemporaryAccountLockoutDurationMinutes,
+                SecurityLogRetentionEnabled = settings.SecurityLogRetentionEnabled,
+                SecurityLogRetentionDays = settings.SecurityLogRetentionDays,
+                SecurityLogAutoPruneEnabled = settings.SecurityLogAutoPruneEnabled,
                 UpdatedAtUtc = settings.UpdatedAtUtc
             },
-            ManualIpBlockForm = manualIpBlockFormOverride ?? new ManualIpBlockForm()
+            ManualIpBlockForm = manualIpBlockFormOverride ?? new ManualIpBlockForm(),
+            PruneForm = pruneFormOverride ?? new SecurityLogPruneForm()
         };
     }
 
@@ -427,7 +497,7 @@ public sealed class AdminSecurityController : Controller
         return null;
     }
 
-    private static object BuildRouteValues(SecurityAuthLogFilterForm logFilterForm, bool settingsSaved = false, bool blockSaved = false)
+    private static object BuildRouteValues(SecurityAuthLogFilterForm logFilterForm, bool settingsSaved = false, bool blockSaved = false, bool pruneSaved = false)
     {
         return new
         {
@@ -437,7 +507,8 @@ public sealed class AdminSecurityController : Controller
             fromUtc = logFilterForm.FromUtc,
             toUtc = logFilterForm.ToUtc,
             settingsSaved,
-            blockSaved
+            blockSaved,
+            pruneSaved
         };
     }
 

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -262,6 +262,9 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         securitySettings.Property(x => x.UserFailedAttemptsBeforePermanentIpBlock).IsRequired();
         securitySettings.Property(x => x.UserFailedAttemptsBeforeTemporaryAccountLockout).IsRequired();
         securitySettings.Property(x => x.UserTemporaryAccountLockoutDurationMinutes).IsRequired();
+        securitySettings.Property(x => x.SecurityLogRetentionEnabled).IsRequired();
+        securitySettings.Property(x => x.SecurityLogRetentionDays).IsRequired();
+        securitySettings.Property(x => x.SecurityLogAutoPruneEnabled).IsRequired();
         securitySettings.Property(x => x.UpdatedAtUtc).IsRequired();
 
         var securityIpBlock = modelBuilder.Entity<SecurityIpBlock>();

--- a/src/WebApp/PingMonitor.Web/Models/EventType.cs
+++ b/src/WebApp/PingMonitor.Web/Models/EventType.cs
@@ -19,4 +19,7 @@ public static class EventType
     public const string SecurityManualIpBlockRemoveRejected = "security_manual_ip_block_remove_rejected";
     public const string SecurityManualUserUnlockApplied = "security_manual_user_unlock_applied";
     public const string SecurityManualUserUnlockRejected = "security_manual_user_unlock_rejected";
+    public const string SecurityAuthLogManualPruneRequested = "security_auth_log_manual_prune_requested";
+    public const string SecurityAuthLogManualPruneCompleted = "security_auth_log_manual_prune_completed";
+    public const string SecurityAuthLogAutomaticPruneCompleted = "security_auth_log_automatic_prune_completed";
 }

--- a/src/WebApp/PingMonitor.Web/Models/SecuritySettings.cs
+++ b/src/WebApp/PingMonitor.Web/Models/SecuritySettings.cs
@@ -15,6 +15,9 @@ public sealed class SecuritySettings
     public int UserFailedAttemptsBeforePermanentIpBlock { get; set; } = 20;
     public int UserFailedAttemptsBeforeTemporaryAccountLockout { get; set; } = 5;
     public int UserTemporaryAccountLockoutDurationMinutes { get; set; } = 15;
+    public bool SecurityLogRetentionEnabled { get; set; } = false;
+    public int SecurityLogRetentionDays { get; set; } = 90;
+    public bool SecurityLogAutoPruneEnabled { get; set; } = false;
 
     public DateTimeOffset UpdatedAtUtc { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -117,6 +117,7 @@ builder.Services.AddScoped<IEventLogQueryService, EventLogQueryService>();
 builder.Services.AddScoped<ISecurityAuthLogService, SecurityAuthLogService>();
 builder.Services.AddScoped<ISecurityAuthLogQueryService, SecurityAuthLogQueryService>();
 builder.Services.AddScoped<ISecuritySettingsService, SecuritySettingsService>();
+builder.Services.AddScoped<ISecurityLogRetentionService, SecurityLogRetentionService>();
 builder.Services.AddScoped<ISecurityIpBlockService, SecurityIpBlockService>();
 builder.Services.AddScoped<ISecurityOperatorActionService, SecurityOperatorActionService>();
 builder.Services.AddScoped<ISecurityEnforcementService, SecurityEnforcementService>();

--- a/src/WebApp/PingMonitor.Web/Services/Security/ISecurityLogRetentionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/ISecurityLogRetentionService.cs
@@ -1,0 +1,7 @@
+namespace PingMonitor.Web.Services.Security;
+
+public interface ISecurityLogRetentionService
+{
+    Task<SecurityLogRetentionPreview> GetPreviewAsync(CancellationToken cancellationToken);
+    Task<SecurityLogPruneResult> PruneAsync(SecurityLogPruneRequest request, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityLogRetentionModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityLogRetentionModels.cs
@@ -1,0 +1,28 @@
+namespace PingMonitor.Web.Services.Security;
+
+public sealed class SecurityLogRetentionPreview
+{
+    public bool RetentionEnabled { get; init; }
+    public int RetentionDays { get; init; }
+    public bool AutoPruneEnabled { get; init; }
+    public DateTimeOffset? CutoffUtc { get; init; }
+    public int EligibleAuthLogRows { get; init; }
+    public bool PruneSkipped { get; init; }
+    public string? SkipReason { get; init; }
+}
+
+public sealed class SecurityLogPruneRequest
+{
+    public required string ConfirmationText { get; init; }
+    public string? RequestedByUserId { get; init; }
+    public required bool IsManual { get; init; }
+}
+
+public sealed class SecurityLogPruneResult
+{
+    public required SecurityLogRetentionPreview Preview { get; init; }
+    public int RowsDeleted { get; init; }
+    public int RowsRemaining { get; init; }
+    public bool Succeeded { get; init; }
+    public string? Error { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityLogRetentionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityLogRetentionService.cs
@@ -1,0 +1,158 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.EventLogs;
+
+namespace PingMonitor.Web.Services.Security;
+
+internal sealed class SecurityLogRetentionService : ISecurityLogRetentionService
+{
+    public const string ManualPruneConfirmationKeyword = "PRUNE";
+
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly ISecuritySettingsService _securitySettingsService;
+    private readonly IEventLogService _eventLogService;
+    private readonly ILogger<SecurityLogRetentionService> _logger;
+
+    public SecurityLogRetentionService(
+        PingMonitorDbContext dbContext,
+        ISecuritySettingsService securitySettingsService,
+        IEventLogService eventLogService,
+        ILogger<SecurityLogRetentionService> logger)
+    {
+        _dbContext = dbContext;
+        _securitySettingsService = securitySettingsService;
+        _eventLogService = eventLogService;
+        _logger = logger;
+    }
+
+    public async Task<SecurityLogRetentionPreview> GetPreviewAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _securitySettingsService.GetCurrentAsync(cancellationToken);
+
+        if (!settings.SecurityLogRetentionEnabled)
+        {
+            return new SecurityLogRetentionPreview
+            {
+                RetentionEnabled = false,
+                RetentionDays = settings.SecurityLogRetentionDays,
+                AutoPruneEnabled = settings.SecurityLogAutoPruneEnabled,
+                PruneSkipped = true,
+                SkipReason = "Security auth log retention is disabled."
+            };
+        }
+
+        if (settings.SecurityLogRetentionDays < 1)
+        {
+            return new SecurityLogRetentionPreview
+            {
+                RetentionEnabled = true,
+                RetentionDays = settings.SecurityLogRetentionDays,
+                AutoPruneEnabled = settings.SecurityLogAutoPruneEnabled,
+                PruneSkipped = true,
+                SkipReason = "Retention days must be greater than zero."
+            };
+        }
+
+        var cutoffUtc = DateTimeOffset.UtcNow.AddDays(-settings.SecurityLogRetentionDays);
+        var eligibleRows = await _dbContext.SecurityAuthLogs
+            .AsNoTracking()
+            .Where(x => x.OccurredAtUtc < cutoffUtc)
+            .CountAsync(cancellationToken);
+
+        return new SecurityLogRetentionPreview
+        {
+            RetentionEnabled = true,
+            RetentionDays = settings.SecurityLogRetentionDays,
+            AutoPruneEnabled = settings.SecurityLogAutoPruneEnabled,
+            CutoffUtc = cutoffUtc,
+            EligibleAuthLogRows = eligibleRows,
+            PruneSkipped = false,
+            SkipReason = null
+        };
+    }
+
+    public async Task<SecurityLogPruneResult> PruneAsync(SecurityLogPruneRequest request, CancellationToken cancellationToken)
+    {
+        var preview = await GetPreviewAsync(cancellationToken);
+        if (preview.PruneSkipped)
+        {
+            return new SecurityLogPruneResult
+            {
+                Preview = preview,
+                Succeeded = false,
+                Error = preview.SkipReason,
+                RowsDeleted = 0,
+                RowsRemaining = await _dbContext.SecurityAuthLogs.AsNoTracking().CountAsync(cancellationToken)
+            };
+        }
+
+        if (!string.Equals(request.ConfirmationText?.Trim(), ManualPruneConfirmationKeyword, StringComparison.Ordinal))
+        {
+            return new SecurityLogPruneResult
+            {
+                Preview = preview,
+                Succeeded = false,
+                Error = $"Type {ManualPruneConfirmationKeyword} to confirm pruning security auth logs.",
+                RowsDeleted = 0,
+                RowsRemaining = await _dbContext.SecurityAuthLogs.AsNoTracking().CountAsync(cancellationToken)
+            };
+        }
+
+        var cutoffUtc = preview.CutoffUtc!.Value;
+
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.Security,
+            EventType = EventType.SecurityAuthLogManualPruneRequested,
+            Severity = EventSeverity.Warning,
+            Message = "Manual security auth log prune was requested.",
+            DetailsJson = $"{{\"requestedByUserId\":{FormatJsonString(request.RequestedByUserId)},\"cutoffUtc\":\"{cutoffUtc:O}\",\"eligibleRows\":{preview.EligibleAuthLogRows}}}"
+        }, cancellationToken);
+
+        var rowsDeleted = await _dbContext.SecurityAuthLogs
+            .Where(x => x.OccurredAtUtc < cutoffUtc)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        var rowsRemaining = await _dbContext.SecurityAuthLogs
+            .AsNoTracking()
+            .CountAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Security auth log prune completed. Manual: {IsManual}. CutoffUtc: {CutoffUtc}. RowsDeleted: {RowsDeleted}. RowsRemaining: {RowsRemaining}.",
+            request.IsManual,
+            cutoffUtc,
+            rowsDeleted,
+            rowsRemaining);
+
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.Security,
+            EventType = request.IsManual ? EventType.SecurityAuthLogManualPruneCompleted : EventType.SecurityAuthLogAutomaticPruneCompleted,
+            Severity = EventSeverity.Info,
+            Message = request.IsManual
+                ? "Manual security auth log prune completed."
+                : "Automatic security auth log prune completed.",
+            DetailsJson = $"{{\"requestedByUserId\":{FormatJsonString(request.RequestedByUserId)},\"cutoffUtc\":\"{cutoffUtc:O}\",\"rowsDeleted\":{rowsDeleted},\"rowsRemaining\":{rowsRemaining}}}"
+        }, cancellationToken);
+
+        return new SecurityLogPruneResult
+        {
+            Preview = preview,
+            Succeeded = true,
+            Error = null,
+            RowsDeleted = rowsDeleted,
+            RowsRemaining = rowsRemaining
+        };
+    }
+
+    private static string FormatJsonString(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "null";
+        }
+
+        return $"\"{value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal)}\"";
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecuritySettingsModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecuritySettingsModels.cs
@@ -11,6 +11,9 @@ public sealed class SecuritySettingsDto
     public int UserFailedAttemptsBeforePermanentIpBlock { get; init; }
     public int UserFailedAttemptsBeforeTemporaryAccountLockout { get; init; }
     public int UserTemporaryAccountLockoutDurationMinutes { get; init; }
+    public bool SecurityLogRetentionEnabled { get; init; }
+    public int SecurityLogRetentionDays { get; init; }
+    public bool SecurityLogAutoPruneEnabled { get; init; }
 
     public DateTimeOffset UpdatedAtUtc { get; init; }
 }
@@ -26,4 +29,7 @@ public sealed class UpdateSecuritySettingsCommand
     public int UserFailedAttemptsBeforePermanentIpBlock { get; init; }
     public int UserFailedAttemptsBeforeTemporaryAccountLockout { get; init; }
     public int UserTemporaryAccountLockoutDurationMinutes { get; init; }
+    public bool SecurityLogRetentionEnabled { get; init; }
+    public int SecurityLogRetentionDays { get; init; }
+    public bool SecurityLogAutoPruneEnabled { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecuritySettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecuritySettingsService.cs
@@ -35,6 +35,9 @@ internal sealed class SecuritySettingsService : ISecuritySettingsService
         settings.UserFailedAttemptsBeforePermanentIpBlock = command.UserFailedAttemptsBeforePermanentIpBlock;
         settings.UserFailedAttemptsBeforeTemporaryAccountLockout = command.UserFailedAttemptsBeforeTemporaryAccountLockout;
         settings.UserTemporaryAccountLockoutDurationMinutes = command.UserTemporaryAccountLockoutDurationMinutes;
+        settings.SecurityLogRetentionEnabled = command.SecurityLogRetentionEnabled;
+        settings.SecurityLogRetentionDays = command.SecurityLogRetentionDays;
+        settings.SecurityLogAutoPruneEnabled = command.SecurityLogAutoPruneEnabled;
         settings.UpdatedAtUtc = DateTimeOffset.UtcNow;
 
         await _dbContext.SaveChangesAsync(cancellationToken);
@@ -44,7 +47,7 @@ internal sealed class SecuritySettingsService : ISecuritySettingsService
             EventType = EventType.SecuritySettingsUpdated,
             Severity = EventSeverity.Info,
             Message = "Security settings were updated.",
-            DetailsJson = $"{{\"updatedAtUtc\":\"{settings.UpdatedAtUtc:O}\"}}"
+            DetailsJson = $"{{\"updatedAtUtc\":\"{settings.UpdatedAtUtc:O}\",\"securityLogRetentionEnabled\":{settings.SecurityLogRetentionEnabled.ToString().ToLowerInvariant()},\"securityLogRetentionDays\":{settings.SecurityLogRetentionDays},\"securityLogAutoPruneEnabled\":{settings.SecurityLogAutoPruneEnabled.ToString().ToLowerInvariant()}}}"
         }, cancellationToken);
 
         return ToDto(settings);
@@ -81,6 +84,10 @@ internal sealed class SecuritySettingsService : ISecuritySettingsService
         EnsurePositive(command.UserFailedAttemptsBeforePermanentIpBlock, nameof(command.UserFailedAttemptsBeforePermanentIpBlock));
         EnsurePositive(command.UserFailedAttemptsBeforeTemporaryAccountLockout, nameof(command.UserFailedAttemptsBeforeTemporaryAccountLockout));
         EnsurePositive(command.UserTemporaryAccountLockoutDurationMinutes, nameof(command.UserTemporaryAccountLockoutDurationMinutes));
+        if (command.SecurityLogRetentionEnabled)
+        {
+            EnsurePositive(command.SecurityLogRetentionDays, nameof(command.SecurityLogRetentionDays));
+        }
     }
 
     private static void EnsurePositive(int value, string name)
@@ -103,6 +110,9 @@ internal sealed class SecuritySettingsService : ISecuritySettingsService
             UserFailedAttemptsBeforePermanentIpBlock = settings.UserFailedAttemptsBeforePermanentIpBlock,
             UserFailedAttemptsBeforeTemporaryAccountLockout = settings.UserFailedAttemptsBeforeTemporaryAccountLockout,
             UserTemporaryAccountLockoutDurationMinutes = settings.UserTemporaryAccountLockoutDurationMinutes,
+            SecurityLogRetentionEnabled = settings.SecurityLogRetentionEnabled,
+            SecurityLogRetentionDays = settings.SecurityLogRetentionDays,
+            SecurityLogAutoPruneEnabled = settings.SecurityLogAutoPruneEnabled,
             UpdatedAtUtc = settings.UpdatedAtUtc
         };
     }

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -50,6 +50,22 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "Tags",
         "IconKey"
     ];
+    private static readonly string[] RequiredSecuritySettingsColumns =
+    [
+        "SecuritySettingsId",
+        "AgentFailedAttemptsBeforeTemporaryIpBlock",
+        "AgentTemporaryIpBlockDurationMinutes",
+        "AgentFailedAttemptsBeforePermanentIpBlock",
+        "UserFailedAttemptsBeforeTemporaryIpBlock",
+        "UserTemporaryIpBlockDurationMinutes",
+        "UserFailedAttemptsBeforePermanentIpBlock",
+        "UserFailedAttemptsBeforeTemporaryAccountLockout",
+        "UserTemporaryAccountLockoutDurationMinutes",
+        "SecurityLogRetentionEnabled",
+        "SecurityLogRetentionDays",
+        "SecurityLogAutoPruneEnabled",
+        "UpdatedAtUtc"
+    ];
 
     private readonly IDbContextFactory<PingMonitorDbContext> _dbContextFactory;
     private readonly IStartupDatabaseConfigurationStore _configurationStore;
@@ -118,6 +134,13 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         {
             var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
             status.Diagnostics.Add($"Endpoints table is missing required columns: {string.Join(", ", missingEndpointColumns)}.");
+            return status;
+        }
+        var missingSecuritySettingsColumns = await GetMissingSecuritySettingsColumnsAsync(connection, cancellationToken);
+        if (missingSecuritySettingsColumns.Length > 0)
+        {
+            var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
+            status.Diagnostics.Add($"SecuritySettings table is missing required columns: {string.Join(", ", missingSecuritySettingsColumns)}.");
             return status;
         }
 
@@ -237,6 +260,9 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 `UserFailedAttemptsBeforePermanentIpBlock` int NOT NULL,
                 `UserFailedAttemptsBeforeTemporaryAccountLockout` int NOT NULL,
                 `UserTemporaryAccountLockoutDurationMinutes` int NOT NULL,
+                `SecurityLogRetentionEnabled` tinyint(1) NOT NULL DEFAULT 0,
+                `SecurityLogRetentionDays` int NOT NULL DEFAULT 90,
+                `SecurityLogAutoPruneEnabled` tinyint(1) NOT NULL DEFAULT 0,
                 `UpdatedAtUtc` datetime(6) NOT NULL,
                 PRIMARY KEY (`SecuritySettingsId`)
             );
@@ -380,6 +406,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await dbContext.Database.ExecuteSqlRawAsync(createUserEndpointAccessesSql, cancellationToken);
         await EnsureEndpointDependenciesColumnsAsync(dbContext, cancellationToken);
         await EnsureEndpointColumnsAsync(dbContext, cancellationToken);
+        await EnsureSecuritySettingsColumnsAsync(dbContext, cancellationToken);
         await EnsureAgentColumnsAsync(dbContext, cancellationToken);
         await MigrateLegacyEndpointDependenciesAsync(dbContext, cancellationToken);
     }
@@ -424,6 +451,28 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         }
 
         return RequiredEndpointColumns
+            .Where(column => !existingColumns.Contains(column))
+            .ToArray();
+    }
+
+    private static async Task<string[]> GetMissingSecuritySettingsColumnsAsync(MySqlConnection connection, CancellationToken cancellationToken)
+    {
+        var existingColumns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COLUMN_NAME
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'SecuritySettings';
+            """;
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            existingColumns.Add(reader.GetString(0));
+        }
+
+        return RequiredSecuritySettingsColumns
             .Where(column => !existingColumns.Contains(column))
             .ToArray();
     }
@@ -565,6 +614,45 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         }
     }
 
+    private static async Task EnsureSecuritySettingsColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
+    {
+        await using var connection = dbContext.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        if (!await HasSecuritySettingsColumnAsync(connection, "SecurityLogRetentionEnabled", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `SecuritySettings`
+                ADD COLUMN `SecurityLogRetentionEnabled` tinyint(1) NOT NULL DEFAULT 0;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasSecuritySettingsColumnAsync(connection, "SecurityLogRetentionDays", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `SecuritySettings`
+                ADD COLUMN `SecurityLogRetentionDays` int NOT NULL DEFAULT 90;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasSecuritySettingsColumnAsync(connection, "SecurityLogAutoPruneEnabled", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `SecuritySettings`
+                ADD COLUMN `SecurityLogAutoPruneEnabled` tinyint(1) NOT NULL DEFAULT 0;
+                """,
+                cancellationToken);
+        }
+    }
+
     private static async Task EnsureEndpointColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
     {
         await using var connection = dbContext.Database.GetDbConnection();
@@ -625,6 +713,24 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             FROM information_schema.columns
             WHERE table_schema = DATABASE()
               AND table_name = 'EndpointDependencies'
+              AND column_name = @columnName;
+            """;
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "@columnName";
+        parameter.Value = columnName;
+        command.Parameters.Add(parameter);
+
+        return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
+    }
+
+    private static async Task<bool> HasSecuritySettingsColumnAsync(System.Data.Common.DbConnection connection, string columnName, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'SecuritySettings'
               AND column_name = @columnName;
             """;
         var parameter = command.CreateParameter();

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/AdminSecurityPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/AdminSecurityPageViewModel.cs
@@ -17,6 +17,10 @@ public sealed class AdminSecurityPageViewModel
     public bool BlockSaved { get; init; }
     public bool UnblockSaved { get; init; }
     public bool UnlockSaved { get; init; }
+    public bool PruneSaved { get; init; }
+    public string? PruneError { get; init; }
+    public SecurityLogRetentionPreview? RetentionPreview { get; init; }
+    public SecurityLogPruneForm PruneForm { get; init; } = new();
 }
 
 
@@ -47,7 +51,7 @@ public sealed class LockedOutUserListItem
     public DateTimeOffset LockoutEndUtc { get; init; }
 }
 
-public sealed class SecuritySettingsForm
+public sealed class SecuritySettingsForm : IValidatableObject
 {
     [Range(1, int.MaxValue, ErrorMessage = "Agent failed attempts before temporary IP block must be at least 1.")]
     [Display(Name = "Failed attempts before temporary IP block")]
@@ -81,7 +85,26 @@ public sealed class SecuritySettingsForm
     [Display(Name = "Temporary account lockout duration (minutes)")]
     public int UserTemporaryAccountLockoutDurationMinutes { get; set; }
 
+    [Display(Name = "Enable security auth log retention")]
+    public bool SecurityLogRetentionEnabled { get; set; }
+
+    [Display(Name = "Security auth log retention days")]
+    public int SecurityLogRetentionDays { get; set; }
+
+    [Display(Name = "Enable automatic security auth log prune")]
+    public bool SecurityLogAutoPruneEnabled { get; set; }
+
     public DateTimeOffset UpdatedAtUtc { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (SecurityLogRetentionEnabled && SecurityLogRetentionDays < 1)
+        {
+            yield return new ValidationResult(
+                "Security auth log retention days must be greater than 0 when retention is enabled.",
+                [nameof(SecurityLogRetentionDays)]);
+        }
+    }
 }
 
 public sealed class ManualIpBlockForm
@@ -97,4 +120,10 @@ public sealed class ManualIpBlockForm
     [StringLength(512, ErrorMessage = "Reason must be 512 characters or fewer.")]
     [Display(Name = "Reason")]
     public string? Reason { get; set; }
+}
+
+public sealed class SecurityLogPruneForm
+{
+    [Display(Name = "Type PRUNE to confirm")]
+    public string? ConfirmationText { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
@@ -166,6 +166,23 @@
                         <input asp-for="SettingsForm.UserTemporaryAccountLockoutDurationMinutes" type="number" min="1" />
                         <div class="field-error"><span asp-validation-for="SettingsForm.UserTemporaryAccountLockoutDurationMinutes"></span></div>
                     </div>
+                    <div class="field">
+                        <label>
+                            <input asp-for="SettingsForm.SecurityLogRetentionEnabled" type="checkbox" />
+                            Enable security auth log retention
+                        </label>
+                    </div>
+                    <div class="field">
+                        <label asp-for="SettingsForm.SecurityLogRetentionDays"></label>
+                        <input asp-for="SettingsForm.SecurityLogRetentionDays" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="SettingsForm.SecurityLogRetentionDays"></span></div>
+                    </div>
+                    <div class="field">
+                        <label>
+                            <input asp-for="SettingsForm.SecurityLogAutoPruneEnabled" type="checkbox" />
+                            Enable automatic security auth log prune (not yet implemented)
+                        </label>
+                    </div>
                 </section>
             </div>
             <p class="muted">Last updated: @Model.SettingsForm.UpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</p>
@@ -261,6 +278,50 @@
                 </tbody>
             </table>
         </div>
+    </section>
+
+    <section class="card">
+        <h2>Security auth log retention and prune</h2>
+        <p class="muted">Pruning is destructive and irreversible. This action only prunes authentication-attempt logs older than the cutoff. It does not modify active IP blocks or active user lockouts.</p>
+        @if (Model.PruneSaved && TempData["SecurityLogPruneSummary"] is string pruneSummary && !string.IsNullOrWhiteSpace(pruneSummary))
+        {
+            <div class="saved" role="status">@pruneSummary</div>
+        }
+        @if (!string.IsNullOrWhiteSpace(Model.PruneError))
+        {
+            <div class="errors" role="alert">@Model.PruneError</div>
+        }
+        @if (Model.RetentionPreview is not null)
+        {
+            <div class="grid-two">
+                <div><strong>Retention enabled:</strong> @(Model.RetentionPreview.RetentionEnabled ? "Yes" : "No")</div>
+                <div><strong>Retention days:</strong> @Model.RetentionPreview.RetentionDays</div>
+                <div><strong>Auto-prune enabled:</strong> @(Model.RetentionPreview.AutoPruneEnabled ? "Yes" : "No")</div>
+                <div><strong>Eligible auth log rows:</strong> @Model.RetentionPreview.EligibleAuthLogRows</div>
+                <div style="grid-column: 1 / -1;"><strong>Current cutoff (UTC):</strong> @(Model.RetentionPreview.CutoffUtc.HasValue ? Model.RetentionPreview.CutoffUtc.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") : "n/a")</div>
+                @if (Model.RetentionPreview.PruneSkipped && !string.IsNullOrWhiteSpace(Model.RetentionPreview.SkipReason))
+                {
+                    <div class="muted" style="grid-column: 1 / -1;">Prune preview skipped: @Model.RetentionPreview.SkipReason</div>
+                }
+            </div>
+        }
+
+        <form method="post" action="/admin/security/logs/prune" style="margin-top: 1rem;">
+            @Html.AntiForgeryToken()
+            <input type="hidden" name="LogFilterForm.IncludeSuccessfulUsers" value="@Model.LogFilterForm.IncludeSuccessfulUsers.ToString().ToLowerInvariant()" />
+            <input type="hidden" name="LogFilterForm.IncludeSuccessfulAgents" value="@Model.LogFilterForm.IncludeSuccessfulAgents.ToString().ToLowerInvariant()" />
+            <input type="hidden" name="LogFilterForm.SearchText" value="@Model.LogFilterForm.SearchText" />
+            <input type="hidden" name="LogFilterForm.FromUtc" value="@Model.LogFilterForm.FromUtc" />
+            <input type="hidden" name="LogFilterForm.ToUtc" value="@Model.LogFilterForm.ToUtc" />
+            <div class="field">
+                <label asp-for="PruneForm.ConfirmationText"></label>
+                <input asp-for="PruneForm.ConfirmationText" placeholder="PRUNE" />
+                <div class="field-error"><span asp-validation-for="PruneForm.ConfirmationText"></span></div>
+            </div>
+            <div class="button-row">
+                <button type="submit">Prune old security auth logs</button>
+            </div>
+        </form>
     </section>
 
     <section class="card">


### PR DESCRIPTION
### Motivation

- Provide operators explicit, auditable controls to retain and prune authentication/security logs while avoiding any impact to active enforcement state. 
- Keep prune behavior scoped, deterministic and reversible only by operator intent (no automatic destructive actions without confirmation). 
- Make retention settings visible and persisted so operators can inspect cutoff and eligible counts before pruning. 

### Description

- Added persisted security retention fields to the model: `SecurityLogRetentionEnabled`, `SecurityLogRetentionDays`, and `SecurityLogAutoPruneEnabled` with safe defaults (disabled, 90 days, auto-prune disabled). (Model + DbContext mapping updates.)
- Implemented `ISecurityLogRetentionService` and `SecurityLogRetentionService` that compute a deterministic cutoff, preview eligible `SecurityAuthLogs` rows, and delete only `SecurityAuthLogs` rows older than the cutoff; service returns auditable summaries (cutoff, rows deleted/remaining, skipped reason).
- Added manual prune UI and controller endpoint (`POST /admin/security/logs/prune`) which enforces typed confirmation `PRUNE` server-side, shows preview (cutoff and eligible count), and writes event-log entries for request and completion; automatic prune execution is persisted as a setting but intentionally deferred (not scheduled in this PR).
- Extended admin security page/view-model to surface retention settings, preview, eligible counts and the manual prune form; extended settings flow to persist and validate retention settings (retention days > 0 when enabled).
- Extended startup/schema logic to include new `SecuritySettings` columns and additive `ALTER TABLE` migration helpers to keep MySQL schema-compatible on upgrade.
- Added event types and event logging for manual prune requested/completed to make pruning auditable, and updated docs (`docs/security-logging.md`, `docs/security-settings.md`) to define scope, in-scope/out-of-scope data, manual behavior, and irreversibility.

### Testing

- Created GitHub tracking issue `#176` before implementation and linked the change to it (issue created programmatically). (Succeeded.)
- Verified the .NET 10 build: `dotnet build src/WebApp/PingMonitor.WebApp.slnx` succeeded using .NET SDK 10.0.104 after installing SDK; build output: "Build succeeded." (Succeeded.)
- Performed static/runtime checks: updated `StartupSchemaService` to detect and add new columns for MySQL schema compatibility and ensured the new DbContext mappings compile (build-time validation). (Succeeded via build.)
- No unit/integration test suite was executed in this change; no live DB prune was executed here so runtime deletion behavior should be validated in a controlled environment before production use. (No automated tests run beyond `dotnet build`.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9497b1b74832a8c10b731fb4797db)