### PR TITLE
Implement phase-1 Telegram per-user linking, polling inbound, and verified delivery

### DIFF
--- a/docs/event-logging.md
+++ b/docs/event-logging.md
@@ -184,6 +184,27 @@ Quiet hours integration (phase 1):
 - suppression affects delivery only; underlying event-log records are still written normally
 - suppressed notifications are dropped in phase 1 (not queued for later delivery)
 
+## Telegram notification integration (phase 1)
+
+Telegram notification delivery uses event-log records as the source of truth and remains aligned with meaningful event types only.
+
+Only this explicit subset is Telegram-eligible in phase 1:
+
+- endpoint down
+- endpoint recovered
+- agent became offline
+- agent became online
+
+Telegram delivery is additionally gated by:
+
+- global Telegram bot/channel infrastructure enabled
+- user has a verified linked Telegram private chat account
+- user Telegram notifications enabled
+- specific Telegram event-type toggle enabled
+- user quiet-hours suppression policy
+
+Suppressed deliveries are dropped in phase 1 (not queued), while event-log persistence remains unchanged.
+
 ## SMTP notification integration (phase 1)
 
 SMTP notification delivery also uses event-log records as the source of truth.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -14,9 +14,11 @@ This design is operator-focused and aligned with the control-plane role of the w
 
 The first implementation phase is browser notifications delivered while an operator has the web application open.
 
-### Telegram (future)
+### Telegram (phase 1, polling inbound)
 
-Telegram delivery is planned as a future notification channel.
+Telegram delivery is supported as a per-user notification channel in phase 1.
+
+Phase 1 transport mode is polling inbound updates via the Telegram Bot API. Webhook mode remains optional future scope.
 
 ### SMTP email (phase 1)
 
@@ -65,9 +67,15 @@ Initial settings scope is split by ownership:
   - suppress browser notifications during quiet hours
   - suppress SMTP notifications during quiet hours
 
+Additional phase 1 per-user Telegram settings:
+
+- Telegram notifications enabled/disabled
+- Telegram notifications enabled/disabled per supported event type
+- Telegram account linking status (verified only delivery)
+
 Future settings scope:
 
-- channel-specific settings for Telegram
+- webhook mode activation controls
 - additional controls as new channels are introduced
 
 ## Quiet hours / suppression windows (phase 1)
@@ -79,7 +87,7 @@ Phase 1 scope:
 - each authenticated user manages their own quiet-hours values in their profile
 - browser delivery respects that user's quiet-hours browser suppression toggle
 - SMTP delivery eligibility respects each user's quiet-hours SMTP suppression toggle
-- Telegram is not included in this phase
+- Telegram delivery eligibility respects each user's quiet-hours Telegram suppression toggle
 
 Critical semantics:
 

--- a/src/WebApp/PingMonitor.Web/Controllers/NotificationSettingsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/NotificationSettingsController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Models;
 using PingMonitor.Web.Models.Identity;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.Identity;
@@ -58,6 +59,11 @@ public sealed class NotificationSettingsController : Controller
                 BrowserNotifyAgentOffline = true,
                 BrowserNotifyAgentOnline = true,
                 BrowserNotificationsPermissionState = "default",
+                TelegramEnabled = model.TelegramEnabled,
+                TelegramBotToken = model.TelegramBotToken,
+                TelegramClearBotToken = model.TelegramClearBotToken,
+                TelegramInboundMode = ParseInboundMode(model.TelegramInboundMode),
+                TelegramPollIntervalSeconds = model.TelegramPollIntervalSeconds,
                 QuietHoursEnabled = false,
                 QuietHoursStartLocalTime = "22:00",
                 QuietHoursEndLocalTime = "07:00",
@@ -106,6 +112,11 @@ public sealed class NotificationSettingsController : Controller
                 BrowserNotifyAgentOffline = true,
                 BrowserNotifyAgentOnline = true,
                 BrowserNotificationsPermissionState = "default",
+                TelegramEnabled = model.TelegramEnabled,
+                TelegramBotToken = model.TelegramBotToken,
+                TelegramClearBotToken = model.TelegramClearBotToken,
+                TelegramInboundMode = ParseInboundMode(model.TelegramInboundMode),
+                TelegramPollIntervalSeconds = model.TelegramPollIntervalSeconds,
                 QuietHoursEnabled = false,
                 QuietHoursStartLocalTime = "22:00",
                 QuietHoursEndLocalTime = "07:00",
@@ -179,10 +190,19 @@ public sealed class NotificationSettingsController : Controller
 
     }
 
+    private static TelegramInboundMode ParseInboundMode(string? value)
+    {
+        return Enum.TryParse<TelegramInboundMode>(value?.Trim(), true, out var parsed) ? parsed : TelegramInboundMode.Polling;
+    }
+
     private async Task<NotificationSettingsPageViewModel> ToViewModelAsync(NotificationSettingsDto settings, bool saved, CancellationToken cancellationToken)
     {
         return new NotificationSettingsPageViewModel
         {
+            TelegramEnabled = settings.TelegramEnabled,
+            TelegramInboundMode = settings.TelegramInboundMode.ToString(),
+            TelegramPollIntervalSeconds = settings.TelegramPollIntervalSeconds,
+            TelegramBotTokenConfigured = settings.TelegramBotTokenConfigured,
             SmtpNotificationsEnabled = settings.SmtpNotificationsEnabled,
             SmtpHost = settings.SmtpHost,
             SmtpPort = settings.SmtpPort,

--- a/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Models.Identity;
 using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.Telegram;
 using PingMonitor.Web.ViewModels.Profile;
 
 namespace PingMonitor.Web.Controllers;
@@ -15,13 +16,16 @@ public sealed class ProfileController : Controller
 {
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly IUserNotificationSettingsService _userNotificationSettingsService;
+    private readonly ITelegramLinkService _telegramLinkService;
 
     public ProfileController(
         UserManager<ApplicationUser> userManager,
-        IUserNotificationSettingsService userNotificationSettingsService)
+        IUserNotificationSettingsService userNotificationSettingsService,
+        ITelegramLinkService telegramLinkService)
     {
         _userManager = userManager;
         _userNotificationSettingsService = userNotificationSettingsService;
+        _telegramLinkService = telegramLinkService;
     }
 
     [HttpGet("")]
@@ -173,16 +177,39 @@ public sealed class ProfileController : Controller
             SmtpNotifyEndpointRecovered = model.SmtpNotifyEndpointRecovered,
             SmtpNotifyAgentOffline = model.SmtpNotifyAgentOffline,
             SmtpNotifyAgentOnline = model.SmtpNotifyAgentOnline,
+            TelegramNotificationsEnabled = model.TelegramNotificationsEnabled,
+            TelegramNotifyEndpointDown = model.TelegramNotifyEndpointDown,
+            TelegramNotifyEndpointRecovered = model.TelegramNotifyEndpointRecovered,
+            TelegramNotifyAgentOffline = model.TelegramNotifyAgentOffline,
+            TelegramNotifyAgentOnline = model.TelegramNotifyAgentOnline,
             QuietHoursEnabled = model.QuietHoursEnabled,
             QuietHoursStartLocalTime = model.QuietHoursStartLocalTime ?? "22:00",
             QuietHoursEndLocalTime = model.QuietHoursEndLocalTime ?? "07:00",
             QuietHoursTimeZoneId = model.QuietHoursTimeZoneId ?? "UTC",
             QuietHoursSuppressBrowserNotifications = model.QuietHoursSuppressBrowserNotifications,
-            QuietHoursSuppressSmtpNotifications = model.QuietHoursSuppressSmtpNotifications
+            QuietHoursSuppressSmtpNotifications = model.QuietHoursSuppressSmtpNotifications,
+            QuietHoursSuppressTelegramNotifications = model.QuietHoursSuppressTelegramNotifications
         }, cancellationToken);
 
         var refreshed = await BuildModelAsync(cancellationToken);
         refreshed.NotificationsSaved = true;
+        return View("Index", refreshed);
+    }
+
+
+    [HttpPost("telegram/generate-code")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> GenerateTelegramCode(CancellationToken cancellationToken)
+    {
+        var user = await RequireUserAsync();
+        if (user is null)
+        {
+            return Challenge();
+        }
+
+        await _telegramLinkService.GenerateCodeAsync(user.Id, cancellationToken);
+        var refreshed = await BuildModelAsync(cancellationToken);
+        refreshed.TelegramCodeGenerated = true;
         return View("Index", refreshed);
     }
 
@@ -201,6 +228,8 @@ public sealed class ProfileController : Controller
         }
 
         var settings = await _userNotificationSettingsService.GetCurrentAsync(user.Id, cancellationToken);
+        var pendingCode = await _telegramLinkService.GetActiveCodeAsync(user.Id, cancellationToken);
+        var telegramAccount = await _telegramLinkService.GetAccountStatusAsync(user.Id, cancellationToken);
         return new ProfilePageViewModel
         {
             UserName = user.UserName ?? string.Empty,
@@ -216,13 +245,26 @@ public sealed class ProfileController : Controller
             SmtpNotifyEndpointRecovered = source?.SmtpNotifyEndpointRecovered ?? settings.SmtpNotifyEndpointRecovered,
             SmtpNotifyAgentOffline = source?.SmtpNotifyAgentOffline ?? settings.SmtpNotifyAgentOffline,
             SmtpNotifyAgentOnline = source?.SmtpNotifyAgentOnline ?? settings.SmtpNotifyAgentOnline,
+            TelegramNotificationsEnabled = source?.TelegramNotificationsEnabled ?? settings.TelegramNotificationsEnabled,
+            TelegramNotifyEndpointDown = source?.TelegramNotifyEndpointDown ?? settings.TelegramNotifyEndpointDown,
+            TelegramNotifyEndpointRecovered = source?.TelegramNotifyEndpointRecovered ?? settings.TelegramNotifyEndpointRecovered,
+            TelegramNotifyAgentOffline = source?.TelegramNotifyAgentOffline ?? settings.TelegramNotifyAgentOffline,
+            TelegramNotifyAgentOnline = source?.TelegramNotifyAgentOnline ?? settings.TelegramNotifyAgentOnline,
             QuietHoursEnabled = source?.QuietHoursEnabled ?? settings.QuietHoursEnabled,
             QuietHoursStartLocalTime = source?.QuietHoursStartLocalTime ?? settings.QuietHoursStartLocalTime,
             QuietHoursEndLocalTime = source?.QuietHoursEndLocalTime ?? settings.QuietHoursEndLocalTime,
             QuietHoursTimeZoneId = source?.QuietHoursTimeZoneId ?? settings.QuietHoursTimeZoneId,
             QuietHoursSuppressBrowserNotifications = source?.QuietHoursSuppressBrowserNotifications ?? settings.QuietHoursSuppressBrowserNotifications,
             QuietHoursSuppressSmtpNotifications = source?.QuietHoursSuppressSmtpNotifications ?? settings.QuietHoursSuppressSmtpNotifications,
-            NotificationSettingsUpdatedAtUtc = settings.UpdatedAtUtc
+            QuietHoursSuppressTelegramNotifications = source?.QuietHoursSuppressTelegramNotifications ?? settings.QuietHoursSuppressTelegramNotifications,
+            NotificationSettingsUpdatedAtUtc = settings.UpdatedAtUtc,
+            ActiveTelegramCode = pendingCode?.Code,
+            ActiveTelegramCodeExpiresAtUtc = pendingCode?.ExpiresAtUtc,
+            TelegramLinked = telegramAccount is not null && telegramAccount.Verified,
+            TelegramLinkedChatId = telegramAccount?.ChatId,
+            TelegramLinkedUsername = telegramAccount?.Username,
+            TelegramLinkedDisplayName = telegramAccount?.DisplayName,
+            TelegramLinkedAtUtc = telegramAccount?.LinkedAtUtc
         };
     }
 }

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -37,6 +37,8 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
     public DbSet<SecurityIpBlock> SecurityIpBlocks => Set<SecurityIpBlock>();
     public DbSet<NotificationSettings> NotificationSettings => Set<NotificationSettings>();
     public DbSet<UserNotificationSettings> UserNotificationSettings => Set<UserNotificationSettings>();
