### PR TITLE
Fix Telegram notifications being skipped after successful SMTP delivery

### DIFF
--- a/docs/notifications-setup.md
+++ b/docs/notifications-setup.md
@@ -26,7 +26,6 @@ It is intended for operators and admins running the .NET 10 web app against MySQ
 - **Browser notifications** are phase-1 polling notifications while the app is open in the browser (no background service-worker push when browser/app is closed).
 - **Telegram inbound mode** is effectively polling in phase 1. Webhook-related fields exist in data model/spec, but there is no webhook inbound controller/handler path documented in runtime code yet.
 - **Telegram poll interval setting is saved**, but current polling worker loop runs every 10 seconds.
-- **Current event-dispatch limitation:** event pipeline currently returns early after a successful SMTP send, so Telegram event delivery may be skipped when SMTP succeeds for that same event.
 - **Notification source events** are an explicit subset of event-log events:
   - endpoint down
   - endpoint recovered

--- a/src/WebApp/PingMonitor.Web/Services/EventLogs/EventLogService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/EventLogs/EventLogService.cs
@@ -45,12 +45,7 @@ internal sealed class EventLogService : IEventLogService
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         var smtpResult = await _smtpNotificationSender.SendForEventAsync(eventLog, cancellationToken);
-        if (smtpResult.Success)
-        {
-            return;
-        }
-
-        if (!smtpResult.Skipped)
+        if (!smtpResult.Success && !smtpResult.Skipped)
         {
             _logger.LogWarning(
                 "SMTP notification was not delivered for event {EventType}: {Message}",


### PR DESCRIPTION
### Motivation
- An early return in `EventLogService.WriteAsync` caused Telegram delivery to be skipped when `ISmtpNotificationSender.SendForEventAsync` succeeded, preventing users from receiving Telegram alerts even when SMTP worked.

### Description
- Remove the early return so `EventLogService` always proceeds to attempt Telegram dispatch after SMTP, update `docs/notifications-setup.md` to remove the outdated limitation note, and link the change to issue `#221`.

### Testing
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -v minimal` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cacd072798832a8726b23b5e782335)