### PR TITLE
Show dark mode selector only on operational status page

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Account/Login.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Account/Login.cshtml
@@ -5,7 +5,6 @@
     @await Html.PartialAsync("Shared/_ThemeHead")
     <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Login</title></head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main style="max-width:420px;margin:2rem auto;font-family:Arial,sans-serif;">
     <h1>Sign in</h1>
     @Html.ValidationSummary(false)

--- a/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
@@ -41,7 +41,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
@@ -55,7 +55,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnblockIp.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnblockIp.cshtml
@@ -8,7 +8,6 @@
     <title>Confirm unblock IP</title>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main style="max-width:700px;margin:1rem auto;padding:1rem;font-family:Arial,sans-serif;">
     <h1>Confirm active IP block removal</h1>
     <p>This action clears an active enforcement block immediately and is audited.</p>

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnlockUser.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnlockUser.cshtml
@@ -8,7 +8,6 @@
     <title>Confirm unlock user</title>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main style="max-width:700px;margin:1rem auto;padding:1rem;font-family:Arial,sans-serif;">
     <h1>Confirm manual user unlock</h1>
     <p>This action clears an active Identity lockout immediately and is audited.</p>

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
@@ -49,7 +49,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main>
     <section class="card">
         <h1>Security logs and settings</h1>

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Deploy.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Deploy.cshtml
@@ -35,7 +35,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main>
     <section class="card stack">
         <h1>Deploy new agent</h1>

--- a/src/WebApp/PingMonitor.Web/Views/Agents/History.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/History.cshtml
@@ -46,7 +46,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
@@ -57,7 +57,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Remove.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Remove.cshtml
@@ -24,7 +24,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main>
     <section class="card">
         <h1>Remove agent</h1>

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Edit.cshtml
@@ -32,7 +32,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/History.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/History.cshtml
@@ -46,7 +46,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
@@ -52,7 +52,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/New.cshtml
@@ -44,7 +44,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml
@@ -45,7 +45,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Remove.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Remove.cshtml
@@ -24,7 +24,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main>
     <section class="card">
         <h1>Remove endpoint</h1>

--- a/src/WebApp/PingMonitor.Web/Views/Groups/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/Edit.cshtml
@@ -23,7 +23,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main>
     <form method="post" asp-controller="Groups" asp-action="Edit" asp-route-id="@Model.GroupId" class="stack">
         @Html.AntiForgeryToken()

--- a/src/WebApp/PingMonitor.Web/Views/Groups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/Index.cshtml
@@ -22,7 +22,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Groups/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/New.cshtml
@@ -23,7 +23,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main>
     <form method="post" asp-controller="Groups" asp-action="New" class="stack">
         @Html.AntiForgeryToken()

--- a/src/WebApp/PingMonitor.Web/Views/StartupGate/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/StartupGate/Index.cshtml
@@ -33,7 +33,6 @@
     </style>
 </head>
 <body>
-@await Html.PartialAsync("_ThemeSelector")
 <main>
     <section class="card">
         <h1>Startup gate</h1>

--- a/src/WebApp/PingMonitor.Web/Views/Users/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/Edit.cshtml
@@ -3,7 +3,6 @@
     @await Html.PartialAsync("Shared/_ThemeHead")
     <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Edit User</title></head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main style="font-family:Arial;max-width:980px;margin:1rem auto;">
 <h1>Edit user</h1>
 @Html.ValidationSummary(false)

--- a/src/WebApp/PingMonitor.Web/Views/Users/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/Index.cshtml
@@ -3,7 +3,6 @@
     @await Html.PartialAsync("Shared/_ThemeHead")
     <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Users</title></head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main style="font-family:Arial;max-width:980px;margin:1rem auto;">
 <h1>Manage users</h1>
 @if (!string.IsNullOrWhiteSpace(Model.StatusMessage)) { <p>@Model.StatusMessage</p> }

--- a/src/WebApp/PingMonitor.Web/Views/Users/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/New.cshtml
@@ -4,7 +4,6 @@
     @await Html.PartialAsync("Shared/_ThemeHead")
     <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>@ViewData["Title"]</title></head>
 <body>
-@await Html.PartialAsync("Shared/_ThemeSelector")
 <main style="font-family:Arial;max-width:980px;margin:1rem auto;">
 <h1>Create user</h1>
 @Html.ValidationSummary(false)


### PR DESCRIPTION
### Motivation
- The dark mode control was rendered on many pages and caused layout shift outside the operational status page. 
- The operational status page is the primary landing page so the selector should be shown there only while preserving global theme behaviour.

### Description
- Removed `@await Html.PartialAsync("Shared/_ThemeSelector")` render calls from non-status views so the selector is now only rendered in `Views/Status/Index.cshtml`.
- Left `Views/Shared/_ThemeHead.cshtml` and `Views/Shared/_ThemeSelector.cshtml` unchanged so theme resolution, persistence (`localStorage`/cookie), and application logic remain intact.
- Ensured the selected theme remains global because every page still includes the `_ThemeHead` partial which applies the persisted mode on page load.
- Tracked the change to issue `#192` with `Fixes #192` for PR/issue traceability.

### Testing
- Verified with repository search that `_ThemeSelector` occurs only once using `rg -n "_ThemeSelector" src/WebApp/PingMonitor.Web/Views` and the single occurrence is `Views/Status/Index.cshtml`, which succeeded.
- Verified `_ThemeHead` remains included across pages (sample count: `24` occurrences) so the persisted theme continues to be applied globally, which succeeded.
- Attempted runtime validation with `dotnet --version` but the container lacks the .NET SDK so a full build/run smoke test could not be executed; view-only changes were validated via text diffs and searches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c95db7500c832aa655f92a3e039474)