+    public DbSet<PendingTelegramLink> PendingTelegramLinks => Set<PendingTelegramLink>();
+    public DbSet<TelegramAccount> TelegramAccounts => Set<TelegramAccount>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -262,7 +264,13 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         notificationSettings.Property(x => x.BrowserNotifyAgentOffline).IsRequired();
         notificationSettings.Property(x => x.BrowserNotifyAgentOnline).IsRequired();
         notificationSettings.Property(x => x.BrowserNotificationsPermissionState).HasMaxLength(16);
-        notificationSettings.Property(x => x.TelegramNotificationsEnabled).IsRequired();
+        notificationSettings.Property(x => x.TelegramEnabled).IsRequired();
+        notificationSettings.Property(x => x.TelegramBotTokenProtected).HasMaxLength(4096);
+        notificationSettings.Property(x => x.TelegramInboundMode).HasConversion<string>().HasMaxLength(16).IsRequired();
+        notificationSettings.Property(x => x.TelegramPollIntervalSeconds).IsRequired();
+        notificationSettings.Property(x => x.TelegramLastProcessedUpdateId).IsRequired();
+        notificationSettings.Property(x => x.TelegramWebhookUrl).HasMaxLength(2048);
+        notificationSettings.Property(x => x.TelegramWebhookSecretToken).HasMaxLength(512);
         notificationSettings.Property(x => x.QuietHoursEnabled).IsRequired();
         notificationSettings.Property(x => x.QuietHoursStartLocalTime).HasMaxLength(5).IsRequired();
         notificationSettings.Property(x => x.QuietHoursEndLocalTime).HasMaxLength(5).IsRequired();
@@ -300,14 +308,46 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         userNotificationSettings.Property(x => x.SmtpNotifyEndpointRecovered).IsRequired();
         userNotificationSettings.Property(x => x.SmtpNotifyAgentOffline).IsRequired();
         userNotificationSettings.Property(x => x.SmtpNotifyAgentOnline).IsRequired();
+        userNotificationSettings.Property(x => x.TelegramNotificationsEnabled).IsRequired();
+        userNotificationSettings.Property(x => x.TelegramNotifyEndpointDown).IsRequired();
+        userNotificationSettings.Property(x => x.TelegramNotifyEndpointRecovered).IsRequired();
+        userNotificationSettings.Property(x => x.TelegramNotifyAgentOffline).IsRequired();
+        userNotificationSettings.Property(x => x.TelegramNotifyAgentOnline).IsRequired();
         userNotificationSettings.Property(x => x.QuietHoursEnabled).IsRequired();
         userNotificationSettings.Property(x => x.QuietHoursStartLocalTime).HasMaxLength(5).IsRequired();
         userNotificationSettings.Property(x => x.QuietHoursEndLocalTime).HasMaxLength(5).IsRequired();
         userNotificationSettings.Property(x => x.QuietHoursTimeZoneId).HasMaxLength(128).IsRequired();
         userNotificationSettings.Property(x => x.QuietHoursSuppressBrowserNotifications).IsRequired();
         userNotificationSettings.Property(x => x.QuietHoursSuppressSmtpNotifications).IsRequired();
+        userNotificationSettings.Property(x => x.QuietHoursSuppressTelegramNotifications).IsRequired();
         userNotificationSettings.Property(x => x.UpdatedAtUtc).IsRequired();
 
+
+        var pendingTelegramLink = modelBuilder.Entity<PendingTelegramLink>();
+        pendingTelegramLink.ToTable("PendingTelegramLinks");
+        pendingTelegramLink.HasKey(x => x.PendingTelegramLinkId);
+        pendingTelegramLink.Property(x => x.PendingTelegramLinkId).HasMaxLength(64);
+        pendingTelegramLink.Property(x => x.UserId).HasMaxLength(255).IsRequired();
+        pendingTelegramLink.Property(x => x.Code).HasMaxLength(16).IsRequired();
+        pendingTelegramLink.Property(x => x.CreatedAtUtc).IsRequired();
+        pendingTelegramLink.Property(x => x.ExpiresAtUtc).IsRequired();
+        pendingTelegramLink.Property(x => x.ConsumedByChatId).HasMaxLength(64);
+        pendingTelegramLink.Property(x => x.Status).HasConversion<string>().HasMaxLength(16).IsRequired();
+        pendingTelegramLink.HasIndex(x => new { x.Code, x.Status });
+
+        var telegramAccount = modelBuilder.Entity<TelegramAccount>();
+        telegramAccount.ToTable("TelegramAccounts");
+        telegramAccount.HasKey(x => x.TelegramAccountId);
+        telegramAccount.Property(x => x.TelegramAccountId).HasMaxLength(64);
+        telegramAccount.Property(x => x.UserId).HasMaxLength(255).IsRequired();
+        telegramAccount.Property(x => x.ChatId).HasMaxLength(64).IsRequired();
+        telegramAccount.Property(x => x.Verified).IsRequired();
+        telegramAccount.Property(x => x.LinkedAtUtc).IsRequired();
+        telegramAccount.Property(x => x.Username).HasMaxLength(255);
+        telegramAccount.Property(x => x.DisplayName).HasMaxLength(255);
+        telegramAccount.Property(x => x.IsActive).IsRequired();
+        telegramAccount.HasIndex(x => x.UserId).IsUnique();
+        telegramAccount.HasIndex(x => x.ChatId).IsUnique();
         var securitySettings = modelBuilder.Entity<SecuritySettings>();
         securitySettings.ToTable("SecuritySettings");
         securitySettings.HasKey(x => x.SecuritySettingsId);

--- a/src/WebApp/PingMonitor.Web/Models/NotificationSettings.cs
+++ b/src/WebApp/PingMonitor.Web/Models/NotificationSettings.cs
@@ -15,7 +15,13 @@ public sealed class NotificationSettings
 
     public string? BrowserNotificationsPermissionState { get; set; }
 
-    public bool TelegramNotificationsEnabled { get; set; }
+    public bool TelegramEnabled { get; set; }
+    public string? TelegramBotTokenProtected { get; set; }
+    public TelegramInboundMode TelegramInboundMode { get; set; } = TelegramInboundMode.Polling;
+    public int TelegramPollIntervalSeconds { get; set; } = 10;
+    public long TelegramLastProcessedUpdateId { get; set; }
+    public string? TelegramWebhookUrl { get; set; }
+    public string? TelegramWebhookSecretToken { get; set; }
 
     public bool QuietHoursEnabled { get; set; }
     public string QuietHoursStartLocalTime { get; set; } = "22:00";

