### PR TITLE
Add user profile page and per-user notification preferences

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -43,17 +43,21 @@ For phase 1 browser and SMTP delivery, notification events are sourced from the 
 
 The system will support notification settings.
 
-Initial settings scope:
+Initial settings scope is split by ownership:
+
+### Admin-owned channel infrastructure settings
+
+- SMTP server settings (host, port, TLS mode, username, password secret, from address/display name)
+- SMTP infrastructure test-send action for operator verification
+
+### User-owned profile notification preferences
 
 - browser notifications enabled/disabled
 - browser notifications enabled/disabled per supported event type
-- test notification action for operator verification
+- cached browser permission state
 - SMTP notifications enabled/disabled
-- SMTP server settings (host, port, TLS mode, username, password secret, from address/display name)
-- SMTP recipient address list
 - SMTP notifications enabled/disabled per supported event type
-- SMTP test-send action for operator verification
-- quiet hours enabled/disabled (global delivery suppression window)
+- quiet hours enabled/disabled (per-user delivery suppression window)
 - quiet hours start local time (daily)
 - quiet hours end local time (daily)
 - quiet hours time zone basis
@@ -68,13 +72,13 @@ Future settings scope:
 
 ## Quiet hours / suppression windows (phase 1)
 
-Quiet hours are a **global daily notification-delivery suppression window** for operator convenience.
+Quiet hours are a **per-user daily notification-delivery suppression window** for operator convenience.
 
 Phase 1 scope:
 
-- applies globally across notification delivery
-- browser delivery respects quiet hours when browser suppression is enabled
-- SMTP delivery respects quiet hours when SMTP suppression is enabled
+- each authenticated user manages their own quiet-hours values in their profile
+- browser delivery respects that user's quiet-hours browser suppression toggle
+- SMTP delivery eligibility respects each user's quiet-hours SMTP suppression toggle
 - Telegram is not included in this phase
 
 Critical semantics:
@@ -124,8 +128,8 @@ Supported browser-deliverable event types in phase 1:
 
 Phase 1 browser settings are explicit and require both:
 
-- global browser notifications enabled in app settings, and
-- the specific event type enabled in app settings.
+- browser notifications enabled in the current authenticated user's profile, and
+- the specific browser event type enabled in that same user profile.
 
 Browser permission remains separate and must still be granted by the operator in the browser.
 
@@ -149,6 +153,13 @@ Future channel additions should reuse a common event model and avoid coupling no
 
 ## UI direction
 
-The next implementation step is a dedicated notification settings page in the web application.
+Phase 1 per-user ownership starts with a dedicated authenticated `/profile` page in the web application.
 
-That page should start with browser notification controls and provide clear placeholders for future Telegram and SMTP email settings.
+That page includes:
+
+- account details (username display + email update)
+- password change
+- user-owned browser and SMTP notification preferences
+- user-owned quiet-hours preferences
+
+The admin notification settings page remains for channel infrastructure (SMTP transport/server configuration), while per-user delivery preferences live in each user profile.

