### PR TITLE
Add global quiet-hours suppression for browser and SMTP notifications

### DIFF
--- a/docs/event-logging.md
+++ b/docs/event-logging.md
@@ -178,6 +178,12 @@ Browser notification delivery for these eligible event types is additionally gat
 
 Global browser notifications must also be enabled, and browser permission must be granted.
 
+Quiet hours integration (phase 1):
+
+- browser delivery may be suppressed by the global quiet-hours window when browser quiet-hours suppression is enabled
+- suppression affects delivery only; underlying event-log records are still written normally
+- suppressed notifications are dropped in phase 1 (not queued for later delivery)
+
 ## SMTP notification integration (phase 1)
 
 SMTP notification delivery also uses event-log records as the source of truth.
@@ -194,6 +200,12 @@ SMTP delivery for eligible events is additionally gated by explicit SMTP setting
 - global SMTP notifications enabled
 - SMTP channel settings complete and valid (server/auth/from/recipients)
 - specific SMTP event-type setting enabled
+
+Quiet hours integration (phase 1):
+
+- SMTP delivery may be suppressed by the global quiet-hours window when SMTP quiet-hours suppression is enabled
+- suppression affects delivery only; event-log persistence is unchanged
+- suppressed notifications are dropped in phase 1 (not queued for later delivery)
 
 Routine heartbeat and high-frequency/non-actionable events remain excluded from notification delivery.
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -53,11 +53,48 @@ Initial settings scope:
 - SMTP recipient address list
 - SMTP notifications enabled/disabled per supported event type
 - SMTP test-send action for operator verification
+- quiet hours enabled/disabled (global delivery suppression window)
+- quiet hours start local time (daily)
+- quiet hours end local time (daily)
+- quiet hours time zone basis
+- quiet hours channel toggles:
+  - suppress browser notifications during quiet hours
+  - suppress SMTP notifications during quiet hours
 
 Future settings scope:
 
 - channel-specific settings for Telegram
 - additional controls as new channels are introduced
+
+## Quiet hours / suppression windows (phase 1)
+
+Quiet hours are a **global daily notification-delivery suppression window** for operator convenience.
+
+Phase 1 scope:
+
+- applies globally across notification delivery
+- browser delivery respects quiet hours when browser suppression is enabled
+- SMTP delivery respects quiet hours when SMTP suppression is enabled
+- Telegram is not included in this phase
+
+Critical semantics:
+
+- quiet hours suppress **notification delivery only**
+- quiet hours do **not** suppress event logging
+- quiet hours do **not** suppress state calculation or state transitions
+- quiet hours do **not** change alert/state generation logic
+
+Window behaviour:
+
+- evaluated as a daily local-time window
+- evaluated using the configured `QuietHoursTimeZoneId` from notification settings (with UTC fallback if invalid)
+- supports windows that cross midnight (for example, `22:00` → `07:00`)
+- disabled quiet hours means normal delivery behaviour
+
+Phase 1 delivery policy:
+
+- notifications suppressed by quiet hours are **dropped** (not queued for later delivery)
+- operators still have historical visibility via event logs
 
 SMTP secret handling requirements:
 

--- a/src/WebApp/PingMonitor.Web/Controllers/NotificationSettingsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/NotificationSettingsController.cs
@@ -13,15 +13,18 @@ namespace PingMonitor.Web.Controllers;
 public sealed class NotificationSettingsController : Controller
 {
     private readonly INotificationSettingsService _notificationSettingsService;
+    private readonly INotificationSuppressionService _notificationSuppressionService;
     private readonly ISmtpNotificationSender _smtpNotificationSender;
     private readonly ILogger<NotificationSettingsController> _logger;
 
     public NotificationSettingsController(
         INotificationSettingsService notificationSettingsService,
+        INotificationSuppressionService notificationSuppressionService,
         ISmtpNotificationSender smtpNotificationSender,
         ILogger<NotificationSettingsController> logger)
     {
         _notificationSettingsService = notificationSettingsService;
+        _notificationSuppressionService = notificationSuppressionService;
         _smtpNotificationSender = smtpNotificationSender;
         _logger = logger;
     }
@@ -30,7 +33,7 @@ public sealed class NotificationSettingsController : Controller
     public async Task<IActionResult> Index(CancellationToken cancellationToken)
     {
         var settings = await _notificationSettingsService.GetCurrentAsync(cancellationToken);
-        return View("Index", ToViewModel(settings, saved: false));
+        return View("Index", await ToViewModelAsync(settings, saved: false, cancellationToken));
     }
 
     [HttpPost]
@@ -45,6 +48,7 @@ public sealed class NotificationSettingsController : Controller
         }
 
         ValidateSmtpSettings(model);
+        ValidateQuietHours(model);
 
         if (!ModelState.IsValid)
         {
@@ -60,6 +64,12 @@ public sealed class NotificationSettingsController : Controller
                 BrowserNotifyAgentOffline = model.BrowserNotifyAgentOffline,
                 BrowserNotifyAgentOnline = model.BrowserNotifyAgentOnline,
                 BrowserNotificationsPermissionState = model.BrowserNotificationsPermissionState,
+                QuietHoursEnabled = model.QuietHoursEnabled,
+                QuietHoursStartLocalTime = model.QuietHoursStartLocalTime,
+                QuietHoursEndLocalTime = model.QuietHoursEndLocalTime,
+                QuietHoursTimeZoneId = model.QuietHoursTimeZoneId,
+                QuietHoursSuppressBrowserNotifications = model.QuietHoursSuppressBrowserNotifications,
+                QuietHoursSuppressSmtpNotifications = model.QuietHoursSuppressSmtpNotifications,
                 SmtpNotificationsEnabled = model.SmtpNotificationsEnabled,
                 SmtpHost = model.SmtpHost,
                 SmtpPort = model.SmtpPort,
@@ -78,7 +88,7 @@ public sealed class NotificationSettingsController : Controller
             },
             cancellationToken);
 
