### PR TITLE
Add Telegram verification bot replies for link outcomes

### DIFF
--- a/docs/telegram-integration.md
+++ b/docs/telegram-integration.md
@@ -68,6 +68,21 @@ Components: - Telegram Bot API (outbound) - Inbound updates
 6.  Chat ID linked to user
 7.  Bot confirms success
 
+### Bot reply behaviour (phase 1)
+
+When an operator sends a verification attempt to the bot, the bot must
+reply with a single, explicit outcome message.
+
+Reply outcomes:
+
+-   verification successful/link complete
+-   code expired
+-   code invalid/not recognised
+-   code already used
+-   unsupported chat type (non-private chat)
+
+Non-code or unrelated inbound messages may be ignored without reply.
+
 ------------------------------------------------------------------------
 
 ## Verification Rules

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramLinkConsumeResult.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramLinkConsumeResult.cs
@@ -2,6 +2,7 @@ namespace PingMonitor.Web.Services.Telegram;
 
 public sealed class TelegramLinkConsumeResult
 {
+    public TelegramLinkConsumeStatus Status { get; init; }
     public bool Success { get; init; }
     public string Message { get; init; } = string.Empty;
 }

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramLinkConsumeStatus.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramLinkConsumeStatus.cs
@@ -1,0 +1,10 @@
+namespace PingMonitor.Web.Services.Telegram;
+
+public enum TelegramLinkConsumeStatus
+{
+    Success = 0,
+    InvalidCode = 1,
+    ExpiredCode = 2,
+    AlreadyUsedCode = 3,
+    UnsupportedChatType = 4
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramLinkService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramLinkService.cs
@@ -69,7 +69,12 @@ internal sealed class TelegramLinkService : ITelegramLinkService
     {
         if (!string.Equals(chatType, "private", StringComparison.OrdinalIgnoreCase))
         {
-            return new TelegramLinkConsumeResult { Success = false, Message = "Linking is only supported from a private chat." };
+            return new TelegramLinkConsumeResult
+            {
+                Status = TelegramLinkConsumeStatus.UnsupportedChatType,
+                Success = false,
+                Message = "Linking is only supported from a private chat."
+            };
         }
 
         var trimmedCode = code.Trim();
@@ -77,13 +82,38 @@ internal sealed class TelegramLinkService : ITelegramLinkService
 
         await using var tx = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
         var pending = await _dbContext.PendingTelegramLinks
-            .Where(x => x.Code == trimmedCode && x.Status == PendingTelegramLinkStatus.Pending)
+            .Where(x => x.Code == trimmedCode)
             .OrderByDescending(x => x.CreatedAtUtc)
             .FirstOrDefaultAsync(cancellationToken);
 
         if (pending is null)
         {
-            return new TelegramLinkConsumeResult { Success = false, Message = "Code was not found." };
+            return new TelegramLinkConsumeResult
+            {
+                Status = TelegramLinkConsumeStatus.InvalidCode,
+                Success = false,
+                Message = "Code was not found."
+            };
+        }
+
+        if (pending.Status == PendingTelegramLinkStatus.Verified || pending.Status == PendingTelegramLinkStatus.Consumed)
+        {
+            return new TelegramLinkConsumeResult
+            {
+                Status = TelegramLinkConsumeStatus.AlreadyUsedCode,
+                Success = false,
+                Message = "Code was already used."
+            };
+        }
+
+        if (pending.Status == PendingTelegramLinkStatus.Expired)
+        {
+            return new TelegramLinkConsumeResult
+            {
+                Status = TelegramLinkConsumeStatus.ExpiredCode,
+                Success = false,
+                Message = "Code is expired."
+            };
         }
 
         if (pending.ExpiresAtUtc <= now)
@@ -91,7 +121,12 @@ internal sealed class TelegramLinkService : ITelegramLinkService
             pending.Status = PendingTelegramLinkStatus.Expired;
             await _dbContext.SaveChangesAsync(cancellationToken);
             await tx.CommitAsync(cancellationToken);
-            return new TelegramLinkConsumeResult { Success = false, Message = "Code is expired." };
+            return new TelegramLinkConsumeResult
+            {
+                Status = TelegramLinkConsumeStatus.ExpiredCode,
+                Success = false,
+                Message = "Code is expired."
+            };
         }
 
         pending.Status = PendingTelegramLinkStatus.Verified;
@@ -120,7 +155,12 @@ internal sealed class TelegramLinkService : ITelegramLinkService
         await tx.CommitAsync(cancellationToken);
 
         _logger.LogInformation("Telegram account linked for user {UserId}.", pending.UserId);
-        return new TelegramLinkConsumeResult { Success = true, Message = "Telegram account linked." };
+        return new TelegramLinkConsumeResult
+        {
+            Status = TelegramLinkConsumeStatus.Success,
+            Success = true,
+            Message = "Telegram account linked."
+        };
     }
 
 

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessingResult.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessingResult.cs
@@ -2,7 +2,10 @@ namespace PingMonitor.Web.Services.Telegram;
 
 public sealed class TelegramMessageProcessingResult
 {
+    public TelegramMessageProcessingStatus Status { get; init; } = TelegramMessageProcessingStatus.Ignored;
     public bool Handled { get; init; }
     public bool Success { get; init; }
     public string Message { get; init; } = string.Empty;
+    public bool ShouldReply { get; init; }
+    public string? ReplyText { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessingStatus.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessingStatus.cs
@@ -1,0 +1,11 @@
+namespace PingMonitor.Web.Services.Telegram;
+
+public enum TelegramMessageProcessingStatus
+{
+    Ignored = 0,
+    VerificationSucceeded = 1,
+    InvalidCode = 2,
+    ExpiredCode = 3,
+    AlreadyUsedCode = 4,
+    UnsupportedChatType = 5
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessor.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessor.cs
@@ -15,13 +15,27 @@ internal sealed partial class TelegramMessageProcessor : ITelegramMessageProcess
     {
         if (string.IsNullOrWhiteSpace(inboundMessage.Text))
         {
-            return new TelegramMessageProcessingResult { Handled = false, Success = true, Message = "No text content." };
+            return new TelegramMessageProcessingResult
+            {
+                Status = TelegramMessageProcessingStatus.Ignored,
+                Handled = false,
+                Success = true,
+                Message = "No text content.",
+                ShouldReply = false
+            };
         }
 
         var match = CodeRegex().Match(inboundMessage.Text.Trim());
         if (!match.Success)
         {
-            return new TelegramMessageProcessingResult { Handled = false, Success = true, Message = "Unsupported message content." };
+            return new TelegramMessageProcessingResult
+            {
+                Status = TelegramMessageProcessingStatus.Ignored,
+                Handled = false,
+                Success = true,
+                Message = "Unsupported message content.",
+                ShouldReply = false
+            };
         }
 
         var result = await _telegramLinkService.ConsumeCodeAsync(
@@ -32,8 +46,38 @@ internal sealed partial class TelegramMessageProcessor : ITelegramMessageProcess
             inboundMessage.DisplayName,
             cancellationToken);
 
-        return new TelegramMessageProcessingResult { Handled = true, Success = result.Success, Message = result.Message };
+        return new TelegramMessageProcessingResult
+        {
+            Status = MapStatus(result.Status),
+            Handled = true,
+            Success = result.Success,
+            Message = result.Message,
+            ShouldReply = true,
+            ReplyText = GetReplyText(result.Status)
+        };
     }
+
+    private static TelegramMessageProcessingStatus MapStatus(TelegramLinkConsumeStatus status)
+        => status switch
+        {
+            TelegramLinkConsumeStatus.Success => TelegramMessageProcessingStatus.VerificationSucceeded,
+            TelegramLinkConsumeStatus.InvalidCode => TelegramMessageProcessingStatus.InvalidCode,
+            TelegramLinkConsumeStatus.ExpiredCode => TelegramMessageProcessingStatus.ExpiredCode,
+            TelegramLinkConsumeStatus.AlreadyUsedCode => TelegramMessageProcessingStatus.AlreadyUsedCode,
+            TelegramLinkConsumeStatus.UnsupportedChatType => TelegramMessageProcessingStatus.UnsupportedChatType,
+            _ => TelegramMessageProcessingStatus.Ignored
+        };
+
+    private static string GetReplyText(TelegramLinkConsumeStatus status)
+        => status switch
+        {
+            TelegramLinkConsumeStatus.Success => "✅ Verification successful. Your Telegram account is now linked to Ping Monitor.",
+            TelegramLinkConsumeStatus.ExpiredCode => "⚠️ This verification code has expired. Please generate a new code in Ping Monitor and try again.",
+            TelegramLinkConsumeStatus.InvalidCode => "⚠️ Verification code not recognised. Please check the code and try again.",
+            TelegramLinkConsumeStatus.AlreadyUsedCode => "⚠️ This verification code has already been used. Please generate a new code in Ping Monitor if needed.",
+            TelegramLinkConsumeStatus.UnsupportedChatType => "⚠️ Verification must be completed in a private chat with this bot.",
+            _ => string.Empty
+        };
 
     [GeneratedRegex("^(\\d{8})$")]
     private static partial Regex CodeRegex();

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramPollingService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramPollingService.cs
@@ -93,7 +93,16 @@ internal sealed class TelegramPollingService : ITelegramPollingService
 
             if (processingResult.Handled)
             {
-                _logger.LogInformation("Telegram inbound message processed. Success={Success} Detail={Detail}", processingResult.Success, processingResult.Message);
+                _logger.LogInformation(
+                    "Telegram inbound message processed. Success={Success} Status={Status} Detail={Detail}",
+                    processingResult.Success,
+                    processingResult.Status,
+                    processingResult.Message);
+            }
+
+            if (processingResult.ShouldReply && !string.IsNullOrWhiteSpace(processingResult.ReplyText))
+            {
+                await SendReplyAsync(settings.TelegramBotToken, chatId, processingResult.ReplyText, cancellationToken);
             }
         }
 
@@ -132,6 +141,30 @@ internal sealed class TelegramPollingService : ITelegramPollingService
                 SmtpNotifyAgentOnline = current.SmtpNotifyAgentOnline,
                 UpdatedByUserId = current.UpdatedByUserId
             }, cancellationToken);
