### PR TITLE
Add per-event-type browser notification preferences

### DIFF
--- a/docs/event-logging.md
+++ b/docs/event-logging.md
@@ -169,6 +169,15 @@ Only a small, explicit subset of meaningful events is eligible for browser notif
 
 Routine heartbeat and other noisy/non-actionable events are intentionally excluded from browser notification delivery.
 
+Browser notification delivery for these eligible event types is additionally gated by explicit app-level per-event-type settings:
+
+- endpoint down setting
+- endpoint recovered setting
+- agent offline setting
+- agent online setting
+
+Global browser notifications must also be enabled, and browser permission must be granted.
+
 ### Status Page
 
 - Displays **recent events**

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -46,6 +46,7 @@ The system will support notification settings.
 Initial settings scope:
 
 - browser notifications enabled/disabled
+- browser notifications enabled/disabled per supported event type
 - test notification action for operator verification
 
 Future settings scope:
@@ -71,6 +72,13 @@ Supported browser-deliverable event types in phase 1:
 - endpoint recovered
 - agent offline
 - agent online
+
+Phase 1 browser settings are explicit and require both:
+
+- global browser notifications enabled in app settings, and
+- the specific event type enabled in app settings.
+
+Browser permission remains separate and must still be granted by the operator in the browser.
 
 This phase does not include background push delivery when the app/browser is closed.
 

--- a/src/WebApp/PingMonitor.Web/Controllers/NotificationSettingsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/NotificationSettingsController.cs
@@ -44,6 +44,10 @@ public sealed class NotificationSettingsController : Controller
             new UpdateNotificationSettingsCommand
             {
                 BrowserNotificationsEnabled = model.BrowserNotificationsEnabled,
+                BrowserNotifyEndpointDown = model.BrowserNotifyEndpointDown,
+                BrowserNotifyEndpointRecovered = model.BrowserNotifyEndpointRecovered,
+                BrowserNotifyAgentOffline = model.BrowserNotifyAgentOffline,
+                BrowserNotifyAgentOnline = model.BrowserNotifyAgentOnline,
                 BrowserNotificationsPermissionState = model.BrowserNotificationsPermissionState,
                 UpdatedByUserId = User.Identity?.Name
             },
@@ -62,6 +66,10 @@ public sealed class NotificationSettingsController : Controller
         return new NotificationSettingsPageViewModel
         {
             BrowserNotificationsEnabled = settings.BrowserNotificationsEnabled,
+            BrowserNotifyEndpointDown = settings.BrowserNotifyEndpointDown,
+            BrowserNotifyEndpointRecovered = settings.BrowserNotifyEndpointRecovered,
+            BrowserNotifyAgentOffline = settings.BrowserNotifyAgentOffline,
+            BrowserNotifyAgentOnline = settings.BrowserNotifyAgentOnline,
             BrowserNotificationsPermissionState = settings.BrowserNotificationsPermissionState ?? "default",
             UpdatedAtUtc = settings.UpdatedAtUtc,
             UpdatedByUserId = settings.UpdatedByUserId,

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -256,6 +256,10 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         notificationSettings.HasKey(x => x.NotificationSettingsId);
         notificationSettings.Property(x => x.NotificationSettingsId).ValueGeneratedNever();
         notificationSettings.Property(x => x.BrowserNotificationsEnabled).IsRequired();
+        notificationSettings.Property(x => x.BrowserNotifyEndpointDown).IsRequired();
+        notificationSettings.Property(x => x.BrowserNotifyEndpointRecovered).IsRequired();
+        notificationSettings.Property(x => x.BrowserNotifyAgentOffline).IsRequired();
+        notificationSettings.Property(x => x.BrowserNotifyAgentOnline).IsRequired();
         notificationSettings.Property(x => x.BrowserNotificationsPermissionState).HasMaxLength(16);
         notificationSettings.Property(x => x.TelegramNotificationsEnabled).IsRequired();
         notificationSettings.Property(x => x.SmtpNotificationsEnabled).IsRequired();

--- a/src/WebApp/PingMonitor.Web/Models/NotificationSettings.cs
+++ b/src/WebApp/PingMonitor.Web/Models/NotificationSettings.cs
@@ -8,6 +8,10 @@ public sealed class NotificationSettings
 
     // Phase 1 uses explicit global settings to keep notification scope unambiguous.
     public bool BrowserNotificationsEnabled { get; set; }
+    public bool BrowserNotifyEndpointDown { get; set; }
+    public bool BrowserNotifyEndpointRecovered { get; set; }
+    public bool BrowserNotifyAgentOffline { get; set; }
+    public bool BrowserNotifyAgentOnline { get; set; }
 
     public string? BrowserNotificationsPermissionState { get; set; }
 

--- a/src/WebApp/PingMonitor.Web/Services/BrowserNotifications/BrowserNotificationQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BrowserNotifications/BrowserNotificationQueryService.cs
@@ -43,7 +43,7 @@ internal sealed class BrowserNotificationQueryService : IBrowserNotificationQuer
         var rows = await GetFeedRowsAsync(lastEventId, boundedMaxItems, cancellationToken);
 
         var items = rows
-            .Select(MapNotification)
+            .Select(row => MapNotification(row, settings))
             .Where(x => x is not null)
             .Cast<BrowserNotificationEventDto>()
             .ToArray();
@@ -119,18 +119,34 @@ internal sealed class BrowserNotificationQueryService : IBrowserNotificationQuer
         });
     }
 
