### PR TITLE
Add notification settings page with browser-notification groundwork (phase 1)

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -18,9 +18,9 @@ The first implementation phase is browser notifications delivered while an opera
 
 Telegram delivery is planned as a future notification channel.
 
-### Email (future)
+### SMTP email (future)
 
-Email delivery is planned as a future notification channel.
+SMTP-backed email delivery is planned as a future notification channel.
 
 ---
 
@@ -48,7 +48,7 @@ Initial settings scope:
 
 Future settings scope:
 
-- channel-specific settings for Telegram and email
+- channel-specific settings for Telegram and SMTP email
 - additional controls as new channels are introduced
 
 ---
@@ -84,4 +84,4 @@ Future channel additions should reuse a common event model and avoid coupling no
 
 The next implementation step is a dedicated notification settings page in the web application.
 
-That page should start with browser notification controls and provide clear placeholders for future Telegram and email settings.
+That page should start with browser notification controls and provide clear placeholders for future Telegram and SMTP email settings.

--- a/src/WebApp/PingMonitor.Web/Controllers/NotificationSettingsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/NotificationSettingsController.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.Identity;
+using PingMonitor.Web.ViewModels.Admin;
+
+namespace PingMonitor.Web.Controllers;
+
+[Authorize(Roles = ApplicationRoles.Admin)]
+[Route("settings/notifications")]
+public sealed class NotificationSettingsController : Controller
+{
+    private readonly INotificationSettingsService _notificationSettingsService;
+
+    public NotificationSettingsController(INotificationSettingsService notificationSettingsService)
+    {
+        _notificationSettingsService = notificationSettingsService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Index(CancellationToken cancellationToken)
+    {
+        var settings = await _notificationSettingsService.GetCurrentAsync(cancellationToken);
+        return View("Index", ToViewModel(settings, saved: false));
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Index([FromForm] NotificationSettingsPageViewModel model, CancellationToken cancellationToken)
+    {
+        if (!IsValidPermissionState(model.BrowserNotificationsPermissionState))
+        {
+            ModelState.AddModelError(
+                nameof(NotificationSettingsPageViewModel.BrowserNotificationsPermissionState),
+                "Permission state must be default, granted, or denied.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return View("Index", model);
+        }
+
+        var updated = await _notificationSettingsService.UpdateAsync(
+            new UpdateNotificationSettingsCommand
+            {
+                BrowserNotificationsEnabled = model.BrowserNotificationsEnabled,
+                BrowserNotificationsPermissionState = model.BrowserNotificationsPermissionState,
+                UpdatedByUserId = User.Identity?.Name
+            },
+            cancellationToken);
+
+        return View("Index", ToViewModel(updated, saved: true));
+    }
+
+    private static bool IsValidPermissionState(string value)
+    {
+        return value is "default" or "granted" or "denied";
+    }
+
+    private static NotificationSettingsPageViewModel ToViewModel(NotificationSettingsDto settings, bool saved)
+    {
+        return new NotificationSettingsPageViewModel
+        {
+            BrowserNotificationsEnabled = settings.BrowserNotificationsEnabled,
+            BrowserNotificationsPermissionState = settings.BrowserNotificationsPermissionState ?? "default",
+            UpdatedAtUtc = settings.UpdatedAtUtc,
+            UpdatedByUserId = settings.UpdatedByUserId,
+            Saved = saved
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -35,6 +35,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
     public DbSet<ApplicationSettings> ApplicationSettings => Set<ApplicationSettings>();
     public DbSet<SecuritySettings> SecuritySettings => Set<SecuritySettings>();
     public DbSet<SecurityIpBlock> SecurityIpBlocks => Set<SecurityIpBlock>();
+    public DbSet<NotificationSettings> NotificationSettings => Set<NotificationSettings>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -249,6 +250,17 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         appSettings.Property(x => x.DefaultFailureThreshold).IsRequired();
         appSettings.Property(x => x.DefaultRecoveryThreshold).IsRequired();
         appSettings.Property(x => x.UpdatedAtUtc).IsRequired();
+
+        var notificationSettings = modelBuilder.Entity<NotificationSettings>();
+        notificationSettings.ToTable("NotificationSettings");
+        notificationSettings.HasKey(x => x.NotificationSettingsId);
+        notificationSettings.Property(x => x.NotificationSettingsId).ValueGeneratedNever();
+        notificationSettings.Property(x => x.BrowserNotificationsEnabled).IsRequired();
+        notificationSettings.Property(x => x.BrowserNotificationsPermissionState).HasMaxLength(16);
+        notificationSettings.Property(x => x.TelegramNotificationsEnabled).IsRequired();
+        notificationSettings.Property(x => x.SmtpNotificationsEnabled).IsRequired();
+        notificationSettings.Property(x => x.UpdatedAtUtc).IsRequired();
+        notificationSettings.Property(x => x.UpdatedByUserId).HasMaxLength(255);
 
         var securitySettings = modelBuilder.Entity<SecuritySettings>();
         securitySettings.ToTable("SecuritySettings");

--- a/src/WebApp/PingMonitor.Web/Models/NotificationSettings.cs
+++ b/src/WebApp/PingMonitor.Web/Models/NotificationSettings.cs
@@ -1,0 +1,21 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class NotificationSettings
+{
+    public const int SingletonId = 1;
+
+    public int NotificationSettingsId { get; set; } = SingletonId;
+
+    // Phase 1 uses explicit global settings to keep notification scope unambiguous.
+    public bool BrowserNotificationsEnabled { get; set; }
+
+    public string? BrowserNotificationsPermissionState { get; set; }
+
+    public bool TelegramNotificationsEnabled { get; set; }
+
+    public bool SmtpNotificationsEnabled { get; set; }
+
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+
+    public string? UpdatedByUserId { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
@@ -5,6 +5,6 @@ public sealed class StartupGateOptions
     public const string SectionName = "StartupGate";
 
     public string StorageDirectory { get; set; } = "App_Data/StartupGate";
-    public int RequiredSchemaVersion { get; set; } = 6;
+    public int RequiredSchemaVersion { get; set; } = 7;
     public int DefaultMySqlPort { get; set; } = 3306;
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -131,6 +131,7 @@ builder.Services.AddScoped<DevelopmentAgentSeeder>();
 builder.Services.AddScoped<IAgentPackageBuilder, AgentPackageBuilder>();
 builder.Services.AddScoped<IAgentProvisioningService, AgentProvisioningService>();
 builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsService>();
+builder.Services.AddScoped<INotificationSettingsService, NotificationSettingsService>();
 builder.Services.AddScoped<IEndpointCreationQueryService, EndpointCreationQueryService>();
 builder.Services.AddScoped<IEndpointManagementQueryService, EndpointManagementQueryService>();
 builder.Services.AddScoped<IEndpointManagementService, EndpointManagementService>();

--- a/src/WebApp/PingMonitor.Web/Services/INotificationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/INotificationSettingsService.cs
@@ -1,0 +1,8 @@
+namespace PingMonitor.Web.Services;
+
+public interface INotificationSettingsService
+{
+    Task<NotificationSettingsDto> GetCurrentAsync(CancellationToken cancellationToken);
+
+    Task<NotificationSettingsDto> UpdateAsync(UpdateNotificationSettingsCommand command, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/NotificationSettingsDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NotificationSettingsDto.cs
@@ -1,0 +1,16 @@
+namespace PingMonitor.Web.Services;
+
+public sealed class NotificationSettingsDto
+{
+    public bool BrowserNotificationsEnabled { get; set; }
+
+    public string? BrowserNotificationsPermissionState { get; set; }
+
+    public bool TelegramNotificationsEnabled { get; set; }
+
+    public bool SmtpNotificationsEnabled { get; set; }
+
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+
+    public string? UpdatedByUserId { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/NotificationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NotificationSettingsService.cs
@@ -1,0 +1,82 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services;
+
+internal sealed class NotificationSettingsService : INotificationSettingsService
+{
+    private readonly PingMonitorDbContext _dbContext;
+
+    public NotificationSettingsService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<NotificationSettingsDto> GetCurrentAsync(CancellationToken cancellationToken)
+    {
+        var settings = await GetOrCreateEntityAsync(cancellationToken);
+        return ToDto(settings);
+    }
+
+    public async Task<NotificationSettingsDto> UpdateAsync(UpdateNotificationSettingsCommand command, CancellationToken cancellationToken)
+    {
+        var settings = await GetOrCreateEntityAsync(cancellationToken);
+
+        settings.BrowserNotificationsEnabled = command.BrowserNotificationsEnabled;
+        settings.BrowserNotificationsPermissionState = NormalizePermissionState(command.BrowserNotificationsPermissionState);
+        settings.UpdatedAtUtc = DateTimeOffset.UtcNow;
+        settings.UpdatedByUserId = string.IsNullOrWhiteSpace(command.UpdatedByUserId)
+            ? null
+            : command.UpdatedByUserId.Trim();
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return ToDto(settings);
+    }
+
+    private async Task<NotificationSettings> GetOrCreateEntityAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _dbContext.NotificationSettings
+            .SingleOrDefaultAsync(x => x.NotificationSettingsId == NotificationSettings.SingletonId, cancellationToken);
+
+        if (settings is not null)
+        {
+            return settings;
+        }
+
+        settings = new NotificationSettings
+        {
+            NotificationSettingsId = NotificationSettings.SingletonId,
+            BrowserNotificationsEnabled = false,
+            BrowserNotificationsPermissionState = "default",
+            TelegramNotificationsEnabled = false,
+            SmtpNotificationsEnabled = false,
+            UpdatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        _dbContext.NotificationSettings.Add(settings);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return settings;
+    }
+
+    private static string NormalizePermissionState(string? permissionState)
+    {
+        var normalized = permissionState?.Trim().ToLowerInvariant();
+        return normalized is "default" or "granted" or "denied"
+            ? normalized
+            : "default";
+    }
+
+    private static NotificationSettingsDto ToDto(NotificationSettings settings)
+    {
+        return new NotificationSettingsDto
+        {
+            BrowserNotificationsEnabled = settings.BrowserNotificationsEnabled,
+            BrowserNotificationsPermissionState = settings.BrowserNotificationsPermissionState,
+            TelegramNotificationsEnabled = settings.TelegramNotificationsEnabled,
+            SmtpNotificationsEnabled = settings.SmtpNotificationsEnabled,
+            UpdatedAtUtc = settings.UpdatedAtUtc,
+            UpdatedByUserId = settings.UpdatedByUserId
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -32,7 +32,8 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "SecurityAuthLogs",
         "ApplicationSettings",
         "SecuritySettings",
-        "SecurityIpBlocks"
+        "SecurityIpBlocks",
+        "NotificationSettings"
     ];
     private static readonly string[] RequiredEndpointDependencyColumns =
     [
@@ -286,6 +287,19 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             );
             """;
 
+        const string createNotificationSettingsSql = """
+            CREATE TABLE IF NOT EXISTS `NotificationSettings` (
+                `NotificationSettingsId` int NOT NULL,
+                `BrowserNotificationsEnabled` tinyint(1) NOT NULL,
+                `BrowserNotificationsPermissionState` varchar(16) NULL,
+                `TelegramNotificationsEnabled` tinyint(1) NOT NULL,
+                `SmtpNotificationsEnabled` tinyint(1) NOT NULL,
+                `UpdatedAtUtc` datetime(6) NOT NULL,
+                `UpdatedByUserId` varchar(255) NULL,
+                PRIMARY KEY (`NotificationSettingsId`)
+            );
+            """;
+
         const string createEventLogsSql = """
             CREATE TABLE IF NOT EXISTS `EventLogs` (
                 `EventLogId` varchar(64) NOT NULL,
@@ -398,6 +412,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await dbContext.Database.ExecuteSqlRawAsync(createApplicationSettingsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createSecuritySettingsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createSecurityIpBlocksSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createNotificationSettingsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointDependenciesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createAgentHeartbeatHistorySql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createGroupsSql, cancellationToken);

--- a/src/WebApp/PingMonitor.Web/Services/UpdateNotificationSettingsCommand.cs
+++ b/src/WebApp/PingMonitor.Web/Services/UpdateNotificationSettingsCommand.cs
@@ -1,0 +1,10 @@
+namespace PingMonitor.Web.Services;
+
+public sealed class UpdateNotificationSettingsCommand
+{
+    public bool BrowserNotificationsEnabled { get; set; }
+
+    public string? BrowserNotificationsPermissionState { get; set; }
+
+    public string? UpdatedByUserId { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/NotificationSettingsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/NotificationSettingsPageViewModel.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PingMonitor.Web.ViewModels.Admin;
+
+public sealed class NotificationSettingsPageViewModel
+{
+    [Display(Name = "Enable browser notifications while this app is open")]
+    public bool BrowserNotificationsEnabled { get; set; }
+
+    [Display(Name = "Cached browser permission state")]
+    public string BrowserNotificationsPermissionState { get; set; } = "default";
+
+    public bool Saved { get; set; }
+
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+
+    public string? UpdatedByUserId { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
@@ -50,6 +50,7 @@
                 <a class="button-secondary" href="/status">Back to status</a>
                 <a class="button-secondary" href="/admin/backups">Configuration backups</a>
                 <a class="button-secondary" href="/admin/security">Security logs and settings</a>
+                <a class="button-secondary" href="/settings/notifications">Notification settings</a>
             </div>
         </section>
 

--- a/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
@@ -1,0 +1,186 @@
+@model PingMonitor.Web.ViewModels.Admin.NotificationSettingsPageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    @await Html.PartialAsync("_ThemeHead")
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Notification settings</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #f3f6f8;
+            --card: #ffffff;
+            --text: #102a43;
+            --muted: #52606d;
+            --border: #d9e2ec;
+            --accent: #0f62fe;
+            --success: #137333;
+            --error-bg: #fee4e2;
+            --error-text: #b42318;
+        }
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 760px; margin: 0 auto; padding: 1rem; }
+        .stack { display: grid; gap: 1rem; }
+        .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
+        .button-row { display: flex; gap: .75rem; flex-wrap: wrap; }
+        .button, .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 48px; padding: .8rem 1rem; border-radius: 10px; font-weight: 600; text-decoration: none; }
+        .button { border: 0; background: var(--accent); color: white; cursor: pointer; }
+        .button-secondary { border: 1px solid var(--border); color: var(--text); background: white; cursor: pointer; }
+        .saved { border: 1px solid #c2f0c2; background: #ebffee; color: var(--success); border-radius: 10px; padding: .8rem; }
+        .errors { border: 1px solid #fda29b; background: var(--error-bg); color: var(--error-text); border-radius: 10px; padding: .8rem; }
+        .muted { color: var(--muted); }
+        .field-error { color: var(--error-text); font-size: .9rem; margin-top: .25rem; }
+        .status-pill { display: inline-block; padding: .3rem .55rem; border-radius: 999px; font-size: .85rem; border: 1px solid var(--border); background: #f8fafc; }
+        .switch-row { display: flex; align-items: center; gap: .75rem; }
+        input[type="checkbox"] { inline-size: 1.2rem; block-size: 1.2rem; }
+    </style>
+</head>
+<body>
+<main>
+    <div class="stack">
+        <section class="card">
+            <h1>Notification settings</h1>
+            <p class="muted">Scope: global app setting for now. Browser permission is controlled by each browser; this page stores app preference separately.</p>
+            <div class="button-row">
+                <a class="button-secondary" href="/admin">Back to admin settings</a>
+                <a class="button-secondary" href="/status">Back to status</a>
+            </div>
+        </section>
+
+        <form method="post" action="/settings/notifications" class="stack">
+            @Html.AntiForgeryToken()
+            <input type="hidden" asp-for="BrowserNotificationsPermissionState" id="browserPermissionStateInput" />
+
+            @if (Model.Saved)
+            {
+                <div class="saved" role="status">Notification settings saved.</div>
+            }
+
+            @if (!ViewData.ModelState.IsValid)
+            {
+                <div class="errors" asp-validation-summary="ModelOnly"></div>
+            }
+
+            <section class="card stack">
+                <h2>Browser notifications (phase 1)</h2>
+                <p class="muted">Works while this app is open in your browser. Background push/service workers are not included in this phase.</p>
+
+                <div class="switch-row">
+                    <input asp-for="BrowserNotificationsEnabled" type="checkbox" />
+                    <label asp-for="BrowserNotificationsEnabled"></label>
+                </div>
+
+                <div class="field-error"><span asp-validation-for="BrowserNotificationsPermissionState"></span></div>
+
+                <div>
+                    <div>Browser support: <span id="browserSupportStatus" class="status-pill">Checking…</span></div>
+                    <div style="margin-top:.5rem;">Browser permission: <span id="browserPermissionState" class="status-pill">@Model.BrowserNotificationsPermissionState</span></div>
+                    <p class="muted">Cached permission from server save: <strong>@Model.BrowserNotificationsPermissionState</strong></p>
+                </div>
+
+                <div class="button-row">
+                    <button type="button" id="requestPermissionButton" class="button-secondary">Request browser permission</button>
+                    <button type="button" id="testNotificationButton" class="button-secondary">Send test notification</button>
+                </div>
+                <p id="browserNotificationMessage" class="muted" role="status"></p>
+            </section>
+
+            <section class="card stack">
+                <h2>Future channels</h2>
+                <div>
+                    <h3>Telegram notifications</h3>
+                    <p class="muted">Coming later. Delivery and channel settings are not implemented in phase 1.</p>
+                </div>
+                <div>
+                    <h3>SMTP email notifications</h3>
+                    <p class="muted">Coming later. SMTP delivery and credential settings are not implemented in phase 1.</p>
+                </div>
+            </section>
+
+            <section class="card">
+                <p class="muted">Last updated: @Model.UpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</p>
+                @if (!string.IsNullOrWhiteSpace(Model.UpdatedByUserId))
+                {
+                    <p class="muted">Last updated by: @Model.UpdatedByUserId</p>
+                }
+                <div class="button-row">
+                    <button class="button" type="submit">Save notification settings</button>
+                </div>
+            </section>
+        </form>
+    </div>
+</main>
+
+<script>
+(() => {
+    const permissionStateDisplay = document.getElementById('browserPermissionState');
+    const permissionStateInput = document.getElementById('browserPermissionStateInput');
+    const supportStatusDisplay = document.getElementById('browserSupportStatus');
+    const messageDisplay = document.getElementById('browserNotificationMessage');
+    const requestPermissionButton = document.getElementById('requestPermissionButton');
+    const testNotificationButton = document.getElementById('testNotificationButton');
+
+    const hasNotificationApi = typeof window !== 'undefined' && 'Notification' in window;
+
+    function setMessage(message) {
+        messageDisplay.textContent = message;
+    }
+
+    function updatePermissionState(state) {
+        permissionStateDisplay.textContent = state;
+        permissionStateInput.value = state;
+    }
+
+    if (!hasNotificationApi) {
+        supportStatusDisplay.textContent = 'Not supported';
+        updatePermissionState('default');
+        requestPermissionButton.disabled = true;
+        testNotificationButton.disabled = true;
+        setMessage('This browser does not support notifications.');
+        return;
+    }
+
+    supportStatusDisplay.textContent = 'Supported';
+    updatePermissionState(Notification.permission);
+
+    requestPermissionButton.addEventListener('click', async () => {
+        try {
+            const permission = await Notification.requestPermission();
+            updatePermissionState(permission);
+
+            if (permission === 'granted') {
+                setMessage('Browser permission granted. Save settings to persist this cached state.');
+                return;
+            }
+
+            if (permission === 'denied') {
+                setMessage('Browser permission denied. Update browser site permissions to enable notifications.');
+                return;
+            }
+
+            setMessage('Permission request dismissed.');
+        } catch {
+            setMessage('Unable to request browser notification permission.');
+        }
+    });
+
+    testNotificationButton.addEventListener('click', () => {
+        if (Notification.permission !== 'granted') {
+            updatePermissionState(Notification.permission);
+            setMessage('Test notification requires granted browser permission.');
+            return;
+        }
+
+        new Notification('Ping Monitor Test', {
+            body: 'Browser notifications are working.'
+        });
+
+        updatePermissionState(Notification.permission);
+        setMessage('Test notification sent.');
+    });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Implement the first-phase notifications feature to provide an in-app browser notification channel and a place to persist operator preferences (`Fixes #197`).
- Keep phase 1 minimal and explicit: browser notifications work while the app is open, require explicit browser permission, and do not introduce service-worker/web-push, SMTP, or Telegram delivery yet.
- Use a conservative, auditable approach for persistence and startup schema changes to remain MySQL-first and align with platform constraints.

### Description
- Added a persisted `NotificationSettings` entity and EF mapping with a singleton/global scope to keep behaviour unambiguous in phase 1 (`NotificationSettings` table, `NotificationSettingsId = 1`).
- Implemented `INotificationSettingsService` and `NotificationSettingsService` to load/create defaults and save updates; these services do not implement delivery logic for any channel.
- Added an admin settings page at `GET/POST /settings/notifications` with a plain UI that stores an app preference toggle for browser notifications, shows cached permission state, includes a client-side permission request flow, and provides a client-side `new Notification(...)` test action; placeholders for Telegram and SMTP are shown and clearly marked as future work.
- Wired startup/schema creation SQL to create the `NotificationSettings` table and bumped the `StartupGate` required schema version to `7`, and registered the new service in DI with a navigation link from the admin settings page.

### Testing
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -v minimal` which succeeded.
- Ran `dotnet test -v minimal` in the repository root which failed with an MSBuild error because no project/solution file was specified in the current working directory (this command was run as-is and is not indicative of product test failures for the added project).
- Verified `dotnet --version` and `pwsh -v` commands completed successfully to ensure the .NET 10 SDK and PowerShell are available for local build/test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c966c29eb4832aabff3ade5a1aae37)