-        return View("Index", ToViewModel(updated, saved: true));
+        return View("Index", await ToViewModelAsync(updated, saved: true, cancellationToken));
     }
 
     [HttpPost("smtp-test")]
@@ -91,6 +101,7 @@ public sealed class NotificationSettingsController : Controller
         }
 
         ValidateSmtpSettings(model);
+        ValidateQuietHours(model);
         if (!ModelState.IsValid)
         {
             model.SmtpTestSent = false;
@@ -107,6 +118,12 @@ public sealed class NotificationSettingsController : Controller
                 BrowserNotifyAgentOffline = model.BrowserNotifyAgentOffline,
                 BrowserNotifyAgentOnline = model.BrowserNotifyAgentOnline,
                 BrowserNotificationsPermissionState = model.BrowserNotificationsPermissionState,
+                QuietHoursEnabled = model.QuietHoursEnabled,
+                QuietHoursStartLocalTime = model.QuietHoursStartLocalTime,
+                QuietHoursEndLocalTime = model.QuietHoursEndLocalTime,
+                QuietHoursTimeZoneId = model.QuietHoursTimeZoneId,
+                QuietHoursSuppressBrowserNotifications = model.QuietHoursSuppressBrowserNotifications,
+                QuietHoursSuppressSmtpNotifications = model.QuietHoursSuppressSmtpNotifications,
                 SmtpNotificationsEnabled = model.SmtpNotificationsEnabled,
                 SmtpHost = model.SmtpHost,
                 SmtpPort = model.SmtpPort,
@@ -136,7 +153,7 @@ public sealed class NotificationSettingsController : Controller
         }
 
         var refreshed = await _notificationSettingsService.GetCurrentAsync(cancellationToken);
-        var viewModel = ToViewModel(refreshed, saved: false);
+        var viewModel = await ToViewModelAsync(refreshed, saved: false, cancellationToken);
         viewModel.SmtpTestSent = result.Success;
         viewModel.SmtpTestMessage = result.Message;
         return View("Index", viewModel);
@@ -175,8 +192,41 @@ public sealed class NotificationSettingsController : Controller
         }
     }
 