+        }
+    }
+
+    private async Task SendReplyAsync(string botToken, string chatId, string text, CancellationToken cancellationToken)
+    {
+        var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["chat_id"] = chatId,
+            ["text"] = text
+        });
+
+        var url = $"https://api.telegram.org/bot{botToken}/sendMessage";
+
+        try
+        {
+            var response = await _httpClient.PostAsync(url, content, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Telegram verification reply failed for chat {ChatId} with status {StatusCode}.", chatId, (int)response.StatusCode);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Telegram verification reply request failed for chat {ChatId}.", chatId);
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Provide immediate, operator-friendly bot replies during the Telegram account-link verification flow so users receive clear feedback in-chat for success and failure outcomes. 
- Keep inbound transport decoupled from message processing and preserve phase‑1 private-chat only semantics. 
- Make verification outcomes explicit in service/output models to avoid duplicate replies and to support deterministic handling. 

### Description

- Documented phase‑1 bot reply behaviour in `docs/telegram-integration.md` describing the five reply outcomes and that non-code messages may be ignored. 
- Added `TelegramLinkConsumeStatus` and `TelegramMessageProcessingStatus` enums and extended `TelegramLinkConsumeResult` and `TelegramMessageProcessingResult` to carry explicit `Status`, `ShouldReply`, and `ReplyText` so the processor determines outcome and the transport sends replies. 
- Updated `TelegramLinkService.ConsumeCodeAsync` to return specific statuses for `Success`, `InvalidCode`, `ExpiredCode`, `AlreadyUsedCode`, and `UnsupportedChatType`, and to evaluate stored pending link status (including already-used and expired flags) before consuming. 
- Updated `TelegramMessageProcessor` to map consume statuses to processor statuses and to provide the exact operator-facing reply text (success, expired, invalid, already-used, unsupported chat type). 
- Updated `TelegramPollingService` to send a single reply when `ShouldReply` is true via a new `SendReplyAsync` helper while only invoking the processor once per inbound update, preserving transport/processing separation. 
- No webhook mode changes or notification template system were introduced. 
- Fixes #223.

### Testing

- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which succeeded with a successful build. 
- Verified `dotnet --version` reported the installed SDK as required by the project (`10.0.104`) during the build step. 
- No unit tests were added in this change; behavior was validated by automated build success and code-path review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cad1374ecc832a9ef027725478a992)