--- a/src/WebApp/PingMonitor.Web/Models/PendingTelegramLink.cs
+++ b/src/WebApp/PingMonitor.Web/Models/PendingTelegramLink.cs
@@ -1,0 +1,13 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class PendingTelegramLink
+{
+    public string PendingTelegramLinkId { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAtUtc { get; set; }
+    public DateTimeOffset ExpiresAtUtc { get; set; }
+    public DateTimeOffset? UsedAtUtc { get; set; }
+    public string? ConsumedByChatId { get; set; }
+    public PendingTelegramLinkStatus Status { get; set; } = PendingTelegramLinkStatus.Pending;
+}

--- a/src/WebApp/PingMonitor.Web/Models/PendingTelegramLinkStatus.cs
+++ b/src/WebApp/PingMonitor.Web/Models/PendingTelegramLinkStatus.cs
@@ -1,0 +1,9 @@
+namespace PingMonitor.Web.Models;
+
+public enum PendingTelegramLinkStatus
+{
+    Pending = 0,
+    Verified = 1,
+    Expired = 2,
+    Consumed = 3
+}

--- a/src/WebApp/PingMonitor.Web/Models/TelegramAccount.cs
+++ b/src/WebApp/PingMonitor.Web/Models/TelegramAccount.cs
@@ -1,0 +1,13 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class TelegramAccount
+{
+    public string TelegramAccountId { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+    public string ChatId { get; set; } = string.Empty;
+    public bool Verified { get; set; }
+    public DateTimeOffset LinkedAtUtc { get; set; }
+    public string? Username { get; set; }
+    public string? DisplayName { get; set; }
+    public bool IsActive { get; set; } = true;
+}

--- a/src/WebApp/PingMonitor.Web/Models/TelegramInboundMode.cs
+++ b/src/WebApp/PingMonitor.Web/Models/TelegramInboundMode.cs
@@ -1,0 +1,7 @@
+namespace PingMonitor.Web.Models;
+
+public enum TelegramInboundMode
+{
+    Polling = 0,
+    Webhook = 1
+}

--- a/src/WebApp/PingMonitor.Web/Models/UserNotificationSettings.cs
+++ b/src/WebApp/PingMonitor.Web/Models/UserNotificationSettings.cs
@@ -17,6 +17,13 @@ public sealed class UserNotificationSettings
     public bool SmtpNotifyAgentOffline { get; set; }
     public bool SmtpNotifyAgentOnline { get; set; }
 
+    public bool TelegramNotificationsEnabled { get; set; }
+    public bool TelegramNotifyEndpointDown { get; set; }
+    public bool TelegramNotifyEndpointRecovered { get; set; }
+    public bool TelegramNotifyAgentOffline { get; set; }
+    public bool TelegramNotifyAgentOnline { get; set; }
+    public bool QuietHoursSuppressTelegramNotifications { get; set; } = true;
+
     public bool QuietHoursEnabled { get; set; }
     public string QuietHoursStartLocalTime { get; set; } = "22:00";
     public string QuietHoursEndLocalTime { get; set; } = "07:00";

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -21,6 +21,7 @@ using PingMonitor.Web.Services.Status;
 using PingMonitor.Web.Services.Security;
 using PingMonitor.Web.Services.SmtpNotifications;
 using PingMonitor.Web.Services.BrowserNotifications;
+using PingMonitor.Web.Services.Telegram;
 using PingMonitor.Web.Support;
 using Microsoft.Extensions.Options;
 
@@ -138,6 +139,10 @@ builder.Services.AddScoped<IUserNotificationSettingsService, UserNotificationSet
 builder.Services.AddScoped<INotificationSuppressionService, NotificationSuppressionService>();
 builder.Services.AddScoped<ISmtpNotificationSender, SmtpNotificationSender>();
 builder.Services.AddScoped<IBrowserNotificationQueryService, BrowserNotificationQueryService>();
+builder.Services.AddScoped<ITelegramLinkService, TelegramLinkService>();
+builder.Services.AddScoped<ITelegramMessageProcessor, TelegramMessageProcessor>();
+builder.Services.AddScoped<ITelegramPollingService, TelegramPollingService>();
+builder.Services.AddScoped<ITelegramNotificationSender, TelegramNotificationSender>();
 builder.Services.AddScoped<IEndpointCreationQueryService, EndpointCreationQueryService>();
 builder.Services.AddScoped<IEndpointManagementQueryService, EndpointManagementQueryService>();
 builder.Services.AddScoped<IEndpointManagementService, EndpointManagementService>();
@@ -163,6 +168,7 @@ builder.Services.AddSingleton<ConfigurationAutoBackupBackgroundService>();
 builder.Services.AddSingleton<IConfigurationChangeBackupSignal>(sp => sp.GetRequiredService<ConfigurationAutoBackupBackgroundService>());
 builder.Services.AddHostedService(sp => sp.GetRequiredService<ConfigurationAutoBackupBackgroundService>());
 builder.Services.AddHostedService<AgentStatusTransitionBackgroundService>();
+builder.Services.AddHostedService<TelegramPollingBackgroundService>();
 
 var app = builder.Build();
 

--- a/src/WebApp/PingMonitor.Web/Services/EventLogs/EventLogService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/EventLogs/EventLogService.cs
@@ -1,6 +1,7 @@
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Services.SmtpNotifications;
+using PingMonitor.Web.Services.Telegram;
 
 namespace PingMonitor.Web.Services.EventLogs;
 
@@ -8,15 +9,18 @@ internal sealed class EventLogService : IEventLogService
 {
     private readonly PingMonitorDbContext _dbContext;
     private readonly ISmtpNotificationSender _smtpNotificationSender;
+    private readonly ITelegramNotificationSender _telegramNotificationSender;
     private readonly ILogger<EventLogService> _logger;
 
     public EventLogService(
         PingMonitorDbContext dbContext,
         ISmtpNotificationSender smtpNotificationSender,
+        ITelegramNotificationSender telegramNotificationSender,
         ILogger<EventLogService> logger)
     {
         _dbContext = dbContext;
         _smtpNotificationSender = smtpNotificationSender;
+        _telegramNotificationSender = telegramNotificationSender;
         _logger = logger;
     }
 
@@ -52,6 +56,15 @@ internal sealed class EventLogService : IEventLogService
                 "SMTP notification was not delivered for event {EventType}: {Message}",
                 eventLog.EventType,
                 smtpResult.Message);
+        }
+
+        var telegramResult = await _telegramNotificationSender.SendForEventAsync(eventLog, cancellationToken);
+        if (!telegramResult.Success && !telegramResult.Skipped)
+        {
+            _logger.LogWarning(
+                "Telegram notification was not delivered for event {EventType}: {Message}",
+                eventLog.EventType,
+                telegramResult.Message);
         }
     }
 

--- a/src/WebApp/PingMonitor.Web/Services/INotificationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/INotificationSettingsService.cs
@@ -4,6 +4,7 @@ public interface INotificationSettingsService
 {
     Task<NotificationSettingsDto> GetCurrentAsync(CancellationToken cancellationToken);
     Task<SmtpChannelSettingsDto> GetSmtpChannelAsync(CancellationToken cancellationToken);
+    Task<TelegramChannelSettingsDto> GetTelegramChannelAsync(CancellationToken cancellationToken);
 
     Task<NotificationSettingsDto> UpdateAsync(UpdateNotificationSettingsCommand command, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/Services/INotificationSuppressionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/INotificationSuppressionService.cs
@@ -4,5 +4,6 @@ public interface INotificationSuppressionService
 {
     NotificationSuppressionDecision IsBrowserNotificationSuppressed(UserNotificationSettingsDto settings);
     NotificationSuppressionDecision IsSmtpNotificationSuppressed(UserNotificationSettingsDto settings);
+    NotificationSuppressionDecision IsTelegramNotificationSuppressed(UserNotificationSettingsDto settings);
     NotificationSuppressionStatus GetCurrentStatus(UserNotificationSettingsDto settings);
 }

--- a/src/WebApp/PingMonitor.Web/Services/NotificationSettingsDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NotificationSettingsDto.cs
@@ -1,3 +1,5 @@
+using PingMonitor.Web.Models;
+
 namespace PingMonitor.Web.Services;
 
 public sealed class NotificationSettingsDto
@@ -10,7 +12,10 @@ public sealed class NotificationSettingsDto
 
     public string? BrowserNotificationsPermissionState { get; set; }
 
-    public bool TelegramNotificationsEnabled { get; set; }
+    public bool TelegramEnabled { get; set; }
+    public TelegramInboundMode TelegramInboundMode { get; set; } = TelegramInboundMode.Polling;
+    public int TelegramPollIntervalSeconds { get; set; } = 10;
+    public bool TelegramBotTokenConfigured { get; set; }
 
     public bool QuietHoursEnabled { get; set; }
     public string QuietHoursStartLocalTime { get; set; } = "22:00";

--- a/src/WebApp/PingMonitor.Web/Services/NotificationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NotificationSettingsService.cs
@@ -33,9 +33,22 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
             SmtpPort = settings.SmtpPort <= 0 ? 25 : settings.SmtpPort,
             SmtpUseTls = settings.SmtpUseTls,
             SmtpUsername = settings.SmtpUsername,
-            SmtpPassword = UnprotectSmtpSecret(settings.SmtpPasswordProtected),
+            SmtpPassword = UnprotectSecret(settings.SmtpPasswordProtected),
             SmtpFromAddress = settings.SmtpFromAddress,
             SmtpFromDisplayName = settings.SmtpFromDisplayName
+        };
+    }
+
+    public async Task<TelegramChannelSettingsDto> GetTelegramChannelAsync(CancellationToken cancellationToken)
+    {
+        var settings = await GetOrCreateEntityAsync(cancellationToken);
+        return new TelegramChannelSettingsDto
+        {
+            TelegramEnabled = settings.TelegramEnabled,
+            TelegramBotToken = UnprotectSecret(settings.TelegramBotTokenProtected),
+            TelegramInboundMode = settings.TelegramInboundMode,
+            TelegramPollIntervalSeconds = settings.TelegramPollIntervalSeconds <= 0 ? 10 : settings.TelegramPollIntervalSeconds,
+            TelegramLastProcessedUpdateId = settings.TelegramLastProcessedUpdateId
         };
     }
 
@@ -49,6 +62,25 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
         settings.BrowserNotifyAgentOffline = command.BrowserNotifyAgentOffline;
         settings.BrowserNotifyAgentOnline = command.BrowserNotifyAgentOnline;
         settings.BrowserNotificationsPermissionState = NormalizePermissionState(command.BrowserNotificationsPermissionState);
+        settings.TelegramEnabled = command.TelegramEnabled;
+        settings.TelegramInboundMode = command.TelegramInboundMode;
+        settings.TelegramPollIntervalSeconds = command.TelegramPollIntervalSeconds <= 0 ? 10 : command.TelegramPollIntervalSeconds;
+        settings.TelegramWebhookUrl = NormalizeString(command.TelegramWebhookUrl);
+        if (command.TelegramLastProcessedUpdateId >= 0)
+        {
+            settings.TelegramLastProcessedUpdateId = command.TelegramLastProcessedUpdateId;
+        }
+        settings.TelegramWebhookSecretToken = NormalizeString(command.TelegramWebhookSecretToken);
+
+        if (command.TelegramClearBotToken)
+        {
+            settings.TelegramBotTokenProtected = null;
+        }
+        else if (!string.IsNullOrWhiteSpace(command.TelegramBotToken))
+        {
+            settings.TelegramBotTokenProtected = ProtectSecret(command.TelegramBotToken.Trim(), "Telegram bot token");
+        }
+
         settings.QuietHoursEnabled = command.QuietHoursEnabled;
         settings.QuietHoursStartLocalTime = NormalizeQuietHoursTime(command.QuietHoursStartLocalTime, fallback: "22:00");
         settings.QuietHoursEndLocalTime = NormalizeQuietHoursTime(command.QuietHoursEndLocalTime, fallback: "07:00");
@@ -74,7 +106,7 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
         }
         else if (!string.IsNullOrWhiteSpace(command.SmtpPassword))
         {
-            settings.SmtpPasswordProtected = ProtectSmtpSecret(command.SmtpPassword.Trim());
+            settings.SmtpPasswordProtected = ProtectSecret(command.SmtpPassword.Trim(), "SMTP password");
         }
 
         settings.UpdatedAtUtc = DateTimeOffset.UtcNow;
@@ -115,7 +147,10 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
             BrowserNotifyAgentOffline = true,
             BrowserNotifyAgentOnline = true,
             BrowserNotificationsPermissionState = "default",
-            TelegramNotificationsEnabled = false,
+            TelegramEnabled = false,
+            TelegramInboundMode = TelegramInboundMode.Polling,
+            TelegramPollIntervalSeconds = 10,
+            TelegramLastProcessedUpdateId = 0,
             QuietHoursEnabled = false,
             QuietHoursStartLocalTime = "22:00",
             QuietHoursEndLocalTime = "07:00",
@@ -181,7 +216,7 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
         return split.Length == 0 ? null : string.Join(Environment.NewLine, split);
     }
 
-    private string ProtectSmtpSecret(string secret)
+    private string ProtectSecret(string secret, string secretName)
     {
         var payload = Encoding.UTF8.GetBytes(secret);
         if (OperatingSystem.IsWindows())
@@ -190,13 +225,13 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
         }
         else
         {
-            _logger.LogWarning("SMTP password fallback storage is in use because DPAPI is only available on Windows.");
+            _logger.LogWarning("{SecretName} fallback storage is in use because DPAPI is only available on Windows.", secretName);
         }
 
         return Convert.ToBase64String(payload);
     }
 
