### PR TITLE
Add phase-1 browser notifications from event log with polling feed

### DIFF
--- a/docs/event-logging.md
+++ b/docs/event-logging.md
@@ -156,6 +156,19 @@ These belong in **metrics or telemetry systems**, not event logs.
 
 ## UI Integration
 
+## Browser notification integration (phase 1)
+
+The browser notification feed uses event-log records as its source of truth.
+
+Only a small, explicit subset of meaningful events is eligible for browser notification delivery in phase 1:
+
+- endpoint down
+- endpoint recovered
+- agent became offline
+- agent became online
+
+Routine heartbeat and other noisy/non-actionable events are intentionally excluded from browser notification delivery.
+
 ### Status Page
 
 - Displays **recent events**

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -35,6 +35,8 @@ Initial intended notification event types:
 
 Future scope may include security-oriented notifications (for example, authentication/security events), but these are not part of the first implementation.
 
+For phase 1 browser delivery, notification events are sourced from the persisted event log (not raw check-result ingestion). Only meaningful event types are eligible for browser delivery.
+
 ---
 
 ## Settings model
@@ -59,8 +61,16 @@ Phase 1 browser notifications are intentionally simple:
 
 - work while the web app is open in the browser
 - require browser notification permission from the operator
+- require browser notifications to be enabled in app settings
 - do not require service workers or full push infrastructure yet
 - provide the first, lowest-complexity notification channel
+
+Supported browser-deliverable event types in phase 1:
+
+- endpoint down
+- endpoint recovered
+- agent offline
+- agent online
 
 This phase does not include background push delivery when the app/browser is closed.
 