-    private static BrowserNotificationEventDto? MapNotification(EventRow row)
+    private static BrowserNotificationEventDto? MapNotification(EventRow row, NotificationSettings settings)
+    {
+        var mappedEvent = MapSupportedEventType(row);
+        if (mappedEvent is null)
+        {
+            return null;
+        }
+
+        if (!IsEventTypeEnabled(mappedEvent.Value.EventKind, settings))
+        {
+            return null;
+        }
+
+        return Build(row, mappedEvent.Value.Title);
+    }
+
+    private static SupportedBrowserEventType? MapSupportedEventType(EventRow row)
     {
         if (row.EventType == EventType.EndpointStateChanged)
         {
             if (row.Message.Contains("went down.", StringComparison.Ordinal))
             {
-                return Build(row, "Endpoint Down");
+                return new SupportedBrowserEventType(BrowserNotificationEventKind.EndpointDown, "Endpoint Down");
             }
 
             if (row.Message.Contains("recovered", StringComparison.Ordinal))
             {
-                return Build(row, "Endpoint Recovered");
+                return new SupportedBrowserEventType(BrowserNotificationEventKind.EndpointRecovered, "Endpoint Recovered");
             }
 
             return null;
@@ -138,15 +154,27 @@ internal sealed class BrowserNotificationQueryService : IBrowserNotificationQuer
 
         if (row.EventType == EventType.AgentBecameOffline)
         {
-            return Build(row, "Agent Offline");
+            return new SupportedBrowserEventType(BrowserNotificationEventKind.AgentOffline, "Agent Offline");
         }
 
         if (row.EventType == EventType.AgentBecameOnline)
         {
-            return Build(row, "Agent Online");
+            return new SupportedBrowserEventType(BrowserNotificationEventKind.AgentOnline, "Agent Online");
         }
 
         return null;
+    }
+
+    private static bool IsEventTypeEnabled(BrowserNotificationEventKind eventKind, NotificationSettings settings)
+    {
+        return eventKind switch
+        {
+            BrowserNotificationEventKind.EndpointDown => settings.BrowserNotifyEndpointDown,
+            BrowserNotificationEventKind.EndpointRecovered => settings.BrowserNotifyEndpointRecovered,
+            BrowserNotificationEventKind.AgentOffline => settings.BrowserNotifyAgentOffline,
+            BrowserNotificationEventKind.AgentOnline => settings.BrowserNotifyAgentOnline,
+            _ => false
+        };
     }
 
     private static BrowserNotificationEventDto Build(EventRow row, string title)
@@ -190,4 +218,14 @@ internal sealed class BrowserNotificationQueryService : IBrowserNotificationQuer
         public string? EndpointId { get; init; }
         public string? AgentId { get; init; }
     }
+
+    private enum BrowserNotificationEventKind
+    {
+        EndpointDown,
+        EndpointRecovered,
+        AgentOffline,
+        AgentOnline
+    }
+
+    private readonly record struct SupportedBrowserEventType(BrowserNotificationEventKind EventKind, string Title);
 }

