### PR TITLE
Add Telegram unlink button to My Profile page

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
@@ -197,6 +197,23 @@ public sealed class ProfileController : Controller
     }
 
 
+
+    [HttpPost("telegram/remove")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RemoveTelegramAccount(CancellationToken cancellationToken)
+    {
+        var user = await RequireUserAsync();
+        if (user is null)
+        {
+            return Challenge();
+        }
+
+        await _telegramLinkService.UnlinkAccountAsync(user.Id, cancellationToken);
+        var refreshed = await BuildModelAsync(cancellationToken);
+        refreshed.TelegramAccountRemoved = true;
+        return View("Index", refreshed);
+    }
+
     [HttpPost("telegram/generate-code")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> GenerateTelegramCode(CancellationToken cancellationToken)

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/ITelegramLinkService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/ITelegramLinkService.cs
@@ -6,4 +6,5 @@ public interface ITelegramLinkService
     Task<PendingTelegramLinkDto?> GetActiveCodeAsync(string userId, CancellationToken cancellationToken);
     Task<TelegramLinkConsumeResult> ConsumeCodeAsync(string code, string chatId, string chatType, string? username, string? displayName, CancellationToken cancellationToken);
     Task<TelegramAccountStatusDto?> GetAccountStatusAsync(string userId, CancellationToken cancellationToken);
+    Task<bool> UnlinkAccountAsync(string userId, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramLinkService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramLinkService.cs
@@ -123,6 +123,26 @@ internal sealed class TelegramLinkService : ITelegramLinkService
         return new TelegramLinkConsumeResult { Success = true, Message = "Telegram account linked." };
     }
 
+
+    public async Task<bool> UnlinkAccountAsync(string userId, CancellationToken cancellationToken)
+    {
+        var normalizedUserId = userId.Trim();
+        var account = await _dbContext.TelegramAccounts
+            .SingleOrDefaultAsync(x => x.UserId == normalizedUserId && x.IsActive, cancellationToken);
+
+        if (account is null)
+        {
+            return false;
+        }
+
+        account.IsActive = false;
+        account.Verified = false;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("Telegram account unlinked for user {UserId}.", normalizedUserId);
+
+        return true;
+    }
     public async Task<TelegramAccountStatusDto?> GetAccountStatusAsync(string userId, CancellationToken cancellationToken)
     {
         var row = await _dbContext.TelegramAccounts.AsNoTracking()

--- a/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
@@ -53,4 +53,5 @@ public sealed class ProfilePageViewModel
     public string? TelegramLinkedDisplayName { get; set; }
     public DateTimeOffset? TelegramLinkedAtUtc { get; set; }
     public bool TelegramCodeGenerated { get; set; }
+    public bool TelegramAccountRemoved { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
@@ -95,6 +95,7 @@
     <h2>Telegram account linking</h2>
     <p class="muted">Generate a verification code, send it to the bot in a private chat, and wait for confirmation.</p>
     @if (Model.TelegramCodeGenerated) { <div class="saved">A new Telegram link code was generated.</div> }
+    @if (Model.TelegramAccountRemoved) { <div class="saved">Telegram account removed.</div> }
     @if (!string.IsNullOrWhiteSpace(Model.ActiveTelegramCode))
     {
         <p><strong>Active code:</strong> @Model.ActiveTelegramCode (expires @Model.ActiveTelegramCodeExpiresAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'"))</p>
@@ -104,10 +105,19 @@
         <p><strong>Linked chat:</strong> @Model.TelegramLinkedChatId</p>
         @if (!string.IsNullOrWhiteSpace(Model.TelegramLinkedUsername)) { <p><strong>Username:</strong> @Model.TelegramLinkedUsername</p> }
     }
-    <form method="post" action="/profile/telegram/generate-code" class="stack">
-        @Html.AntiForgeryToken()
-        <div class="button-row"><button class="button-secondary" type="submit">Generate link code</button></div>
-    </form>
+    <div class="button-row">
+        <form method="post" action="/profile/telegram/generate-code" class="stack">
+            @Html.AntiForgeryToken()
+            <button class="button-secondary" type="submit">Generate link code</button>
+        </form>
+        @if (Model.TelegramLinked)
+        {
+            <form method="post" action="/profile/telegram/remove" class="stack">
+                @Html.AntiForgeryToken()
+                <button class="button-secondary" type="submit">Remove linked Telegram account</button>
+            </form>
+        }
+    </div>
 </section>
 
 </div>


### PR DESCRIPTION
### Motivation
- Users could link a Telegram account from My Profile but had no in-page action to remove/unlink it, preventing simple self-service account management.
- Provide an explicit, authenticated unlink action and visible confirmation so users can safely manage notification targets from the profile UI.
- Ensure traceability by creating an issue for the change (`#217`).

### Description
- Added an authenticated POST endpoint `POST /profile/telegram/remove` that unlinks the current user's active Telegram account and returns the profile view with a success flag. (Controller: `ProfileController`)
- Extended the Telegram link service interface with `UnlinkAccountAsync` and implemented it to mark the active `TelegramAccount` record as inactive and unverified. (Files: `ITelegramLinkService.cs`, `TelegramLinkService.cs`)
- Added `TelegramAccountRemoved` to the profile view model and updated the My Profile Razor view to show a success message and render a new "Remove linked Telegram account" button when an account is linked. (Files: `ProfilePageViewModel.cs`, `Views/Profile/Index.cshtml`)
- Kept the existing "Generate link code" action and UI layout; the new remove button is shown alongside it when `Model.TelegramLinked` is true.

### Testing
- Ran `bash /tmp/dotnet-install.sh --version 10.0.104 --install-dir $HOME/.dotnet` to install .NET 10 SDK and confirmed installation succeeded. (Succeeded)
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -v minimal` to validate compilation of the updated code; the build succeeded. (Succeeded)
- Attempted to build a top-level solution with `dotnet build PingMonitor.sln -v minimal` but this repository does not contain `PingMonitor.sln`, so that specific command failed; project-level build was used for validation instead. (Top-level solution build failed due to missing .sln, not code errors)
- No automated unit tests were present or executed for this change in the environment; compilation verification was used as the automated validation step.

Fixes #217

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cab57162f4832a9741d516de1ed67d)