-    private static NotificationSettingsPageViewModel ToViewModel(NotificationSettingsDto settings, bool saved)
+    private void ValidateQuietHours(NotificationSettingsPageViewModel model)
     {
+        if (!TimeOnly.TryParseExact(model.QuietHoursStartLocalTime?.Trim(), "HH:mm", out _))
+        {
+            ModelState.AddModelError(nameof(model.QuietHoursStartLocalTime), "Quiet hours start time must use HH:mm (24-hour) format.");
+        }
+
+        if (!TimeOnly.TryParseExact(model.QuietHoursEndLocalTime?.Trim(), "HH:mm", out _))
+        {
+            ModelState.AddModelError(nameof(model.QuietHoursEndLocalTime), "Quiet hours end time must use HH:mm (24-hour) format.");
+        }
+
+        if (string.IsNullOrWhiteSpace(model.QuietHoursTimeZoneId))
+        {
+            ModelState.AddModelError(nameof(model.QuietHoursTimeZoneId), "Quiet hours time zone ID is required.");
+            return;
+        }
+
+        try
+        {
+            TimeZoneInfo.FindSystemTimeZoneById(model.QuietHoursTimeZoneId.Trim());
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            ModelState.AddModelError(nameof(model.QuietHoursTimeZoneId), "Quiet hours time zone ID was not found on this server.");
+        }
+        catch (InvalidTimeZoneException)
+        {
+            ModelState.AddModelError(nameof(model.QuietHoursTimeZoneId), "Quiet hours time zone ID is invalid.");
+        }
+    }
+
+    private async Task<NotificationSettingsPageViewModel> ToViewModelAsync(NotificationSettingsDto settings, bool saved, CancellationToken cancellationToken)
+    {
+        var suppressionStatus = await _notificationSuppressionService.GetCurrentStatusAsync(cancellationToken);
         return new NotificationSettingsPageViewModel
         {
             BrowserNotificationsEnabled = settings.BrowserNotificationsEnabled,
@@ -185,6 +235,17 @@ public sealed class NotificationSettingsController : Controller
             BrowserNotifyAgentOffline = settings.BrowserNotifyAgentOffline,
             BrowserNotifyAgentOnline = settings.BrowserNotifyAgentOnline,
             BrowserNotificationsPermissionState = settings.BrowserNotificationsPermissionState ?? "default",
+            QuietHoursEnabled = settings.QuietHoursEnabled,
+            QuietHoursStartLocalTime = settings.QuietHoursStartLocalTime,
+            QuietHoursEndLocalTime = settings.QuietHoursEndLocalTime,
+            QuietHoursTimeZoneId = settings.QuietHoursTimeZoneId,
+            QuietHoursSuppressBrowserNotifications = settings.QuietHoursSuppressBrowserNotifications,
+            QuietHoursSuppressSmtpNotifications = settings.QuietHoursSuppressSmtpNotifications,
+            QuietHoursCurrentlyActive = suppressionStatus.QuietHoursActiveNow,
+            QuietHoursCurrentStatusLabel = suppressionStatus.QuietHoursActiveNow ? "active" : "inactive",
+            QuietHoursCurrentReason = suppressionStatus.Reason,
+            QuietHoursResolvedTimeZoneId = suppressionStatus.EffectiveTimeZoneId,
+            QuietHoursEvaluatedAtUtc = suppressionStatus.EvaluatedAtUtc,
             SmtpNotificationsEnabled = settings.SmtpNotificationsEnabled,
             SmtpHost = settings.SmtpHost,
             SmtpPort = settings.SmtpPort,

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -262,6 +262,12 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         notificationSettings.Property(x => x.BrowserNotifyAgentOnline).IsRequired();
         notificationSettings.Property(x => x.BrowserNotificationsPermissionState).HasMaxLength(16);
         notificationSettings.Property(x => x.TelegramNotificationsEnabled).IsRequired();
+        notificationSettings.Property(x => x.QuietHoursEnabled).IsRequired();
+        notificationSettings.Property(x => x.QuietHoursStartLocalTime).HasMaxLength(5).IsRequired();
+        notificationSettings.Property(x => x.QuietHoursEndLocalTime).HasMaxLength(5).IsRequired();
+        notificationSettings.Property(x => x.QuietHoursTimeZoneId).HasMaxLength(128).IsRequired();
+        notificationSettings.Property(x => x.QuietHoursSuppressBrowserNotifications).IsRequired();
+        notificationSettings.Property(x => x.QuietHoursSuppressSmtpNotifications).IsRequired();
         notificationSettings.Property(x => x.SmtpNotificationsEnabled).IsRequired();
         notificationSettings.Property(x => x.SmtpHost).HasMaxLength(255);
         notificationSettings.Property(x => x.SmtpPort).IsRequired();

--- a/src/WebApp/PingMonitor.Web/Models/NotificationSettings.cs
+++ b/src/WebApp/PingMonitor.Web/Models/NotificationSettings.cs
@@ -17,6 +17,13 @@ public sealed class NotificationSettings
 
     public bool TelegramNotificationsEnabled { get; set; }
 
+    public bool QuietHoursEnabled { get; set; }
+    public string QuietHoursStartLocalTime { get; set; } = "22:00";
+    public string QuietHoursEndLocalTime { get; set; } = "07:00";
+    public string QuietHoursTimeZoneId { get; set; } = "UTC";
+    public bool QuietHoursSuppressBrowserNotifications { get; set; }
+    public bool QuietHoursSuppressSmtpNotifications { get; set; }
+
     public bool SmtpNotificationsEnabled { get; set; }
     public string? SmtpHost { get; set; }
     public int SmtpPort { get; set; }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -134,6 +134,7 @@ builder.Services.AddScoped<IAgentPackageBuilder, AgentPackageBuilder>();
 builder.Services.AddScoped<IAgentProvisioningService, AgentProvisioningService>();
 builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsService>();
 builder.Services.AddScoped<INotificationSettingsService, NotificationSettingsService>();
+builder.Services.AddScoped<INotificationSuppressionService, NotificationSuppressionService>();
 builder.Services.AddScoped<ISmtpNotificationSender, SmtpNotificationSender>();
 builder.Services.AddScoped<IBrowserNotificationQueryService, BrowserNotificationQueryService>();
 builder.Services.AddScoped<IEndpointCreationQueryService, EndpointCreationQueryService>();

--- a/src/WebApp/PingMonitor.Web/Services/BrowserNotifications/BrowserNotificationQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BrowserNotifications/BrowserNotificationQueryService.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
+using PingMonitor.Web.Services;
 
 namespace PingMonitor.Web.Services.BrowserNotifications;
 
@@ -17,10 +18,14 @@ internal sealed class BrowserNotificationQueryService : IBrowserNotificationQuer
     ];
 
     private readonly PingMonitorDbContext _dbContext;
+    private readonly INotificationSuppressionService _notificationSuppressionService;
 
-    public BrowserNotificationQueryService(PingMonitorDbContext dbContext)
+    public BrowserNotificationQueryService(
+        PingMonitorDbContext dbContext,
+        INotificationSuppressionService notificationSuppressionService)
     {
         _dbContext = dbContext;
+        _notificationSuppressionService = notificationSuppressionService;
     }
 
     public async Task<BrowserNotificationFeedDto> GetFeedAsync(string? lastEventId, int maxItems, CancellationToken cancellationToken)
@@ -33,6 +38,16 @@ internal sealed class BrowserNotificationQueryService : IBrowserNotificationQuer
             return new BrowserNotificationFeedDto
             {
                 BrowserNotificationsEnabled = false
+            };
+        }
+
+        var suppressionDecision = await _notificationSuppressionService.IsBrowserNotificationSuppressedAsync(cancellationToken);
+        if (suppressionDecision.IsSuppressed)
+        {
+            return new BrowserNotificationFeedDto
+            {
+                BrowserNotificationsEnabled = true,
+                LastEventId = lastEventId
             };
         }
 