--- a/src/WebApp/PingMonitor.Web/Services/NotificationSettingsDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NotificationSettingsDto.cs
@@ -3,6 +3,10 @@ namespace PingMonitor.Web.Services;
 public sealed class NotificationSettingsDto
 {
     public bool BrowserNotificationsEnabled { get; set; }
+    public bool BrowserNotifyEndpointDown { get; set; }
+    public bool BrowserNotifyEndpointRecovered { get; set; }
+    public bool BrowserNotifyAgentOffline { get; set; }
+    public bool BrowserNotifyAgentOnline { get; set; }
 
     public string? BrowserNotificationsPermissionState { get; set; }
 

--- a/src/WebApp/PingMonitor.Web/Services/NotificationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NotificationSettingsService.cs
@@ -24,6 +24,10 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
         var settings = await GetOrCreateEntityAsync(cancellationToken);
 
         settings.BrowserNotificationsEnabled = command.BrowserNotificationsEnabled;
+        settings.BrowserNotifyEndpointDown = command.BrowserNotifyEndpointDown;
+        settings.BrowserNotifyEndpointRecovered = command.BrowserNotifyEndpointRecovered;
+        settings.BrowserNotifyAgentOffline = command.BrowserNotifyAgentOffline;
+        settings.BrowserNotifyAgentOnline = command.BrowserNotifyAgentOnline;
         settings.BrowserNotificationsPermissionState = NormalizePermissionState(command.BrowserNotificationsPermissionState);
         settings.UpdatedAtUtc = DateTimeOffset.UtcNow;
         settings.UpdatedByUserId = string.IsNullOrWhiteSpace(command.UpdatedByUserId)
@@ -48,6 +52,10 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
         {
             NotificationSettingsId = NotificationSettings.SingletonId,
             BrowserNotificationsEnabled = false,
+            BrowserNotifyEndpointDown = true,
+            BrowserNotifyEndpointRecovered = true,
+            BrowserNotifyAgentOffline = true,
+            BrowserNotifyAgentOnline = true,
             BrowserNotificationsPermissionState = "default",
             TelegramNotificationsEnabled = false,
             SmtpNotificationsEnabled = false,
@@ -72,6 +80,10 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
         return new NotificationSettingsDto
         {
             BrowserNotificationsEnabled = settings.BrowserNotificationsEnabled,
+            BrowserNotifyEndpointDown = settings.BrowserNotifyEndpointDown,
+            BrowserNotifyEndpointRecovered = settings.BrowserNotifyEndpointRecovered,
+            BrowserNotifyAgentOffline = settings.BrowserNotifyAgentOffline,
+            BrowserNotifyAgentOnline = settings.BrowserNotifyAgentOnline,
             BrowserNotificationsPermissionState = settings.BrowserNotificationsPermissionState,
             TelegramNotificationsEnabled = settings.TelegramNotificationsEnabled,
             SmtpNotificationsEnabled = settings.SmtpNotificationsEnabled,

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -67,6 +67,20 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "SecurityLogAutoPruneEnabled",
         "UpdatedAtUtc"
     ];
+    private static readonly string[] RequiredNotificationSettingsColumns =
+    [
+        "NotificationSettingsId",
+        "BrowserNotificationsEnabled",
+        "BrowserNotifyEndpointDown",
+        "BrowserNotifyEndpointRecovered",
+        "BrowserNotifyAgentOffline",
+        "BrowserNotifyAgentOnline",
+        "BrowserNotificationsPermissionState",
+        "TelegramNotificationsEnabled",
+        "SmtpNotificationsEnabled",
+        "UpdatedAtUtc",
+        "UpdatedByUserId"
+    ];
 
     private readonly IDbContextFactory<PingMonitorDbContext> _dbContextFactory;
     private readonly IStartupDatabaseConfigurationStore _configurationStore;
@@ -142,6 +156,13 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         {
             var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
             status.Diagnostics.Add($"SecuritySettings table is missing required columns: {string.Join(", ", missingSecuritySettingsColumns)}.");
+            return status;
+        }
+        var missingNotificationSettingsColumns = await GetMissingNotificationSettingsColumnsAsync(connection, cancellationToken);
+        if (missingNotificationSettingsColumns.Length > 0)
+        {
+            var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
+            status.Diagnostics.Add($"NotificationSettings table is missing required columns: {string.Join(", ", missingNotificationSettingsColumns)}.");
             return status;
         }
 
@@ -291,6 +312,10 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             CREATE TABLE IF NOT EXISTS `NotificationSettings` (
                 `NotificationSettingsId` int NOT NULL,
                 `BrowserNotificationsEnabled` tinyint(1) NOT NULL,
+                `BrowserNotifyEndpointDown` tinyint(1) NOT NULL DEFAULT 1,
+                `BrowserNotifyEndpointRecovered` tinyint(1) NOT NULL DEFAULT 1,
+                `BrowserNotifyAgentOffline` tinyint(1) NOT NULL DEFAULT 1,
+                `BrowserNotifyAgentOnline` tinyint(1) NOT NULL DEFAULT 1,
                 `BrowserNotificationsPermissionState` varchar(16) NULL,
                 `TelegramNotificationsEnabled` tinyint(1) NOT NULL,
                 `SmtpNotificationsEnabled` tinyint(1) NOT NULL,
@@ -422,6 +447,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await EnsureEndpointDependenciesColumnsAsync(dbContext, cancellationToken);
         await EnsureEndpointColumnsAsync(dbContext, cancellationToken);
         await EnsureSecuritySettingsColumnsAsync(dbContext, cancellationToken);
+        await EnsureNotificationSettingsColumnsAsync(dbContext, cancellationToken);
         await EnsureAgentColumnsAsync(dbContext, cancellationToken);
         await MigrateLegacyEndpointDependenciesAsync(dbContext, cancellationToken);
     }
@@ -488,6 +514,28 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         }
 
         return RequiredSecuritySettingsColumns
+            .Where(column => !existingColumns.Contains(column))
+            .ToArray();
+    }
+
+    private static async Task<string[]> GetMissingNotificationSettingsColumnsAsync(MySqlConnection connection, CancellationToken cancellationToken)
+    {
+        var existingColumns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COLUMN_NAME
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'NotificationSettings';
+            """;
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            existingColumns.Add(reader.GetString(0));
+        }
+
+        return RequiredNotificationSettingsColumns
             .Where(column => !existingColumns.Contains(column))
             .ToArray();
     }
@@ -668,6 +716,55 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         }
     }
 
+    private static async Task EnsureNotificationSettingsColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
+    {
+        await using var connection = dbContext.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "BrowserNotifyEndpointDown", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `BrowserNotifyEndpointDown` tinyint(1) NOT NULL DEFAULT 1;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "BrowserNotifyEndpointRecovered", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `BrowserNotifyEndpointRecovered` tinyint(1) NOT NULL DEFAULT 1;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "BrowserNotifyAgentOffline", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `BrowserNotifyAgentOffline` tinyint(1) NOT NULL DEFAULT 1;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "BrowserNotifyAgentOnline", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `BrowserNotifyAgentOnline` tinyint(1) NOT NULL DEFAULT 1;
+                """,
+                cancellationToken);
+        }
+    }
+
     private static async Task EnsureEndpointColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
     {
         await using var connection = dbContext.Database.GetDbConnection();
@@ -746,6 +843,24 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             FROM information_schema.columns
             WHERE table_schema = DATABASE()
               AND table_name = 'SecuritySettings'
+              AND column_name = @columnName;
+            """;
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "@columnName";
+        parameter.Value = columnName;
+        command.Parameters.Add(parameter);
+
+        return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
+    }
+
+    private static async Task<bool> HasNotificationSettingsColumnAsync(System.Data.Common.DbConnection connection, string columnName, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'NotificationSettings'
               AND column_name = @columnName;
             """;
         var parameter = command.CreateParameter();

--- a/src/WebApp/PingMonitor.Web/Services/UpdateNotificationSettingsCommand.cs
+++ b/src/WebApp/PingMonitor.Web/Services/UpdateNotificationSettingsCommand.cs
@@ -3,6 +3,10 @@ namespace PingMonitor.Web.Services;
 public sealed class UpdateNotificationSettingsCommand
 {
     public bool BrowserNotificationsEnabled { get; set; }
+    public bool BrowserNotifyEndpointDown { get; set; }
+    public bool BrowserNotifyEndpointRecovered { get; set; }
+    public bool BrowserNotifyAgentOffline { get; set; }
+    public bool BrowserNotifyAgentOnline { get; set; }
 
     public string? BrowserNotificationsPermissionState { get; set; }
 

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/NotificationSettingsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/NotificationSettingsPageViewModel.cs
@@ -7,6 +7,18 @@ public sealed class NotificationSettingsPageViewModel
     [Display(Name = "Enable browser notifications while this app is open")]
     public bool BrowserNotificationsEnabled { get; set; }
 
+    [Display(Name = "Endpoint down")]
+    public bool BrowserNotifyEndpointDown { get; set; }
+
+    [Display(Name = "Endpoint recovered")]
+    public bool BrowserNotifyEndpointRecovered { get; set; }
+
+    [Display(Name = "Agent offline")]
+    public bool BrowserNotifyAgentOffline { get; set; }
+
+    [Display(Name = "Agent online")]
+    public bool BrowserNotifyAgentOnline { get; set; }
+
     [Display(Name = "Cached browser permission state")]
     public string BrowserNotificationsPermissionState { get; set; } = "default";
 

--- a/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
@@ -66,10 +66,31 @@
             <section class="card stack">
                 <h2>Browser notifications (phase 1)</h2>
                 <p class="muted">Works while this app is open in your browser. Background push/service workers are not included in this phase.</p>
+                <p class="muted">These settings apply only while the app is open and browser permission is granted.</p>
 
                 <div class="switch-row">
                     <input asp-for="BrowserNotificationsEnabled" type="checkbox" />
                     <label asp-for="BrowserNotificationsEnabled"></label>
+                </div>
+
+                <div class="stack" style="margin-top:.5rem;">
+                    <p class="muted">Event types (used only when browser notifications are enabled):</p>
+                    <div class="switch-row">
+                        <input asp-for="BrowserNotifyEndpointDown" type="checkbox" />
+                        <label asp-for="BrowserNotifyEndpointDown"></label>
+                    </div>
+                    <div class="switch-row">
+                        <input asp-for="BrowserNotifyEndpointRecovered" type="checkbox" />
+                        <label asp-for="BrowserNotifyEndpointRecovered"></label>
+                    </div>
+                    <div class="switch-row">
+                        <input asp-for="BrowserNotifyAgentOffline" type="checkbox" />
+                        <label asp-for="BrowserNotifyAgentOffline"></label>
+                    </div>
+                    <div class="switch-row">
+                        <input asp-for="BrowserNotifyAgentOnline" type="checkbox" />
+                        <label asp-for="BrowserNotifyAgentOnline"></label>
+                    </div>
                 </div>
 
                 <div class="field-error"><span asp-validation-for="BrowserNotificationsPermissionState"></span></div>


### PR DESCRIPTION
### Motivation
- Operators need finer-grained control over which monitoring events produce browser notifications so they can mute noisy classes while keeping critical alerts visible. 
- The change must preserve the existing global `BrowserNotificationsEnabled` flag and keep browser permission handling separate while remaining simple and explicit. 
- Docs and startup/schema checks must reflect and enable a safe rollout of the new per-event settings in MySQL-backed deployments (issue linked as `#201`).

### Description
- Added four explicit per-event toggles to the settings model/DTO/command: `BrowserNotifyEndpointDown`, `BrowserNotifyEndpointRecovered`, `BrowserNotifyAgentOffline`, and `BrowserNotifyAgentOnline`, with defaults enabled for new records and global browser notifications still defaulting to disabled. 
- Extended `NotificationSettingsService` to load/save the new fields and updated the `UpdateNotificationSettingsCommand`, `NotificationSettingsDto`, controller, and viewmodel to persist them. 
- Exposed per-event checkboxes and concise help text on the notifications settings page so the UI clearly shows that these toggles only apply while the app is open and browser permission is granted. 
- Applied explicit per-event filtering in the browser notification feed (`BrowserNotificationQueryService`) by mapping eligible `EventLog` rows to supported kinds and checking the corresponding setting before producing a `BrowserNotificationEventDto`, and updated startup/schema logic (`StartupSchemaService` and `PingMonitorDbContext`) to ensure the new MySQL columns exist with safe defaults; documentation in `docs/notifications.md` and `docs/event-logging.md` was updated to match the behavior.

### Testing
- Confirmed .NET 10 SDK is available via `dotnet --version` (reported `10.0.104`).
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the build completed successfully (`Build succeeded`, `0 Warning(s)`, `0 Error(s)`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c97e3b991c832a8efc4e1ba51c7c03)