--- a/src/WebApp/PingMonitor.Web/Controllers/BrowserNotificationsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/BrowserNotificationsController.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Services.BrowserNotifications;
+
+namespace PingMonitor.Web.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/notifications")]
+public sealed class BrowserNotificationsController : ControllerBase
+{
+    private readonly IBrowserNotificationQueryService _browserNotificationQueryService;
+
+    public BrowserNotificationsController(IBrowserNotificationQueryService browserNotificationQueryService)
+    {
+        _browserNotificationQueryService = browserNotificationQueryService;
+    }
+
+    [HttpGet("browser-feed")]
+    public async Task<ActionResult<BrowserNotificationFeedDto>> GetBrowserFeed(
+        [FromQuery] string? lastEventId,
+        [FromQuery] int maxItems = 25,
+        CancellationToken cancellationToken = default)
+    {
+        var feed = await _browserNotificationQueryService.GetFeedAsync(lastEventId, maxItems, cancellationToken);
+        return Ok(feed);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -19,6 +19,7 @@ using PingMonitor.Web.Services.Metrics;
 using PingMonitor.Web.Services.StartupGate;
 using PingMonitor.Web.Services.Status;
 using PingMonitor.Web.Services.Security;
+using PingMonitor.Web.Services.BrowserNotifications;
 using PingMonitor.Web.Support;
 using Microsoft.Extensions.Options;
 
@@ -132,6 +133,7 @@ builder.Services.AddScoped<IAgentPackageBuilder, AgentPackageBuilder>();
 builder.Services.AddScoped<IAgentProvisioningService, AgentProvisioningService>();
 builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsService>();
 builder.Services.AddScoped<INotificationSettingsService, NotificationSettingsService>();
+builder.Services.AddScoped<IBrowserNotificationQueryService, BrowserNotificationQueryService>();
 builder.Services.AddScoped<IEndpointCreationQueryService, EndpointCreationQueryService>();
 builder.Services.AddScoped<IEndpointManagementQueryService, EndpointManagementQueryService>();
 builder.Services.AddScoped<IEndpointManagementService, EndpointManagementService>();

--- a/src/WebApp/PingMonitor.Web/Services/BrowserNotifications/BrowserNotificationEventDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BrowserNotifications/BrowserNotificationEventDto.cs
@@ -1,0 +1,14 @@
+namespace PingMonitor.Web.Services.BrowserNotifications;
+
+public sealed class BrowserNotificationEventDto
+{
+    public string EventId { get; init; } = string.Empty;
+    public string EventType { get; init; } = string.Empty;
+    public string Title { get; init; } = string.Empty;
+    public string Body { get; init; } = string.Empty;
+    public string Severity { get; init; } = string.Empty;
+    public DateTimeOffset OccurredAtUtc { get; init; }
+    public string? RelatedEndpointId { get; init; }
+    public string? RelatedAgentId { get; init; }
+    public string? Url { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/BrowserNotifications/BrowserNotificationFeedDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BrowserNotifications/BrowserNotificationFeedDto.cs
@@ -1,0 +1,8 @@
+namespace PingMonitor.Web.Services.BrowserNotifications;
+
+public sealed class BrowserNotificationFeedDto
+{
+    public bool BrowserNotificationsEnabled { get; init; }
+    public string? LastEventId { get; init; }
+    public IReadOnlyList<BrowserNotificationEventDto> Items { get; init; } = [];
+}

--- a/src/WebApp/PingMonitor.Web/Services/BrowserNotifications/BrowserNotificationQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BrowserNotifications/BrowserNotificationQueryService.cs
@@ -1,0 +1,193 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.BrowserNotifications;
+
+internal sealed class BrowserNotificationQueryService : IBrowserNotificationQueryService
+{
+    private const int DefaultMaxItems = 25;
+    private const int AbsoluteMaxItems = 100;
+
+    private static readonly string[] EligibleEventTypes =
+    [
+        EventType.EndpointStateChanged,
+        EventType.AgentBecameOffline,
+        EventType.AgentBecameOnline
+    ];
+
+    private readonly PingMonitorDbContext _dbContext;
+
+    public BrowserNotificationQueryService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<BrowserNotificationFeedDto> GetFeedAsync(string? lastEventId, int maxItems, CancellationToken cancellationToken)
+    {
+        var settings = await _dbContext.NotificationSettings.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.NotificationSettingsId == NotificationSettings.SingletonId, cancellationToken);
+
+        if (settings is null || !settings.BrowserNotificationsEnabled)
+        {
+            return new BrowserNotificationFeedDto
+            {
+                BrowserNotificationsEnabled = false
+            };
+        }
+
+        var boundedMaxItems = maxItems <= 0
+            ? DefaultMaxItems
+            : Math.Min(maxItems, AbsoluteMaxItems);
+
+        var rows = await GetFeedRowsAsync(lastEventId, boundedMaxItems, cancellationToken);
+
+        var items = rows
+            .Select(MapNotification)
+            .Where(x => x is not null)
+            .Cast<BrowserNotificationEventDto>()
+            .ToArray();
+
+        return new BrowserNotificationFeedDto
+        {
+            BrowserNotificationsEnabled = true,
+            LastEventId = items.Length == 0 ? lastEventId : items[^1].EventId,
+            Items = items
+        };
+    }
+
+    private async Task<IReadOnlyList<EventRow>> GetFeedRowsAsync(string? lastEventId, int boundedMaxItems, CancellationToken cancellationToken)
+    {
+        var query = _dbContext.EventLogs.AsNoTracking()
+            .Where(x => EligibleEventTypes.Contains(x.EventType));
+
+        if (string.IsNullOrWhiteSpace(lastEventId))
+        {
+            return await ProjectFeedRows(query)
+                .OrderBy(x => x.OccurredAtUtc)
+                .ThenBy(x => x.EventLogId)
+                .Take(boundedMaxItems)
+                .ToArrayAsync(cancellationToken);
+        }
+
+        var marker = await _dbContext.EventLogs.AsNoTracking()
+            .Where(x => x.EventLogId == lastEventId)
+            .Select(x => new { x.EventLogId, x.OccurredAtUtc })
+            .SingleOrDefaultAsync(cancellationToken);
+
+        if (marker is null)
+        {
+            return await ProjectFeedRows(query)
+                .OrderBy(x => x.OccurredAtUtc)
+                .ThenBy(x => x.EventLogId)
+                .Take(boundedMaxItems)
+                .ToArrayAsync(cancellationToken);
+        }
+
+        var markerWindow = await ProjectFeedRows(query.Where(x => x.OccurredAtUtc >= marker.OccurredAtUtc))
+            .OrderBy(x => x.OccurredAtUtc)
+            .ThenBy(x => x.EventLogId)
+            .Take(AbsoluteMaxItems * 5)
+            .ToArrayAsync(cancellationToken);
+
+        var markerIndex = Array.FindIndex(markerWindow, x => string.Equals(x.EventLogId, marker.EventLogId, StringComparison.Ordinal));
+        if (markerIndex >= 0)
+        {
+            return markerWindow
+                .Skip(markerIndex + 1)
+                .Take(boundedMaxItems)
+                .ToArray();
+        }
+
+        return markerWindow
+            .Where(x => x.OccurredAtUtc > marker.OccurredAtUtc)
+            .Take(boundedMaxItems)
+            .ToArray();
+    }
+
+    private static IQueryable<EventRow> ProjectFeedRows(IQueryable<EventLog> query)
+    {
+        return query.Select(x => new EventRow
+        {
+            EventLogId = x.EventLogId,
+            EventType = x.EventType,
+            Message = x.Message,
+            Severity = x.Severity,
+            OccurredAtUtc = x.OccurredAtUtc,
+            EndpointId = x.EndpointId,
+            AgentId = x.AgentId
+        });
+    }
+
+    private static BrowserNotificationEventDto? MapNotification(EventRow row)
+    {
+        if (row.EventType == EventType.EndpointStateChanged)
+        {
+            if (row.Message.Contains("went down.", StringComparison.Ordinal))
+            {
+                return Build(row, "Endpoint Down");
+            }
+
+            if (row.Message.Contains("recovered", StringComparison.Ordinal))
+            {
+                return Build(row, "Endpoint Recovered");
+            }
+
+            return null;
+        }
+
+        if (row.EventType == EventType.AgentBecameOffline)
+        {
+            return Build(row, "Agent Offline");
+        }
+
+        if (row.EventType == EventType.AgentBecameOnline)
+        {
+            return Build(row, "Agent Online");
+        }
+
+        return null;
+    }
+
+    private static BrowserNotificationEventDto Build(EventRow row, string title)
+    {
+        return new BrowserNotificationEventDto
+        {
+            EventId = row.EventLogId,
+            EventType = row.EventType,
+            Title = title,
+            Body = row.Message,
+            Severity = row.Severity.ToString().ToLowerInvariant(),
+            OccurredAtUtc = row.OccurredAtUtc,
+            RelatedEndpointId = row.EndpointId,
+            RelatedAgentId = row.AgentId,
+            Url = ResolveUrl(row)
+        };
+    }
+
+    private static string? ResolveUrl(EventRow row)
+    {
+        if (!string.IsNullOrWhiteSpace(row.EndpointId))
+        {
+            return $"/endpoints/{row.EndpointId}/history";
+        }
+
+        if (!string.IsNullOrWhiteSpace(row.AgentId))
+        {
+            return $"/agents/{row.AgentId}/history";
+        }
+
+        return null;
+    }
+
+    private sealed class EventRow
+    {
+        public string EventLogId { get; init; } = string.Empty;
+        public string EventType { get; init; } = string.Empty;
+        public string Message { get; init; } = string.Empty;
+        public EventSeverity Severity { get; init; }
+        public DateTimeOffset OccurredAtUtc { get; init; }
+        public string? EndpointId { get; init; }
+        public string? AgentId { get; init; }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/BrowserNotifications/IBrowserNotificationQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BrowserNotifications/IBrowserNotificationQueryService.cs
@@ -1,0 +1,6 @@
+namespace PingMonitor.Web.Services.BrowserNotifications;
+
+public interface IBrowserNotificationQueryService
+{
+    Task<BrowserNotificationFeedDto> GetFeedAsync(string? lastEventId, int maxItems, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -420,5 +420,99 @@
         </section>
     </div>
 </main>
+<script>
+(() => {
+    if (typeof window === 'undefined' || !('Notification' in window)) {
+        return;
+    }
+
+    const pollIntervalMs = 8000;
+    const maxShownIds = 200;
+    const shownEventIds = [];
+    const shownEventLookup = new Set();
+    let lastEventId = null;
+    let isPolling = false;
+
+    function trackShownEvent(eventId) {
+        if (!eventId || shownEventLookup.has(eventId)) {
+            return;
+        }
+
+        shownEventLookup.add(eventId);
+        shownEventIds.push(eventId);
+
+        if (shownEventIds.length > maxShownIds) {
+            const removedEventId = shownEventIds.shift();
+            if (removedEventId) {
+                shownEventLookup.delete(removedEventId);
+            }
+        }
+    }
+
+    async function pollBrowserNotifications() {
+        if (isPolling) {
+            return;
+        }
+
+        if (Notification.permission !== 'granted') {
+            return;
+        }
+
+        isPolling = true;
+        try {
+            const feedUrl = lastEventId
+                ? `/api/notifications/browser-feed?lastEventId=${encodeURIComponent(lastEventId)}`
+                : '/api/notifications/browser-feed';
+            const response = await fetch(feedUrl, {
+                method: 'GET',
+                credentials: 'same-origin',
+                headers: {
+                    'Accept': 'application/json'
+                }
+            });
+
+            if (!response.ok) {
+                return;
+            }
+
+            const feed = await response.json();
+            if (!feed || feed.browserNotificationsEnabled !== true || !Array.isArray(feed.items)) {
+                return;
+            }
+
+            for (const item of feed.items) {
+                if (!item || typeof item.eventId !== 'string' || shownEventLookup.has(item.eventId)) {
+                    continue;
+                }
+
+                const notification = new Notification(item.title || 'Ping Monitor', {
+                    body: item.body || '',
+                    tag: item.eventId
+                });
+
+                if (item.url && typeof item.url === 'string') {
+                    notification.onclick = () => {
+                        window.focus();
+                        window.location.href = item.url;
+                    };
+                }
+
+                trackShownEvent(item.eventId);
+            }
+
+            if (typeof feed.lastEventId === 'string' && feed.lastEventId.length > 0) {
+                lastEventId = feed.lastEventId;
+            }
+        } catch {
+            // Intentionally quiet for phase 1 browser polling.
+        } finally {
+            isPolling = false;
+        }
+    }
+
+    pollBrowserNotifications();
+    window.setInterval(pollBrowserNotifications, pollIntervalMs);
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation

- Implement a safe, first-phase browser notification channel that only delivers meaningful monitoring/agent events while the web app is open, per the platform constraints and notification docs.
- Use persisted event-log records as the single source of truth so notifications map to high-signal events (not raw check-result spam). 
- Keep the phase-1 design simple and explicit: foreground-only polling, app preference + browser permission required, no background push/service worker, no Telegram/SMTP.

### Description

- Added a small explicit notification model and feed contract: `BrowserNotificationEventDto` and `BrowserNotificationFeedDto`, and `IBrowserNotificationQueryService` / `BrowserNotificationQueryService` that queries `EventLogs` and shapes payloads for the browser. 
- Implemented explicit eligibility mapping in `BrowserNotificationQueryService` so only meaningful events are returned: `endpoint_state_changed` (filtered to down/recovered messages), `agent_became_offline`, and `agent_became_online`, and server-side app preference gate using `NotificationSettings.BrowserNotificationsEnabled`. 
- Exposed a lightweight authenticated endpoint `GET /api/notifications/browser-feed` via `BrowserNotificationsController` that accepts `lastEventId` and `maxItems` markers and returns a bounded, ordered feed for client polling. 
- Added minimal client-side polling on the status page that: polls every 8s, requires `Notification.permission === 'granted'` and server `browserNotificationsEnabled`, advances a `lastEventId` marker, prevents in-session duplicates using shown event IDs, and optionally supports click-through URLs to endpoint/agent history. 
- Registered the query service in DI and updated docs (`docs/notifications.md`, `docs/event-logging.md`) to state that phase-1 browser notifications are event-log driven, foreground-only, and list supported event types.
- Intentionally omitted background push/service workers, Telegram, and SMTP changes for this phase.

### Testing

- Created GitHub issue `#199` to track the work and link the change (issue created via the repository API). 
- Verified .NET SDK presence with `dotnet --version` (`10.0.104`) and built the web project with `dotnet build src/WebApp/PingMonitor.WebApp.slnx`, which completed successfully with `0 Warning(s), 0 Error(s)`.
- Per-phase validations performed: compilation succeeded and the new API/controller and DI registration compile; client-side polling code is present on the status page and observes browser permission and server preference (functional runtime validation recommended in a running environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c96be35558832a8b809e01d1420bfc)