-    private string? UnprotectSmtpSecret(string? protectedSecret)
+    private string? UnprotectSecret(string? protectedSecret)
     {
         if (string.IsNullOrWhiteSpace(protectedSecret))
         {
@@ -210,7 +245,7 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
         }
         catch (FormatException)
         {
-            _logger.LogWarning("Stored SMTP secret could not be decoded.");
+            _logger.LogWarning("Stored protected secret could not be decoded.");
             return null;
         }
 
@@ -232,7 +267,10 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
             BrowserNotifyAgentOffline = settings.BrowserNotifyAgentOffline,
             BrowserNotifyAgentOnline = settings.BrowserNotifyAgentOnline,
             BrowserNotificationsPermissionState = settings.BrowserNotificationsPermissionState,
-            TelegramNotificationsEnabled = settings.TelegramNotificationsEnabled,
+            TelegramEnabled = settings.TelegramEnabled,
+            TelegramInboundMode = settings.TelegramInboundMode,
+            TelegramPollIntervalSeconds = settings.TelegramPollIntervalSeconds <= 0 ? 10 : settings.TelegramPollIntervalSeconds,
+            TelegramBotTokenConfigured = !string.IsNullOrWhiteSpace(settings.TelegramBotTokenProtected),
             QuietHoursEnabled = settings.QuietHoursEnabled,
             QuietHoursStartLocalTime = NormalizeQuietHoursTime(settings.QuietHoursStartLocalTime, "22:00"),
             QuietHoursEndLocalTime = NormalizeQuietHoursTime(settings.QuietHoursEndLocalTime, "07:00"),

--- a/src/WebApp/PingMonitor.Web/Services/NotificationSuppressionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NotificationSuppressionService.cs
@@ -40,6 +40,25 @@ internal sealed class NotificationSuppressionService : INotificationSuppressionS
         };
     }
 
+    public NotificationSuppressionDecision IsTelegramNotificationSuppressed(UserNotificationSettingsDto settings)
+    {
+        if (!settings.QuietHoursSuppressTelegramNotifications)
+        {
+            return new NotificationSuppressionDecision
+            {
+                IsSuppressed = false,
+                Reason = "Quiet hours Telegram suppression is disabled."
+            };
+        }
+
+        var evaluation = EvaluateQuietHours(settings);
+        return new NotificationSuppressionDecision
+        {
+            IsSuppressed = evaluation.QuietHoursActiveNow,
+            Reason = evaluation.Reason
+        };
+    }
+
     public NotificationSuppressionStatus GetCurrentStatus(UserNotificationSettingsDto settings)
     {
         return EvaluateQuietHours(settings);

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -34,7 +34,9 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "SecuritySettings",
         "SecurityIpBlocks",
         "NotificationSettings",
-        "UserNotificationSettings"
+        "UserNotificationSettings",
+        "PendingTelegramLinks",
+        "TelegramAccounts"
     ];
     private static readonly string[] RequiredEndpointDependencyColumns =
     [
@@ -77,7 +79,13 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "BrowserNotifyAgentOffline",
         "BrowserNotifyAgentOnline",
         "BrowserNotificationsPermissionState",
-        "TelegramNotificationsEnabled",
+        "TelegramEnabled",
+        "TelegramBotTokenProtected",
+        "TelegramInboundMode",
+        "TelegramPollIntervalSeconds",
+        "TelegramLastProcessedUpdateId",
+        "TelegramWebhookUrl",
+        "TelegramWebhookSecretToken",
         "QuietHoursEnabled",
         "QuietHoursStartLocalTime",
         "QuietHoursEndLocalTime",
@@ -336,13 +344,20 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 `BrowserNotifyAgentOffline` tinyint(1) NOT NULL DEFAULT 1,
                 `BrowserNotifyAgentOnline` tinyint(1) NOT NULL DEFAULT 1,
                 `BrowserNotificationsPermissionState` varchar(16) NULL,
-                `TelegramNotificationsEnabled` tinyint(1) NOT NULL,
+                `TelegramEnabled` tinyint(1) NOT NULL DEFAULT 0,
+                `TelegramBotTokenProtected` varchar(4096) NULL,
+                `TelegramInboundMode` varchar(16) NOT NULL DEFAULT 'Polling',
+                `TelegramPollIntervalSeconds` int NOT NULL DEFAULT 10,
+                `TelegramLastProcessedUpdateId` bigint NOT NULL DEFAULT 0,
+                `TelegramWebhookUrl` varchar(2048) NULL,
+                `TelegramWebhookSecretToken` varchar(512) NULL,
                 `QuietHoursEnabled` tinyint(1) NOT NULL DEFAULT 0,
                 `QuietHoursStartLocalTime` varchar(5) NOT NULL DEFAULT '22:00',
                 `QuietHoursEndLocalTime` varchar(5) NOT NULL DEFAULT '07:00',
                 `QuietHoursTimeZoneId` varchar(128) NOT NULL DEFAULT 'UTC',
                 `QuietHoursSuppressBrowserNotifications` tinyint(1) NOT NULL DEFAULT 1,
                 `QuietHoursSuppressSmtpNotifications` tinyint(1) NOT NULL DEFAULT 1,
+                `QuietHoursSuppressTelegramNotifications` tinyint(1) NOT NULL DEFAULT 1,
                 `SmtpNotificationsEnabled` tinyint(1) NOT NULL,
                 `SmtpHost` varchar(255) NULL,
                 `SmtpPort` int NOT NULL DEFAULT 25,
@@ -375,14 +390,52 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 `SmtpNotifyEndpointRecovered` tinyint(1) NOT NULL DEFAULT 1,
                 `SmtpNotifyAgentOffline` tinyint(1) NOT NULL DEFAULT 1,
                 `SmtpNotifyAgentOnline` tinyint(1) NOT NULL DEFAULT 1,
+                `TelegramNotificationsEnabled` tinyint(1) NOT NULL DEFAULT 0,
+                `TelegramNotifyEndpointDown` tinyint(1) NOT NULL DEFAULT 1,
+                `TelegramNotifyEndpointRecovered` tinyint(1) NOT NULL DEFAULT 1,
+                `TelegramNotifyAgentOffline` tinyint(1) NOT NULL DEFAULT 1,
+                `TelegramNotifyAgentOnline` tinyint(1) NOT NULL DEFAULT 1,
                 `QuietHoursEnabled` tinyint(1) NOT NULL DEFAULT 0,
                 `QuietHoursStartLocalTime` varchar(5) NOT NULL DEFAULT '22:00',
                 `QuietHoursEndLocalTime` varchar(5) NOT NULL DEFAULT '07:00',
                 `QuietHoursTimeZoneId` varchar(128) NOT NULL DEFAULT 'UTC',
                 `QuietHoursSuppressBrowserNotifications` tinyint(1) NOT NULL DEFAULT 1,
                 `QuietHoursSuppressSmtpNotifications` tinyint(1) NOT NULL DEFAULT 1,
+                `QuietHoursSuppressTelegramNotifications` tinyint(1) NOT NULL DEFAULT 1,
                 `UpdatedAtUtc` datetime(6) NOT NULL,
                 PRIMARY KEY (`UserId`)
+            );
+            """;
+
+
+        const string createPendingTelegramLinksSql = """
+            CREATE TABLE IF NOT EXISTS `PendingTelegramLinks` (
+                `PendingTelegramLinkId` varchar(64) NOT NULL,
+                `UserId` varchar(255) NOT NULL,
+                `Code` varchar(16) NOT NULL,
+                `CreatedAtUtc` datetime(6) NOT NULL,
+                `ExpiresAtUtc` datetime(6) NOT NULL,
+                `UsedAtUtc` datetime(6) NULL,
+                `ConsumedByChatId` varchar(64) NULL,
+                `Status` varchar(16) NOT NULL,
+                PRIMARY KEY (`PendingTelegramLinkId`),
+                KEY `IX_PendingTelegramLinks_Code_Status` (`Code`, `Status`)
+            );
+            """;
+
+        const string createTelegramAccountsSql = """
+            CREATE TABLE IF NOT EXISTS `TelegramAccounts` (
+                `TelegramAccountId` varchar(64) NOT NULL,
+                `UserId` varchar(255) NOT NULL,
+                `ChatId` varchar(64) NOT NULL,
+                `Verified` tinyint(1) NOT NULL,
+                `LinkedAtUtc` datetime(6) NOT NULL,
+                `Username` varchar(255) NULL,
+                `DisplayName` varchar(255) NULL,
+                `IsActive` tinyint(1) NOT NULL DEFAULT 1,
+                PRIMARY KEY (`TelegramAccountId`),
+                UNIQUE KEY `UX_TelegramAccounts_UserId` (`UserId`),
+                UNIQUE KEY `UX_TelegramAccounts_ChatId` (`ChatId`)
             );
             """;
 
@@ -500,6 +553,8 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await dbContext.Database.ExecuteSqlRawAsync(createSecurityIpBlocksSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createNotificationSettingsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createUserNotificationSettingsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createPendingTelegramLinksSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createTelegramAccountsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointDependenciesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createAgentHeartbeatHistorySql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createGroupsSql, cancellationToken);
@@ -822,6 +877,77 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 """
                 ALTER TABLE `NotificationSettings`
                 ADD COLUMN `BrowserNotifyAgentOnline` tinyint(1) NOT NULL DEFAULT 1;
