### PR TITLE
Fix startup gate remediation for missing Telegram user notification columns

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -1210,6 +1210,56 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             await connection.OpenAsync(cancellationToken);
         }
 
+        if (!await HasUserNotificationSettingsColumnAsync(connection, "TelegramNotificationsEnabled", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `UserNotificationSettings`
+                ADD COLUMN `TelegramNotificationsEnabled` tinyint(1) NOT NULL DEFAULT 0;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasUserNotificationSettingsColumnAsync(connection, "TelegramNotifyEndpointDown", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `UserNotificationSettings`
+                ADD COLUMN `TelegramNotifyEndpointDown` tinyint(1) NOT NULL DEFAULT 1;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasUserNotificationSettingsColumnAsync(connection, "TelegramNotifyEndpointRecovered", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `UserNotificationSettings`
+                ADD COLUMN `TelegramNotifyEndpointRecovered` tinyint(1) NOT NULL DEFAULT 1;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasUserNotificationSettingsColumnAsync(connection, "TelegramNotifyAgentOffline", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `UserNotificationSettings`
+                ADD COLUMN `TelegramNotifyAgentOffline` tinyint(1) NOT NULL DEFAULT 1;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasUserNotificationSettingsColumnAsync(connection, "TelegramNotifyAgentOnline", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `UserNotificationSettings`
+                ADD COLUMN `TelegramNotifyAgentOnline` tinyint(1) NOT NULL DEFAULT 1;
+                """,
+                cancellationToken);
+        }
+
         if (!await HasUserNotificationSettingsColumnAsync(connection, "QuietHoursSuppressTelegramNotifications", cancellationToken))
         {
             await dbContext.Database.ExecuteSqlRawAsync(


### PR DESCRIPTION
### Motivation
- Startup gate reported `UserNotificationSettings` was missing Telegram-related columns (`TelegramNotificationsEnabled`, `TelegramNotifyEndpointDown`, `TelegramNotifyEndpointRecovered`, `TelegramNotifyAgentOffline`, `TelegramNotifyAgentOnline`) but the schema apply path did not create those columns so the gate remained blocked.
- Existing deployments with the older `UserNotificationSettings` schema could not recover automatically and needed an explicit remediation path to match the compatibility checks.

### Description
- Extend `EnsureUserNotificationSettingsColumnsAsync` in `StartupSchemaService` to add explicit MySQL-safe `ALTER TABLE ... ADD COLUMN` statements for the five missing Telegram per-user notification columns with defaults matching table creation semantics.
- Preserve the existing `QuietHoursSuppressTelegramNotifications` remediation and place the new column adds adjacent to it so the startup-gate remediation path is complete.
- Changes are localized to `src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs` and use explicit DDL to avoid provider-translation issues.
- This change aligns `GetStatusAsync` expectations with `ApplySchemaAsync` so `ApplySchemaAsync` can resolve the incompatibility reported by the startup gate (Fixes #213).

### Testing
- Performed a smoke build with `dotnet --version` (reported `10.0.104`) and `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, and the project built successfully.
- No unit tests targeted the startup-gate migration path in the repository, so a deterministic reproduction checklist was added to the issue/PR to validate the migration before and after apply.
- Attempted to install `powershell` in the environment for additional checks but the package was not available in the current apt sources (installation failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caa7d106e4832aba911eca80aa6bb8)