### PR TITLE
Fix Telegram polling duplicate update processing and reply spam

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/INotificationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/INotificationSettingsService.cs
@@ -6,5 +6,7 @@ public interface INotificationSettingsService
     Task<SmtpChannelSettingsDto> GetSmtpChannelAsync(CancellationToken cancellationToken);
     Task<TelegramChannelSettingsDto> GetTelegramChannelAsync(CancellationToken cancellationToken);
 
+    Task AdvanceTelegramLastProcessedUpdateIdAsync(long updateId, CancellationToken cancellationToken);
+
     Task<NotificationSettingsDto> UpdateAsync(UpdateNotificationSettingsCommand command, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/Services/NotificationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NotificationSettingsService.cs
@@ -52,6 +52,26 @@ internal sealed class NotificationSettingsService : INotificationSettingsService
         };
     }
 
+    public async Task AdvanceTelegramLastProcessedUpdateIdAsync(long updateId, CancellationToken cancellationToken)
+    {
+        if (updateId < 0)
+        {
+            return;
+        }
+
+        var settings = await GetOrCreateEntityAsync(cancellationToken);
+        if (updateId <= settings.TelegramLastProcessedUpdateId)
+        {
+            return;
+        }
+
+        settings.TelegramLastProcessedUpdateId = updateId;
+        settings.UpdatedAtUtc = DateTimeOffset.UtcNow;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        _logger.LogDebug("Telegram last processed update advanced to {UpdateId}.", updateId);
+    }
+
     public async Task<NotificationSettingsDto> UpdateAsync(UpdateNotificationSettingsCommand command, CancellationToken cancellationToken)
     {
         var settings = await GetOrCreateEntityAsync(cancellationToken);

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramPollingService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramPollingService.cs
@@ -28,7 +28,8 @@ internal sealed class TelegramPollingService : ITelegramPollingService
             return;
         }
 
-        var offset = settings.TelegramLastProcessedUpdateId + 1;
+        var lastProcessedUpdateId = settings.TelegramLastProcessedUpdateId;
+        var offset = lastProcessedUpdateId + 1;
         var url = $"https://api.telegram.org/bot{settings.TelegramBotToken}/getUpdates?timeout=25&offset={offset}";
 
         HttpResponseMessage response;
@@ -55,23 +56,57 @@ internal sealed class TelegramPollingService : ITelegramPollingService
             return;
         }
 
