### PR TITLE
Fix startup-gate theme partial resolution

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/StartupGate/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/StartupGate/Index.cshtml
@@ -3,7 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Ping Monitor startup gate</title>
@@ -33,7 +33,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <section class="card">
         <h1>Startup gate</h1>


### PR DESCRIPTION
### Motivation
- The startup-gate page was throwing `InvalidOperationException` because Razor partials were referenced as `"Shared/_ThemeHead"` and `"Shared/_ThemeSelector"`, causing Razor to search `Views/Shared/Shared/*` and preventing the diagnostics UI from rendering.

### Description
- Update `src/WebApp/PingMonitor.Web/Views/StartupGate/Index.cshtml` to use `@await Html.PartialAsync("_ThemeHead")` and `@await Html.PartialAsync("_ThemeSelector")` so the shared partials resolve from `Views/Shared`; this PR links the change to the tracking issue using `Fixes #180`.

### Testing
- Automated build with `dotnet build` succeeded, and a smoke run using `ASPNETCORE_URLS=http://127.0.0.1:5078 dotnet run --no-launch-profile` followed by `curl` to `/startup-gate` returned HTTP `200` and the startup-gate HTML rendered as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c94e960ec0832ab3eb0cb13baff00f)