### PR TITLE
Escape Razor @media in theme selector to fix Release build

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Shared/_ThemeSelector.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_ThemeSelector.cshtml
@@ -48,7 +48,7 @@
         flex-basis: 100%;
     }
 
-    @media (min-width: 720px) {
+    @@media (min-width: 720px) {
         .theme-selector {
             justify-content: flex-end;
         }


### PR DESCRIPTION
### Motivation
- Razor was interpreting the CSS `@media` token in `Views/Shared/_ThemeSelector.cshtml` as C# which caused a `CS0103` build error during Release builds, so the view must emit a literal `@media` token.

### Description
- Replace `@media` with `@@media` in `src/WebApp/PingMonitor.Web/Views/Shared/_ThemeSelector.cshtml` so Razor treats the media query as literal CSS, and link the change to the tracked issue with `Fixes #188`.

### Testing
- Verified the fix by running `dotnet build ./src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj --configuration Release`, which now completes successfully with 0 errors.
- Reproduced the original failure by running the same `dotnet build` before the change, which failed with `CS0103: The name 'media' does not exist in the current context`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c95876ceb8832aade92b195a1d9036)