### PR TITLE
Fix profile notification settings save failing with required Email validation

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
@@ -41,6 +41,7 @@
     @if (Model.PasswordSaved) { <div class="saved">Password changed.</div> }
     <form method="post" action="/profile/password" class="stack">
         @Html.AntiForgeryToken()
+        <input type="hidden" asp-for="Email" />
         <div><label asp-for="CurrentPassword"></label><input asp-for="CurrentPassword" type="password" autocomplete="current-password" /><div class="field-error"><span asp-validation-for="CurrentPassword"></span></div></div>
         <div><label asp-for="NewPassword"></label><input asp-for="NewPassword" type="password" autocomplete="new-password" /><div class="field-error"><span asp-validation-for="NewPassword"></span></div></div>
         <div><label asp-for="ConfirmNewPassword"></label><input asp-for="ConfirmNewPassword" type="password" autocomplete="new-password" /><div class="field-error"><span asp-validation-for="ConfirmNewPassword"></span></div></div>
@@ -52,6 +53,7 @@
     @if (Model.NotificationsSaved) { <div class="saved">Notification preferences saved.</div> }
     <form method="post" action="/profile/notifications" class="stack">
         @Html.AntiForgeryToken()
+        <input type="hidden" asp-for="Email" />
         <input type="hidden" asp-for="BrowserNotificationsPermissionState" id="browserPermissionStateInput" />
         <h3>Browser</h3>
         <div class="switch-row"><input asp-for="BrowserNotificationsEnabled" type="checkbox" /><label asp-for="BrowserNotificationsEnabled">Enable browser notifications</label></div>


### PR DESCRIPTION
### Motivation
- The shared `ProfilePageViewModel` marks `Email` as `[Required]` while the non-account forms did not post the email field, causing model validation to fail with "The Email field is required" when saving notification preferences or submitting the password form. 
- This prevented users from saving per-user notification preferences and could block other profile actions that reuse the same view model.

### Description
- Added a hidden `Email` input (`<input type="hidden" asp-for="Email" />`) to the `/profile/password` form in `src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml` so password posts include the email value. 
- Added a hidden `Email` input to the `/profile/notifications` form in `src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml` so notification preference posts include the email value. 
- Created and linked an issue to track the regression and fix (`Fixes #215`) and preserved the existing account form semantics while ensuring shared-model validation passes for non-account posts.

### Testing
- Automated build: ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which completed successfully with the built assembly produced and no errors. 
- Regression proof recorded: a deterministic reproduction and verification are documented in the linked issue (#215) showing the validation error occurs before the change and that saving notification preferences and password-related posts succeed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cab04a3c20832a93f3b2c425097bea)