+                """,
+                cancellationToken);
+        }
+
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "TelegramEnabled", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `TelegramEnabled` tinyint(1) NOT NULL DEFAULT 0;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "TelegramBotTokenProtected", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `TelegramBotTokenProtected` varchar(4096) NULL;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "TelegramInboundMode", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `TelegramInboundMode` varchar(16) NOT NULL DEFAULT 'Polling';
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "TelegramPollIntervalSeconds", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `TelegramPollIntervalSeconds` int NOT NULL DEFAULT 10;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "TelegramLastProcessedUpdateId", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `TelegramLastProcessedUpdateId` bigint NOT NULL DEFAULT 0;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "TelegramWebhookUrl", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `TelegramWebhookUrl` varchar(2048) NULL;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasNotificationSettingsColumnAsync(connection, "TelegramWebhookSecretToken", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `NotificationSettings`
+                ADD COLUMN `TelegramWebhookSecretToken` varchar(512) NULL;
                 """,
                 cancellationToken);
         }

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/ITelegramLinkService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/ITelegramLinkService.cs
@@ -1,0 +1,9 @@
+namespace PingMonitor.Web.Services.Telegram;
+
+public interface ITelegramLinkService
+{
+    Task<PendingTelegramLinkDto> GenerateCodeAsync(string userId, CancellationToken cancellationToken);
+    Task<PendingTelegramLinkDto?> GetActiveCodeAsync(string userId, CancellationToken cancellationToken);
+    Task<TelegramLinkConsumeResult> ConsumeCodeAsync(string code, string chatId, string chatType, string? username, string? displayName, CancellationToken cancellationToken);
+    Task<TelegramAccountStatusDto?> GetAccountStatusAsync(string userId, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/ITelegramMessageProcessor.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/ITelegramMessageProcessor.cs
@@ -1,0 +1,6 @@
+namespace PingMonitor.Web.Services.Telegram;
+
+public interface ITelegramMessageProcessor
+{
+    Task<TelegramMessageProcessingResult> ProcessAsync(TelegramInboundMessage inboundMessage, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/ITelegramNotificationSender.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/ITelegramNotificationSender.cs
@@ -1,0 +1,8 @@
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.Telegram;
+
+public interface ITelegramNotificationSender
+{
+    Task<TelegramNotificationSendResult> SendForEventAsync(EventLog eventLog, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/ITelegramPollingService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/ITelegramPollingService.cs
@@ -1,0 +1,6 @@
+namespace PingMonitor.Web.Services.Telegram;
+
+public interface ITelegramPollingService
+{
+    Task PollOnceAsync(CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/PendingTelegramLinkDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/PendingTelegramLinkDto.cs
@@ -1,0 +1,7 @@
+namespace PingMonitor.Web.Services.Telegram;
+
+public sealed class PendingTelegramLinkDto
+{
+    public string Code { get; init; } = string.Empty;
+    public DateTimeOffset ExpiresAtUtc { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramAccountStatusDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramAccountStatusDto.cs
@@ -1,0 +1,10 @@
+namespace PingMonitor.Web.Services.Telegram;
+
+public sealed class TelegramAccountStatusDto
+{
+    public bool Verified { get; init; }
+    public string ChatId { get; init; } = string.Empty;
+    public string? Username { get; init; }
+    public string? DisplayName { get; init; }
+    public DateTimeOffset LinkedAtUtc { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramInboundMessage.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramInboundMessage.cs
@@ -1,0 +1,11 @@
+namespace PingMonitor.Web.Services.Telegram;
+
+public sealed class TelegramInboundMessage
+{
+    public long UpdateId { get; init; }
+    public string ChatId { get; init; } = string.Empty;
+    public string ChatType { get; init; } = string.Empty;
+    public string? Username { get; init; }
+    public string? DisplayName { get; init; }
+    public string Text { get; init; } = string.Empty;
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramLinkConsumeResult.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramLinkConsumeResult.cs
@@ -1,0 +1,7 @@
+namespace PingMonitor.Web.Services.Telegram;
+
+public sealed class TelegramLinkConsumeResult
+{
+    public bool Success { get; init; }
+    public string Message { get; init; } = string.Empty;
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramLinkService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramLinkService.cs
@@ -1,0 +1,145 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using System.Security.Cryptography;
+
+namespace PingMonitor.Web.Services.Telegram;
+
+internal sealed class TelegramLinkService : ITelegramLinkService
+{
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly ILogger<TelegramLinkService> _logger;
+
+    public TelegramLinkService(PingMonitorDbContext dbContext, ILogger<TelegramLinkService> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<PendingTelegramLinkDto> GenerateCodeAsync(string userId, CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var normalizedUserId = userId.Trim();
+
+        var stale = await _dbContext.PendingTelegramLinks
+            .Where(x => x.UserId == normalizedUserId && x.Status == PendingTelegramLinkStatus.Pending)
+            .ToListAsync(cancellationToken);
+
+        foreach (var pending in stale)
+        {
+            pending.Status = PendingTelegramLinkStatus.Expired;
+        }
+
+        var code = RandomNumberGenerator.GetInt32(0, 100_000_000).ToString("D8");
+        var row = new PendingTelegramLink
+        {
+            PendingTelegramLinkId = $"tgl_{Guid.NewGuid():N}",
+            UserId = normalizedUserId,
+            Code = code,
+            CreatedAtUtc = now,
+            ExpiresAtUtc = now.AddMinutes(15),
+            Status = PendingTelegramLinkStatus.Pending
+        };
+
+        _dbContext.PendingTelegramLinks.Add(row);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("Telegram link code generated for user {UserId}.", normalizedUserId);
+
+        return new PendingTelegramLinkDto { Code = code, ExpiresAtUtc = row.ExpiresAtUtc };
+    }
+
+    public async Task<PendingTelegramLinkDto?> GetActiveCodeAsync(string userId, CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var normalizedUserId = userId.Trim();
+        var row = await _dbContext.PendingTelegramLinks.AsNoTracking()
+            .Where(x => x.UserId == normalizedUserId && x.Status == PendingTelegramLinkStatus.Pending && x.ExpiresAtUtc > now)
+            .OrderByDescending(x => x.CreatedAtUtc)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (row is null)
+        {
+            return null;
+        }
+
+        return new PendingTelegramLinkDto { Code = row.Code, ExpiresAtUtc = row.ExpiresAtUtc };
+    }
+
+    public async Task<TelegramLinkConsumeResult> ConsumeCodeAsync(string code, string chatId, string chatType, string? username, string? displayName, CancellationToken cancellationToken)
+    {
+        if (!string.Equals(chatType, "private", StringComparison.OrdinalIgnoreCase))
+        {
+            return new TelegramLinkConsumeResult { Success = false, Message = "Linking is only supported from a private chat." };
+        }
+
+        var trimmedCode = code.Trim();
+        var now = DateTimeOffset.UtcNow;
+
+        await using var tx = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+        var pending = await _dbContext.PendingTelegramLinks
+            .Where(x => x.Code == trimmedCode && x.Status == PendingTelegramLinkStatus.Pending)
+            .OrderByDescending(x => x.CreatedAtUtc)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (pending is null)
+        {
+            return new TelegramLinkConsumeResult { Success = false, Message = "Code was not found." };
+        }
+
+        if (pending.ExpiresAtUtc <= now)
+        {
+            pending.Status = PendingTelegramLinkStatus.Expired;
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            await tx.CommitAsync(cancellationToken);
+            return new TelegramLinkConsumeResult { Success = false, Message = "Code is expired." };
+        }
+
+        pending.Status = PendingTelegramLinkStatus.Verified;
+        pending.UsedAtUtc = now;
+        pending.ConsumedByChatId = chatId;
+
+        var existing = await _dbContext.TelegramAccounts.SingleOrDefaultAsync(x => x.UserId == pending.UserId, cancellationToken);
+        if (existing is null)
+        {
+            existing = new TelegramAccount
+            {
+                TelegramAccountId = $"tga_{Guid.NewGuid():N}",
+                UserId = pending.UserId
+            };
+            _dbContext.TelegramAccounts.Add(existing);
+        }
+
+        existing.ChatId = chatId;
+        existing.Verified = true;
+        existing.LinkedAtUtc = now;
+        existing.Username = string.IsNullOrWhiteSpace(username) ? null : username.Trim();
+        existing.DisplayName = string.IsNullOrWhiteSpace(displayName) ? null : displayName.Trim();
+        existing.IsActive = true;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        await tx.CommitAsync(cancellationToken);
+
+        _logger.LogInformation("Telegram account linked for user {UserId}.", pending.UserId);
+        return new TelegramLinkConsumeResult { Success = true, Message = "Telegram account linked." };
+    }
+
+    public async Task<TelegramAccountStatusDto?> GetAccountStatusAsync(string userId, CancellationToken cancellationToken)
+    {
+        var row = await _dbContext.TelegramAccounts.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.UserId == userId && x.IsActive, cancellationToken);
+
+        if (row is null)
+        {
+            return null;
+        }
+
+        return new TelegramAccountStatusDto
+        {
+            Verified = row.Verified,
+            ChatId = row.ChatId,
+            Username = row.Username,
+            DisplayName = row.DisplayName,
+            LinkedAtUtc = row.LinkedAtUtc
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessingResult.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessingResult.cs
@@ -1,0 +1,8 @@
+namespace PingMonitor.Web.Services.Telegram;
+
+public sealed class TelegramMessageProcessingResult
+{
+    public bool Handled { get; init; }
+    public bool Success { get; init; }
+    public string Message { get; init; } = string.Empty;
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessor.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessor.cs
@@ -1,0 +1,40 @@
+using System.Text.RegularExpressions;
+
+namespace PingMonitor.Web.Services.Telegram;
+
+internal sealed partial class TelegramMessageProcessor : ITelegramMessageProcessor
+{
+    private readonly ITelegramLinkService _telegramLinkService;
+
+    public TelegramMessageProcessor(ITelegramLinkService telegramLinkService)
+    {
+        _telegramLinkService = telegramLinkService;
+    }
+
+    public async Task<TelegramMessageProcessingResult> ProcessAsync(TelegramInboundMessage inboundMessage, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(inboundMessage.Text))
+        {
+            return new TelegramMessageProcessingResult { Handled = false, Success = true, Message = "No text content." };
+        }
+
+        var match = CodeRegex().Match(inboundMessage.Text.Trim());
+        if (!match.Success)
+        {
+            return new TelegramMessageProcessingResult { Handled = false, Success = true, Message = "Unsupported message content." };
+        }
+
+        var result = await _telegramLinkService.ConsumeCodeAsync(
+            match.Groups[1].Value,
+            inboundMessage.ChatId,
+            inboundMessage.ChatType,
+            inboundMessage.Username,
+            inboundMessage.DisplayName,
+            cancellationToken);
+
+        return new TelegramMessageProcessingResult { Handled = true, Success = result.Success, Message = result.Message };
+    }
+
+    [GeneratedRegex("^(\\d{8})$")]
+    private static partial Regex CodeRegex();
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramNotificationSendResult.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramNotificationSendResult.cs
@@ -1,0 +1,12 @@
+namespace PingMonitor.Web.Services.Telegram;
+
+public sealed class TelegramNotificationSendResult
+{
+    public bool Success { get; init; }
+    public bool Skipped { get; init; }
+    public string Message { get; init; } = string.Empty;
+
+    public static TelegramNotificationSendResult Sent(string message) => new() { Success = true, Message = message };
+    public static TelegramNotificationSendResult Skip(string message) => new() { Skipped = true, Message = message };
+    public static TelegramNotificationSendResult Failed(string message) => new() { Message = message };
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramNotificationSender.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramNotificationSender.cs
@@ -1,0 +1,141 @@
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.Telegram;
+
+internal sealed class TelegramNotificationSender : ITelegramNotificationSender
+{
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly INotificationSettingsService _notificationSettingsService;
+    private readonly IUserNotificationSettingsService _userNotificationSettingsService;
+    private readonly INotificationSuppressionService _notificationSuppressionService;
+    private readonly ILogger<TelegramNotificationSender> _logger;
+    private readonly HttpClient _httpClient = new();
+
+    public TelegramNotificationSender(
+        PingMonitorDbContext dbContext,
+        INotificationSettingsService notificationSettingsService,
+        IUserNotificationSettingsService userNotificationSettingsService,
+        INotificationSuppressionService notificationSuppressionService,
+        ILogger<TelegramNotificationSender> logger)
+    {
+        _dbContext = dbContext;
+        _notificationSettingsService = notificationSettingsService;
+        _userNotificationSettingsService = userNotificationSettingsService;
+        _notificationSuppressionService = notificationSuppressionService;
+        _logger = logger;
+    }
+
+    public async Task<TelegramNotificationSendResult> SendForEventAsync(EventLog eventLog, CancellationToken cancellationToken)
+    {
+        var mapped = MapEvent(eventLog);
+        if (mapped is null)
+        {
+            return TelegramNotificationSendResult.Skip("Event type is not supported for Telegram notifications.");
+        }
+
+        var channel = await _notificationSettingsService.GetTelegramChannelAsync(cancellationToken);
+        if (!channel.TelegramEnabled)
+        {
+            return TelegramNotificationSendResult.Skip("Telegram notifications are disabled globally.");
+        }
+
+        if (string.IsNullOrWhiteSpace(channel.TelegramBotToken))
+        {
+            return TelegramNotificationSendResult.Skip("Telegram bot token is not configured.");
+        }
+
+        var accounts = await _dbContext.TelegramAccounts.AsNoTracking().Where(x => x.Verified && x.IsActive).ToArrayAsync(cancellationToken);
+        var eligibleChatIds = new List<string>();
+
+        foreach (var account in accounts)
+        {
+            var settings = await _userNotificationSettingsService.GetCurrentAsync(account.UserId, cancellationToken);
+            if (!settings.TelegramNotificationsEnabled || !IsEventEnabled(mapped.Value.Toggle, settings))
+            {
+                continue;
+            }
+
+            if (_notificationSuppressionService.IsTelegramNotificationSuppressed(settings).IsSuppressed)
+            {
+                continue;
+            }
+
+            eligibleChatIds.Add(account.ChatId);
+        }
+
+        if (eligibleChatIds.Count == 0)
+        {
+            return TelegramNotificationSendResult.Skip("No users are eligible for Telegram delivery for this event.");
+        }
+
+        var text = mapped.Value.Title + " - " + eventLog.Message;
+        foreach (var chatId in eligibleChatIds)
+        {
+            var content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["chat_id"] = chatId,
+                ["text"] = text
+            });
+
+            var url = $"https://api.telegram.org/bot{channel.TelegramBotToken}/sendMessage";
+            var response = await _httpClient.PostAsync(url, content, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Telegram send failed for chat {ChatId} with status {StatusCode}.", chatId, (int)response.StatusCode);
+            }
+        }
+
+        return TelegramNotificationSendResult.Sent("Telegram notifications processed.");
+    }
+
+    private static bool IsEventEnabled(TelegramToggle toggle, UserNotificationSettingsDto settings)
+        => toggle switch
+        {
+            TelegramToggle.EndpointDown => settings.TelegramNotifyEndpointDown,
+            TelegramToggle.EndpointRecovered => settings.TelegramNotifyEndpointRecovered,
+            TelegramToggle.AgentOffline => settings.TelegramNotifyAgentOffline,
+            TelegramToggle.AgentOnline => settings.TelegramNotifyAgentOnline,
+            _ => false
+        };
+
+    private static MappedEvent? MapEvent(EventLog eventLog)
+    {
+        if (eventLog.EventType == EventType.EndpointStateChanged)
+        {
+            if (eventLog.Message.Contains("went down.", StringComparison.Ordinal))
+            {
+                return new MappedEvent(TelegramToggle.EndpointDown, "Ping Monitor: Endpoint Down");
+            }
+
+            if (eventLog.Message.Contains("recovered", StringComparison.Ordinal))
+            {
+                return new MappedEvent(TelegramToggle.EndpointRecovered, "Ping Monitor: Endpoint Recovered");
+            }
+        }
+
+        if (eventLog.EventType == EventType.AgentBecameOffline)
+        {
+            return new MappedEvent(TelegramToggle.AgentOffline, "Ping Monitor: Agent Offline");
+        }
+
+        if (eventLog.EventType == EventType.AgentBecameOnline)
+        {
+            return new MappedEvent(TelegramToggle.AgentOnline, "Ping Monitor: Agent Online");
+        }
+
+        return null;
+    }
+
+    private enum TelegramToggle
+    {
+        EndpointDown,
+        EndpointRecovered,
+        AgentOffline,
+        AgentOnline
+    }
+
+    private readonly record struct MappedEvent(TelegramToggle Toggle, string Title);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramPollingBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramPollingBackgroundService.cs
@@ -1,0 +1,43 @@
+namespace PingMonitor.Web.Services.Telegram;
+
+internal sealed class TelegramPollingBackgroundService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<TelegramPollingBackgroundService> _logger;
+
+    public TelegramPollingBackgroundService(IServiceScopeFactory scopeFactory, ILogger<TelegramPollingBackgroundService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Telegram polling background service started.");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                using var scope = _scopeFactory.CreateScope();
+                var polling = scope.ServiceProvider.GetRequiredService<ITelegramPollingService>();
+                await polling.PollOnceAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Telegram polling cycle failed.");
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+            }
+            catch (TaskCanceledException)
+            {
+                break;
+            }
+        }
+
+        _logger.LogInformation("Telegram polling background service stopped.");
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramPollingService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramPollingService.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.Telegram;
+
+internal sealed class TelegramPollingService : ITelegramPollingService
+{
+    private readonly INotificationSettingsService _notificationSettingsService;
+    private readonly ITelegramMessageProcessor _telegramMessageProcessor;
+    private readonly ILogger<TelegramPollingService> _logger;
+    private readonly HttpClient _httpClient = new();
+
+    public TelegramPollingService(
+        INotificationSettingsService notificationSettingsService,
+        ITelegramMessageProcessor telegramMessageProcessor,
+        ILogger<TelegramPollingService> logger)
+    {
+        _notificationSettingsService = notificationSettingsService;
+        _telegramMessageProcessor = telegramMessageProcessor;
+        _logger = logger;
+    }
+
+    public async Task PollOnceAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _notificationSettingsService.GetTelegramChannelAsync(cancellationToken);
+        if (!settings.TelegramEnabled || settings.TelegramInboundMode != TelegramInboundMode.Polling || string.IsNullOrWhiteSpace(settings.TelegramBotToken))
+        {
+            return;
+        }
+
+        var offset = settings.TelegramLastProcessedUpdateId + 1;
+        var url = $"https://api.telegram.org/bot{settings.TelegramBotToken}/getUpdates?timeout=25&offset={offset}";
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await _httpClient.GetAsync(url, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Telegram polling request failed.");
+            return;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("Telegram polling returned non-success status code {StatusCode}.", (int)response.StatusCode);
+            return;
+        }
+
+        await using var body = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var document = await JsonDocument.ParseAsync(body, cancellationToken: cancellationToken);
+        if (!document.RootElement.TryGetProperty("result", out var result) || result.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        long maxUpdateId = settings.TelegramLastProcessedUpdateId;
+        foreach (var item in result.EnumerateArray())
+        {
+            var updateId = item.GetProperty("update_id").GetInt64();
+            if (updateId > maxUpdateId)
+            {
+                maxUpdateId = updateId;
+            }
+
+            if (!item.TryGetProperty("message", out var message) || message.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            if (!message.TryGetProperty("chat", out var chat) || !chat.TryGetProperty("id", out var chatIdElement))
+            {
+                continue;
+            }
+
+            var chatId = chatIdElement.ToString();
+            var chatType = chat.TryGetProperty("type", out var chatTypeElement) ? chatTypeElement.GetString() ?? string.Empty : string.Empty;
+            var text = message.TryGetProperty("text", out var textElement) ? textElement.GetString() ?? string.Empty : string.Empty;
+            var from = message.TryGetProperty("from", out var fromElement) ? fromElement : default;
+            var username = from.ValueKind == JsonValueKind.Object && from.TryGetProperty("username", out var usernameElement) ? usernameElement.GetString() : null;
+            var displayName = from.ValueKind == JsonValueKind.Object && from.TryGetProperty("first_name", out var firstNameElement) ? firstNameElement.GetString() : null;
+
+            var processingResult = await _telegramMessageProcessor.ProcessAsync(new TelegramInboundMessage
+            {
+                UpdateId = updateId,
+                ChatId = chatId,
+                ChatType = chatType,
+                Text = text,
+                Username = username,
+                DisplayName = displayName
+            }, cancellationToken);
+
+            if (processingResult.Handled)
+            {
+                _logger.LogInformation("Telegram inbound message processed. Success={Success} Detail={Detail}", processingResult.Success, processingResult.Message);
+            }
+        }
+
+        if (maxUpdateId > settings.TelegramLastProcessedUpdateId)
+        {
+            var current = await _notificationSettingsService.GetCurrentAsync(cancellationToken);
+            await _notificationSettingsService.UpdateAsync(new UpdateNotificationSettingsCommand
+            {
+                BrowserNotificationsEnabled = current.BrowserNotificationsEnabled,
+                BrowserNotifyEndpointDown = current.BrowserNotifyEndpointDown,
+                BrowserNotifyEndpointRecovered = current.BrowserNotifyEndpointRecovered,
+                BrowserNotifyAgentOffline = current.BrowserNotifyAgentOffline,
+                BrowserNotifyAgentOnline = current.BrowserNotifyAgentOnline,
+                BrowserNotificationsPermissionState = current.BrowserNotificationsPermissionState,
+                TelegramEnabled = current.TelegramEnabled,
+                TelegramInboundMode = current.TelegramInboundMode,
+                TelegramPollIntervalSeconds = current.TelegramPollIntervalSeconds,
+                TelegramLastProcessedUpdateId = maxUpdateId,
+                QuietHoursEnabled = current.QuietHoursEnabled,
+                QuietHoursStartLocalTime = current.QuietHoursStartLocalTime,
+                QuietHoursEndLocalTime = current.QuietHoursEndLocalTime,
+                QuietHoursTimeZoneId = current.QuietHoursTimeZoneId,
+                QuietHoursSuppressBrowserNotifications = current.QuietHoursSuppressBrowserNotifications,
+                QuietHoursSuppressSmtpNotifications = current.QuietHoursSuppressSmtpNotifications,
+                SmtpNotificationsEnabled = current.SmtpNotificationsEnabled,
+                SmtpHost = current.SmtpHost,
+                SmtpPort = current.SmtpPort,
+                SmtpUseTls = current.SmtpUseTls,
+                SmtpUsername = current.SmtpUsername,
+                SmtpFromAddress = current.SmtpFromAddress,
+                SmtpFromDisplayName = current.SmtpFromDisplayName,
+                SmtpRecipientAddresses = current.SmtpRecipientAddresses,
+                SmtpNotifyEndpointDown = current.SmtpNotifyEndpointDown,
+                SmtpNotifyEndpointRecovered = current.SmtpNotifyEndpointRecovered,
+                SmtpNotifyAgentOffline = current.SmtpNotifyAgentOffline,
+                SmtpNotifyAgentOnline = current.SmtpNotifyAgentOnline,
+                UpdatedByUserId = current.UpdatedByUserId
+            }, cancellationToken);
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/TelegramChannelSettingsDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/TelegramChannelSettingsDto.cs
@@ -1,0 +1,12 @@
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services;
+
+public sealed class TelegramChannelSettingsDto
+{
+    public bool TelegramEnabled { get; set; }
+    public string? TelegramBotToken { get; set; }
+    public TelegramInboundMode TelegramInboundMode { get; set; } = TelegramInboundMode.Polling;
+    public int TelegramPollIntervalSeconds { get; set; } = 10;
+    public long TelegramLastProcessedUpdateId { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/UpdateNotificationSettingsCommand.cs
+++ b/src/WebApp/PingMonitor.Web/Services/UpdateNotificationSettingsCommand.cs
@@ -1,3 +1,5 @@
+using PingMonitor.Web.Models;
+
 namespace PingMonitor.Web.Services;
 
 public sealed class UpdateNotificationSettingsCommand
@@ -9,6 +11,15 @@ public sealed class UpdateNotificationSettingsCommand
     public bool BrowserNotifyAgentOnline { get; set; }
 
     public string? BrowserNotificationsPermissionState { get; set; }
+
+    public bool TelegramEnabled { get; set; }
+    public string? TelegramBotToken { get; set; }
+    public bool TelegramClearBotToken { get; set; }
+    public TelegramInboundMode TelegramInboundMode { get; set; } = TelegramInboundMode.Polling;
+    public int TelegramPollIntervalSeconds { get; set; } = 10;
+    public long TelegramLastProcessedUpdateId { get; set; } = -1;
+    public string? TelegramWebhookUrl { get; set; }
+    public string? TelegramWebhookSecretToken { get; set; }
 
     public bool QuietHoursEnabled { get; set; }
     public string QuietHoursStartLocalTime { get; set; } = "22:00";

--- a/src/WebApp/PingMonitor.Web/Services/UpdateUserNotificationSettingsCommand.cs
+++ b/src/WebApp/PingMonitor.Web/Services/UpdateUserNotificationSettingsCommand.cs
@@ -14,10 +14,16 @@ public sealed class UpdateUserNotificationSettingsCommand
     public bool SmtpNotifyEndpointRecovered { get; set; }
     public bool SmtpNotifyAgentOffline { get; set; }
     public bool SmtpNotifyAgentOnline { get; set; }
+    public bool TelegramNotificationsEnabled { get; set; }
+    public bool TelegramNotifyEndpointDown { get; set; }
+    public bool TelegramNotifyEndpointRecovered { get; set; }
+    public bool TelegramNotifyAgentOffline { get; set; }
+    public bool TelegramNotifyAgentOnline { get; set; }
     public bool QuietHoursEnabled { get; set; }
     public string QuietHoursStartLocalTime { get; set; } = "22:00";
     public string QuietHoursEndLocalTime { get; set; } = "07:00";
     public string QuietHoursTimeZoneId { get; set; } = "UTC";
     public bool QuietHoursSuppressBrowserNotifications { get; set; }
     public bool QuietHoursSuppressSmtpNotifications { get; set; }
+    public bool QuietHoursSuppressTelegramNotifications { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/UserNotificationSettingsDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/UserNotificationSettingsDto.cs
@@ -14,11 +14,17 @@ public sealed class UserNotificationSettingsDto
     public bool SmtpNotifyEndpointRecovered { get; set; }
     public bool SmtpNotifyAgentOffline { get; set; }
     public bool SmtpNotifyAgentOnline { get; set; }
+    public bool TelegramNotificationsEnabled { get; set; }
+    public bool TelegramNotifyEndpointDown { get; set; }
+    public bool TelegramNotifyEndpointRecovered { get; set; }
+    public bool TelegramNotifyAgentOffline { get; set; }
+    public bool TelegramNotifyAgentOnline { get; set; }
     public bool QuietHoursEnabled { get; set; }
     public string QuietHoursStartLocalTime { get; set; } = "22:00";
     public string QuietHoursEndLocalTime { get; set; } = "07:00";
     public string QuietHoursTimeZoneId { get; set; } = "UTC";
     public bool QuietHoursSuppressBrowserNotifications { get; set; } = true;
     public bool QuietHoursSuppressSmtpNotifications { get; set; } = true;
+    public bool QuietHoursSuppressTelegramNotifications { get; set; } = true;
     public DateTimeOffset UpdatedAtUtc { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/UserNotificationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/UserNotificationSettingsService.cs
@@ -33,12 +33,18 @@ internal sealed class UserNotificationSettingsService : IUserNotificationSetting
         row.SmtpNotifyEndpointRecovered = command.SmtpNotifyEndpointRecovered;
         row.SmtpNotifyAgentOffline = command.SmtpNotifyAgentOffline;
         row.SmtpNotifyAgentOnline = command.SmtpNotifyAgentOnline;
+        row.TelegramNotificationsEnabled = command.TelegramNotificationsEnabled;
+        row.TelegramNotifyEndpointDown = command.TelegramNotifyEndpointDown;
+        row.TelegramNotifyEndpointRecovered = command.TelegramNotifyEndpointRecovered;
+        row.TelegramNotifyAgentOffline = command.TelegramNotifyAgentOffline;
+        row.TelegramNotifyAgentOnline = command.TelegramNotifyAgentOnline;
         row.QuietHoursEnabled = command.QuietHoursEnabled;
         row.QuietHoursStartLocalTime = NormalizeQuietHoursTime(command.QuietHoursStartLocalTime, "22:00");
         row.QuietHoursEndLocalTime = NormalizeQuietHoursTime(command.QuietHoursEndLocalTime, "07:00");
         row.QuietHoursTimeZoneId = NormalizeTimeZoneId(command.QuietHoursTimeZoneId);
         row.QuietHoursSuppressBrowserNotifications = command.QuietHoursSuppressBrowserNotifications;
         row.QuietHoursSuppressSmtpNotifications = command.QuietHoursSuppressSmtpNotifications;
+        row.QuietHoursSuppressTelegramNotifications = command.QuietHoursSuppressTelegramNotifications;
         row.UpdatedAtUtc = DateTimeOffset.UtcNow;
 
         await _dbContext.SaveChangesAsync(cancellationToken);
@@ -71,12 +77,18 @@ internal sealed class UserNotificationSettingsService : IUserNotificationSetting
             SmtpNotifyEndpointRecovered = global?.SmtpNotifyEndpointRecovered ?? true,
             SmtpNotifyAgentOffline = global?.SmtpNotifyAgentOffline ?? true,
             SmtpNotifyAgentOnline = global?.SmtpNotifyAgentOnline ?? true,
+            TelegramNotificationsEnabled = global?.TelegramEnabled ?? false,
+            TelegramNotifyEndpointDown = true,
+            TelegramNotifyEndpointRecovered = true,
+            TelegramNotifyAgentOffline = true,
+            TelegramNotifyAgentOnline = true,
             QuietHoursEnabled = global?.QuietHoursEnabled ?? false,
             QuietHoursStartLocalTime = NormalizeQuietHoursTime(global?.QuietHoursStartLocalTime, "22:00"),
             QuietHoursEndLocalTime = NormalizeQuietHoursTime(global?.QuietHoursEndLocalTime, "07:00"),
             QuietHoursTimeZoneId = NormalizeTimeZoneId(global?.QuietHoursTimeZoneId),
             QuietHoursSuppressBrowserNotifications = global?.QuietHoursSuppressBrowserNotifications ?? true,
             QuietHoursSuppressSmtpNotifications = global?.QuietHoursSuppressSmtpNotifications ?? true,
+            QuietHoursSuppressTelegramNotifications = true,
             UpdatedAtUtc = DateTimeOffset.UtcNow
         };
 
@@ -99,12 +111,18 @@ internal sealed class UserNotificationSettingsService : IUserNotificationSetting
         SmtpNotifyEndpointRecovered = row.SmtpNotifyEndpointRecovered,
         SmtpNotifyAgentOffline = row.SmtpNotifyAgentOffline,
         SmtpNotifyAgentOnline = row.SmtpNotifyAgentOnline,
+        TelegramNotificationsEnabled = row.TelegramNotificationsEnabled,
+        TelegramNotifyEndpointDown = row.TelegramNotifyEndpointDown,
+        TelegramNotifyEndpointRecovered = row.TelegramNotifyEndpointRecovered,
+        TelegramNotifyAgentOffline = row.TelegramNotifyAgentOffline,
+        TelegramNotifyAgentOnline = row.TelegramNotifyAgentOnline,
         QuietHoursEnabled = row.QuietHoursEnabled,
         QuietHoursStartLocalTime = NormalizeQuietHoursTime(row.QuietHoursStartLocalTime, "22:00"),
         QuietHoursEndLocalTime = NormalizeQuietHoursTime(row.QuietHoursEndLocalTime, "07:00"),
         QuietHoursTimeZoneId = NormalizeTimeZoneId(row.QuietHoursTimeZoneId),
         QuietHoursSuppressBrowserNotifications = row.QuietHoursSuppressBrowserNotifications,
         QuietHoursSuppressSmtpNotifications = row.QuietHoursSuppressSmtpNotifications,
+        QuietHoursSuppressTelegramNotifications = row.QuietHoursSuppressTelegramNotifications,
         UpdatedAtUtc = row.UpdatedAtUtc
     };
 

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/NotificationSettingsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/NotificationSettingsPageViewModel.cs
@@ -4,6 +4,24 @@ namespace PingMonitor.Web.ViewModels.Admin;
 
 public sealed class NotificationSettingsPageViewModel
 {
+    [Display(Name = "Enable Telegram infrastructure")]
+    public bool TelegramEnabled { get; set; }
+
+    [Display(Name = "Telegram bot token")]
+    public string? TelegramBotToken { get; set; }
+
+    [Display(Name = "Clear stored Telegram bot token")]
+    public bool TelegramClearBotToken { get; set; }
+
+    [Display(Name = "Telegram bot token configured")]
+    public bool TelegramBotTokenConfigured { get; set; }
+
+    [Display(Name = "Telegram inbound mode")]
+    public string TelegramInboundMode { get; set; } = "Polling";
+
+    [Display(Name = "Telegram poll interval (seconds)")]
+    public int TelegramPollIntervalSeconds { get; set; } = 10;
+
     [Display(Name = "Enable SMTP delivery infrastructure")]
     public bool SmtpNotificationsEnabled { get; set; }
 

--- a/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
@@ -28,14 +28,29 @@ public sealed class ProfilePageViewModel
     public bool SmtpNotifyEndpointRecovered { get; set; }
     public bool SmtpNotifyAgentOffline { get; set; }
     public bool SmtpNotifyAgentOnline { get; set; }
+    public bool TelegramNotificationsEnabled { get; set; }
+    public bool TelegramNotifyEndpointDown { get; set; }
+    public bool TelegramNotifyEndpointRecovered { get; set; }
+    public bool TelegramNotifyAgentOffline { get; set; }
+    public bool TelegramNotifyAgentOnline { get; set; }
     public bool QuietHoursEnabled { get; set; }
     public string QuietHoursStartLocalTime { get; set; } = "22:00";
     public string QuietHoursEndLocalTime { get; set; } = "07:00";
     public string QuietHoursTimeZoneId { get; set; } = "UTC";
     public bool QuietHoursSuppressBrowserNotifications { get; set; }
     public bool QuietHoursSuppressSmtpNotifications { get; set; }
+    public bool QuietHoursSuppressTelegramNotifications { get; set; }
     public DateTimeOffset NotificationSettingsUpdatedAtUtc { get; set; }
     public bool AccountSaved { get; set; }
     public bool PasswordSaved { get; set; }
     public bool NotificationsSaved { get; set; }
+
+    public string? ActiveTelegramCode { get; set; }
+    public DateTimeOffset? ActiveTelegramCodeExpiresAtUtc { get; set; }
+    public bool TelegramLinked { get; set; }
+    public string? TelegramLinkedChatId { get; set; }
+    public string? TelegramLinkedUsername { get; set; }
+    public string? TelegramLinkedDisplayName { get; set; }
+    public DateTimeOffset? TelegramLinkedAtUtc { get; set; }
+    public bool TelegramCodeGenerated { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
@@ -22,7 +22,7 @@
     <div class="stack">
         <section class="card">
             <h1>Notification infrastructure</h1>
-            <p class="muted">This page controls SMTP transport infrastructure only. Per-user notification preferences moved to each user's <a href="/profile">profile page</a>.</p>
+            <p class="muted">This page controls notification transport infrastructure (SMTP + Telegram polling settings). Per-user notification preferences moved to each user's <a href="/profile">profile page</a>.</p>
             <div class="button-row">
                 <a class="button-secondary" href="/admin">Back to admin settings</a>
                 <a class="button-secondary" href="/status">Back to status</a>
@@ -31,8 +31,23 @@
 
         <form method="post" action="/settings/notifications" class="stack">
             @Html.AntiForgeryToken()
-            @if (Model.Saved) { <div class="saved" role="status">SMTP infrastructure settings saved.</div> }
+            @if (Model.Saved) { <div class="saved" role="status">Notification infrastructure settings saved.</div> }
             @if (!ViewData.ModelState.IsValid) { <div class="errors" asp-validation-summary="ModelOnly"></div> }
+
+
+            <section class="card stack">
+                <h2>Telegram transport settings</h2>
+                <div class="switch-row"><input asp-for="TelegramEnabled" type="checkbox" /><label asp-for="TelegramEnabled"></label></div>
+                <div><label asp-for="TelegramInboundMode"></label><input asp-for="TelegramInboundMode" type="text" /></div>
+                <div><label asp-for="TelegramPollIntervalSeconds"></label><input asp-for="TelegramPollIntervalSeconds" type="number" min="1" max="120" /></div>
+                <div>
+                    <label asp-for="TelegramBotToken"></label>
+                    <input asp-for="TelegramBotToken" type="password" autocomplete="new-password" />
+                    @if (Model.TelegramBotTokenConfigured) { <p class="muted">A Telegram bot token is already stored. Leave blank to keep it unchanged.</p> }
+                </div>
+                <div class="switch-row"><input asp-for="TelegramClearBotToken" type="checkbox" /><label asp-for="TelegramClearBotToken"></label></div>
+                <p class="muted">Polling is the supported inbound mode in phase 1. Webhook fields are reserved for future use.</p>
+            </section>
 
             <section class="card stack">
                 <h2>SMTP transport settings</h2>
@@ -68,7 +83,7 @@
             <section class="card">
                 <p class="muted">Last updated: @Model.UpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</p>
                 @if (!string.IsNullOrWhiteSpace(Model.UpdatedByUserId)) { <p class="muted">Last updated by: @Model.UpdatedByUserId</p> }
-                <div class="button-row"><button class="button" type="submit">Save SMTP infrastructure settings</button></div>
+                <div class="button-row"><button class="button" type="submit">Save notification infrastructure settings</button></div>
             </section>
         </form>
     </div>

--- a/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
@@ -67,6 +67,15 @@
         <div class="switch-row"><input asp-for="SmtpNotifyAgentOffline" type="checkbox" /><label asp-for="SmtpNotifyAgentOffline">Agent offline</label></div>
         <div class="switch-row"><input asp-for="SmtpNotifyAgentOnline" type="checkbox" /><label asp-for="SmtpNotifyAgentOnline">Agent online</label></div>
 
+
+
+        <h3>Telegram</h3>
+        <div class="switch-row"><input asp-for="TelegramNotificationsEnabled" type="checkbox" /><label asp-for="TelegramNotificationsEnabled">Enable Telegram notifications</label></div>
+        <div class="switch-row"><input asp-for="TelegramNotifyEndpointDown" type="checkbox" /><label asp-for="TelegramNotifyEndpointDown">Endpoint down</label></div>
+        <div class="switch-row"><input asp-for="TelegramNotifyEndpointRecovered" type="checkbox" /><label asp-for="TelegramNotifyEndpointRecovered">Endpoint recovered</label></div>
+        <div class="switch-row"><input asp-for="TelegramNotifyAgentOffline" type="checkbox" /><label asp-for="TelegramNotifyAgentOffline">Agent offline</label></div>
+        <div class="switch-row"><input asp-for="TelegramNotifyAgentOnline" type="checkbox" /><label asp-for="TelegramNotifyAgentOnline">Agent online</label></div>
+
         <h3>Quiet hours</h3>
         <div class="switch-row"><input asp-for="QuietHoursEnabled" type="checkbox" /><label asp-for="QuietHoursEnabled">Enable quiet hours</label></div>
         <div><label asp-for="QuietHoursStartLocalTime">Start</label><input asp-for="QuietHoursStartLocalTime" type="time" /><div class="field-error"><span asp-validation-for="QuietHoursStartLocalTime"></span></div></div>
@@ -74,10 +83,31 @@
         <div><label asp-for="QuietHoursTimeZoneId">Time zone ID</label><input asp-for="QuietHoursTimeZoneId" type="text" /><div class="field-error"><span asp-validation-for="QuietHoursTimeZoneId"></span></div></div>
         <div class="switch-row"><input asp-for="QuietHoursSuppressBrowserNotifications" type="checkbox" /><label asp-for="QuietHoursSuppressBrowserNotifications">Suppress browser during quiet hours</label></div>
         <div class="switch-row"><input asp-for="QuietHoursSuppressSmtpNotifications" type="checkbox" /><label asp-for="QuietHoursSuppressSmtpNotifications">Suppress SMTP during quiet hours</label></div>
+        <div class="switch-row"><input asp-for="QuietHoursSuppressTelegramNotifications" type="checkbox" /><label asp-for="QuietHoursSuppressTelegramNotifications">Suppress Telegram during quiet hours</label></div>
         <p class="muted">Settings last updated at @Model.NotificationSettingsUpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'").</p>
         <div class="button-row"><button class="button" type="submit">Save notification preferences</button></div>
     </form>
 </section>
+
+<section class="card stack">
+    <h2>Telegram account linking</h2>
+    <p class="muted">Generate a verification code, send it to the bot in a private chat, and wait for confirmation.</p>
+    @if (Model.TelegramCodeGenerated) { <div class="saved">A new Telegram link code was generated.</div> }
+    @if (!string.IsNullOrWhiteSpace(Model.ActiveTelegramCode))
+    {
+        <p><strong>Active code:</strong> @Model.ActiveTelegramCode (expires @Model.ActiveTelegramCodeExpiresAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'"))</p>
+    }
+    @if (Model.TelegramLinked)
+    {
+        <p><strong>Linked chat:</strong> @Model.TelegramLinkedChatId</p>
+        @if (!string.IsNullOrWhiteSpace(Model.TelegramLinkedUsername)) { <p><strong>Username:</strong> @Model.TelegramLinkedUsername</p> }
+    }
+    <form method="post" action="/profile/telegram/generate-code" class="stack">
+        @Html.AntiForgeryToken()
+        <div class="button-row"><button class="button-secondary" type="submit">Generate link code</button></div>
+    </form>
+</section>
+
 </div>
 </main>
 <script>


### PR DESCRIPTION
### Motivation
- Enable phase‑1 Telegram notifications as a per‑user channel following the repository's Telegram spec (private-chat linking, polling inbound, verified-only delivery). 
- Keep inbound transport decoupled from processing to allow future webhook support without changing linking logic. 
- Respect existing per-user quiet-hours and per-event toggles and reuse the event-log meaningful-event delivery model to avoid raw-result spam. 

### Description
- Added data models and schema support for Telegram: `PendingTelegramLink`, `PendingTelegramLinkStatus`, `TelegramAccount`, and `TelegramInboundMode`, plus DB mappings and startup schema changes to create/alter Notification/UserNotification tables and create PendingTelegramLinks/TelegramAccounts. 
- Implemented secure admin-level Telegram channel settings with protected token storage, inbound-mode toggles, poll interval, and last-processed update id, and preserved secret handling so tokens are not logged or echoed in UI. 
- Implemented linking and processing services: `ITelegramLinkService`/`TelegramLinkService` (8‑digit one‑time codes, expiry, private‑chat only consumption, single account per user), transport‑decoupled `ITelegramMessageProcessor`/`TelegramMessageProcessor`, polling `ITelegramPollingService`/`TelegramPollingService` with a hosted `TelegramPollingBackgroundService`, and `ITelegramNotificationSender`/`TelegramNotificationSender` for outbound sends. 
- Added profile UI and admin UI pieces: per‑user Telegram toggles and event toggles, one‑click generate‑code flow and linking status display, and admin notification settings for Telegram (token input is password field and not echoed). 
- Wired Telegram delivery into the event log pipeline so meaningful events (endpoint down, endpoint recovered, agent offline, agent online) are eligible for Telegram delivery only to verified linked accounts and subject to per-user toggles and quiet‑hours suppression. 

### Testing
- Created tracking issue via GitHub API (`#209`) to follow the change before implementation and recorded successful creation (automated HTTP request succeeded). 
- Built the web app with the project SDK after installing .NET 10 (`dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`), and the build completed successfully. 
- Installed the .NET SDK via the official install script in the environment as part of the verification steps and the SDK install completed successfully. 
- Environment package install for PowerShell failed in this environment (non-blocking), noted as unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca9cd9f124832a893ec6bd46f41c97)