--- a/src/WebApp/PingMonitor.Web/Services/INotificationSuppressionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/INotificationSuppressionService.cs
@@ -1,0 +1,8 @@
+namespace PingMonitor.Web.Services;
+
+public interface INotificationSuppressionService
+{
+    Task<NotificationSuppressionDecision> IsBrowserNotificationSuppressedAsync(CancellationToken cancellationToken);
+    Task<NotificationSuppressionDecision> IsSmtpNotificationSuppressedAsync(CancellationToken cancellationToken);
+    Task<NotificationSuppressionStatus> GetCurrentStatusAsync(CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/NotificationSettingsDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NotificationSettingsDto.cs
@@ -12,6 +12,13 @@ public sealed class NotificationSettingsDto
 
     public bool TelegramNotificationsEnabled { get; set; }
 
+    public bool QuietHoursEnabled { get; set; }
+    public string QuietHoursStartLocalTime { get; set; } = "22:00";
+    public string QuietHoursEndLocalTime { get; set; } = "07:00";
+    public string QuietHoursTimeZoneId { get; set; } = "UTC";
+    public bool QuietHoursSuppressBrowserNotifications { get; set; }
+    public bool QuietHoursSuppressSmtpNotifications { get; set; }
+
     public bool SmtpNotificationsEnabled { get; set; }
     public string? SmtpHost { get; set; }
     public int SmtpPort { get; set; }

--- a/src/WebApp/PingMonitor.Web/Services/NotificationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NotificationSettingsService.cs
@@ -54,6 +54,12 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
         settings.BrowserNotifyAgentOffline = command.BrowserNotifyAgentOffline;
         settings.BrowserNotifyAgentOnline = command.BrowserNotifyAgentOnline;
         settings.BrowserNotificationsPermissionState = NormalizePermissionState(command.BrowserNotificationsPermissionState);
+        settings.QuietHoursEnabled = command.QuietHoursEnabled;
+        settings.QuietHoursStartLocalTime = NormalizeQuietHoursTime(command.QuietHoursStartLocalTime, fallback: "22:00");
+        settings.QuietHoursEndLocalTime = NormalizeQuietHoursTime(command.QuietHoursEndLocalTime, fallback: "07:00");
+        settings.QuietHoursTimeZoneId = NormalizeTimeZoneId(command.QuietHoursTimeZoneId);
+        settings.QuietHoursSuppressBrowserNotifications = command.QuietHoursSuppressBrowserNotifications;
+        settings.QuietHoursSuppressSmtpNotifications = command.QuietHoursSuppressSmtpNotifications;
         settings.SmtpNotificationsEnabled = command.SmtpNotificationsEnabled;
         settings.SmtpHost = NormalizeString(command.SmtpHost);
         settings.SmtpPort = command.SmtpPort <= 0 ? 25 : command.SmtpPort;
@@ -83,10 +89,14 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
 
         await _dbContext.SaveChangesAsync(cancellationToken);
         _logger.LogInformation(
-            "Notification settings updated by {UpdatedByUserId}. BrowserEnabled={BrowserEnabled} SmtpEnabled={SmtpEnabled}",
+            "Notification settings updated by {UpdatedByUserId}. BrowserEnabled={BrowserEnabled} SmtpEnabled={SmtpEnabled} QuietHoursEnabled={QuietHoursEnabled} QuietHours={QuietHoursStart}->{QuietHoursEnd} QuietHoursTimeZoneId={QuietHoursTimeZoneId}",
             settings.UpdatedByUserId ?? "(unknown)",
             settings.BrowserNotificationsEnabled,
-            settings.SmtpNotificationsEnabled);
+            settings.SmtpNotificationsEnabled,
+            settings.QuietHoursEnabled,
+            settings.QuietHoursStartLocalTime,
+            settings.QuietHoursEndLocalTime,
+            settings.QuietHoursTimeZoneId);
 
         return ToDto(settings);
     }
@@ -111,6 +121,12 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
             BrowserNotifyAgentOnline = true,
             BrowserNotificationsPermissionState = "default",
             TelegramNotificationsEnabled = false,
+            QuietHoursEnabled = false,
+            QuietHoursStartLocalTime = "22:00",
+            QuietHoursEndLocalTime = "07:00",
+            QuietHoursTimeZoneId = "UTC",
+            QuietHoursSuppressBrowserNotifications = true,
+            QuietHoursSuppressSmtpNotifications = true,
             SmtpNotificationsEnabled = false,
             SmtpPort = 25,
             SmtpUseTls = true,
