### PR TITLE
Update dark mode selector UI copy for clarity

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Shared/_ThemeSelector.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_ThemeSelector.cshtml
@@ -1,10 +1,11 @@
-<div class="theme-selector" aria-label="Theme selector">
-    <label for="theme-mode-select">Theme</label>
-    <select id="theme-mode-select" name="theme-mode">
+<div class="theme-selector" aria-label="Dark mode selector">
+    <label for="theme-mode-select" title="On = always dark; Off = always light; System = follows your OS/browser preference.">Dark mode</label>
+    <select id="theme-mode-select" name="theme-mode" aria-describedby="theme-mode-help" title="On = always dark; Off = always light; System = follows your OS/browser preference.">
         <option value="on">On</option>
         <option value="off">Off</option>
         <option value="system">System</option>
     </select>
+    <span id="theme-mode-help" class="theme-selector-muted">On = always dark · Off = always light · System = follows OS/browser</span>
     <span id="theme-mode-effective" class="theme-selector-muted"></span>
 </div>
 <style>


### PR DESCRIPTION
### Motivation
- Improve clarity of the site-wide theme control by renaming it from `Theme` to `Dark mode` and adding concise help text so users understand `On`, `Off`, and `System` without changing existing behavior.

### Description
- Update `src/WebApp/PingMonitor.Web/Views/Shared/_ThemeSelector.cshtml` to change the label to `Dark mode`, add `aria`/`title` help text, and add an inline help span clarifying `On = always dark`, `Off = always light`, and `System = follows OS/browser` while keeping the option values `On`/`Off`/`System` and leaving theme logic unchanged.

### Testing
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which succeeded, confirming the web project compiles after the change.

Fixes #184

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c95411701c832a959111860d460e47)