### PR TITLE
Fix Razor theme partial resolution across views

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Account/Login.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Account/Login.cshtml
@@ -2,10 +2,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Login</title></head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main style="max-width:420px;margin:2rem auto;font-family:Arial,sans-serif;">
     <h1>Sign in</h1>
     @Html.ValidationSummary(false)

--- a/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Admin settings</title>
@@ -41,7 +41,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Configuration backups</title>
@@ -55,7 +55,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnblockIp.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnblockIp.cshtml
@@ -2,13 +2,13 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Confirm unblock IP</title>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main style="max-width:700px;margin:1rem auto;padding:1rem;font-family:Arial,sans-serif;">
     <h1>Confirm active IP block removal</h1>
     <p>This action clears an active enforcement block immediately and is audited.</p>

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnlockUser.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnlockUser.cshtml
@@ -2,13 +2,13 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Confirm unlock user</title>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main style="max-width:700px;margin:1rem auto;padding:1rem;font-family:Arial,sans-serif;">
     <h1>Confirm manual user unlock</h1>
     <p>This action clears an active Identity lockout immediately and is audited.</p>

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Security logs and settings</title>
@@ -49,7 +49,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <section class="card">
         <h1>Security logs and settings</h1>

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Deploy.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Deploy.cshtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Deploy new agent</title>
@@ -35,7 +35,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <section class="card stack">
         <h1>Deploy new agent</h1>

--- a/src/WebApp/PingMonitor.Web/Views/Agents/History.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/History.cshtml
@@ -20,7 +20,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>@Model.ScopeLabel history</title>
@@ -46,7 +46,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
@@ -6,7 +6,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Manage agents</title>
@@ -57,7 +57,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Remove.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Remove.cshtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Remove agent</title>
@@ -24,7 +24,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <section class="card">
         <h1>Remove agent</h1>

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Edit.cshtml
@@ -3,7 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Edit endpoint assignment</title>
@@ -32,7 +32,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/History.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/History.cshtml
@@ -20,7 +20,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>@Model.ScopeLabel history</title>
@@ -46,7 +46,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
@@ -15,7 +15,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Manage endpoints</title>
@@ -52,7 +52,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/New.cshtml
@@ -3,7 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Add new endpoint</title>
@@ -44,7 +44,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml
@@ -15,7 +15,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Endpoint performance</title>
@@ -45,7 +45,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Remove.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Remove.cshtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Remove endpoint</title>
@@ -24,7 +24,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <section class="card">
         <h1>Remove endpoint</h1>

--- a/src/WebApp/PingMonitor.Web/Views/Groups/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/Edit.cshtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Edit group</title>
@@ -23,7 +23,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <form method="post" asp-controller="Groups" asp-action="Edit" asp-route-id="@Model.GroupId" class="stack">
         @Html.AntiForgeryToken()

--- a/src/WebApp/PingMonitor.Web/Views/Groups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/Index.cshtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Manage groups</title>
@@ -22,7 +22,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Groups/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/New.cshtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Create group</title>
@@ -23,7 +23,7 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main>
     <form method="post" asp-controller="Groups" asp-action="New" class="stack">
         @Html.AntiForgeryToken()

--- a/src/WebApp/PingMonitor.Web/Views/Users/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/Edit.cshtml
@@ -1,9 +1,9 @@
 @model PingMonitor.Web.ViewModels.Users.UserEditPageViewModel
 <!DOCTYPE html><html><head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Edit User</title></head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main style="font-family:Arial;max-width:980px;margin:1rem auto;">
 <h1>Edit user</h1>
 @Html.ValidationSummary(false)

--- a/src/WebApp/PingMonitor.Web/Views/Users/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/Index.cshtml
@@ -1,9 +1,9 @@
 @model PingMonitor.Web.ViewModels.Users.ManageUsersPageViewModel
 <!DOCTYPE html><html><head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Users</title></head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main style="font-family:Arial;max-width:980px;margin:1rem auto;">
 <h1>Manage users</h1>
 @if (!string.IsNullOrWhiteSpace(Model.StatusMessage)) { <p>@Model.StatusMessage</p> }

--- a/src/WebApp/PingMonitor.Web/Views/Users/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/New.cshtml
@@ -1,10 +1,10 @@
 @model PingMonitor.Web.ViewModels.Users.UserEditPageViewModel
 @{ ViewData["Title"] = "New User"; }
 <!DOCTYPE html><html><head>
-    @await Html.PartialAsync("Shared/_ThemeHead")
+    @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>@ViewData["Title"]</title></head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
+@await Html.PartialAsync("_ThemeSelector")
 <main style="font-family:Arial;max-width:980px;margin:1rem auto;">
 <h1>Create user</h1>
 @Html.ValidationSummary(false)


### PR DESCRIPTION
### Motivation
- Razor views referenced theme partials as `"Shared/_ThemeHead"` and `"Shared/_ThemeSelector"`, which caused the view engine to look for `/Views/<Controller>/Shared/...` or `/Views/Shared/Shared/...` and produced runtime `InvalidOperationException` on pages such as `/users`.
- The change ensures the shared theme partials resolve deterministically from `/Views/Shared` so pages render reliably without duplicating the `Shared/` path segment.

### Description
- Replaced `Html.PartialAsync("Shared/_ThemeHead")` with `Html.PartialAsync("_ThemeHead")` across Razor views to use provider-safe shared partial names.
- Replaced `Html.PartialAsync("Shared/_ThemeSelector")` with `Html.PartialAsync("_ThemeSelector")` across Razor views so the view lookup uses the existing files in `Views/Shared`.
- Applied the change consistently to 22 view files (login, admin, agents, endpoints, groups, users, history, etc.).
- This PR is linked to the tracking issue and includes the regression reproduction checklist (see `Fixes #190`).

### Testing
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` using the SDK specified in `global.json` (`10.0.104`) and the build completed successfully.
- Verified no remaining occurrences of the old calls by searching for `PartialAsync("Shared/_ThemeHead")` and `PartialAsync("Shared/_ThemeSelector")` in `Views`, which returned no matches.
- Confirmed the shared partial files exist at `Views/Shared/_ThemeHead.cshtml` and `Views/Shared/_ThemeSelector.cshtml` and that the updated pages render locally during build verification (no partial lookup errors were produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c95a1ef76c832aa49904c4e0d60427)