### PR TITLE
Fix Status view partial lookup for theme head/selector

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -64,7 +64,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Endpoint status</title>
@@ -168,7 +168,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">


### PR DESCRIPTION
### Motivation
- Prevent the root status page from throwing `InvalidOperationException` when Razor cannot find the theme partials due to an incorrect relative lookup path.

### Description
- Update `src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml` to use shared partial names (`_ThemeHead` and `_ThemeSelector`) instead of `Shared/_ThemeHead` and `Shared/_ThemeSelector` so Razor resolves to `/Views/Shared/*`, addressing the runtime lookup failure (Fixes #182).

### Testing
- Ran `dotnet --version` and `pwsh --version` and executed `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -v minimal` on .NET `10.0.104`, and the build completed successfully with 0 warnings and 0 errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c950a72f40832abb29ca5ac4239afd)