-        long maxUpdateId = settings.TelegramLastProcessedUpdateId;
-        foreach (var item in result.EnumerateArray())
+        var seenUpdateIds = new HashSet<long>();
+        var updates = result.EnumerateArray()
+            .OrderBy(item => item.TryGetProperty("update_id", out var updateIdElement) ? updateIdElement.GetInt64() : long.MaxValue)
+            .ToList();
+
+        foreach (var item in updates)
         {
-            var updateId = item.GetProperty("update_id").GetInt64();
-            if (updateId > maxUpdateId)
+            if (!item.TryGetProperty("update_id", out var updateIdElement))
             {
-                maxUpdateId = updateId;
+                _logger.LogWarning("Telegram update did not contain update_id and was skipped.");
+                continue;
             }
 
-            if (!item.TryGetProperty("message", out var message) || message.ValueKind != JsonValueKind.Object)
+            var updateId = updateIdElement.GetInt64();
+            if (updateId <= lastProcessedUpdateId)
             {
                 continue;
+            }
+
+            if (!seenUpdateIds.Add(updateId))
+            {
+                _logger.LogWarning("Duplicate Telegram update {UpdateId} encountered in same poll cycle and skipped.", updateId);
+                continue;
+            }
+
+            var handledSuccessfully = await ProcessUpdateAsync(settings.TelegramBotToken, updateId, item, cancellationToken);
+            if (!handledSuccessfully)
+            {
+                _logger.LogWarning("Telegram update {UpdateId} failed processing and will be retried in a future poll cycle.", updateId);
+                continue;
+            }
+
+            await _notificationSettingsService.AdvanceTelegramLastProcessedUpdateIdAsync(updateId, cancellationToken);
+            lastProcessedUpdateId = updateId;
+        }
+    }
+
+    private async Task<bool> ProcessUpdateAsync(string botToken, long updateId, JsonElement item, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (!item.TryGetProperty("message", out var message) || message.ValueKind != JsonValueKind.Object)
+            {
+                _logger.LogDebug("Telegram update {UpdateId} contained no message payload and was acknowledged.", updateId);
+                return true;
             }
 
             if (!message.TryGetProperty("chat", out var chat) || !chat.TryGetProperty("id", out var chatIdElement))
             {
-                continue;
+                _logger.LogWarning("Telegram update {UpdateId} had message payload without chat id and was acknowledged.", updateId);
+                return true;
             }
 
             var chatId = chatIdElement.ToString();
@@ -94,7 +129,8 @@ internal sealed class TelegramPollingService : ITelegramPollingService
             if (processingResult.Handled)
             {
                 _logger.LogInformation(
-                    "Telegram inbound message processed. Success={Success} Status={Status} Detail={Detail}",
+                    "Telegram inbound message processed. UpdateId={UpdateId} Success={Success} Status={Status} Detail={Detail}",
+                    updateId,
                     processingResult.Success,
                     processingResult.Status,
                     processingResult.Message);
@@ -102,49 +138,19 @@ internal sealed class TelegramPollingService : ITelegramPollingService
 
             if (processingResult.ShouldReply && !string.IsNullOrWhiteSpace(processingResult.ReplyText))
             {
-                await SendReplyAsync(settings.TelegramBotToken, chatId, processingResult.ReplyText, cancellationToken);
+                await SendReplyAsync(botToken, chatId, updateId, processingResult.ReplyText, cancellationToken);
             }
-        }
 
-        if (maxUpdateId > settings.TelegramLastProcessedUpdateId)
+            return true;
+        }
+        catch (Exception ex)
         {
-            var current = await _notificationSettingsService.GetCurrentAsync(cancellationToken);
-            await _notificationSettingsService.UpdateAsync(new UpdateNotificationSettingsCommand
-            {
-                BrowserNotificationsEnabled = current.BrowserNotificationsEnabled,
-                BrowserNotifyEndpointDown = current.BrowserNotifyEndpointDown,
-                BrowserNotifyEndpointRecovered = current.BrowserNotifyEndpointRecovered,
-                BrowserNotifyAgentOffline = current.BrowserNotifyAgentOffline,
-                BrowserNotifyAgentOnline = current.BrowserNotifyAgentOnline,
-                BrowserNotificationsPermissionState = current.BrowserNotificationsPermissionState,
-                TelegramEnabled = current.TelegramEnabled,
-                TelegramInboundMode = current.TelegramInboundMode,
-                TelegramPollIntervalSeconds = current.TelegramPollIntervalSeconds,
-                TelegramLastProcessedUpdateId = maxUpdateId,
-                QuietHoursEnabled = current.QuietHoursEnabled,
-                QuietHoursStartLocalTime = current.QuietHoursStartLocalTime,
-                QuietHoursEndLocalTime = current.QuietHoursEndLocalTime,
-                QuietHoursTimeZoneId = current.QuietHoursTimeZoneId,
-                QuietHoursSuppressBrowserNotifications = current.QuietHoursSuppressBrowserNotifications,
-                QuietHoursSuppressSmtpNotifications = current.QuietHoursSuppressSmtpNotifications,
-                SmtpNotificationsEnabled = current.SmtpNotificationsEnabled,
-                SmtpHost = current.SmtpHost,
-                SmtpPort = current.SmtpPort,
-                SmtpUseTls = current.SmtpUseTls,
-                SmtpUsername = current.SmtpUsername,
-                SmtpFromAddress = current.SmtpFromAddress,
-                SmtpFromDisplayName = current.SmtpFromDisplayName,
-                SmtpRecipientAddresses = current.SmtpRecipientAddresses,
-                SmtpNotifyEndpointDown = current.SmtpNotifyEndpointDown,
-                SmtpNotifyEndpointRecovered = current.SmtpNotifyEndpointRecovered,
-                SmtpNotifyAgentOffline = current.SmtpNotifyAgentOffline,
-                SmtpNotifyAgentOnline = current.SmtpNotifyAgentOnline,
-                UpdatedByUserId = current.UpdatedByUserId
-            }, cancellationToken);
+            _logger.LogWarning(ex, "Telegram update {UpdateId} processing failed.", updateId);
+            return false;
         }
     }
 