--- a/src/WebApp/PingMonitor.Web/Controllers/NotificationSettingsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/NotificationSettingsController.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Models.Identity;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.Services.SmtpNotifications;
@@ -13,18 +15,18 @@ namespace PingMonitor.Web.Controllers;
 public sealed class NotificationSettingsController : Controller
 {
     private readonly INotificationSettingsService _notificationSettingsService;
-    private readonly INotificationSuppressionService _notificationSuppressionService;
+    private readonly UserManager<ApplicationUser> _userManager;
     private readonly ISmtpNotificationSender _smtpNotificationSender;
     private readonly ILogger<NotificationSettingsController> _logger;
 
     public NotificationSettingsController(
         INotificationSettingsService notificationSettingsService,
-        INotificationSuppressionService notificationSuppressionService,
+        UserManager<ApplicationUser> userManager,
         ISmtpNotificationSender smtpNotificationSender,
         ILogger<NotificationSettingsController> logger)
     {
         _notificationSettingsService = notificationSettingsService;
-        _notificationSuppressionService = notificationSuppressionService;
+        _userManager = userManager;
         _smtpNotificationSender = smtpNotificationSender;
         _logger = logger;
     }
@@ -40,15 +42,7 @@ public sealed class NotificationSettingsController : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Index([FromForm] NotificationSettingsPageViewModel model, CancellationToken cancellationToken)
     {
-        if (!IsValidPermissionState(model.BrowserNotificationsPermissionState))
-        {
-            ModelState.AddModelError(
-                nameof(NotificationSettingsPageViewModel.BrowserNotificationsPermissionState),
-                "Permission state must be default, granted, or denied.");
-        }
-
         ValidateSmtpSettings(model);
-        ValidateQuietHours(model);
 
         if (!ModelState.IsValid)
         {
@@ -58,18 +52,18 @@ public sealed class NotificationSettingsController : Controller
         var updated = await _notificationSettingsService.UpdateAsync(
             new UpdateNotificationSettingsCommand
             {
-                BrowserNotificationsEnabled = model.BrowserNotificationsEnabled,
-                BrowserNotifyEndpointDown = model.BrowserNotifyEndpointDown,
-                BrowserNotifyEndpointRecovered = model.BrowserNotifyEndpointRecovered,
-                BrowserNotifyAgentOffline = model.BrowserNotifyAgentOffline,
-                BrowserNotifyAgentOnline = model.BrowserNotifyAgentOnline,
-                BrowserNotificationsPermissionState = model.BrowserNotificationsPermissionState,
-                QuietHoursEnabled = model.QuietHoursEnabled,
-                QuietHoursStartLocalTime = model.QuietHoursStartLocalTime,
-                QuietHoursEndLocalTime = model.QuietHoursEndLocalTime,
-                QuietHoursTimeZoneId = model.QuietHoursTimeZoneId,
-                QuietHoursSuppressBrowserNotifications = model.QuietHoursSuppressBrowserNotifications,
-                QuietHoursSuppressSmtpNotifications = model.QuietHoursSuppressSmtpNotifications,
+                BrowserNotificationsEnabled = false,
+                BrowserNotifyEndpointDown = true,
+                BrowserNotifyEndpointRecovered = true,
+                BrowserNotifyAgentOffline = true,
+                BrowserNotifyAgentOnline = true,
+                BrowserNotificationsPermissionState = "default",
+                QuietHoursEnabled = false,
+                QuietHoursStartLocalTime = "22:00",
+                QuietHoursEndLocalTime = "07:00",
+                QuietHoursTimeZoneId = "UTC",
+                QuietHoursSuppressBrowserNotifications = true,
+                QuietHoursSuppressSmtpNotifications = true,
                 SmtpNotificationsEnabled = model.SmtpNotificationsEnabled,
                 SmtpHost = model.SmtpHost,
                 SmtpPort = model.SmtpPort,
@@ -79,11 +73,11 @@ public sealed class NotificationSettingsController : Controller
                 SmtpClearPassword = model.SmtpClearPassword,
                 SmtpFromAddress = model.SmtpFromAddress,
                 SmtpFromDisplayName = model.SmtpFromDisplayName,
-                SmtpRecipientAddresses = model.SmtpRecipientAddresses,
-                SmtpNotifyEndpointDown = model.SmtpNotifyEndpointDown,
-                SmtpNotifyEndpointRecovered = model.SmtpNotifyEndpointRecovered,
-                SmtpNotifyAgentOffline = model.SmtpNotifyAgentOffline,
-                SmtpNotifyAgentOnline = model.SmtpNotifyAgentOnline,
+                SmtpRecipientAddresses = null,
+                SmtpNotifyEndpointDown = true,
+                SmtpNotifyEndpointRecovered = true,
+                SmtpNotifyAgentOffline = true,
+                SmtpNotifyAgentOnline = true,
                 UpdatedByUserId = User.Identity?.Name
             },
             cancellationToken);
@@ -95,13 +89,7 @@ public sealed class NotificationSettingsController : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SendSmtpTest([FromForm] NotificationSettingsPageViewModel model, CancellationToken cancellationToken)
     {
-        if (!IsValidPermissionState(model.BrowserNotificationsPermissionState))
-        {
-            model.BrowserNotificationsPermissionState = "default";
-        }
-
         ValidateSmtpSettings(model);
-        ValidateQuietHours(model);
         if (!ModelState.IsValid)
         {
             model.SmtpTestSent = false;
@@ -112,18 +100,18 @@ public sealed class NotificationSettingsController : Controller
         await _notificationSettingsService.UpdateAsync(
             new UpdateNotificationSettingsCommand
             {
-                BrowserNotificationsEnabled = model.BrowserNotificationsEnabled,
-                BrowserNotifyEndpointDown = model.BrowserNotifyEndpointDown,
-                BrowserNotifyEndpointRecovered = model.BrowserNotifyEndpointRecovered,
-                BrowserNotifyAgentOffline = model.BrowserNotifyAgentOffline,
-                BrowserNotifyAgentOnline = model.BrowserNotifyAgentOnline,
-                BrowserNotificationsPermissionState = model.BrowserNotificationsPermissionState,
-                QuietHoursEnabled = model.QuietHoursEnabled,
-                QuietHoursStartLocalTime = model.QuietHoursStartLocalTime,
-                QuietHoursEndLocalTime = model.QuietHoursEndLocalTime,
-                QuietHoursTimeZoneId = model.QuietHoursTimeZoneId,
-                QuietHoursSuppressBrowserNotifications = model.QuietHoursSuppressBrowserNotifications,
-                QuietHoursSuppressSmtpNotifications = model.QuietHoursSuppressSmtpNotifications,
+                BrowserNotificationsEnabled = false,
+                BrowserNotifyEndpointDown = true,
+                BrowserNotifyEndpointRecovered = true,
+                BrowserNotifyAgentOffline = true,
+                BrowserNotifyAgentOnline = true,
+                BrowserNotificationsPermissionState = "default",
+                QuietHoursEnabled = false,
+                QuietHoursStartLocalTime = "22:00",
+                QuietHoursEndLocalTime = "07:00",
+                QuietHoursTimeZoneId = "UTC",
+                QuietHoursSuppressBrowserNotifications = true,
+                QuietHoursSuppressSmtpNotifications = true,
                 SmtpNotificationsEnabled = model.SmtpNotificationsEnabled,
                 SmtpHost = model.SmtpHost,
                 SmtpPort = model.SmtpPort,
@@ -133,16 +121,24 @@ public sealed class NotificationSettingsController : Controller
                 SmtpClearPassword = model.SmtpClearPassword,
                 SmtpFromAddress = model.SmtpFromAddress,
                 SmtpFromDisplayName = model.SmtpFromDisplayName,
-                SmtpRecipientAddresses = model.SmtpRecipientAddresses,
-                SmtpNotifyEndpointDown = model.SmtpNotifyEndpointDown,
-                SmtpNotifyEndpointRecovered = model.SmtpNotifyEndpointRecovered,
-                SmtpNotifyAgentOffline = model.SmtpNotifyAgentOffline,
-                SmtpNotifyAgentOnline = model.SmtpNotifyAgentOnline,
+                SmtpRecipientAddresses = null,
+                SmtpNotifyEndpointDown = true,
+                SmtpNotifyEndpointRecovered = true,
+                SmtpNotifyAgentOffline = true,
+                SmtpNotifyAgentOnline = true,
                 UpdatedByUserId = User.Identity?.Name
             },
             cancellationToken);
 
-        var result = await _smtpNotificationSender.SendTestAsync(cancellationToken);
+        var user = await _userManager.GetUserAsync(User);
+        if (user is null || string.IsNullOrWhiteSpace(user.Email) || !MailAddress.TryCreate(user.Email, out _))
+        {
+            model.SmtpTestSent = false;
+            model.SmtpTestMessage = "Current user requires a valid email address for SMTP test.";
+            return View("Index", model);
+        }
+
+        var result = await _smtpNotificationSender.SendTestAsync(user.Email, cancellationToken);
         if (result.Success)
         {
             _logger.LogInformation("SMTP test send succeeded for user {UserId}.", User.Identity?.Name ?? "(unknown)");
@@ -157,11 +153,6 @@ public sealed class NotificationSettingsController : Controller
         viewModel.SmtpTestSent = result.Success;
         viewModel.SmtpTestMessage = result.Message;
         return View("Index", viewModel);
-    }
-
-    private static bool IsValidPermissionState(string value)
-    {
-        return value is "default" or "granted" or "denied";
     }
 
     private void ValidateSmtpSettings(NotificationSettingsPageViewModel model)
@@ -186,66 +177,12 @@ public sealed class NotificationSettingsController : Controller
             ModelState.AddModelError(nameof(model.SmtpFromAddress), "A valid SMTP from address is required.");
         }
 
-        if (string.IsNullOrWhiteSpace(model.SmtpRecipientAddresses))
-        {
-            ModelState.AddModelError(nameof(model.SmtpRecipientAddresses), "At least one SMTP recipient address is required.");
-        }
-    }
-
-    private void ValidateQuietHours(NotificationSettingsPageViewModel model)
-    {
-        if (!TimeOnly.TryParseExact(model.QuietHoursStartLocalTime?.Trim(), "HH:mm", out _))
-        {
-            ModelState.AddModelError(nameof(model.QuietHoursStartLocalTime), "Quiet hours start time must use HH:mm (24-hour) format.");
-        }
-
-        if (!TimeOnly.TryParseExact(model.QuietHoursEndLocalTime?.Trim(), "HH:mm", out _))
-        {
-            ModelState.AddModelError(nameof(model.QuietHoursEndLocalTime), "Quiet hours end time must use HH:mm (24-hour) format.");
-        }
-
-        if (string.IsNullOrWhiteSpace(model.QuietHoursTimeZoneId))
-        {
-            ModelState.AddModelError(nameof(model.QuietHoursTimeZoneId), "Quiet hours time zone ID is required.");
-            return;
-        }
-
-        try
-        {
-            TimeZoneInfo.FindSystemTimeZoneById(model.QuietHoursTimeZoneId.Trim());
-        }
-        catch (TimeZoneNotFoundException)
-        {
-            ModelState.AddModelError(nameof(model.QuietHoursTimeZoneId), "Quiet hours time zone ID was not found on this server.");
-        }
-        catch (InvalidTimeZoneException)
-        {
-            ModelState.AddModelError(nameof(model.QuietHoursTimeZoneId), "Quiet hours time zone ID is invalid.");
-        }
     }
 
     private async Task<NotificationSettingsPageViewModel> ToViewModelAsync(NotificationSettingsDto settings, bool saved, CancellationToken cancellationToken)
     {
-        var suppressionStatus = await _notificationSuppressionService.GetCurrentStatusAsync(cancellationToken);
         return new NotificationSettingsPageViewModel
         {
-            BrowserNotificationsEnabled = settings.BrowserNotificationsEnabled,
-            BrowserNotifyEndpointDown = settings.BrowserNotifyEndpointDown,
-            BrowserNotifyEndpointRecovered = settings.BrowserNotifyEndpointRecovered,
-            BrowserNotifyAgentOffline = settings.BrowserNotifyAgentOffline,
-            BrowserNotifyAgentOnline = settings.BrowserNotifyAgentOnline,
-            BrowserNotificationsPermissionState = settings.BrowserNotificationsPermissionState ?? "default",
-            QuietHoursEnabled = settings.QuietHoursEnabled,
-            QuietHoursStartLocalTime = settings.QuietHoursStartLocalTime,
-            QuietHoursEndLocalTime = settings.QuietHoursEndLocalTime,
-            QuietHoursTimeZoneId = settings.QuietHoursTimeZoneId,
-            QuietHoursSuppressBrowserNotifications = settings.QuietHoursSuppressBrowserNotifications,
-            QuietHoursSuppressSmtpNotifications = settings.QuietHoursSuppressSmtpNotifications,
-            QuietHoursCurrentlyActive = suppressionStatus.QuietHoursActiveNow,
-            QuietHoursCurrentStatusLabel = suppressionStatus.QuietHoursActiveNow ? "active" : "inactive",
-            QuietHoursCurrentReason = suppressionStatus.Reason,
-            QuietHoursResolvedTimeZoneId = suppressionStatus.EffectiveTimeZoneId,
-            QuietHoursEvaluatedAtUtc = suppressionStatus.EvaluatedAtUtc,
             SmtpNotificationsEnabled = settings.SmtpNotificationsEnabled,
             SmtpHost = settings.SmtpHost,
             SmtpPort = settings.SmtpPort,
@@ -254,11 +191,6 @@ public sealed class NotificationSettingsController : Controller
             SmtpPasswordConfigured = settings.SmtpPasswordConfigured,
             SmtpFromAddress = settings.SmtpFromAddress,
             SmtpFromDisplayName = settings.SmtpFromDisplayName,
-            SmtpRecipientAddresses = settings.SmtpRecipientAddresses,
-            SmtpNotifyEndpointDown = settings.SmtpNotifyEndpointDown,
-            SmtpNotifyEndpointRecovered = settings.SmtpNotifyEndpointRecovered,
-            SmtpNotifyAgentOffline = settings.SmtpNotifyAgentOffline,
-            SmtpNotifyAgentOnline = settings.SmtpNotifyAgentOnline,
             UpdatedAtUtc = settings.UpdatedAtUtc,
             UpdatedByUserId = settings.UpdatedByUserId,
             Saved = saved

--- a/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
@@ -1,0 +1,228 @@
+using System.Net.Mail;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Models.Identity;
+using PingMonitor.Web.Services;
+using PingMonitor.Web.ViewModels.Profile;
+
+namespace PingMonitor.Web.Controllers;
+
+[Authorize]
+[Route("profile")]
+public sealed class ProfileController : Controller
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IUserNotificationSettingsService _userNotificationSettingsService;
+
+    public ProfileController(
+        UserManager<ApplicationUser> userManager,
+        IUserNotificationSettingsService userNotificationSettingsService)
+    {
+        _userManager = userManager;
+        _userNotificationSettingsService = userNotificationSettingsService;
+    }
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index(CancellationToken cancellationToken)
+    {
+        var model = await BuildModelAsync(cancellationToken);
+        return View("Index", model);
+    }
+
+    [HttpPost("account")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UpdateAccount([FromForm] ProfilePageViewModel model, CancellationToken cancellationToken)
+    {
+        var user = await RequireUserAsync();
+        if (user is null)
+        {
+            return Challenge();
+        }
+
+        if (string.IsNullOrWhiteSpace(model.Email) || !MailAddress.TryCreate(model.Email, out _))
+        {
+            ModelState.AddModelError(nameof(ProfilePageViewModel.Email), "A valid email address is required.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return View("Index", await BuildModelAsync(cancellationToken, model));
+        }
+
+        var trimmedEmail = model.Email.Trim();
+        var setEmailResult = await _userManager.SetEmailAsync(user, trimmedEmail);
+        if (!setEmailResult.Succeeded)
+        {
+            foreach (var error in setEmailResult.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
+
+            return View("Index", await BuildModelAsync(cancellationToken, model));
+        }
+
+        user.NormalizedEmail = trimmedEmail.ToUpperInvariant();
+        var updateResult = await _userManager.UpdateAsync(user);
+        if (!updateResult.Succeeded)
+        {
+            foreach (var error in updateResult.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
+
+            return View("Index", await BuildModelAsync(cancellationToken, model));
+        }
+
+        var refreshed = await BuildModelAsync(cancellationToken);
+        refreshed.AccountSaved = true;
+        return View("Index", refreshed);
+    }
+
+    [HttpPost("password")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UpdatePassword([FromForm] ProfilePageViewModel model, CancellationToken cancellationToken)
+    {
+        var user = await RequireUserAsync();
+        if (user is null)
+        {
+            return Challenge();
+        }
+
+        if (string.IsNullOrWhiteSpace(model.CurrentPassword))
+        {
+            ModelState.AddModelError(nameof(ProfilePageViewModel.CurrentPassword), "Current password is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(model.NewPassword))
+        {
+            ModelState.AddModelError(nameof(ProfilePageViewModel.NewPassword), "New password is required.");
+        }
+
+        if (!string.Equals(model.NewPassword, model.ConfirmNewPassword, StringComparison.Ordinal))
+        {
+            ModelState.AddModelError(nameof(ProfilePageViewModel.ConfirmNewPassword), "New password confirmation must match.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return View("Index", await BuildModelAsync(cancellationToken, model));
+        }
+
+        var result = await _userManager.ChangePasswordAsync(user, model.CurrentPassword, model.NewPassword);
+        if (!result.Succeeded)
+        {
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
+
+            return View("Index", await BuildModelAsync(cancellationToken, model));
+        }
+
+        var refreshed = await BuildModelAsync(cancellationToken);
+        refreshed.PasswordSaved = true;
+        return View("Index", refreshed);
+    }
+
+    [HttpPost("notifications")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UpdateNotifications([FromForm] ProfilePageViewModel model, CancellationToken cancellationToken)
+    {
+        var user = await RequireUserAsync();
+        if (user is null)
+        {
+            return Challenge();
+        }
+
+        if (!TimeOnly.TryParseExact(model.QuietHoursStartLocalTime?.Trim(), "HH:mm", out _))
+        {
+            ModelState.AddModelError(nameof(ProfilePageViewModel.QuietHoursStartLocalTime), "Use HH:mm format.");
+        }
+        if (!TimeOnly.TryParseExact(model.QuietHoursEndLocalTime?.Trim(), "HH:mm", out _))
+        {
+            ModelState.AddModelError(nameof(ProfilePageViewModel.QuietHoursEndLocalTime), "Use HH:mm format.");
+        }
+
+        try
+        {
+            TimeZoneInfo.FindSystemTimeZoneById(model.QuietHoursTimeZoneId.Trim());
+        }
+        catch
+        {
+            ModelState.AddModelError(nameof(ProfilePageViewModel.QuietHoursTimeZoneId), "Quiet hours time zone ID is invalid.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return View("Index", await BuildModelAsync(cancellationToken, model));
+        }
+
+        await _userNotificationSettingsService.UpdateAsync(new UpdateUserNotificationSettingsCommand
+        {
+            UserId = user.Id,
+            BrowserNotificationsEnabled = model.BrowserNotificationsEnabled,
+            BrowserNotifyEndpointDown = model.BrowserNotifyEndpointDown,
+            BrowserNotifyEndpointRecovered = model.BrowserNotifyEndpointRecovered,
+            BrowserNotifyAgentOffline = model.BrowserNotifyAgentOffline,
+            BrowserNotifyAgentOnline = model.BrowserNotifyAgentOnline,
+            BrowserNotificationsPermissionState = model.BrowserNotificationsPermissionState,
+            SmtpNotificationsEnabled = model.SmtpNotificationsEnabled,
+            SmtpNotifyEndpointDown = model.SmtpNotifyEndpointDown,
+            SmtpNotifyEndpointRecovered = model.SmtpNotifyEndpointRecovered,
+            SmtpNotifyAgentOffline = model.SmtpNotifyAgentOffline,
+            SmtpNotifyAgentOnline = model.SmtpNotifyAgentOnline,
+            QuietHoursEnabled = model.QuietHoursEnabled,
+            QuietHoursStartLocalTime = model.QuietHoursStartLocalTime ?? "22:00",
+            QuietHoursEndLocalTime = model.QuietHoursEndLocalTime ?? "07:00",
+            QuietHoursTimeZoneId = model.QuietHoursTimeZoneId ?? "UTC",
+            QuietHoursSuppressBrowserNotifications = model.QuietHoursSuppressBrowserNotifications,
+            QuietHoursSuppressSmtpNotifications = model.QuietHoursSuppressSmtpNotifications
+        }, cancellationToken);
+
+        var refreshed = await BuildModelAsync(cancellationToken);
+        refreshed.NotificationsSaved = true;
+        return View("Index", refreshed);
+    }
+
+    private async Task<ApplicationUser?> RequireUserAsync()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        return string.IsNullOrWhiteSpace(userId) ? null : await _userManager.FindByIdAsync(userId);
+    }
+
+    private async Task<ProfilePageViewModel> BuildModelAsync(CancellationToken cancellationToken, ProfilePageViewModel? source = null)
+    {
+        var user = await RequireUserAsync();
+        if (user is null)
+        {
+            return new ProfilePageViewModel();
+        }
+
+        var settings = await _userNotificationSettingsService.GetCurrentAsync(user.Id, cancellationToken);
+        return new ProfilePageViewModel
+        {
+            UserName = user.UserName ?? string.Empty,
+            Email = source?.Email ?? user.Email ?? string.Empty,
+            BrowserNotificationsEnabled = source?.BrowserNotificationsEnabled ?? settings.BrowserNotificationsEnabled,
+            BrowserNotifyEndpointDown = source?.BrowserNotifyEndpointDown ?? settings.BrowserNotifyEndpointDown,
+            BrowserNotifyEndpointRecovered = source?.BrowserNotifyEndpointRecovered ?? settings.BrowserNotifyEndpointRecovered,
+            BrowserNotifyAgentOffline = source?.BrowserNotifyAgentOffline ?? settings.BrowserNotifyAgentOffline,
+            BrowserNotifyAgentOnline = source?.BrowserNotifyAgentOnline ?? settings.BrowserNotifyAgentOnline,
+            BrowserNotificationsPermissionState = source?.BrowserNotificationsPermissionState ?? settings.BrowserNotificationsPermissionState,
+            SmtpNotificationsEnabled = source?.SmtpNotificationsEnabled ?? settings.SmtpNotificationsEnabled,
+            SmtpNotifyEndpointDown = source?.SmtpNotifyEndpointDown ?? settings.SmtpNotifyEndpointDown,
+            SmtpNotifyEndpointRecovered = source?.SmtpNotifyEndpointRecovered ?? settings.SmtpNotifyEndpointRecovered,
+            SmtpNotifyAgentOffline = source?.SmtpNotifyAgentOffline ?? settings.SmtpNotifyAgentOffline,
+            SmtpNotifyAgentOnline = source?.SmtpNotifyAgentOnline ?? settings.SmtpNotifyAgentOnline,
+            QuietHoursEnabled = source?.QuietHoursEnabled ?? settings.QuietHoursEnabled,
+            QuietHoursStartLocalTime = source?.QuietHoursStartLocalTime ?? settings.QuietHoursStartLocalTime,
+            QuietHoursEndLocalTime = source?.QuietHoursEndLocalTime ?? settings.QuietHoursEndLocalTime,
+            QuietHoursTimeZoneId = source?.QuietHoursTimeZoneId ?? settings.QuietHoursTimeZoneId,
+            QuietHoursSuppressBrowserNotifications = source?.QuietHoursSuppressBrowserNotifications ?? settings.QuietHoursSuppressBrowserNotifications,
+            QuietHoursSuppressSmtpNotifications = source?.QuietHoursSuppressSmtpNotifications ?? settings.QuietHoursSuppressSmtpNotifications,
+            NotificationSettingsUpdatedAtUtc = settings.UpdatedAtUtc
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -36,6 +36,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
     public DbSet<SecuritySettings> SecuritySettings => Set<SecuritySettings>();
     public DbSet<SecurityIpBlock> SecurityIpBlocks => Set<SecurityIpBlock>();
     public DbSet<NotificationSettings> NotificationSettings => Set<NotificationSettings>();
+    public DbSet<UserNotificationSettings> UserNotificationSettings => Set<UserNotificationSettings>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -283,6 +284,29 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         notificationSettings.Property(x => x.SmtpNotifyAgentOnline).IsRequired();
         notificationSettings.Property(x => x.UpdatedAtUtc).IsRequired();
         notificationSettings.Property(x => x.UpdatedByUserId).HasMaxLength(255);
+
+        var userNotificationSettings = modelBuilder.Entity<UserNotificationSettings>();
+        userNotificationSettings.ToTable("UserNotificationSettings");
+        userNotificationSettings.HasKey(x => x.UserId);
+        userNotificationSettings.Property(x => x.UserId).HasMaxLength(255).ValueGeneratedNever();
+        userNotificationSettings.Property(x => x.BrowserNotificationsEnabled).IsRequired();
+        userNotificationSettings.Property(x => x.BrowserNotifyEndpointDown).IsRequired();
+        userNotificationSettings.Property(x => x.BrowserNotifyEndpointRecovered).IsRequired();
+        userNotificationSettings.Property(x => x.BrowserNotifyAgentOffline).IsRequired();
+        userNotificationSettings.Property(x => x.BrowserNotifyAgentOnline).IsRequired();
+        userNotificationSettings.Property(x => x.BrowserNotificationsPermissionState).HasMaxLength(16);
+        userNotificationSettings.Property(x => x.SmtpNotificationsEnabled).IsRequired();
+        userNotificationSettings.Property(x => x.SmtpNotifyEndpointDown).IsRequired();
+        userNotificationSettings.Property(x => x.SmtpNotifyEndpointRecovered).IsRequired();
+        userNotificationSettings.Property(x => x.SmtpNotifyAgentOffline).IsRequired();
+        userNotificationSettings.Property(x => x.SmtpNotifyAgentOnline).IsRequired();
+        userNotificationSettings.Property(x => x.QuietHoursEnabled).IsRequired();
+        userNotificationSettings.Property(x => x.QuietHoursStartLocalTime).HasMaxLength(5).IsRequired();
+        userNotificationSettings.Property(x => x.QuietHoursEndLocalTime).HasMaxLength(5).IsRequired();
+        userNotificationSettings.Property(x => x.QuietHoursTimeZoneId).HasMaxLength(128).IsRequired();
+        userNotificationSettings.Property(x => x.QuietHoursSuppressBrowserNotifications).IsRequired();
+        userNotificationSettings.Property(x => x.QuietHoursSuppressSmtpNotifications).IsRequired();
+        userNotificationSettings.Property(x => x.UpdatedAtUtc).IsRequired();
 
         var securitySettings = modelBuilder.Entity<SecuritySettings>();
         securitySettings.ToTable("SecuritySettings");

--- a/src/WebApp/PingMonitor.Web/Models/UserNotificationSettings.cs
+++ b/src/WebApp/PingMonitor.Web/Models/UserNotificationSettings.cs
@@ -1,0 +1,28 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class UserNotificationSettings
+{
+    public string UserId { get; set; } = string.Empty;
+
+    public bool BrowserNotificationsEnabled { get; set; }
+    public bool BrowserNotifyEndpointDown { get; set; }
+    public bool BrowserNotifyEndpointRecovered { get; set; }
+    public bool BrowserNotifyAgentOffline { get; set; }
+    public bool BrowserNotifyAgentOnline { get; set; }
+    public string? BrowserNotificationsPermissionState { get; set; }
+
+    public bool SmtpNotificationsEnabled { get; set; }
+    public bool SmtpNotifyEndpointDown { get; set; }
+    public bool SmtpNotifyEndpointRecovered { get; set; }
+    public bool SmtpNotifyAgentOffline { get; set; }
+    public bool SmtpNotifyAgentOnline { get; set; }
+
+    public bool QuietHoursEnabled { get; set; }
+    public string QuietHoursStartLocalTime { get; set; } = "22:00";
+    public string QuietHoursEndLocalTime { get; set; } = "07:00";
+    public string QuietHoursTimeZoneId { get; set; } = "UTC";
+    public bool QuietHoursSuppressBrowserNotifications { get; set; } = true;
+    public bool QuietHoursSuppressSmtpNotifications { get; set; } = true;
+
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -134,6 +134,7 @@ builder.Services.AddScoped<IAgentPackageBuilder, AgentPackageBuilder>();
 builder.Services.AddScoped<IAgentProvisioningService, AgentProvisioningService>();
 builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsService>();
 builder.Services.AddScoped<INotificationSettingsService, NotificationSettingsService>();
+builder.Services.AddScoped<IUserNotificationSettingsService, UserNotificationSettingsService>();
 builder.Services.AddScoped<INotificationSuppressionService, NotificationSuppressionService>();
 builder.Services.AddScoped<ISmtpNotificationSender, SmtpNotificationSender>();
 builder.Services.AddScoped<IBrowserNotificationQueryService, BrowserNotificationQueryService>();

--- a/src/WebApp/PingMonitor.Web/Services/BrowserNotifications/BrowserNotificationQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BrowserNotifications/BrowserNotificationQueryService.cs
@@ -1,7 +1,7 @@
 using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
-using PingMonitor.Web.Services;
 
 namespace PingMonitor.Web.Services.BrowserNotifications;
 
@@ -18,22 +18,33 @@ internal sealed class BrowserNotificationQueryService : IBrowserNotificationQuer
     ];
 
     private readonly PingMonitorDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IUserNotificationSettingsService _userNotificationSettingsService;
     private readonly INotificationSuppressionService _notificationSuppressionService;
 
     public BrowserNotificationQueryService(
         PingMonitorDbContext dbContext,
+        IHttpContextAccessor httpContextAccessor,
+        IUserNotificationSettingsService userNotificationSettingsService,
         INotificationSuppressionService notificationSuppressionService)
     {
         _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+        _userNotificationSettingsService = userNotificationSettingsService;
         _notificationSuppressionService = notificationSuppressionService;
     }
 
     public async Task<BrowserNotificationFeedDto> GetFeedAsync(string? lastEventId, int maxItems, CancellationToken cancellationToken)
     {
-        var settings = await _dbContext.NotificationSettings.AsNoTracking()
-            .SingleOrDefaultAsync(x => x.NotificationSettingsId == NotificationSettings.SingletonId, cancellationToken);
+        var userId = _httpContextAccessor.HttpContext?.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return new BrowserNotificationFeedDto { BrowserNotificationsEnabled = false };
+        }
 
-        if (settings is null || !settings.BrowserNotificationsEnabled)
+        var settings = await _userNotificationSettingsService.GetCurrentAsync(userId, cancellationToken);
+
+        if (!settings.BrowserNotificationsEnabled)
         {
             return new BrowserNotificationFeedDto
             {
@@ -41,7 +52,7 @@ internal sealed class BrowserNotificationQueryService : IBrowserNotificationQuer
             };
         }
 
-        var suppressionDecision = await _notificationSuppressionService.IsBrowserNotificationSuppressedAsync(cancellationToken);
+        var suppressionDecision = _notificationSuppressionService.IsBrowserNotificationSuppressed(settings);
         if (suppressionDecision.IsSuppressed)
         {
             return new BrowserNotificationFeedDto
@@ -134,7 +145,7 @@ internal sealed class BrowserNotificationQueryService : IBrowserNotificationQuer
         });
     }
 
-    private static BrowserNotificationEventDto? MapNotification(EventRow row, NotificationSettings settings)
+    private static BrowserNotificationEventDto? MapNotification(EventRow row, UserNotificationSettingsDto settings)
     {
         var mappedEvent = MapSupportedEventType(row);
         if (mappedEvent is null)
@@ -180,7 +191,7 @@ internal sealed class BrowserNotificationQueryService : IBrowserNotificationQuer
         return null;
     }
 
-    private static bool IsEventTypeEnabled(BrowserNotificationEventKind eventKind, NotificationSettings settings)
+    private static bool IsEventTypeEnabled(BrowserNotificationEventKind eventKind, UserNotificationSettingsDto settings)
     {
         return eventKind switch
         {

--- a/src/WebApp/PingMonitor.Web/Services/INotificationSuppressionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/INotificationSuppressionService.cs
@@ -2,7 +2,7 @@ namespace PingMonitor.Web.Services;
 
 public interface INotificationSuppressionService
 {
-    Task<NotificationSuppressionDecision> IsBrowserNotificationSuppressedAsync(CancellationToken cancellationToken);
-    Task<NotificationSuppressionDecision> IsSmtpNotificationSuppressedAsync(CancellationToken cancellationToken);
-    Task<NotificationSuppressionStatus> GetCurrentStatusAsync(CancellationToken cancellationToken);
+    NotificationSuppressionDecision IsBrowserNotificationSuppressed(UserNotificationSettingsDto settings);
+    NotificationSuppressionDecision IsSmtpNotificationSuppressed(UserNotificationSettingsDto settings);
+    NotificationSuppressionStatus GetCurrentStatus(UserNotificationSettingsDto settings);
 }

--- a/src/WebApp/PingMonitor.Web/Services/IUserNotificationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IUserNotificationSettingsService.cs
@@ -1,0 +1,7 @@
+namespace PingMonitor.Web.Services;
+
+public interface IUserNotificationSettingsService
+{
+    Task<UserNotificationSettingsDto> GetCurrentAsync(string userId, CancellationToken cancellationToken);
+    Task<UserNotificationSettingsDto> UpdateAsync(UpdateUserNotificationSettingsCommand command, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/NotificationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NotificationSettingsService.cs
@@ -35,12 +35,7 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
             SmtpUsername = settings.SmtpUsername,
             SmtpPassword = UnprotectSmtpSecret(settings.SmtpPasswordProtected),
             SmtpFromAddress = settings.SmtpFromAddress,
-            SmtpFromDisplayName = settings.SmtpFromDisplayName,
-            SmtpRecipientAddresses = settings.SmtpRecipientAddresses,
-            SmtpNotifyEndpointDown = settings.SmtpNotifyEndpointDown,
-            SmtpNotifyEndpointRecovered = settings.SmtpNotifyEndpointRecovered,
-            SmtpNotifyAgentOffline = settings.SmtpNotifyAgentOffline,
-            SmtpNotifyAgentOnline = settings.SmtpNotifyAgentOnline
+            SmtpFromDisplayName = settings.SmtpFromDisplayName
         };
     }
 

--- a/src/WebApp/PingMonitor.Web/Services/NotificationSuppressionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NotificationSuppressionService.cs
@@ -2,16 +2,8 @@ namespace PingMonitor.Web.Services;
 
 internal sealed class NotificationSuppressionService : INotificationSuppressionService
 {
-    private readonly INotificationSettingsService _notificationSettingsService;
-
-    public NotificationSuppressionService(INotificationSettingsService notificationSettingsService)
+    public NotificationSuppressionDecision IsBrowserNotificationSuppressed(UserNotificationSettingsDto settings)
     {
-        _notificationSettingsService = notificationSettingsService;
-    }
-
-    public async Task<NotificationSuppressionDecision> IsBrowserNotificationSuppressedAsync(CancellationToken cancellationToken)
-    {
-        var settings = await _notificationSettingsService.GetCurrentAsync(cancellationToken);
         if (!settings.QuietHoursSuppressBrowserNotifications)
         {
             return new NotificationSuppressionDecision
@@ -29,9 +21,8 @@ internal sealed class NotificationSuppressionService : INotificationSuppressionS
         };
     }
 
-    public async Task<NotificationSuppressionDecision> IsSmtpNotificationSuppressedAsync(CancellationToken cancellationToken)
+    public NotificationSuppressionDecision IsSmtpNotificationSuppressed(UserNotificationSettingsDto settings)
     {
-        var settings = await _notificationSettingsService.GetCurrentAsync(cancellationToken);
         if (!settings.QuietHoursSuppressSmtpNotifications)
         {
             return new NotificationSuppressionDecision
@@ -49,13 +40,12 @@ internal sealed class NotificationSuppressionService : INotificationSuppressionS
         };
     }
 
-    public async Task<NotificationSuppressionStatus> GetCurrentStatusAsync(CancellationToken cancellationToken)
+    public NotificationSuppressionStatus GetCurrentStatus(UserNotificationSettingsDto settings)
     {
-        var settings = await _notificationSettingsService.GetCurrentAsync(cancellationToken);
         return EvaluateQuietHours(settings);
     }
 
-    private static NotificationSuppressionStatus EvaluateQuietHours(NotificationSettingsDto settings)
+    private static NotificationSuppressionStatus EvaluateQuietHours(UserNotificationSettingsDto settings)
     {
         var nowUtc = DateTimeOffset.UtcNow;
         var quietHoursStart = ParseLocalTime(settings.QuietHoursStartLocalTime, "22:00");
@@ -101,7 +91,7 @@ internal sealed class NotificationSuppressionService : INotificationSuppressionS
     }
 
     private static NotificationSuppressionStatus BuildStatus(
-        NotificationSettingsDto settings,
+        UserNotificationSettingsDto settings,
         DateTimeOffset evaluatedAtUtc,
         string effectiveTimeZoneId,
         TimeSpan quietHoursStart,

--- a/src/WebApp/PingMonitor.Web/Services/SmtpChannelSettingsDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/SmtpChannelSettingsDto.cs
@@ -10,9 +10,4 @@ public sealed class SmtpChannelSettingsDto
     public string? SmtpPassword { get; set; }
     public string? SmtpFromAddress { get; set; }
     public string? SmtpFromDisplayName { get; set; }
-    public string? SmtpRecipientAddresses { get; set; }
-    public bool SmtpNotifyEndpointDown { get; set; }
-    public bool SmtpNotifyEndpointRecovered { get; set; }
-    public bool SmtpNotifyAgentOffline { get; set; }
-    public bool SmtpNotifyAgentOnline { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/SmtpNotifications/ISmtpNotificationSender.cs
+++ b/src/WebApp/PingMonitor.Web/Services/SmtpNotifications/ISmtpNotificationSender.cs
@@ -4,6 +4,6 @@ namespace PingMonitor.Web.Services.SmtpNotifications;
 
 public interface ISmtpNotificationSender
 {
-    Task<SmtpNotificationSendResult> SendTestAsync(CancellationToken cancellationToken);
+    Task<SmtpNotificationSendResult> SendTestAsync(string recipientAddress, CancellationToken cancellationToken);
     Task<SmtpNotificationSendResult> SendForEventAsync(EventLog eventLog, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/Services/SmtpNotifications/SmtpNotificationSender.cs
+++ b/src/WebApp/PingMonitor.Web/Services/SmtpNotifications/SmtpNotificationSender.cs
@@ -1,39 +1,41 @@
 using System.Net;
 using System.Net.Mail;
+using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Models;
+using PingMonitor.Web.Data;
 using PingMonitor.Web.Services;
 
 namespace PingMonitor.Web.Services.SmtpNotifications;
 
 internal sealed class SmtpNotificationSender : ISmtpNotificationSender
 {
+    private readonly PingMonitorDbContext _dbContext;
     private readonly INotificationSettingsService _notificationSettingsService;
+    private readonly IUserNotificationSettingsService _userNotificationSettingsService;
     private readonly INotificationSuppressionService _notificationSuppressionService;
     private readonly ILogger<SmtpNotificationSender> _logger;
 
     public SmtpNotificationSender(
+        PingMonitorDbContext dbContext,
         INotificationSettingsService notificationSettingsService,
+        IUserNotificationSettingsService userNotificationSettingsService,
         INotificationSuppressionService notificationSuppressionService,
         ILogger<SmtpNotificationSender> logger)
     {
+        _dbContext = dbContext;
         _notificationSettingsService = notificationSettingsService;
+        _userNotificationSettingsService = userNotificationSettingsService;
         _notificationSuppressionService = notificationSuppressionService;
         _logger = logger;
     }
 
-    public async Task<SmtpNotificationSendResult> SendTestAsync(CancellationToken cancellationToken)
+    public async Task<SmtpNotificationSendResult> SendTestAsync(string recipientAddress, CancellationToken cancellationToken)
     {
-        var suppressionDecision = await _notificationSuppressionService.IsSmtpNotificationSuppressedAsync(cancellationToken);
-        if (suppressionDecision.IsSuppressed)
-        {
-            _logger.LogDebug("SMTP test notification suppressed by quiet hours. Reason={Reason}", suppressionDecision.Reason);
-            return SmtpNotificationSendResult.Skip("SMTP notification suppressed by quiet hours.");
-        }
-
         return await SendEmailAsync(
             subject: "Ping Monitor SMTP Test",
             body: "SMTP notifications are working.",
             eventKey: "smtp_test",
+            recipients: [recipientAddress],
             cancellationToken);
     }
 
@@ -45,33 +47,21 @@ internal sealed class SmtpNotificationSender : ISmtpNotificationSender
             return SmtpNotificationSendResult.Skip("Event type is not supported for SMTP notifications.");
         }
 
-        var settings = await _notificationSettingsService.GetSmtpChannelAsync(cancellationToken);
-        if (!settings.SmtpNotificationsEnabled)
+        var eligibleRecipientAddresses = await ResolveEligibleRecipientsAsync(mapped.Value.EventToggle, cancellationToken);
+        if (eligibleRecipientAddresses.Count == 0)
         {
-            return SmtpNotificationSendResult.Skip("SMTP notifications are disabled.");
-        }
-
-        if (!IsEventEnabled(mapped.Value.EventToggle, settings))
-        {
-            _logger.LogDebug("SMTP notification skipped because event toggle is disabled for {EventType}.", eventLog.EventType);
-            return SmtpNotificationSendResult.Skip("SMTP notification is disabled for this event type.");
-        }
-
-        var suppressionDecision = await _notificationSuppressionService.IsSmtpNotificationSuppressedAsync(cancellationToken);
-        if (suppressionDecision.IsSuppressed)
-        {
-            _logger.LogDebug("SMTP notification suppressed by quiet hours for event {EventType}. Reason={Reason}", eventLog.EventType, suppressionDecision.Reason);
-            return SmtpNotificationSendResult.Skip("SMTP notification suppressed by quiet hours.");
+            return SmtpNotificationSendResult.Skip("No users are eligible for SMTP delivery for this event.");
         }
 
         var body = BuildEventBody(eventLog);
-        return await SendEmailAsync(mapped.Value.Subject, body, eventLog.EventType, cancellationToken);
+        return await SendEmailAsync(mapped.Value.Subject, body, eventLog.EventType, eligibleRecipientAddresses, cancellationToken);
     }
 
     private async Task<SmtpNotificationSendResult> SendEmailAsync(
         string subject,
         string body,
         string eventKey,
+        IReadOnlyList<string> recipients,
         CancellationToken cancellationToken)
     {
         var settings = await _notificationSettingsService.GetSmtpChannelAsync(cancellationToken);
@@ -86,8 +76,6 @@ internal sealed class SmtpNotificationSender : ISmtpNotificationSender
             return validation;
         }
 
-        var recipients = ParseRecipients(settings.SmtpRecipientAddresses!);
-
         try
         {
             using var message = new MailMessage
@@ -100,7 +88,7 @@ internal sealed class SmtpNotificationSender : ISmtpNotificationSender
 
             foreach (var recipient in recipients)
             {
-                message.To.Add(recipient);
+                message.To.Add(new MailAddress(recipient));
             }
 
             using var client = new SmtpClient(settings.SmtpHost!, settings.SmtpPort)
@@ -151,39 +139,43 @@ internal sealed class SmtpNotificationSender : ISmtpNotificationSender
             return SmtpNotificationSendResult.Failed("SMTP from address is not valid.");
         }
 
-        if (string.IsNullOrWhiteSpace(settings.SmtpRecipientAddresses))
-        {
-            return SmtpNotificationSendResult.Failed("At least one SMTP recipient address is required.");
-        }
-
         if (!string.IsNullOrWhiteSpace(settings.SmtpUsername) && string.IsNullOrWhiteSpace(settings.SmtpPassword))
         {
             return SmtpNotificationSendResult.Failed("SMTP password is required when SMTP username is provided.");
         }
 
-        var recipients = ParseRecipients(settings.SmtpRecipientAddresses);
-        if (recipients.Count == 0)
-        {
-            return SmtpNotificationSendResult.Failed("At least one valid SMTP recipient address is required.");
-        }
-
         return SmtpNotificationSendResult.Sent("SMTP settings are valid.");
     }
 
-    private static List<MailAddress> ParseRecipients(string recipientAddresses)
+    private async Task<IReadOnlyList<string>> ResolveEligibleRecipientsAsync(SmtpEventToggle toggle, CancellationToken cancellationToken)
     {
-        var recipients = new List<MailAddress>();
-        var pieces = recipientAddresses.Split([',', ';', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var users = await _dbContext.Users
+            .Where(x => !string.IsNullOrWhiteSpace(x.Email))
+            .Select(x => new { x.Id, x.Email })
+            .ToArrayAsync(cancellationToken);
 
-        foreach (var piece in pieces)
+        var recipients = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var user in users)
         {
-            if (MailAddress.TryCreate(piece, out var recipient))
+            var userSettings = await _userNotificationSettingsService.GetCurrentAsync(user.Id, cancellationToken);
+            if (!userSettings.SmtpNotificationsEnabled || !IsEventEnabled(toggle, userSettings))
             {
-                recipients.Add(recipient);
+                continue;
+            }
+
+            var suppressionDecision = _notificationSuppressionService.IsSmtpNotificationSuppressed(userSettings);
+            if (suppressionDecision.IsSuppressed)
+            {
+                continue;
+            }
+
+            if (MailAddress.TryCreate(user.Email, out var recipient))
+            {
+                recipients.Add(recipient.Address);
             }
         }
 
-        return recipients;
+        return recipients.ToArray();
     }
 
     private static MappedEvent? MapEvent(EventLog eventLog)
@@ -216,7 +208,7 @@ internal sealed class SmtpNotificationSender : ISmtpNotificationSender
         return null;
     }
 
-    private static bool IsEventEnabled(SmtpEventToggle toggle, SmtpChannelSettingsDto settings)
+    private static bool IsEventEnabled(SmtpEventToggle toggle, UserNotificationSettingsDto settings)
     {
         return toggle switch
         {

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -33,7 +33,8 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "ApplicationSettings",
         "SecuritySettings",
         "SecurityIpBlocks",
-        "NotificationSettings"
+        "NotificationSettings",
+        "UserNotificationSettings"
     ];
     private static readonly string[] RequiredEndpointDependencyColumns =
     [
@@ -360,6 +361,30 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 PRIMARY KEY (`NotificationSettingsId`)
             );
             """;
+        const string createUserNotificationSettingsSql = """
+            CREATE TABLE IF NOT EXISTS `UserNotificationSettings` (
+                `UserId` varchar(255) NOT NULL,
+                `BrowserNotificationsEnabled` tinyint(1) NOT NULL DEFAULT 0,
+                `BrowserNotifyEndpointDown` tinyint(1) NOT NULL DEFAULT 1,
+                `BrowserNotifyEndpointRecovered` tinyint(1) NOT NULL DEFAULT 1,
+                `BrowserNotifyAgentOffline` tinyint(1) NOT NULL DEFAULT 1,
+                `BrowserNotifyAgentOnline` tinyint(1) NOT NULL DEFAULT 1,
+                `BrowserNotificationsPermissionState` varchar(16) NULL,
+                `SmtpNotificationsEnabled` tinyint(1) NOT NULL DEFAULT 0,
+                `SmtpNotifyEndpointDown` tinyint(1) NOT NULL DEFAULT 1,
+                `SmtpNotifyEndpointRecovered` tinyint(1) NOT NULL DEFAULT 1,
+                `SmtpNotifyAgentOffline` tinyint(1) NOT NULL DEFAULT 1,
+                `SmtpNotifyAgentOnline` tinyint(1) NOT NULL DEFAULT 1,
+                `QuietHoursEnabled` tinyint(1) NOT NULL DEFAULT 0,
+                `QuietHoursStartLocalTime` varchar(5) NOT NULL DEFAULT '22:00',
+                `QuietHoursEndLocalTime` varchar(5) NOT NULL DEFAULT '07:00',
+                `QuietHoursTimeZoneId` varchar(128) NOT NULL DEFAULT 'UTC',
+                `QuietHoursSuppressBrowserNotifications` tinyint(1) NOT NULL DEFAULT 1,
+                `QuietHoursSuppressSmtpNotifications` tinyint(1) NOT NULL DEFAULT 1,
+                `UpdatedAtUtc` datetime(6) NOT NULL,
+                PRIMARY KEY (`UserId`)
+            );
+            """;
 
         const string createEventLogsSql = """
             CREATE TABLE IF NOT EXISTS `EventLogs` (
@@ -474,6 +499,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await dbContext.Database.ExecuteSqlRawAsync(createSecuritySettingsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createSecurityIpBlocksSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createNotificationSettingsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createUserNotificationSettingsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointDependenciesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createAgentHeartbeatHistorySql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createGroupsSql, cancellationToken);

--- a/src/WebApp/PingMonitor.Web/Services/UpdateUserNotificationSettingsCommand.cs
+++ b/src/WebApp/PingMonitor.Web/Services/UpdateUserNotificationSettingsCommand.cs
@@ -1,0 +1,23 @@
+namespace PingMonitor.Web.Services;
+
+public sealed class UpdateUserNotificationSettingsCommand
+{
+    public required string UserId { get; init; }
+    public bool BrowserNotificationsEnabled { get; set; }
+    public bool BrowserNotifyEndpointDown { get; set; }
+    public bool BrowserNotifyEndpointRecovered { get; set; }
+    public bool BrowserNotifyAgentOffline { get; set; }
+    public bool BrowserNotifyAgentOnline { get; set; }
+    public string? BrowserNotificationsPermissionState { get; set; }
+    public bool SmtpNotificationsEnabled { get; set; }
+    public bool SmtpNotifyEndpointDown { get; set; }
+    public bool SmtpNotifyEndpointRecovered { get; set; }
+    public bool SmtpNotifyAgentOffline { get; set; }
+    public bool SmtpNotifyAgentOnline { get; set; }
+    public bool QuietHoursEnabled { get; set; }
+    public string QuietHoursStartLocalTime { get; set; } = "22:00";
+    public string QuietHoursEndLocalTime { get; set; } = "07:00";
+    public string QuietHoursTimeZoneId { get; set; } = "UTC";
+    public bool QuietHoursSuppressBrowserNotifications { get; set; }
+    public bool QuietHoursSuppressSmtpNotifications { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/UserNotificationSettingsDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/UserNotificationSettingsDto.cs
@@ -1,0 +1,24 @@
+namespace PingMonitor.Web.Services;
+
+public sealed class UserNotificationSettingsDto
+{
+    public required string UserId { get; init; }
+    public bool BrowserNotificationsEnabled { get; set; }
+    public bool BrowserNotifyEndpointDown { get; set; }
+    public bool BrowserNotifyEndpointRecovered { get; set; }
+    public bool BrowserNotifyAgentOffline { get; set; }
+    public bool BrowserNotifyAgentOnline { get; set; }
+    public string BrowserNotificationsPermissionState { get; set; } = "default";
+    public bool SmtpNotificationsEnabled { get; set; }
+    public bool SmtpNotifyEndpointDown { get; set; }
+    public bool SmtpNotifyEndpointRecovered { get; set; }
+    public bool SmtpNotifyAgentOffline { get; set; }
+    public bool SmtpNotifyAgentOnline { get; set; }
+    public bool QuietHoursEnabled { get; set; }
+    public string QuietHoursStartLocalTime { get; set; } = "22:00";
+    public string QuietHoursEndLocalTime { get; set; } = "07:00";
+    public string QuietHoursTimeZoneId { get; set; } = "UTC";
+    public bool QuietHoursSuppressBrowserNotifications { get; set; } = true;
+    public bool QuietHoursSuppressSmtpNotifications { get; set; } = true;
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/UserNotificationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/UserNotificationSettingsService.cs
@@ -1,0 +1,131 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services;
+
+internal sealed class UserNotificationSettingsService : IUserNotificationSettingsService
+{
+    private readonly PingMonitorDbContext _dbContext;
+
+    public UserNotificationSettingsService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<UserNotificationSettingsDto> GetCurrentAsync(string userId, CancellationToken cancellationToken)
+    {
+        var row = await GetOrCreateEntityAsync(userId, cancellationToken);
+        return ToDto(row);
+    }
+
+    public async Task<UserNotificationSettingsDto> UpdateAsync(UpdateUserNotificationSettingsCommand command, CancellationToken cancellationToken)
+    {
+        var row = await GetOrCreateEntityAsync(command.UserId, cancellationToken);
+        row.BrowserNotificationsEnabled = command.BrowserNotificationsEnabled;
+        row.BrowserNotifyEndpointDown = command.BrowserNotifyEndpointDown;
+        row.BrowserNotifyEndpointRecovered = command.BrowserNotifyEndpointRecovered;
+        row.BrowserNotifyAgentOffline = command.BrowserNotifyAgentOffline;
+        row.BrowserNotifyAgentOnline = command.BrowserNotifyAgentOnline;
+        row.BrowserNotificationsPermissionState = NormalizePermissionState(command.BrowserNotificationsPermissionState);
+        row.SmtpNotificationsEnabled = command.SmtpNotificationsEnabled;
+        row.SmtpNotifyEndpointDown = command.SmtpNotifyEndpointDown;
+        row.SmtpNotifyEndpointRecovered = command.SmtpNotifyEndpointRecovered;
+        row.SmtpNotifyAgentOffline = command.SmtpNotifyAgentOffline;
+        row.SmtpNotifyAgentOnline = command.SmtpNotifyAgentOnline;
+        row.QuietHoursEnabled = command.QuietHoursEnabled;
+        row.QuietHoursStartLocalTime = NormalizeQuietHoursTime(command.QuietHoursStartLocalTime, "22:00");
+        row.QuietHoursEndLocalTime = NormalizeQuietHoursTime(command.QuietHoursEndLocalTime, "07:00");
+        row.QuietHoursTimeZoneId = NormalizeTimeZoneId(command.QuietHoursTimeZoneId);
+        row.QuietHoursSuppressBrowserNotifications = command.QuietHoursSuppressBrowserNotifications;
+        row.QuietHoursSuppressSmtpNotifications = command.QuietHoursSuppressSmtpNotifications;
+        row.UpdatedAtUtc = DateTimeOffset.UtcNow;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return ToDto(row);
+    }
+
+    private async Task<UserNotificationSettings> GetOrCreateEntityAsync(string userId, CancellationToken cancellationToken)
+    {
+        var normalizedUserId = userId.Trim();
+        var row = await _dbContext.UserNotificationSettings.SingleOrDefaultAsync(x => x.UserId == normalizedUserId, cancellationToken);
+        if (row is not null)
+        {
+            return row;
+        }
+
+        var global = await _dbContext.NotificationSettings.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.NotificationSettingsId == NotificationSettings.SingletonId, cancellationToken);
+
+        row = new UserNotificationSettings
+        {
+            UserId = normalizedUserId,
+            BrowserNotificationsEnabled = global?.BrowserNotificationsEnabled ?? false,
+            BrowserNotifyEndpointDown = global?.BrowserNotifyEndpointDown ?? true,
+            BrowserNotifyEndpointRecovered = global?.BrowserNotifyEndpointRecovered ?? true,
+            BrowserNotifyAgentOffline = global?.BrowserNotifyAgentOffline ?? true,
+            BrowserNotifyAgentOnline = global?.BrowserNotifyAgentOnline ?? true,
+            BrowserNotificationsPermissionState = NormalizePermissionState(global?.BrowserNotificationsPermissionState),
+            SmtpNotificationsEnabled = global?.SmtpNotificationsEnabled ?? false,
+            SmtpNotifyEndpointDown = global?.SmtpNotifyEndpointDown ?? true,
+            SmtpNotifyEndpointRecovered = global?.SmtpNotifyEndpointRecovered ?? true,
+            SmtpNotifyAgentOffline = global?.SmtpNotifyAgentOffline ?? true,
+            SmtpNotifyAgentOnline = global?.SmtpNotifyAgentOnline ?? true,
+            QuietHoursEnabled = global?.QuietHoursEnabled ?? false,
+            QuietHoursStartLocalTime = NormalizeQuietHoursTime(global?.QuietHoursStartLocalTime, "22:00"),
+            QuietHoursEndLocalTime = NormalizeQuietHoursTime(global?.QuietHoursEndLocalTime, "07:00"),
+            QuietHoursTimeZoneId = NormalizeTimeZoneId(global?.QuietHoursTimeZoneId),
+            QuietHoursSuppressBrowserNotifications = global?.QuietHoursSuppressBrowserNotifications ?? true,
+            QuietHoursSuppressSmtpNotifications = global?.QuietHoursSuppressSmtpNotifications ?? true,
+            UpdatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        _dbContext.UserNotificationSettings.Add(row);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return row;
+    }
+
+    private static UserNotificationSettingsDto ToDto(UserNotificationSettings row) => new()
+    {
+        UserId = row.UserId,
+        BrowserNotificationsEnabled = row.BrowserNotificationsEnabled,
+        BrowserNotifyEndpointDown = row.BrowserNotifyEndpointDown,
+        BrowserNotifyEndpointRecovered = row.BrowserNotifyEndpointRecovered,
+        BrowserNotifyAgentOffline = row.BrowserNotifyAgentOffline,
+        BrowserNotifyAgentOnline = row.BrowserNotifyAgentOnline,
+        BrowserNotificationsPermissionState = NormalizePermissionState(row.BrowserNotificationsPermissionState),
+        SmtpNotificationsEnabled = row.SmtpNotificationsEnabled,
+        SmtpNotifyEndpointDown = row.SmtpNotifyEndpointDown,
+        SmtpNotifyEndpointRecovered = row.SmtpNotifyEndpointRecovered,
+        SmtpNotifyAgentOffline = row.SmtpNotifyAgentOffline,
+        SmtpNotifyAgentOnline = row.SmtpNotifyAgentOnline,
+        QuietHoursEnabled = row.QuietHoursEnabled,
+        QuietHoursStartLocalTime = NormalizeQuietHoursTime(row.QuietHoursStartLocalTime, "22:00"),
+        QuietHoursEndLocalTime = NormalizeQuietHoursTime(row.QuietHoursEndLocalTime, "07:00"),
+        QuietHoursTimeZoneId = NormalizeTimeZoneId(row.QuietHoursTimeZoneId),
+        QuietHoursSuppressBrowserNotifications = row.QuietHoursSuppressBrowserNotifications,
+        QuietHoursSuppressSmtpNotifications = row.QuietHoursSuppressSmtpNotifications,
+        UpdatedAtUtc = row.UpdatedAtUtc
+    };
+
+    private static string NormalizePermissionState(string? permissionState)
+    {
+        var normalized = permissionState?.Trim().ToLowerInvariant();
+        return normalized is "default" or "granted" or "denied" ? normalized : "default";
+    }
+
+    private static string NormalizeQuietHoursTime(string? value, string fallback)
+    {
+        if (TimeOnly.TryParseExact(value?.Trim(), "HH:mm", out var parsed))
+        {
+            return parsed.ToString("HH:mm");
+        }
+
+        return fallback;
+    }
+
+    private static string NormalizeTimeZoneId(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? "UTC" : value.Trim();
+    }
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/NotificationSettingsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/NotificationSettingsPageViewModel.cs
@@ -4,49 +4,7 @@ namespace PingMonitor.Web.ViewModels.Admin;
 
 public sealed class NotificationSettingsPageViewModel
 {
-    [Display(Name = "Enable browser notifications while this app is open")]
-    public bool BrowserNotificationsEnabled { get; set; }
-
-    [Display(Name = "Endpoint down")]
-    public bool BrowserNotifyEndpointDown { get; set; }
-
-    [Display(Name = "Endpoint recovered")]
-    public bool BrowserNotifyEndpointRecovered { get; set; }
-
-    [Display(Name = "Agent offline")]
-    public bool BrowserNotifyAgentOffline { get; set; }
-
-    [Display(Name = "Agent online")]
-    public bool BrowserNotifyAgentOnline { get; set; }
-
-    [Display(Name = "Cached browser permission state")]
-    public string BrowserNotificationsPermissionState { get; set; } = "default";
-
-    [Display(Name = "Enable quiet hours")]
-    public bool QuietHoursEnabled { get; set; }
-
-    [Display(Name = "Quiet hours start (local time)")]
-    public string QuietHoursStartLocalTime { get; set; } = "22:00";
-
-    [Display(Name = "Quiet hours end (local time)")]
-    public string QuietHoursEndLocalTime { get; set; } = "07:00";
-
-    [Display(Name = "Quiet hours time zone ID")]
-    public string QuietHoursTimeZoneId { get; set; } = "UTC";
-
-    [Display(Name = "Suppress browser notifications during quiet hours")]
-    public bool QuietHoursSuppressBrowserNotifications { get; set; }
-
-    [Display(Name = "Suppress SMTP notifications during quiet hours")]
-    public bool QuietHoursSuppressSmtpNotifications { get; set; }
-
-    public bool QuietHoursCurrentlyActive { get; set; }
-    public string QuietHoursCurrentStatusLabel { get; set; } = "inactive";
-    public string QuietHoursCurrentReason { get; set; } = string.Empty;
-    public string QuietHoursResolvedTimeZoneId { get; set; } = "UTC";
-    public DateTimeOffset QuietHoursEvaluatedAtUtc { get; set; }
-
-    [Display(Name = "Enable SMTP email notifications")]
+    [Display(Name = "Enable SMTP delivery infrastructure")]
     public bool SmtpNotificationsEnabled { get; set; }
 
     [Display(Name = "SMTP host")]
@@ -76,27 +34,9 @@ public sealed class NotificationSettingsPageViewModel
     [Display(Name = "From display name")]
     public string? SmtpFromDisplayName { get; set; }
 
-    [Display(Name = "Recipient addresses (one per line or comma-separated)")]
-    public string? SmtpRecipientAddresses { get; set; }
-
-    [Display(Name = "Endpoint down")]
-    public bool SmtpNotifyEndpointDown { get; set; }
-
-    [Display(Name = "Endpoint recovered")]
-    public bool SmtpNotifyEndpointRecovered { get; set; }
-
-    [Display(Name = "Agent offline")]
-    public bool SmtpNotifyAgentOffline { get; set; }
-
-    [Display(Name = "Agent online")]
-    public bool SmtpNotifyAgentOnline { get; set; }
-
     public bool SmtpTestSent { get; set; }
     public string? SmtpTestMessage { get; set; }
-
     public bool Saved { get; set; }
-
     public DateTimeOffset UpdatedAtUtc { get; set; }
-
     public string? UpdatedByUserId { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PingMonitor.Web.ViewModels.Profile;
+
+public sealed class ProfilePageViewModel
+{
+    public string UserName { get; set; } = string.Empty;
+
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [DataType(DataType.Password)]
+    public string CurrentPassword { get; set; } = string.Empty;
+    [DataType(DataType.Password)]
+    public string NewPassword { get; set; } = string.Empty;
+    [DataType(DataType.Password)]
+    public string ConfirmNewPassword { get; set; } = string.Empty;
+
+    public bool BrowserNotificationsEnabled { get; set; }
+    public bool BrowserNotifyEndpointDown { get; set; }
+    public bool BrowserNotifyEndpointRecovered { get; set; }
+    public bool BrowserNotifyAgentOffline { get; set; }
+    public bool BrowserNotifyAgentOnline { get; set; }
+    public string BrowserNotificationsPermissionState { get; set; } = "default";
+    public bool SmtpNotificationsEnabled { get; set; }
+    public bool SmtpNotifyEndpointDown { get; set; }
+    public bool SmtpNotifyEndpointRecovered { get; set; }
+    public bool SmtpNotifyAgentOffline { get; set; }
+    public bool SmtpNotifyAgentOnline { get; set; }
+    public bool QuietHoursEnabled { get; set; }
+    public string QuietHoursStartLocalTime { get; set; } = "22:00";
+    public string QuietHoursEndLocalTime { get; set; } = "07:00";
+    public string QuietHoursTimeZoneId { get; set; } = "UTC";
+    public bool QuietHoursSuppressBrowserNotifications { get; set; }
+    public bool QuietHoursSuppressSmtpNotifications { get; set; }
+    public DateTimeOffset NotificationSettingsUpdatedAtUtc { get; set; }
+    public bool AccountSaved { get; set; }
+    public bool PasswordSaved { get; set; }
+    public bool NotificationsSaved { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
@@ -48,6 +48,7 @@
             <p class="muted">Configure application-level settings used by agent provisioning and new endpoint defaults.</p>
             <div class="button-row">
                 <a class="button-secondary" href="/status">Back to status</a>
+                <a class="button-secondary" href="/profile">My profile</a>
                 <a class="button-secondary" href="/admin/backups">Configuration backups</a>
                 <a class="button-secondary" href="/admin/security">Security logs and settings</a>
                 <a class="button-secondary" href="/settings/notifications">Notification settings</a>

--- a/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
@@ -5,56 +5,24 @@
     @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Notification settings</title>
+    <title>Notification infrastructure</title>
     <style>
-        :root {
-            color-scheme: light;
-            --bg: #f3f6f8;
-            --card: #ffffff;
-            --text: #102a43;
-            --muted: #52606d;
-            --border: #d9e2ec;
-            --accent: #0f62fe;
-            --success: #137333;
-            --error-bg: #fee4e2;
-            --error-text: #b42318;
-        }
-        * { box-sizing: border-box; }
-        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
-        main { max-width: 760px; margin: 0 auto; padding: 1rem; }
-        .stack { display: grid; gap: 1rem; }
-        .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
-        .button-row { display: flex; gap: .75rem; flex-wrap: wrap; }
-        .button, .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 48px; padding: .8rem 1rem; border-radius: 10px; font-weight: 600; text-decoration: none; }
-        .button { border: 0; background: var(--accent); color: white; cursor: pointer; }
-        .button-secondary { border: 1px solid var(--border); color: var(--text); background: white; cursor: pointer; }
-        .saved { border: 1px solid #c2f0c2; background: #ebffee; color: var(--success); border-radius: 10px; padding: .8rem; }
-        .errors { border: 1px solid #fda29b; background: var(--error-bg); color: var(--error-text); border-radius: 10px; padding: .8rem; }
-        .muted { color: var(--muted); }
-        .field-error { color: var(--error-text); font-size: .9rem; margin-top: .25rem; }
-        .status-pill { display: inline-block; padding: .3rem .55rem; border-radius: 999px; font-size: .85rem; border: 1px solid var(--border); background: #f8fafc; }
-        .switch-row { display: flex; align-items: center; gap: .75rem; }
-        input[type="checkbox"] { inline-size: 1.2rem; block-size: 1.2rem; }
-        input[type="text"], input[type="password"], input[type="number"], textarea {
-            width: 100%;
-            min-height: 44px;
-            border: 1px solid var(--border);
-            border-radius: 8px;
-            padding: .6rem .7rem;
-            font: inherit;
-        }
-        textarea { min-height: 120px; }
-        label { font-weight: 600; }
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; --success:#137333; --error-bg:#fee4e2; --error-text:#b42318; }
+        *{box-sizing:border-box;} body{margin:0;font-family:Arial,sans-serif;background:var(--bg);color:var(--text);} main{max-width:760px;margin:0 auto;padding:1rem;}
+        .stack{display:grid;gap:1rem;} .card{background:var(--card);border-radius:14px;box-shadow:0 1px 2px rgba(16,24,40,.08);padding:1rem;}
+        .button-row{display:flex;gap:.75rem;flex-wrap:wrap;} .button,.button-secondary{display:inline-flex;align-items:center;justify-content:center;min-height:48px;padding:.8rem 1rem;border-radius:10px;font-weight:600;text-decoration:none;}
+        .button{border:0;background:var(--accent);color:#fff;cursor:pointer;} .button-secondary{border:1px solid var(--border);color:var(--text);background:#fff;cursor:pointer;}
+        .saved{border:1px solid #c2f0c2;background:#ebffee;color:var(--success);border-radius:10px;padding:.8rem;} .errors{border:1px solid #fda29b;background:var(--error-bg);color:var(--error-text);border-radius:10px;padding:.8rem;}
+        .muted{color:var(--muted);} .field-error{color:var(--error-text);font-size:.9rem;margin-top:.25rem;} .switch-row{display:flex;gap:.75rem;align-items:center;}
+        input[type="text"],input[type="password"],input[type="number"]{width:100%;min-height:44px;border:1px solid var(--border);border-radius:8px;padding:.6rem .7rem;font:inherit;}
     </style>
 </head>
 <body>
 <main>
     <div class="stack">
         <section class="card">
-            <h1>Notification settings</h1>
-            <p class="muted">Scope: global app setting for now. Browser permission is controlled by each browser; this page stores app preference separately.</p>
-            <p class="muted">Quiet hours suppress notification delivery only. Events and state changes are still recorded normally.</p>
-            <p class="muted">Phase 1 behaviour: notifications suppressed during quiet hours are dropped and are not queued for later delivery.</p>
+            <h1>Notification infrastructure</h1>
+            <p class="muted">This page controls SMTP transport infrastructure only. Per-user notification preferences moved to each user's <a href="/profile">profile page</a>.</p>
             <div class="button-row">
                 <a class="button-secondary" href="/admin">Back to admin settings</a>
                 <a class="button-secondary" href="/status">Back to status</a>
@@ -63,293 +31,47 @@
 
         <form method="post" action="/settings/notifications" class="stack">
             @Html.AntiForgeryToken()
-            <input type="hidden" asp-for="BrowserNotificationsPermissionState" id="browserPermissionStateInput" />
-
-            @if (Model.Saved)
-            {
-                <div class="saved" role="status">Notification settings saved.</div>
-            }
-
-            @if (!ViewData.ModelState.IsValid)
-            {
-                <div class="errors" asp-validation-summary="ModelOnly"></div>
-            }
+            @if (Model.Saved) { <div class="saved" role="status">SMTP infrastructure settings saved.</div> }
+            @if (!ViewData.ModelState.IsValid) { <div class="errors" asp-validation-summary="ModelOnly"></div> }
 
             <section class="card stack">
-                <h2>Browser notifications (phase 1)</h2>
-                <p class="muted">Works while this app is open in your browser. Background push/service workers are not included in this phase.</p>
-                <p class="muted">These settings apply only while the app is open and browser permission is granted.</p>
-
-                <div class="switch-row">
-                    <input asp-for="BrowserNotificationsEnabled" type="checkbox" />
-                    <label asp-for="BrowserNotificationsEnabled"></label>
-                </div>
-
-                <div class="stack" style="margin-top:.5rem;">
-                    <p class="muted">Event types (used only when browser notifications are enabled):</p>
-                    <div class="switch-row">
-                        <input asp-for="BrowserNotifyEndpointDown" type="checkbox" />
-                        <label asp-for="BrowserNotifyEndpointDown"></label>
-                    </div>
-                    <div class="switch-row">
-                        <input asp-for="BrowserNotifyEndpointRecovered" type="checkbox" />
-                        <label asp-for="BrowserNotifyEndpointRecovered"></label>
-                    </div>
-                    <div class="switch-row">
-                        <input asp-for="BrowserNotifyAgentOffline" type="checkbox" />
-                        <label asp-for="BrowserNotifyAgentOffline"></label>
-                    </div>
-                    <div class="switch-row">
-                        <input asp-for="BrowserNotifyAgentOnline" type="checkbox" />
-                        <label asp-for="BrowserNotifyAgentOnline"></label>
-                    </div>
-                </div>
-
-                <div class="field-error"><span asp-validation-for="BrowserNotificationsPermissionState"></span></div>
-
+                <h2>SMTP transport settings</h2>
+                @if (!string.IsNullOrWhiteSpace(Model.SmtpTestMessage)) { <div class="@(Model.SmtpTestSent ? "saved" : "errors")" role="status">@Model.SmtpTestMessage</div> }
+                <div class="switch-row"><input asp-for="SmtpNotificationsEnabled" type="checkbox" /><label asp-for="SmtpNotificationsEnabled"></label></div>
                 <div>
-                    <div>Browser support: <span id="browserSupportStatus" class="status-pill">Checking…</span></div>
-                    <div style="margin-top:.5rem;">Browser permission: <span id="browserPermissionState" class="status-pill">@Model.BrowserNotificationsPermissionState</span></div>
-                    <p class="muted">Cached permission from server save: <strong>@Model.BrowserNotificationsPermissionState</strong></p>
+                    <label asp-for="SmtpHost"></label>
+                    <input asp-for="SmtpHost" type="text" />
+                    <div class="field-error"><span asp-validation-for="SmtpHost"></span></div>
                 </div>
-
-                <div class="button-row">
-                    <button type="button" id="requestPermissionButton" class="button-secondary">Request browser permission</button>
-                    <button type="button" id="testNotificationButton" class="button-secondary">Send test notification</button>
-                </div>
-                <p id="browserNotificationMessage" class="muted" role="status"></p>
-            </section>
-
-            <section class="card stack">
-                <h2>SMTP email notifications (phase 1)</h2>
-                <p class="muted">SMTP delivery is configured separately from browser notifications and is sent only for supported event types.</p>
-
-                @if (!string.IsNullOrWhiteSpace(Model.SmtpTestMessage))
-                {
-                    <div class="@(Model.SmtpTestSent ? "saved" : "errors")" role="status">@Model.SmtpTestMessage</div>
-                }
-
-                <div class="switch-row">
-                    <input asp-for="SmtpNotificationsEnabled" type="checkbox" />
-                    <label asp-for="SmtpNotificationsEnabled"></label>
-                </div>
-
-                <div class="stack">
-                    <div>
-                        <label asp-for="SmtpHost"></label>
-                        <input asp-for="SmtpHost" type="text" />
-                        <div class="field-error"><span asp-validation-for="SmtpHost"></span></div>
-                    </div>
-                    <div>
-                        <label asp-for="SmtpPort"></label>
-                        <input asp-for="SmtpPort" type="number" min="1" max="65535" />
-                        <div class="field-error"><span asp-validation-for="SmtpPort"></span></div>
-                    </div>
-                    <div class="switch-row">
-                        <input asp-for="SmtpUseTls" type="checkbox" />
-                        <label asp-for="SmtpUseTls"></label>
-                    </div>
-                    <div>
-                        <label asp-for="SmtpUsername"></label>
-                        <input asp-for="SmtpUsername" type="text" />
-                    </div>
-                    <div>
-                        <label asp-for="SmtpPassword"></label>
-                        <input asp-for="SmtpPassword" type="password" autocomplete="new-password" />
-                        @if (Model.SmtpPasswordConfigured)
-                        {
-                            <p class="muted">A password is already stored. Leave blank to keep it unchanged.</p>
-                        }
-                    </div>
-                    <div class="switch-row">
-                        <input asp-for="SmtpClearPassword" type="checkbox" />
-                        <label asp-for="SmtpClearPassword"></label>
-                    </div>
-                    <div>
-                        <label asp-for="SmtpFromAddress"></label>
-                        <input asp-for="SmtpFromAddress" type="text" />
-                        <div class="field-error"><span asp-validation-for="SmtpFromAddress"></span></div>
-                    </div>
-                    <div>
-                        <label asp-for="SmtpFromDisplayName"></label>
-                        <input asp-for="SmtpFromDisplayName" type="text" />
-                    </div>
-                    <div>
-                        <label asp-for="SmtpRecipientAddresses"></label>
-                        <textarea asp-for="SmtpRecipientAddresses"></textarea>
-                        <div class="field-error"><span asp-validation-for="SmtpRecipientAddresses"></span></div>
-                    </div>
-                </div>
-
-                <div class="stack" style="margin-top:.5rem;">
-                    <p class="muted">SMTP event types:</p>
-                    <div class="switch-row">
-                        <input asp-for="SmtpNotifyEndpointDown" type="checkbox" />
-                        <label asp-for="SmtpNotifyEndpointDown"></label>
-                    </div>
-                    <div class="switch-row">
-                        <input asp-for="SmtpNotifyEndpointRecovered" type="checkbox" />
-                        <label asp-for="SmtpNotifyEndpointRecovered"></label>
-                    </div>
-                    <div class="switch-row">
-                        <input asp-for="SmtpNotifyAgentOffline" type="checkbox" />
-                        <label asp-for="SmtpNotifyAgentOffline"></label>
-                    </div>
-                    <div class="switch-row">
-                        <input asp-for="SmtpNotifyAgentOnline" type="checkbox" />
-                        <label asp-for="SmtpNotifyAgentOnline"></label>
-                    </div>
-                </div>
-
-                <div class="button-row">
-                    <button class="button-secondary" type="submit" formaction="/settings/notifications/smtp-test">Send SMTP test email</button>
-                </div>
-            </section>
-
-            <section class="card stack">
-                <h2>Quiet hours (global delivery suppression)</h2>
-                <p class="muted">Quiet hours are evaluated daily in the configured time zone and apply to delivery only.</p>
-                <p class="muted">Cross-midnight example: start 22:00 and end 07:00 keeps suppression active overnight.</p>
-
-                <div class="switch-row">
-                    <input asp-for="QuietHoursEnabled" type="checkbox" />
-                    <label asp-for="QuietHoursEnabled"></label>
-                </div>
-
-                <div class="stack">
-                    <div>
-                        <label asp-for="QuietHoursStartLocalTime"></label>
-                        <input asp-for="QuietHoursStartLocalTime" type="time" />
-                        <div class="field-error"><span asp-validation-for="QuietHoursStartLocalTime"></span></div>
-                    </div>
-                    <div>
-                        <label asp-for="QuietHoursEndLocalTime"></label>
-                        <input asp-for="QuietHoursEndLocalTime" type="time" />
-                        <div class="field-error"><span asp-validation-for="QuietHoursEndLocalTime"></span></div>
-                    </div>
-                    <div>
-                        <label asp-for="QuietHoursTimeZoneId"></label>
-                        <input asp-for="QuietHoursTimeZoneId" type="text" />
-                        <div class="field-error"><span asp-validation-for="QuietHoursTimeZoneId"></span></div>
-                    </div>
-                </div>
-
-                <div class="stack" style="margin-top:.5rem;">
-                    <p class="muted">Channel suppression during quiet hours:</p>
-                    <div class="switch-row">
-                        <input asp-for="QuietHoursSuppressBrowserNotifications" type="checkbox" />
-                        <label asp-for="QuietHoursSuppressBrowserNotifications"></label>
-                    </div>
-                    <div class="switch-row">
-                        <input asp-for="QuietHoursSuppressSmtpNotifications" type="checkbox" />
-                        <label asp-for="QuietHoursSuppressSmtpNotifications"></label>
-                    </div>
-                </div>
-
                 <div>
-                    <div>
-                        Quiet hours status now:
-                        <span class="status-pill">@Model.QuietHoursCurrentStatusLabel</span>
-                    </div>
-                    <div style="margin-top:.5rem;">
-                        Evaluation time zone:
-                        <span class="status-pill">@Model.QuietHoursResolvedTimeZoneId</span>
-                    </div>
-                    <p class="muted">@Model.QuietHoursCurrentReason</p>
-                    <p class="muted">Evaluated at @Model.QuietHoursEvaluatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'").</p>
+                    <label asp-for="SmtpPort"></label>
+                    <input asp-for="SmtpPort" type="number" min="1" max="65535" />
+                    <div class="field-error"><span asp-validation-for="SmtpPort"></span></div>
                 </div>
-            </section>
-
-            <section class="card stack">
-                <h2>Future channels</h2>
+                <div class="switch-row"><input asp-for="SmtpUseTls" type="checkbox" /><label asp-for="SmtpUseTls"></label></div>
+                <div><label asp-for="SmtpUsername"></label><input asp-for="SmtpUsername" type="text" /></div>
                 <div>
-                    <h3>Telegram notifications</h3>
-                    <p class="muted">Coming later. Delivery and channel settings are not implemented in phase 1.</p>
+                    <label asp-for="SmtpPassword"></label>
+                    <input asp-for="SmtpPassword" type="password" autocomplete="new-password" />
+                    @if (Model.SmtpPasswordConfigured) { <p class="muted">A password is already stored. Leave blank to keep it unchanged.</p> }
                 </div>
+                <div class="switch-row"><input asp-for="SmtpClearPassword" type="checkbox" /><label asp-for="SmtpClearPassword"></label></div>
+                <div>
+                    <label asp-for="SmtpFromAddress"></label>
+                    <input asp-for="SmtpFromAddress" type="text" />
+                    <div class="field-error"><span asp-validation-for="SmtpFromAddress"></span></div>
+                </div>
+                <div><label asp-for="SmtpFromDisplayName"></label><input asp-for="SmtpFromDisplayName" type="text" /></div>
+                <div class="button-row"><button class="button-secondary" type="submit" formaction="/settings/notifications/smtp-test">Send SMTP test email to my account</button></div>
             </section>
 
             <section class="card">
                 <p class="muted">Last updated: @Model.UpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</p>
-                @if (!string.IsNullOrWhiteSpace(Model.UpdatedByUserId))
-                {
-                    <p class="muted">Last updated by: @Model.UpdatedByUserId</p>
-                }
-                <div class="button-row">
-                    <button class="button" type="submit">Save notification settings</button>
-                </div>
+                @if (!string.IsNullOrWhiteSpace(Model.UpdatedByUserId)) { <p class="muted">Last updated by: @Model.UpdatedByUserId</p> }
+                <div class="button-row"><button class="button" type="submit">Save SMTP infrastructure settings</button></div>
             </section>
         </form>
     </div>
 </main>
-
-<script>
-(() => {
-    const permissionStateDisplay = document.getElementById('browserPermissionState');
-    const permissionStateInput = document.getElementById('browserPermissionStateInput');
-    const supportStatusDisplay = document.getElementById('browserSupportStatus');
-    const messageDisplay = document.getElementById('browserNotificationMessage');
-    const requestPermissionButton = document.getElementById('requestPermissionButton');
-    const testNotificationButton = document.getElementById('testNotificationButton');
-
-    const hasNotificationApi = typeof window !== 'undefined' && 'Notification' in window;
-
-    function setMessage(message) {
-        messageDisplay.textContent = message;
-    }
-
-    function updatePermissionState(state) {
-        permissionStateDisplay.textContent = state;
-        permissionStateInput.value = state;
-    }
-
-    if (!hasNotificationApi) {
-        supportStatusDisplay.textContent = 'Not supported';
-        updatePermissionState('default');
-        requestPermissionButton.disabled = true;
-        testNotificationButton.disabled = true;
-        setMessage('This browser does not support notifications.');
-        return;
-    }
-
-    supportStatusDisplay.textContent = 'Supported';
-    updatePermissionState(Notification.permission);
-
-    requestPermissionButton.addEventListener('click', async () => {
-        try {
-            const permission = await Notification.requestPermission();
-            updatePermissionState(permission);
-
-            if (permission === 'granted') {
-                setMessage('Browser permission granted. Save settings to persist this cached state.');
-                return;
-            }
-
-            if (permission === 'denied') {
-                setMessage('Browser permission denied. Update browser site permissions to enable notifications.');
-                return;
-            }
-
-            setMessage('Permission request dismissed.');
-        } catch {
-            setMessage('Unable to request browser notification permission.');
-        }
-    });
-
-    testNotificationButton.addEventListener('click', () => {
-        if (Notification.permission !== 'granted') {
-            updatePermissionState(Notification.permission);
-            setMessage('Test notification requires granted browser permission.');
-            return;
-        }
-
-        new Notification('Ping Monitor Test', {
-            body: 'Browser notifications are working.'
-        });
-
-        updatePermissionState(Notification.permission);
-        setMessage('Test notification sent.');
-    });
-})();
-</script>
 </body>
 </html>

--- a/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
@@ -1,0 +1,90 @@
+@model PingMonitor.Web.ViewModels.Profile.ProfilePageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    @await Html.PartialAsync("_ThemeHead")
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>My profile</title>
+    <style>
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; --success:#137333; --error-bg:#fee4e2; --error-text:#b42318; }
+        *{box-sizing:border-box;} body{margin:0;font-family:Arial,sans-serif;background:var(--bg);color:var(--text);} main{max-width:820px;margin:0 auto;padding:1rem;}
+        .stack{display:grid;gap:1rem;} .card{background:var(--card);border-radius:14px;box-shadow:0 1px 2px rgba(16,24,40,.08);padding:1rem;}
+        .button-row{display:flex;gap:.75rem;flex-wrap:wrap;} .button,.button-secondary{display:inline-flex;align-items:center;justify-content:center;min-height:44px;padding:.7rem 1rem;border-radius:10px;font-weight:600;text-decoration:none;}
+        .button{border:0;background:var(--accent);color:#fff;cursor:pointer;} .button-secondary{border:1px solid var(--border);color:var(--text);background:#fff;cursor:pointer;}
+        .saved{border:1px solid #c2f0c2;background:#ebffee;color:var(--success);border-radius:10px;padding:.8rem;} .errors{border:1px solid #fda29b;background:var(--error-bg);color:var(--error-text);border-radius:10px;padding:.8rem;}
+        .muted{color:var(--muted);} .field-error{color:var(--error-text);font-size:.9rem;margin-top:.25rem;} .switch-row{display:flex;align-items:center;gap:.75rem;}
+        input[type="text"],input[type="email"],input[type="password"],input[type="time"]{width:100%;min-height:44px;border:1px solid var(--border);border-radius:8px;padding:.6rem .7rem;font:inherit;}
+    </style>
+</head>
+<body>
+<main>
+<div class="stack">
+<section class="card">
+    <h1>My profile</h1>
+    <p class="muted">Manage your account details and your own notification preferences.</p>
+    <div class="button-row"><a class="button-secondary" href="/status">Back to status</a></div>
+</section>
+@if (!ViewData.ModelState.IsValid) { <div class="errors" asp-validation-summary="ModelOnly"></div> }
+<section class="card stack">
+    <h2>Account details</h2>
+    @if (Model.AccountSaved) { <div class="saved">Email updated.</div> }
+    <form method="post" action="/profile/account" class="stack">
+        @Html.AntiForgeryToken()
+        <div><label>Username</label><input value="@Model.UserName" type="text" readonly /></div>
+        <div><label asp-for="Email"></label><input asp-for="Email" type="email" /><div class="field-error"><span asp-validation-for="Email"></span></div></div>
+        <div class="button-row"><button class="button" type="submit">Save account details</button></div>
+    </form>
+</section>
+<section class="card stack">
+    <h2>Change password</h2>
+    @if (Model.PasswordSaved) { <div class="saved">Password changed.</div> }
+    <form method="post" action="/profile/password" class="stack">
+        @Html.AntiForgeryToken()
+        <div><label asp-for="CurrentPassword"></label><input asp-for="CurrentPassword" type="password" autocomplete="current-password" /><div class="field-error"><span asp-validation-for="CurrentPassword"></span></div></div>
+        <div><label asp-for="NewPassword"></label><input asp-for="NewPassword" type="password" autocomplete="new-password" /><div class="field-error"><span asp-validation-for="NewPassword"></span></div></div>
+        <div><label asp-for="ConfirmNewPassword"></label><input asp-for="ConfirmNewPassword" type="password" autocomplete="new-password" /><div class="field-error"><span asp-validation-for="ConfirmNewPassword"></span></div></div>
+        <div class="button-row"><button class="button" type="submit">Change password</button></div>
+    </form>
+</section>
+<section class="card stack">
+    <h2>Notification preferences</h2>
+    @if (Model.NotificationsSaved) { <div class="saved">Notification preferences saved.</div> }
+    <form method="post" action="/profile/notifications" class="stack">
+        @Html.AntiForgeryToken()
+        <input type="hidden" asp-for="BrowserNotificationsPermissionState" id="browserPermissionStateInput" />
+        <h3>Browser</h3>
+        <div class="switch-row"><input asp-for="BrowserNotificationsEnabled" type="checkbox" /><label asp-for="BrowserNotificationsEnabled">Enable browser notifications</label></div>
+        <div class="switch-row"><input asp-for="BrowserNotifyEndpointDown" type="checkbox" /><label asp-for="BrowserNotifyEndpointDown">Endpoint down</label></div>
+        <div class="switch-row"><input asp-for="BrowserNotifyEndpointRecovered" type="checkbox" /><label asp-for="BrowserNotifyEndpointRecovered">Endpoint recovered</label></div>
+        <div class="switch-row"><input asp-for="BrowserNotifyAgentOffline" type="checkbox" /><label asp-for="BrowserNotifyAgentOffline">Agent offline</label></div>
+        <div class="switch-row"><input asp-for="BrowserNotifyAgentOnline" type="checkbox" /><label asp-for="BrowserNotifyAgentOnline">Agent online</label></div>
+
+        <h3>SMTP</h3>
+        <div class="switch-row"><input asp-for="SmtpNotificationsEnabled" type="checkbox" /><label asp-for="SmtpNotificationsEnabled">Enable SMTP notifications to my email</label></div>
+        <div class="switch-row"><input asp-for="SmtpNotifyEndpointDown" type="checkbox" /><label asp-for="SmtpNotifyEndpointDown">Endpoint down</label></div>
+        <div class="switch-row"><input asp-for="SmtpNotifyEndpointRecovered" type="checkbox" /><label asp-for="SmtpNotifyEndpointRecovered">Endpoint recovered</label></div>
+        <div class="switch-row"><input asp-for="SmtpNotifyAgentOffline" type="checkbox" /><label asp-for="SmtpNotifyAgentOffline">Agent offline</label></div>
+        <div class="switch-row"><input asp-for="SmtpNotifyAgentOnline" type="checkbox" /><label asp-for="SmtpNotifyAgentOnline">Agent online</label></div>
+
+        <h3>Quiet hours</h3>
+        <div class="switch-row"><input asp-for="QuietHoursEnabled" type="checkbox" /><label asp-for="QuietHoursEnabled">Enable quiet hours</label></div>
+        <div><label asp-for="QuietHoursStartLocalTime">Start</label><input asp-for="QuietHoursStartLocalTime" type="time" /><div class="field-error"><span asp-validation-for="QuietHoursStartLocalTime"></span></div></div>
+        <div><label asp-for="QuietHoursEndLocalTime">End</label><input asp-for="QuietHoursEndLocalTime" type="time" /><div class="field-error"><span asp-validation-for="QuietHoursEndLocalTime"></span></div></div>
+        <div><label asp-for="QuietHoursTimeZoneId">Time zone ID</label><input asp-for="QuietHoursTimeZoneId" type="text" /><div class="field-error"><span asp-validation-for="QuietHoursTimeZoneId"></span></div></div>
+        <div class="switch-row"><input asp-for="QuietHoursSuppressBrowserNotifications" type="checkbox" /><label asp-for="QuietHoursSuppressBrowserNotifications">Suppress browser during quiet hours</label></div>
+        <div class="switch-row"><input asp-for="QuietHoursSuppressSmtpNotifications" type="checkbox" /><label asp-for="QuietHoursSuppressSmtpNotifications">Suppress SMTP during quiet hours</label></div>
+        <p class="muted">Settings last updated at @Model.NotificationSettingsUpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'").</p>
+        <div class="button-row"><button class="button" type="submit">Save notification preferences</button></div>
+    </form>
+</section>
+</div>
+</main>
+<script>
+(() => {
+const input=document.getElementById('browserPermissionStateInput');
+if (typeof Notification !== 'undefined' && input) { input.value = Notification.permission; }
+})();
+</script>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -209,6 +209,7 @@
             </div>
             <div class="button-row">
                 <a class="button-secondary" href="/endpoints">Endpoints</a>
+                <a class="button-secondary" href="/profile">My profile</a>
                 @if (User.IsInRole("Admin"))
                 {
                     <a class="button" href="/agents">Manage agents</a>


### PR DESCRIPTION
### Motivation
- Move notification preference ownership from a single global model toward per-user profiles to enable user-specific browser/SMTP delivery and quiet-hours in phase 1. 
- Provide a minimal, explicit profile surface so authenticated users can update email, change password, and manage their own notification preferences without touching authentication semantics.
- Keep SMTP transport configuration admin-owned while enabling per-user delivery eligibility and quiet-hours suppression as a safe incremental step (Telegram out of scope).

### Description
- Docs: updated `docs/notifications.md` to define the phase-1 ownership split (admin-owned SMTP transport vs user-owned profile preferences) and to direct UI to `/profile` for per-user settings. 
- New per-user model and schema: added `UserNotificationSettings` entity, EF mappings, `UserNotificationSettings` table creation in startup schema, and a `UserNotificationSettings` DbSet in `PingMonitorDbContext`.
- Service layer: added `IUserNotificationSettingsService`, `UserNotificationSettingsService`, DTO/command (`UserNotificationSettingsDto`, `UpdateUserNotificationSettingsCommand`) and logic to bootstrap a per-user row from legacy global `NotificationSettings` on first access.
- Profile UI and controller: added authenticated `/profile` route with `ProfileController`, `ProfilePageViewModel`, and view `Views/Profile/Index.cshtml` supporting account email update, password change (current/new/confirm), and per-user notification/quiet-hours toggles.
- Runtime changes: browser notification feed now reads the currently authenticated user’s settings (`BrowserNotificationQueryService`), notification suppression evaluation now accepts user settings, and SMTP delivery was refactored so recipients are resolved from users with enabled per-user SMTP preferences and per-user quiet-hours checks; admin page repurposed to SMTP transport infrastructure only.
- DI & navigation: registered new service in `Program.cs`, added links to `/profile` in status/admin pages, and cleaned up admin notification UI to avoid exposing per-user controls.
- Issue linkage: this work was tracked as an issue and is linked with the change using `Fixes #207` to record the intent and traceability.

### Testing
- Automated build: ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` using .NET SDK 10.0.104 and the build succeeded with 0 errors (initial warning earlier resolved). Build output: success.
- Sanity checks: verified EF model changes compile and startup schema code includes `UserNotificationSettings` table creation checks so MySQL-first schema gating is preserved.
- GitHub: created issue #207 before implementation and referenced it from the change for traceability.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca8f165788832aa67749b2deb7f8df)