@@ -137,6 +153,21 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
     private static string? NormalizeString(string? value)
     {
         return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private static string NormalizeQuietHoursTime(string? value, string fallback)
+    {
+        if (TimeOnly.TryParseExact(value?.Trim(), "HH:mm", out var parsed))
+        {
+            return parsed.ToString("HH:mm");
+        }
+
+        return fallback;
+    }
+
+    private static string NormalizeTimeZoneId(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? "UTC" : value.Trim();
     }
 
     private static string? NormalizeRecipients(string? recipients)
@@ -207,6 +238,12 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
             BrowserNotifyAgentOnline = settings.BrowserNotifyAgentOnline,
             BrowserNotificationsPermissionState = settings.BrowserNotificationsPermissionState,
             TelegramNotificationsEnabled = settings.TelegramNotificationsEnabled,
+            QuietHoursEnabled = settings.QuietHoursEnabled,
+            QuietHoursStartLocalTime = NormalizeQuietHoursTime(settings.QuietHoursStartLocalTime, "22:00"),
+            QuietHoursEndLocalTime = NormalizeQuietHoursTime(settings.QuietHoursEndLocalTime, "07:00"),
+            QuietHoursTimeZoneId = NormalizeTimeZoneId(settings.QuietHoursTimeZoneId),
+            QuietHoursSuppressBrowserNotifications = settings.QuietHoursSuppressBrowserNotifications,
+            QuietHoursSuppressSmtpNotifications = settings.QuietHoursSuppressSmtpNotifications,
             SmtpNotificationsEnabled = settings.SmtpNotificationsEnabled,
             SmtpHost = settings.SmtpHost,
             SmtpPort = settings.SmtpPort <= 0 ? 25 : settings.SmtpPort,

--- a/src/WebApp/PingMonitor.Web/Services/NotificationSuppressionModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NotificationSuppressionModels.cs
@@ -1,0 +1,19 @@
+namespace PingMonitor.Web.Services;
+
+public sealed class NotificationSuppressionDecision
+{
+    public bool IsSuppressed { get; init; }
+    public string Reason { get; init; } = string.Empty;
+}
+
+public sealed class NotificationSuppressionStatus
+{
+    public bool QuietHoursEnabled { get; init; }
+    public bool QuietHoursActiveNow { get; init; }
+    public string QuietHoursStartLocalTime { get; init; } = "22:00";
+    public string QuietHoursEndLocalTime { get; init; } = "07:00";
+    public string ConfiguredTimeZoneId { get; init; } = "UTC";
+    public string EffectiveTimeZoneId { get; init; } = "UTC";
+    public DateTimeOffset EvaluatedAtUtc { get; init; }
+    public string Reason { get; init; } = string.Empty;
+}

--- a/src/WebApp/PingMonitor.Web/Services/NotificationSuppressionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NotificationSuppressionService.cs
@@ -1,0 +1,153 @@
+namespace PingMonitor.Web.Services;
+
+internal sealed class NotificationSuppressionService : INotificationSuppressionService
+{
+    private readonly INotificationSettingsService _notificationSettingsService;
+
+    public NotificationSuppressionService(INotificationSettingsService notificationSettingsService)
+    {
+        _notificationSettingsService = notificationSettingsService;
+    }
+
+    public async Task<NotificationSuppressionDecision> IsBrowserNotificationSuppressedAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _notificationSettingsService.GetCurrentAsync(cancellationToken);
+        if (!settings.QuietHoursSuppressBrowserNotifications)
+        {
+            return new NotificationSuppressionDecision
+            {
+                IsSuppressed = false,
+                Reason = "Quiet hours browser suppression is disabled."
+            };
+        }
+
+        var evaluation = EvaluateQuietHours(settings);
+        return new NotificationSuppressionDecision
+        {
+            IsSuppressed = evaluation.QuietHoursActiveNow,
+            Reason = evaluation.Reason
+        };
+    }
+
+    public async Task<NotificationSuppressionDecision> IsSmtpNotificationSuppressedAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _notificationSettingsService.GetCurrentAsync(cancellationToken);
+        if (!settings.QuietHoursSuppressSmtpNotifications)
+        {
+            return new NotificationSuppressionDecision
+            {
+                IsSuppressed = false,
+                Reason = "Quiet hours SMTP suppression is disabled."
+            };
+        }
+
+        var evaluation = EvaluateQuietHours(settings);
+        return new NotificationSuppressionDecision
+        {
+            IsSuppressed = evaluation.QuietHoursActiveNow,
+            Reason = evaluation.Reason
+        };
+    }
+
+    public async Task<NotificationSuppressionStatus> GetCurrentStatusAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _notificationSettingsService.GetCurrentAsync(cancellationToken);
+        return EvaluateQuietHours(settings);
+    }
+
+    private static NotificationSuppressionStatus EvaluateQuietHours(NotificationSettingsDto settings)
+    {
+        var nowUtc = DateTimeOffset.UtcNow;
+        var quietHoursStart = ParseLocalTime(settings.QuietHoursStartLocalTime, "22:00");
+        var quietHoursEnd = ParseLocalTime(settings.QuietHoursEndLocalTime, "07:00");
+        var resolvedTimeZone = ResolveTimeZone(settings.QuietHoursTimeZoneId);
+        var nowLocal = TimeZoneInfo.ConvertTime(nowUtc, resolvedTimeZone);
+
+        if (!settings.QuietHoursEnabled)
+        {
+            return BuildStatus(
+                settings,
+                nowUtc,
+                resolvedTimeZone.Id,
+                quietHoursStart,
+                quietHoursEnd,
+                isActive: false,
+                reason: "Quiet hours are disabled.");
+        }
+
+        var currentLocalTime = nowLocal.TimeOfDay;
+        var start = quietHoursStart;
+        var end = quietHoursEnd;
+
+        bool isActive;
+        if (start == end)
+        {
+            isActive = true;
+        }
+        else if (start < end)
+        {
+            isActive = currentLocalTime >= start && currentLocalTime < end;
+        }
+        else
+        {
+            isActive = currentLocalTime >= start || currentLocalTime < end;
+        }
+
+        var reason = isActive
+            ? $"Inside quiet hours window ({quietHoursStart:HH\\:mm}-{quietHoursEnd:HH\\:mm}) using timezone {resolvedTimeZone.Id}."
+            : $"Outside quiet hours window ({quietHoursStart:HH\\:mm}-{quietHoursEnd:HH\\:mm}) using timezone {resolvedTimeZone.Id}.";
+
+        return BuildStatus(settings, nowUtc, resolvedTimeZone.Id, quietHoursStart, quietHoursEnd, isActive, reason);
+    }
+
+    private static NotificationSuppressionStatus BuildStatus(
+        NotificationSettingsDto settings,
+        DateTimeOffset evaluatedAtUtc,
+        string effectiveTimeZoneId,
+        TimeSpan quietHoursStart,
+        TimeSpan quietHoursEnd,
+        bool isActive,
+        string reason)
+    {
+        return new NotificationSuppressionStatus
+        {
+            QuietHoursEnabled = settings.QuietHoursEnabled,
+            QuietHoursActiveNow = settings.QuietHoursEnabled && isActive,
+            QuietHoursStartLocalTime = $"{quietHoursStart:hh\\:mm}",
+            QuietHoursEndLocalTime = $"{quietHoursEnd:hh\\:mm}",
+            ConfiguredTimeZoneId = string.IsNullOrWhiteSpace(settings.QuietHoursTimeZoneId) ? "UTC" : settings.QuietHoursTimeZoneId.Trim(),
+            EffectiveTimeZoneId = effectiveTimeZoneId,
+            EvaluatedAtUtc = evaluatedAtUtc,
+            Reason = reason
+        };
+    }
+
+    private static TimeZoneInfo ResolveTimeZone(string? timeZoneId)
+    {
+        if (!string.IsNullOrWhiteSpace(timeZoneId))
+        {
+            try
+            {
+                return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId.Trim());
+            }
+            catch (TimeZoneNotFoundException)
+            {
+            }
+            catch (InvalidTimeZoneException)
+            {
+            }
+        }
+
+        return TimeZoneInfo.Utc;
+    }
+
+    private static TimeSpan ParseLocalTime(string? value, string fallback)
+    {
+        if (TimeOnly.TryParseExact(value?.Trim(), "HH:mm", out var parsed))
+        {
+            return parsed.ToTimeSpan();
+        }
+
+        return TimeOnly.ParseExact(fallback, "HH:mm").ToTimeSpan();
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/SmtpNotifications/SmtpNotificationSender.cs
+++ b/src/WebApp/PingMonitor.Web/Services/SmtpNotifications/SmtpNotificationSender.cs
@@ -1,25 +1,36 @@
 using System.Net;
 using System.Net.Mail;
 using PingMonitor.Web.Models;
+using PingMonitor.Web.Services;
 
 namespace PingMonitor.Web.Services.SmtpNotifications;
 
 internal sealed class SmtpNotificationSender : ISmtpNotificationSender
 {
     private readonly INotificationSettingsService _notificationSettingsService;
+    private readonly INotificationSuppressionService _notificationSuppressionService;
     private readonly ILogger<SmtpNotificationSender> _logger;
 
     public SmtpNotificationSender(
         INotificationSettingsService notificationSettingsService,
+        INotificationSuppressionService notificationSuppressionService,
         ILogger<SmtpNotificationSender> logger)
     {
         _notificationSettingsService = notificationSettingsService;
+        _notificationSuppressionService = notificationSuppressionService;
         _logger = logger;
     }
 
-    public Task<SmtpNotificationSendResult> SendTestAsync(CancellationToken cancellationToken)
+    public async Task<SmtpNotificationSendResult> SendTestAsync(CancellationToken cancellationToken)
     {
-        return SendEmailAsync(
+        var suppressionDecision = await _notificationSuppressionService.IsSmtpNotificationSuppressedAsync(cancellationToken);
+        if (suppressionDecision.IsSuppressed)
+        {
+            _logger.LogDebug("SMTP test notification suppressed by quiet hours. Reason={Reason}", suppressionDecision.Reason);
+            return SmtpNotificationSendResult.Skip("SMTP notification suppressed by quiet hours.");
+        }
+
+        return await SendEmailAsync(
             subject: "Ping Monitor SMTP Test",
             body: "SMTP notifications are working.",
             eventKey: "smtp_test",
@@ -44,6 +55,13 @@ internal sealed class SmtpNotificationSender : ISmtpNotificationSender
         {
             _logger.LogDebug("SMTP notification skipped because event toggle is disabled for {EventType}.", eventLog.EventType);
             return SmtpNotificationSendResult.Skip("SMTP notification is disabled for this event type.");
+        }
+
+        var suppressionDecision = await _notificationSuppressionService.IsSmtpNotificationSuppressedAsync(cancellationToken);
+        if (suppressionDecision.IsSuppressed)
+        {
+            _logger.LogDebug("SMTP notification suppressed by quiet hours for event {EventType}. Reason={Reason}", eventLog.EventType, suppressionDecision.Reason);
+            return SmtpNotificationSendResult.Skip("SMTP notification suppressed by quiet hours.");
         }
 
         var body = BuildEventBody(eventLog);

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -77,6 +77,12 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "BrowserNotifyAgentOnline",
         "BrowserNotificationsPermissionState",
         "TelegramNotificationsEnabled",
+        "QuietHoursEnabled",
+        "QuietHoursStartLocalTime",
+        "QuietHoursEndLocalTime",
+        "QuietHoursTimeZoneId",
+        "QuietHoursSuppressBrowserNotifications",
+        "QuietHoursSuppressSmtpNotifications",
         "SmtpNotificationsEnabled",
         "SmtpHost",
         "SmtpPort",
@@ -330,6 +336,12 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 `BrowserNotifyAgentOnline` tinyint(1) NOT NULL DEFAULT 1,
                 `BrowserNotificationsPermissionState` varchar(16) NULL,
                 `TelegramNotificationsEnabled` tinyint(1) NOT NULL,
+                `QuietHoursEnabled` tinyint(1) NOT NULL DEFAULT 0,
+                `QuietHoursStartLocalTime` varchar(5) NOT NULL DEFAULT '22:00',
+                `QuietHoursEndLocalTime` varchar(5) NOT NULL DEFAULT '07:00',
+                `QuietHoursTimeZoneId` varchar(128) NOT NULL DEFAULT 'UTC',
+                `QuietHoursSuppressBrowserNotifications` tinyint(1) NOT NULL DEFAULT 1,
+                `QuietHoursSuppressSmtpNotifications` tinyint(1) NOT NULL DEFAULT 1,
                 `SmtpNotificationsEnabled` tinyint(1) NOT NULL,
                 `SmtpHost` varchar(255) NULL,
                 `SmtpPort` int NOT NULL DEFAULT 25,
@@ -794,6 +806,66 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 """
                 ALTER TABLE `NotificationSettings`
                 ADD COLUMN `SmtpHost` varchar(255) NULL;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "QuietHoursEnabled", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `QuietHoursEnabled` tinyint(1) NOT NULL DEFAULT 0;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "QuietHoursStartLocalTime", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `QuietHoursStartLocalTime` varchar(5) NOT NULL DEFAULT '22:00';
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "QuietHoursEndLocalTime", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `QuietHoursEndLocalTime` varchar(5) NOT NULL DEFAULT '07:00';
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "QuietHoursTimeZoneId", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `QuietHoursTimeZoneId` varchar(128) NOT NULL DEFAULT 'UTC';
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "QuietHoursSuppressBrowserNotifications", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `QuietHoursSuppressBrowserNotifications` tinyint(1) NOT NULL DEFAULT 1;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "QuietHoursSuppressSmtpNotifications", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `QuietHoursSuppressSmtpNotifications` tinyint(1) NOT NULL DEFAULT 1;
                 """,
                 cancellationToken);
         }

--- a/src/WebApp/PingMonitor.Web/Services/UpdateNotificationSettingsCommand.cs
+++ b/src/WebApp/PingMonitor.Web/Services/UpdateNotificationSettingsCommand.cs
@@ -10,6 +10,13 @@ public sealed class UpdateNotificationSettingsCommand
 
     public string? BrowserNotificationsPermissionState { get; set; }
 
+    public bool QuietHoursEnabled { get; set; }
+    public string QuietHoursStartLocalTime { get; set; } = "22:00";
+    public string QuietHoursEndLocalTime { get; set; } = "07:00";
+    public string QuietHoursTimeZoneId { get; set; } = "UTC";
+    public bool QuietHoursSuppressBrowserNotifications { get; set; }
+    public bool QuietHoursSuppressSmtpNotifications { get; set; }
+
     public bool SmtpNotificationsEnabled { get; set; }
     public string? SmtpHost { get; set; }
     public int SmtpPort { get; set; }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/NotificationSettingsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/NotificationSettingsPageViewModel.cs
@@ -22,6 +22,30 @@ public sealed class NotificationSettingsPageViewModel
     [Display(Name = "Cached browser permission state")]
     public string BrowserNotificationsPermissionState { get; set; } = "default";
 
+    [Display(Name = "Enable quiet hours")]
+    public bool QuietHoursEnabled { get; set; }
+
+    [Display(Name = "Quiet hours start (local time)")]
+    public string QuietHoursStartLocalTime { get; set; } = "22:00";
+
+    [Display(Name = "Quiet hours end (local time)")]
+    public string QuietHoursEndLocalTime { get; set; } = "07:00";
+
+    [Display(Name = "Quiet hours time zone ID")]
+    public string QuietHoursTimeZoneId { get; set; } = "UTC";
+
+    [Display(Name = "Suppress browser notifications during quiet hours")]
+    public bool QuietHoursSuppressBrowserNotifications { get; set; }
+
+    [Display(Name = "Suppress SMTP notifications during quiet hours")]
+    public bool QuietHoursSuppressSmtpNotifications { get; set; }
+
+    public bool QuietHoursCurrentlyActive { get; set; }
+    public string QuietHoursCurrentStatusLabel { get; set; } = "inactive";
+    public string QuietHoursCurrentReason { get; set; } = string.Empty;
+    public string QuietHoursResolvedTimeZoneId { get; set; } = "UTC";
+    public DateTimeOffset QuietHoursEvaluatedAtUtc { get; set; }
+
     [Display(Name = "Enable SMTP email notifications")]
     public bool SmtpNotificationsEnabled { get; set; }
 

--- a/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
@@ -53,6 +53,8 @@
         <section class="card">
             <h1>Notification settings</h1>
             <p class="muted">Scope: global app setting for now. Browser permission is controlled by each browser; this page stores app preference separately.</p>
+            <p class="muted">Quiet hours suppress notification delivery only. Events and state changes are still recorded normally.</p>
+            <p class="muted">Phase 1 behaviour: notifications suppressed during quiet hours are dropped and are not queued for later delivery.</p>
             <div class="button-row">
                 <a class="button-secondary" href="/admin">Back to admin settings</a>
                 <a class="button-secondary" href="/status">Back to status</a>
@@ -201,6 +203,60 @@
 
                 <div class="button-row">
                     <button class="button-secondary" type="submit" formaction="/settings/notifications/smtp-test">Send SMTP test email</button>
+                </div>
+            </section>
+
+            <section class="card stack">
+                <h2>Quiet hours (global delivery suppression)</h2>
+                <p class="muted">Quiet hours are evaluated daily in the configured time zone and apply to delivery only.</p>
+                <p class="muted">Cross-midnight example: start 22:00 and end 07:00 keeps suppression active overnight.</p>
+
+                <div class="switch-row">
+                    <input asp-for="QuietHoursEnabled" type="checkbox" />
+                    <label asp-for="QuietHoursEnabled"></label>
+                </div>
+
+                <div class="stack">
+                    <div>
+                        <label asp-for="QuietHoursStartLocalTime"></label>
+                        <input asp-for="QuietHoursStartLocalTime" type="time" />
+                        <div class="field-error"><span asp-validation-for="QuietHoursStartLocalTime"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="QuietHoursEndLocalTime"></label>
+                        <input asp-for="QuietHoursEndLocalTime" type="time" />
+                        <div class="field-error"><span asp-validation-for="QuietHoursEndLocalTime"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="QuietHoursTimeZoneId"></label>
+                        <input asp-for="QuietHoursTimeZoneId" type="text" />
+                        <div class="field-error"><span asp-validation-for="QuietHoursTimeZoneId"></span></div>
+                    </div>
+                </div>
+
+                <div class="stack" style="margin-top:.5rem;">
+                    <p class="muted">Channel suppression during quiet hours:</p>
+                    <div class="switch-row">
+                        <input asp-for="QuietHoursSuppressBrowserNotifications" type="checkbox" />
+                        <label asp-for="QuietHoursSuppressBrowserNotifications"></label>
+                    </div>
+                    <div class="switch-row">
+                        <input asp-for="QuietHoursSuppressSmtpNotifications" type="checkbox" />
+                        <label asp-for="QuietHoursSuppressSmtpNotifications"></label>
+                    </div>
+                </div>
+
+                <div>
+                    <div>
+                        Quiet hours status now:
+                        <span class="status-pill">@Model.QuietHoursCurrentStatusLabel</span>
+                    </div>
+                    <div style="margin-top:.5rem;">
+                        Evaluation time zone:
+                        <span class="status-pill">@Model.QuietHoursResolvedTimeZoneId</span>
+                    </div>
+                    <p class="muted">@Model.QuietHoursCurrentReason</p>
+                    <p class="muted">Evaluated at @Model.QuietHoursEvaluatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'").</p>
                 </div>
             </section>
 


### PR DESCRIPTION
### Motivation

- Operators need a simple, deterministic way to suppress notification delivery during operator-configured quiet hours without affecting event logs or state transitions.
- The first-phase requirement is global, delivery-only suppression for browser and SMTP channels with predictable cross-midnight semantics and a clear timezone basis.
- Keep the implementation explicit and minimal: no queuing, no state-machine changes, and maintain MySQL-first schema handling.

### Description

- Documented phase‑1 quiet‑hours semantics and integration in `docs/notifications.md` and `docs/event-logging.md` clarifying delivery-only suppression, drop semantics, and timezone basis (configured `QuietHoursTimeZoneId` with UTC fallback). (Fixes #205)
- Extended the notification settings model and DTOs with explicit quiet‑hours fields: `QuietHoursEnabled`, `QuietHoursStartLocalTime`, `QuietHoursEndLocalTime`, `QuietHoursTimeZoneId`, `QuietHoursSuppressBrowserNotifications`, and `QuietHoursSuppressSmtpNotifications`, and wired normalization/defaults in `NotificationSettingsService`.
- Added `INotificationSuppressionService` + `NotificationSuppressionService` and small DTOs to evaluate quiet hours deterministically (uses configured timezone, supports cross‑midnight windows, returns clear reason/status); registered via DI.
- Integrated suppression checks into delivery paths so suppression affects only delivery: `BrowserNotificationQueryService` returns an empty feed when browser quiet hours apply, and `SmtpNotificationSender` skips test/send when SMTP quiet hours apply; event logging and state transitions remain unchanged.
- UI/controller changes: added quiet‑hours controls and validation to the notification settings page and controller, plus a simple current-status indicator showing whether quiet hours are active and the resolved timezone.
- MySQL/startup schema updates: updated `StartupSchemaService` and EF model configuration to add/create the new `NotificationSettings` columns so existing deployments will be evolved safely on startup.

### Testing

- Created a tracking GitHub issue prior to implementation and linked the work as required (issue #205 was created and referenced).
- Built the web project successfully with the .NET 10 SDK using `dotnet build` and fixed compile-time issues introduced during implementation, and the build completed without errors.
- Ran `dotnet test` for the web project; the test invocation completed successfully in this environment (no failing tests observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca5c6d948c832a8b376a16e2481293)