-    private async Task SendReplyAsync(string botToken, string chatId, string text, CancellationToken cancellationToken)
+    private async Task SendReplyAsync(string botToken, string chatId, long updateId, string text, CancellationToken cancellationToken)
     {
         var content = new FormUrlEncodedContent(new Dictionary<string, string>
         {
@@ -159,12 +165,16 @@ internal sealed class TelegramPollingService : ITelegramPollingService
             var response = await _httpClient.PostAsync(url, content, cancellationToken);
             if (!response.IsSuccessStatusCode)
             {
-                _logger.LogWarning("Telegram verification reply failed for chat {ChatId} with status {StatusCode}.", chatId, (int)response.StatusCode);
+                _logger.LogWarning(
+                    "Telegram verification reply failed for update {UpdateId} chat {ChatId} with status {StatusCode}.",
+                    updateId,
+                    chatId,
+                    (int)response.StatusCode);
             }
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Telegram verification reply request failed for chat {ChatId}.", chatId);
+            _logger.LogWarning(ex, "Telegram verification reply request failed for update {UpdateId} chat {ChatId}.", updateId, chatId);
         }
     }
 }


### PR DESCRIPTION
### Motivation

- The poller previously advanced `TelegramLastProcessedUpdateId` only once after processing the entire batch, so if a cycle failed mid-batch previously-handled updates could be re-fetched and cause duplicate bot replies (for example repeated “already used” verification messages). 
- The intent is to ensure each inbound Telegram update is processed at most once and that at most one reply is sent per inbound update. 
- The change adds a minimal, deterministic acknowledgement flow that persists per-update progress and guards against same-poll and cross-poll duplicate processing. 

### Description

- Persist per-update progress by adding `AdvanceTelegramLastProcessedUpdateIdAsync` to `INotificationSettingsService` and implementing it in `NotificationSettingsService` so `TelegramLastProcessedUpdateId` can be advanced immediately after each successfully-handled update. 
- Reworked `TelegramPollingService.PollOnceAsync` to: fetch the last processed id, sort updates by `update_id`, skip updates `<= lastProcessedUpdateId`, apply an in-cycle deduplication `HashSet<long>`, and call a new per-update `ProcessUpdateAsync` helper to isolate handling. 
- Make processing idempotent and safer by wrapping each update handling in its own `try/catch`, logging with `UpdateId`, and only sending a reply when that single processing pass returns `ShouldReply` (reply send now uses `SendReplyAsync(botToken, chatId, updateId, text)`). 
- Remove the previous batch-only settings rewrite for offset persistence and replace it with focused per-update acknowledgement to avoid reprocessing when a later exception occurs. 
- Links and traceability: this change addresses issue #225 and includes a regression checklist in the PR metadata. 

### Testing

- Ran `dotnet --version` which reported the SDK `10.0.104`. 
- Verified PowerShell is available with `pwsh -v`. 
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the build succeeded with zero errors. 
- No automated unit tests were present/modified; a deterministic reproduction checklist is included in the PR to validate at runtime that one inbound Telegram update yields at most one reply and that `TelegramLastProcessedUpdateId` advances per update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cae2c599f8832a8f2bae96d73debc1)