### PR TITLE
Fix dark mode selector layout overlap on operational status page

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Shared/_ThemeSelector.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_ThemeSelector.cshtml
@@ -10,15 +10,14 @@
 </div>
 <style>
     .theme-selector {
-        position: fixed;
-        top: .75rem;
-        right: .75rem;
-        z-index: 1000;
-        display: inline-flex;
-        align-items: center;
-        gap: .45rem;
+        display: flex;
+        align-items: flex-start;
+        gap: .5rem .6rem;
         flex-wrap: wrap;
-        padding: .5rem .65rem;
+        justify-content: flex-start;
+        width: fit-content;
+        max-width: 100%;
+        padding: .6rem .75rem;
         border: 1px solid var(--border);
         border-radius: 10px;
         background: var(--card);
@@ -44,7 +43,15 @@
     .theme-selector-muted {
         color: var(--muted);
         font-size: .8rem;
-        white-space: nowrap;
+        white-space: normal;
+        overflow-wrap: anywhere;
+        flex-basis: 100%;
+    }
+
+    @media (min-width: 720px) {
+        .theme-selector {
+            justify-content: flex-end;
+        }
     }
 </style>
 <script>

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -89,6 +89,26 @@
         .stack { display: grid; gap: 1rem; }
         .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
         .summary-grid, .filter-grid, .row-meta { display: grid; gap: .75rem; }
+        .page-header {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            align-items: flex-start;
+            justify-content: space-between;
+        }
+        .page-header-main {
+            flex: 1 1 320px;
+            min-width: 0;
+        }
+        .page-header-main h1 {
+            margin-top: 0;
+        }
+        .page-header-theme {
+            flex: 1 1 280px;
+            min-width: 0;
+            display: flex;
+            justify-content: flex-start;
+        }
         .summary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
         .summary-item { border: 1px solid var(--border); border-radius: 12px; padding: .85rem; }
         .summary-item strong { display: block; font-size: 1.4rem; margin-top: .25rem; }
@@ -156,6 +176,13 @@
         .event-row-recovery { background: #e8f6ec; }
         .nowrap { white-space: nowrap; }
         @@media (min-width: 720px) {
+            .page-header {
+                flex-wrap: nowrap;
+            }
+            .page-header-theme {
+                flex: 0 1 auto;
+                justify-content: flex-end;
+            }
             .summary-grid { grid-template-columns: repeat(6, minmax(0, 1fr)); }
             .filter-grid { grid-template-columns: 1fr 220px 220px 220px; align-items: end; }
             .status-details > summary { padding: .95rem 1rem; }
@@ -168,12 +195,18 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">
-            <h1>Operational endpoint status</h1>
-            <p class="muted">Current assignment-scoped status derived by the server state engine. Missing state rows are shown as <strong>UNKNOWN</strong> until trusted server-side state exists.</p>
+            <div class="page-header">
+                <div class="page-header-main">
+                    <h1>Operational endpoint status</h1>
+                    <p class="muted">Current assignment-scoped status derived by the server state engine. Missing state rows are shown as <strong>UNKNOWN</strong> until trusted server-side state exists.</p>
+                </div>
+                <div class="page-header-theme">
+                    @await Html.PartialAsync("_ThemeSelector")
+                </div>
+            </div>
             <div class="button-row">
                 <a class="button-secondary" href="/endpoints">Endpoints</a>
                 @if (User.IsInRole("Admin"))


### PR DESCRIPTION
### Motivation
- The theme selector used `position: fixed` which removed it from normal document flow and caused it to visually overlap the top of the operational status page header.
- The goal was to keep the dark mode behavior and wording unchanged while ensuring the control stays inside the header layout and remains responsive.

### Description
- Remove fixed positioning and update `src/WebApp/PingMonitor.Web/Views/Shared/_ThemeSelector.cshtml` to use flow-based `display:flex` with wrapping and helper-text wrapping (`white-space: normal`, `overflow-wrap: anywhere`).
- Add a responsive header layout in `src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml` by introducing `.page-header`, `.page-header-main`, and `.page-header-theme`, and move the theme partial into the header so it participates in normal page flow. (Fixes #186)
- Ensure the theme selector keeps its existing JavaScript and functional behavior unchanged and add a CSS layout guard to prevent future overlay regressions.

### Testing
- Ran `git diff --check` to validate no whitespace/conflict issues and it passed.
- Verified the working tree diff only touches `src/WebApp/PingMonitor.Web/Views/Shared/_ThemeSelector.cshtml` and `src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml` and that no JS behavior was modified.
- Attempted `dotnet --version` in this environment but it is not available here (`dotnet: command not found`), so a full build/smoke test could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c956fe74d8832a9b81bfff4d92f627)