### PR TITLE
Persisted 24h assignment rollups and status-page integration (Fixes #229)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -409,6 +409,37 @@ Represents a historical state change.
 
 ---
 
+
+### AssignmentMetrics24h
+
+Represents persisted assignment-scoped 24-hour summary metrics used by status-page read paths.
+
+#### Purpose
+
+- avoid repeated raw-history scans on status-page load
+- provide lightweight, deterministic 24h assignment summaries
+- keep raw history as source of truth while using an explicit read model
+
+#### Key fields
+
+- `assignmentId` (PK)
+- `windowStartUtc`
+- `windowEndUtc`
+- `uptimeSeconds`
+- `downtimeSeconds`
+- `unknownSeconds`
+- `suppressedSeconds`
+- `lastRttMs` (nullable)
+- `lastSuccessfulCheckUtc` (nullable)
+- `updatedAtUtc`
+
+#### Constraints
+
+- recomputable from raw facts (`CheckResult`, `StateTransition`, `EndpointState`)
+- not a replacement for audit/history tables
+
+---
+
 ### EventLog
 
 Represents a meaningful endpoint/agent operational event.
@@ -523,6 +554,7 @@ Represents an alert lifecycle.
 - MonitorAssignment 1 → many CheckResults  
 - MonitorAssignment 1 → 1 EndpointState  
 - MonitorAssignment 1 → many StateTransitions  
+- MonitorAssignment 1 → 1 AssignmentMetrics24h  
 - MonitorAssignment 1 → many EventLogs  
 - MonitorAssignment 1 → many AlertEvents  
 
@@ -636,7 +668,7 @@ These read-side metrics are derived from existing facts and are intended for ope
 
 ### Endpoint uptime (v1)
 
-- computed from assignment-scoped state history (`EndpointState` + `StateTransition`)
+- persisted in `AssignmentMetrics24h` and recomputed from assignment-scoped state history (`EndpointState` + `StateTransition`)
 - numerator: time in `UP` or `DEGRADED`
 - denominator: full selected window (v1 fixed to last 24 hours)
 - `DOWN` and `SUPPRESSED` count as not-up
@@ -650,7 +682,7 @@ These read-side metrics are derived from existing facts and are intended for ope
 
 ### RTT summary (v1)
 
-- source: successful `CheckResult` rows only (`success = true` with non-null `roundTripMs`)
+- source of truth: successful `CheckResult` rows only (`success = true` with non-null `roundTripMs`)
 - fixed window: last 24 hours
 - summary values:
   - last RTT (most recent successful sample)

--- a/docs/performance-metrics-rollup.md
+++ b/docs/performance-metrics-rollup.md
@@ -1,0 +1,57 @@
+# Performance metrics rollup (24h assignment summary)
+
+## Why this exists
+
+The status page previously recomputed 24-hour metrics by scanning raw `CheckResults` and `StateTransitions` on each page load. That caused repeated high I/O and slow status-page responses as history volume grew.
+
+This document defines the persisted 24-hour rollup used by the status page.
+
+## Source of truth
+
+Raw history remains the source of truth:
+
+- `CheckResults` remains the immutable raw check record.
+- `StateTransitions` remains the auditable state-transition history.
+
+`AssignmentMetrics24h` is a persisted read model optimized for status-page summaries.
+
+## Rolling summary model
+
+Per assignment (`AssignmentId` PK), `AssignmentMetrics24h` stores:
+
+- `WindowStartUtc`
+- `WindowEndUtc`
+- `UptimeSeconds` (UP + DEGRADED)
+- `DowntimeSeconds` (DOWN)
+- `UnknownSeconds` (UNKNOWN)
+- `SuppressedSeconds` (SUPPRESSED)
+- `LastRttMs` (latest successful RTT in-window)
+- `LastSuccessfulCheckUtc`
+- `UpdatedAtUtc` (summary freshness)
+
+## Update strategy
+
+`AssignmentMetrics24hService` updates summaries in the authoritative server-side processing path:
+
+- after assignment state evaluation completes, the evaluated assignment summary is recomputed and persisted
+- dependency-triggered child reevaluation also recomputes child summaries (same evaluation flow)
+- duplicate or invalid result batches do not mutate summaries, because ingestion exits before evaluation in those cases
+
+Status-page reads use persisted rows from `AssignmentMetrics24h`, not 24-hour raw-history scans.
+
+If a row is missing, the status query path triggers a targeted rebuild for that assignment and then reads the persisted row.
+
+## Rebuild / backfill
+
+A deterministic rebuild path is provided:
+
+- targeted rebuild for one assignment
+- full rebuild for all assignments
+
+Rebuilds recompute from raw history (`CheckResults`, `StateTransitions`, `EndpointStates`) and overwrite persisted rollup rows.
+
+## First-implementation limitations
+
+- RTT rollup currently persists last successful RTT only (no persisted 24h avg/high/low/jitter in this phase).
+- Window is fixed to the last 24 hours.
+- Summary writes are recompute-per-affected-assignment (explicit and correct-first), not a global background aggregation pipeline.

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminMetricsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminMetricsController.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Services.Identity;
+using PingMonitor.Web.Services.Metrics;
+
+namespace PingMonitor.Web.Controllers;
+
+[ApiController]
+[Authorize(Roles = ApplicationRoles.Admin)]
+[Route("api/admin/metrics24h")]
+public sealed class AdminMetricsController : ControllerBase
+{
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly IAssignmentMetrics24hService _assignmentMetrics24hService;
+
+    public AdminMetricsController(PingMonitorDbContext dbContext, IAssignmentMetrics24hService assignmentMetrics24hService)
+    {
+        _dbContext = dbContext;
+        _assignmentMetrics24hService = assignmentMetrics24hService;
+    }
+
+    [HttpGet("summary")]
+    public async Task<IActionResult> GetSummary(CancellationToken cancellationToken)
+    {
+        var summary = new
+        {
+            rowCount = await _dbContext.AssignmentMetrics24h.AsNoTracking().CountAsync(cancellationToken),
+            lastUpdatedAtUtc = await _dbContext.AssignmentMetrics24h.AsNoTracking()
+                .OrderByDescending(x => x.UpdatedAtUtc)
+                .Select(x => (DateTimeOffset?)x.UpdatedAtUtc)
+                .FirstOrDefaultAsync(cancellationToken)
+        };
+
+        return Ok(summary);
+    }
+
+    [HttpPost("rebuild/{assignmentId}")]
+    public async Task<IActionResult> RebuildAssignment([FromRoute] string assignmentId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(assignmentId))
+        {
+            return BadRequest(new { message = "Assignment ID is required." });
+        }
+
+        await _assignmentMetrics24hService.RefreshAssignmentAsync(assignmentId.Trim(), cancellationToken);
+        return Ok(new { rebuilt = true, assignmentId = assignmentId.Trim() });
+    }
+
+    [HttpPost("rebuild-all")]
+    public async Task<IActionResult> RebuildAll(CancellationToken cancellationToken)
+    {
+        await _assignmentMetrics24hService.RebuildAllAsync(cancellationToken);
+        return Ok(new { rebuilt = true, scope = "all" });
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -29,6 +29,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
     public DbSet<ResultBatch> ResultBatches => Set<ResultBatch>();
     public DbSet<EndpointState> EndpointStates => Set<EndpointState>();
     public DbSet<StateTransition> StateTransitions => Set<StateTransition>();
+    public DbSet<AssignmentMetrics24h> AssignmentMetrics24h => Set<AssignmentMetrics24h>();
     public DbSet<EventLog> EventLogs => Set<EventLog>();
     public DbSet<SecurityAuthLog> SecurityAuthLogs => Set<SecurityAuthLog>();
     public DbSet<AppSchemaInfo> AppSchemaInfos => Set<AppSchemaInfo>();
@@ -171,6 +172,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         checkResult.Property(x => x.CheckedAtUtc).IsRequired();
         checkResult.Property(x => x.ReceivedAtUtc).IsRequired();
         checkResult.HasIndex(x => new { x.AgentId, x.BatchId });
+        checkResult.HasIndex(x => new { x.AssignmentId, x.CheckedAtUtc });
 
         var resultBatch = modelBuilder.Entity<ResultBatch>();
         resultBatch.ToTable("ResultBatches");
@@ -206,6 +208,22 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         stateTransition.Property(x => x.ReasonCode).HasMaxLength(64);
         stateTransition.Property(x => x.DependencyEndpointId).HasMaxLength(64);
         stateTransition.HasIndex(x => new { x.AssignmentId, x.TransitionAtUtc });
+
+
+        var assignmentMetrics24h = modelBuilder.Entity<AssignmentMetrics24h>();
+        assignmentMetrics24h.ToTable("AssignmentMetrics24h");
+        assignmentMetrics24h.HasKey(x => x.AssignmentId);
+        assignmentMetrics24h.Property(x => x.AssignmentId).HasMaxLength(64);
+        assignmentMetrics24h.Property(x => x.WindowStartUtc).IsRequired();
+        assignmentMetrics24h.Property(x => x.WindowEndUtc).IsRequired();
+        assignmentMetrics24h.Property(x => x.UptimeSeconds).IsRequired();
+        assignmentMetrics24h.Property(x => x.DowntimeSeconds).IsRequired();
+        assignmentMetrics24h.Property(x => x.UnknownSeconds).IsRequired();
+        assignmentMetrics24h.Property(x => x.SuppressedSeconds).IsRequired();
+        assignmentMetrics24h.Property(x => x.LastRttMs);
+        assignmentMetrics24h.Property(x => x.LastSuccessfulCheckUtc);
+        assignmentMetrics24h.Property(x => x.UpdatedAtUtc).IsRequired();
+        assignmentMetrics24h.HasIndex(x => x.AssignmentId).IsUnique();
 
         var eventLog = modelBuilder.Entity<EventLog>();
         eventLog.ToTable("EventLogs");

--- a/src/WebApp/PingMonitor.Web/Models/AssignmentMetrics24h.cs
+++ b/src/WebApp/PingMonitor.Web/Models/AssignmentMetrics24h.cs
@@ -1,0 +1,15 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class AssignmentMetrics24h
+{
+    public string AssignmentId { get; set; } = string.Empty;
+    public DateTimeOffset WindowStartUtc { get; set; }
+    public DateTimeOffset WindowEndUtc { get; set; }
+    public long UptimeSeconds { get; set; }
+    public long DowntimeSeconds { get; set; }
+    public long UnknownSeconds { get; set; }
+    public long SuppressedSeconds { get; set; }
+    public int? LastRttMs { get; set; }
+    public DateTimeOffset? LastSuccessfulCheckUtc { get; set; }
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -149,6 +149,7 @@ builder.Services.AddScoped<IEndpointManagementService, EndpointManagementService
 builder.Services.AddScoped<IEndpointPerformanceQueryService, EndpointPerformanceQueryService>();
 builder.Services.AddScoped<IGroupManagementService, GroupManagementService>();
 builder.Services.AddScoped<IAgentManagementQueryService, AgentManagementQueryService>();
+builder.Services.AddScoped<IAssignmentMetrics24hService, AssignmentMetrics24hService>();
 builder.Services.AddScoped<IEndpointMetricsService, EndpointMetricsService>();
 builder.Services.AddScoped<IAgentMetricsService, AgentMetricsService>();
 builder.Services.AddScoped<IUserAccessScopeService, UserAccessScopeService>();

--- a/src/WebApp/PingMonitor.Web/Services/Metrics/AssignmentMetrics24hService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/AssignmentMetrics24hService.cs
@@ -1,0 +1,269 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.Metrics;
+
+internal sealed class AssignmentMetrics24hService : IAssignmentMetrics24hService
+{
+    private static readonly TimeSpan Window = TimeSpan.FromHours(24);
+    private readonly PingMonitorDbContext _dbContext;
+
+    public AssignmentMetrics24hService(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyDictionary<string, AssignmentMetrics24hSummary>> GetSummariesAsync(
+        IReadOnlyCollection<string> assignmentIds,
+        CancellationToken cancellationToken)
+    {
+        var normalizedAssignmentIds = NormalizeAssignmentIds(assignmentIds);
+        if (normalizedAssignmentIds.Length == 0)
+        {
+            return new Dictionary<string, AssignmentMetrics24hSummary>(StringComparer.Ordinal);
+        }
+
+        var summaries = await _dbContext.AssignmentMetrics24h.AsNoTracking()
+            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId))
+            .ToDictionaryAsync(
+                x => x.AssignmentId,
+                x => new AssignmentMetrics24hSummary
+                {
+                    WindowStartUtc = x.WindowStartUtc,
+                    WindowEndUtc = x.WindowEndUtc,
+                    UptimeSeconds = x.UptimeSeconds,
+                    DowntimeSeconds = x.DowntimeSeconds,
+                    UnknownSeconds = x.UnknownSeconds,
+                    SuppressedSeconds = x.SuppressedSeconds,
+                    UptimePercent = ComputeUptimePercent(x.UptimeSeconds, x.WindowStartUtc, x.WindowEndUtc),
+                    LastRttMs = x.LastRttMs,
+                    LastSuccessfulCheckUtc = x.LastSuccessfulCheckUtc,
+                    UpdatedAtUtc = x.UpdatedAtUtc
+                },
+                cancellationToken);
+
+        return summaries;
+    }
+
+    public async Task RefreshAssignmentAsync(string assignmentId, CancellationToken cancellationToken)
+    {
+        await RefreshAssignmentsAsync([assignmentId], cancellationToken);
+    }
+
+    public async Task RefreshAssignmentsAsync(IReadOnlyCollection<string> assignmentIds, CancellationToken cancellationToken)
+    {
+        var normalizedAssignmentIds = NormalizeAssignmentIds(assignmentIds);
+        if (normalizedAssignmentIds.Length == 0)
+        {
+            return;
+        }
+
+        var nowUtc = DateTimeOffset.UtcNow;
+        var windowStartUtc = nowUtc - Window;
+
+        var existingRows = await _dbContext.AssignmentMetrics24h
+            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId))
+            .ToDictionaryAsync(x => x.AssignmentId, cancellationToken);
+
+        var endpointStates = await _dbContext.EndpointStates.AsNoTracking()
+            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId))
+            .ToDictionaryAsync(x => x.AssignmentId, cancellationToken);
+
+        var transitionsInWindow = await _dbContext.StateTransitions.AsNoTracking()
+            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId)
+                && x.TransitionAtUtc >= windowStartUtc
+                && x.TransitionAtUtc <= nowUtc)
+            .OrderBy(x => x.TransitionAtUtc)
+            .ToListAsync(cancellationToken);
+
+        var transitionsBeforeWindow = await _dbContext.StateTransitions.AsNoTracking()
+            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId)
+                && x.TransitionAtUtc < windowStartUtc)
+            .GroupBy(x => x.AssignmentId)
+            .Select(group => group.OrderByDescending(x => x.TransitionAtUtc).First())
+            .ToListAsync(cancellationToken);
+
+        var latestSuccessfulChecks = await _dbContext.CheckResults.AsNoTracking()
+            .Where(x => normalizedAssignmentIds.Contains(x.AssignmentId)
+                && x.Success
+                && x.RoundTripMs.HasValue
+                && x.CheckedAtUtc >= windowStartUtc
+                && x.CheckedAtUtc <= nowUtc)
+            .GroupBy(x => x.AssignmentId)
+            .Select(group => group
+                .OrderByDescending(x => x.CheckedAtUtc)
+                .ThenByDescending(x => x.ReceivedAtUtc)
+                .ThenByDescending(x => x.CheckResultId)
+                .Select(x => new { x.AssignmentId, x.RoundTripMs, x.CheckedAtUtc })
+                .First())
+            .ToListAsync(cancellationToken);
+
+        var transitionsInWindowByAssignment = transitionsInWindow
+            .GroupBy(x => x.AssignmentId, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => (IReadOnlyList<StateTransition>)group.OrderBy(x => x.TransitionAtUtc).ToArray(), StringComparer.Ordinal);
+
+        var transitionsBeforeWindowLookup = transitionsBeforeWindow
+            .ToDictionary(x => x.AssignmentId, x => x, StringComparer.Ordinal);
+
+        var latestSuccessfulCheckLookup = latestSuccessfulChecks
+            .ToDictionary(
+                x => x.AssignmentId,
+                x => new { LastRttMs = (int?)x.RoundTripMs, LastSuccessfulCheckUtc = (DateTimeOffset?)x.CheckedAtUtc },
+                StringComparer.Ordinal);
+
+        foreach (var assignmentId in normalizedAssignmentIds)
+        {
+            endpointStates.TryGetValue(assignmentId, out var endpointState);
+            transitionsInWindowByAssignment.TryGetValue(assignmentId, out var assignmentTransitions);
+            transitionsBeforeWindowLookup.TryGetValue(assignmentId, out var transitionBeforeWindow);
+            latestSuccessfulCheckLookup.TryGetValue(assignmentId, out var latestSuccessfulCheck);
+
+            var durations = CalculateStateDurations(
+                endpointState,
+                assignmentTransitions ?? [],
+                transitionBeforeWindow,
+                windowStartUtc,
+                nowUtc);
+
+            if (!existingRows.TryGetValue(assignmentId, out var row))
+            {
+                row = new AssignmentMetrics24h
+                {
+                    AssignmentId = assignmentId
+                };
+                _dbContext.AssignmentMetrics24h.Add(row);
+            }
+
+            row.WindowStartUtc = windowStartUtc;
+            row.WindowEndUtc = nowUtc;
+            row.UptimeSeconds = durations.UptimeSeconds;
+            row.DowntimeSeconds = durations.DowntimeSeconds;
+            row.UnknownSeconds = durations.UnknownSeconds;
+            row.SuppressedSeconds = durations.SuppressedSeconds;
+            row.LastRttMs = latestSuccessfulCheck?.LastRttMs;
+            row.LastSuccessfulCheckUtc = latestSuccessfulCheck?.LastSuccessfulCheckUtc;
+            row.UpdatedAtUtc = nowUtc;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task RebuildAllAsync(CancellationToken cancellationToken)
+    {
+        var assignmentIds = await _dbContext.MonitorAssignments.AsNoTracking()
+            .Select(x => x.AssignmentId)
+            .ToArrayAsync(cancellationToken);
+
+        await RefreshAssignmentsAsync(assignmentIds, cancellationToken);
+    }
+
+    private static AssignmentDurationSummary CalculateStateDurations(
+        EndpointState? endpointState,
+        IReadOnlyList<StateTransition> transitionsInWindow,
+        StateTransition? transitionBeforeWindow,
+        DateTimeOffset windowStartUtc,
+        DateTimeOffset windowEndUtc)
+    {
+        if (windowEndUtc <= windowStartUtc)
+        {
+            return AssignmentDurationSummary.Empty;
+        }
+
+        var durationsByState = new Dictionary<EndpointStateKind, TimeSpan>
+        {
+            [EndpointStateKind.Up] = TimeSpan.Zero,
+            [EndpointStateKind.Degraded] = TimeSpan.Zero,
+            [EndpointStateKind.Down] = TimeSpan.Zero,
+            [EndpointStateKind.Unknown] = TimeSpan.Zero,
+            [EndpointStateKind.Suppressed] = TimeSpan.Zero
+        };
+
+        var activeState = DetermineStateAtWindowStart(endpointState, transitionBeforeWindow, windowStartUtc);
+        var segmentStart = windowStartUtc;
+
+        foreach (var transition in transitionsInWindow)
+        {
+            if (transition.TransitionAtUtc < windowStartUtc || transition.TransitionAtUtc > windowEndUtc)
+            {
+                continue;
+            }
+
+            if (transition.TransitionAtUtc > segmentStart)
+            {
+                durationsByState[activeState] += transition.TransitionAtUtc - segmentStart;
+            }
+
+            segmentStart = transition.TransitionAtUtc;
+            activeState = transition.NewState;
+        }
+
+        if (windowEndUtc > segmentStart)
+        {
+            durationsByState[activeState] += windowEndUtc - segmentStart;
+        }
+
+        return new AssignmentDurationSummary(
+            UptimeSeconds: ToWholeSeconds(durationsByState[EndpointStateKind.Up] + durationsByState[EndpointStateKind.Degraded]),
+            DowntimeSeconds: ToWholeSeconds(durationsByState[EndpointStateKind.Down]),
+            UnknownSeconds: ToWholeSeconds(durationsByState[EndpointStateKind.Unknown]),
+            SuppressedSeconds: ToWholeSeconds(durationsByState[EndpointStateKind.Suppressed]));
+    }
+
+    private static EndpointStateKind DetermineStateAtWindowStart(
+        EndpointState? endpointState,
+        StateTransition? transitionBeforeWindow,
+        DateTimeOffset windowStartUtc)
+    {
+        if (endpointState is not null && endpointState.LastStateChangeUtc.HasValue && endpointState.LastStateChangeUtc.Value <= windowStartUtc)
+        {
+            return endpointState.CurrentState;
+        }
+
+        if (transitionBeforeWindow is not null)
+        {
+            return transitionBeforeWindow.NewState;
+        }
+
+        return EndpointStateKind.Unknown;
+    }
+
+    private static long ToWholeSeconds(TimeSpan duration)
+    {
+        if (duration <= TimeSpan.Zero)
+        {
+            return 0;
+        }
+
+        return (long)Math.Floor(duration.TotalSeconds);
+    }
+
+    private static double? ComputeUptimePercent(long uptimeSeconds, DateTimeOffset windowStartUtc, DateTimeOffset windowEndUtc)
+    {
+        var totalWindowSeconds = (long)Math.Floor((windowEndUtc - windowStartUtc).TotalSeconds);
+        if (totalWindowSeconds <= 0)
+        {
+            return null;
+        }
+
+        return uptimeSeconds * 100d / totalWindowSeconds;
+    }
+
+    private static string[] NormalizeAssignmentIds(IReadOnlyCollection<string> assignmentIds)
+    {
+        return assignmentIds
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private readonly record struct AssignmentDurationSummary(
+        long UptimeSeconds,
+        long DowntimeSeconds,
+        long UnknownSeconds,
+        long SuppressedSeconds)
+    {
+        public static AssignmentDurationSummary Empty => new(0, 0, 0, 0);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Metrics/IAssignmentMetrics24hService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/IAssignmentMetrics24hService.cs
@@ -1,0 +1,28 @@
+namespace PingMonitor.Web.Services.Metrics;
+
+public interface IAssignmentMetrics24hService
+{
+    Task<IReadOnlyDictionary<string, AssignmentMetrics24hSummary>> GetSummariesAsync(
+        IReadOnlyCollection<string> assignmentIds,
+        CancellationToken cancellationToken);
+
+    Task RefreshAssignmentAsync(string assignmentId, CancellationToken cancellationToken);
+
+    Task RefreshAssignmentsAsync(IReadOnlyCollection<string> assignmentIds, CancellationToken cancellationToken);
+
+    Task RebuildAllAsync(CancellationToken cancellationToken);
+}
+
+public sealed class AssignmentMetrics24hSummary
+{
+    public DateTimeOffset WindowStartUtc { get; init; }
+    public DateTimeOffset WindowEndUtc { get; init; }
+    public long UptimeSeconds { get; init; }
+    public long DowntimeSeconds { get; init; }
+    public long UnknownSeconds { get; init; }
+    public long SuppressedSeconds { get; init; }
+    public double? UptimePercent { get; init; }
+    public int? LastRttMs { get; init; }
+    public DateTimeOffset? LastSuccessfulCheckUtc { get; init; }
+    public DateTimeOffset UpdatedAtUtc { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -28,6 +28,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "ResultBatches",
         "EndpointStates",
         "StateTransitions",
+        "AssignmentMetrics24h",
         "EventLogs",
         "SecurityAuthLogs",
         "ApplicationSettings",
@@ -475,6 +476,23 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             );
             """;
 
+
+        const string createAssignmentMetrics24hSql = """
+            CREATE TABLE IF NOT EXISTS `AssignmentMetrics24h` (
+                `AssignmentId` varchar(64) NOT NULL,
+                `WindowStartUtc` datetime(6) NOT NULL,
+                `WindowEndUtc` datetime(6) NOT NULL,
+                `UptimeSeconds` bigint NOT NULL,
+                `DowntimeSeconds` bigint NOT NULL,
+                `UnknownSeconds` bigint NOT NULL,
+                `SuppressedSeconds` bigint NOT NULL,
+                `LastRttMs` int NULL,
+                `LastSuccessfulCheckUtc` datetime(6) NULL,
+                `UpdatedAtUtc` datetime(6) NOT NULL,
+                PRIMARY KEY (`AssignmentId`)
+            );
+            """;
+
         const string createEventLogsSql = """
             CREATE TABLE IF NOT EXISTS `EventLogs` (
                 `EventLogId` varchar(64) NOT NULL,
@@ -582,6 +600,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
 
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointStatesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createStateTransitionsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createAssignmentMetrics24hSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createEventLogsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createSecurityAuthLogsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createApplicationSettingsSql, cancellationToken);
@@ -603,7 +622,50 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await EnsureNotificationSettingsColumnsAsync(dbContext, cancellationToken);
         await EnsureUserNotificationSettingsColumnsAsync(dbContext, cancellationToken);
         await EnsureAgentColumnsAsync(dbContext, cancellationToken);
+        await EnsureMetricsIndexesAsync(dbContext, cancellationToken);
         await MigrateLegacyEndpointDependenciesAsync(dbContext, cancellationToken);
+    }
+
+    private static async Task EnsureMetricsIndexesAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
+    {
+        await EnsureIndexExistsAsync(
+            dbContext,
+            "CheckResults",
+            "IX_CheckResults_AssignmentId_CheckedAtUtc",
+            "CREATE INDEX `IX_CheckResults_AssignmentId_CheckedAtUtc` ON `CheckResults` (`AssignmentId`, `CheckedAtUtc`);",
+            cancellationToken);
+
+        await EnsureIndexExistsAsync(
+            dbContext,
+            "StateTransitions",
+            "IX_StateTransitions_AssignmentId_TransitionAtUtc",
+            "CREATE INDEX `IX_StateTransitions_AssignmentId_TransitionAtUtc` ON `StateTransitions` (`AssignmentId`, `TransitionAtUtc`);",
+            cancellationToken);
+    }
+
+    private static async Task EnsureIndexExistsAsync(
+        PingMonitorDbContext dbContext,
+        string tableName,
+        string indexName,
+        string createIndexSql,
+        CancellationToken cancellationToken)
+    {
+        var exists = await dbContext.Database.SqlQueryRaw<int>(
+            """
+            SELECT COUNT(1)
+            FROM information_schema.statistics
+            WHERE table_schema = DATABASE()
+              AND table_name = {0}
+              AND index_name = {1};
+            """,
+            tableName,
+            indexName)
+            .SingleAsync(cancellationToken) > 0;
+
+        if (!exists)
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(createIndexSql, cancellationToken);
+        }
     }
 
     private static async Task<string[]> GetMissingEndpointDependencyColumnsAsync(MySqlConnection connection, CancellationToken cancellationToken)

--- a/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Services.EventLogs;
+using PingMonitor.Web.Services.Metrics;
 using System.Text.Json;
 
 namespace PingMonitor.Web.Services;
@@ -11,15 +12,18 @@ internal sealed class StateEvaluationService : IStateEvaluationService
     private readonly PingMonitorDbContext _dbContext;
     private readonly ILogger<StateEvaluationService> _logger;
     private readonly IEventLogService _eventLogService;
+    private readonly IAssignmentMetrics24hService _assignmentMetrics24hService;
 
     public StateEvaluationService(
         PingMonitorDbContext dbContext,
         ILogger<StateEvaluationService> logger,
-        IEventLogService eventLogService)
+        IEventLogService eventLogService,
+        IAssignmentMetrics24hService assignmentMetrics24hService)
     {
         _dbContext = dbContext;
         _logger = logger;
         _eventLogService = eventLogService;
+        _assignmentMetrics24hService = assignmentMetrics24hService;
     }
 
     public async Task EvaluateAssignmentsAsync(IEnumerable<string> assignmentIds, CancellationToken cancellationToken)
@@ -192,6 +196,7 @@ internal sealed class StateEvaluationService : IStateEvaluationService
         }
 
         await _dbContext.SaveChangesAsync(cancellationToken);
+        await _assignmentMetrics24hService.RefreshAssignmentAsync(assignment.AssignmentId, cancellationToken);
 
         if (CrossedDownBoundary(previousState, nextState))
         {

--- a/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
@@ -12,15 +12,15 @@ namespace PingMonitor.Web.Services.Status;
 internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
 {
     private readonly PingMonitorDbContext _dbContext;
-    private readonly IEndpointMetricsService _endpointMetricsService;
+    private readonly IAssignmentMetrics24hService _assignmentMetrics24hService;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IUserAccessScopeService _userAccessScopeService;
     private readonly IEventLogQueryService _eventLogQueryService;
 
-    public EndpointStatusQueryService(PingMonitorDbContext dbContext, IEndpointMetricsService endpointMetricsService, IHttpContextAccessor httpContextAccessor, IUserAccessScopeService userAccessScopeService, IEventLogQueryService eventLogQueryService)
+    public EndpointStatusQueryService(PingMonitorDbContext dbContext, IAssignmentMetrics24hService assignmentMetrics24hService, IHttpContextAccessor httpContextAccessor, IUserAccessScopeService userAccessScopeService, IEventLogQueryService eventLogQueryService)
     {
         _dbContext = dbContext;
-        _endpointMetricsService = endpointMetricsService;
+        _assignmentMetrics24hService = assignmentMetrics24hService;
         _httpContextAccessor = httpContextAccessor;
         _userAccessScopeService = userAccessScopeService;
         _eventLogQueryService = eventLogQueryService;
@@ -181,9 +181,21 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
             };
         }).ToArray();
 
-        var endpointMetricsByAssignmentId = await _endpointMetricsService.GetEndpointMetricSummariesAsync(
-            projectedRows.Select(x => x.AssignmentId).ToArray(),
+        var projectedAssignmentIds = projectedRows.Select(x => x.AssignmentId).ToArray();
+        var endpointMetricsByAssignmentId = await _assignmentMetrics24hService.GetSummariesAsync(
+            projectedAssignmentIds,
             cancellationToken);
+
+        var missingSummaryAssignmentIds = projectedAssignmentIds
+            .Where(assignmentId => !endpointMetricsByAssignmentId.ContainsKey(assignmentId))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        if (missingSummaryAssignmentIds.Length > 0)
+        {
+            await _assignmentMetrics24hService.RefreshAssignmentsAsync(missingSummaryAssignmentIds, cancellationToken);
+            endpointMetricsByAssignmentId = await _assignmentMetrics24hService.GetSummariesAsync(projectedAssignmentIds, cancellationToken);
+        }
 
         var rowsWithMetrics = projectedRows.Select(row =>
         {
@@ -216,7 +228,7 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
                 GroupNames = row.GroupNames,
                 UptimePercent = metrics?.UptimePercent,
                 LastRttMs = metrics?.LastRttMs,
-                AverageRttMs = metrics?.AverageRttMs
+                AverageRttMs = null
             };
         }).ToArray();
 

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -398,7 +398,6 @@
                                         <div class="meta-item"><span>Consecutive successes</span><div>@row.ConsecutiveSuccessCount</div></div>
                                         <div class="meta-item"><span>Endpoint uptime (24h)</span><div>@FormatPercent(row.UptimePercent)</div></div>
                                         <div class="meta-item"><span>Last RTT (24h)</span><div>@FormatRtt(row.LastRttMs)</div></div>
-                                        <div class="meta-item"><span>Average RTT (24h)</span><div>@FormatRtt(row.AverageRttMs)</div></div>
                                         <div class="meta-item"><span>Groups</span><div>@(row.GroupNames.Count == 0 ? "None" : string.Join(", ", row.GroupNames))</div></div>
                                         <div class="meta-item"><span>Dependency parents</span><div>@FormatDependencies(row.ParentEndpointIds, row.ParentEndpointNames, "None")</div></div>
                                         <div class="meta-item"><span>Suppressed by</span><div>@FormatDependency(row.SuppressedByEndpointId, row.SuppressedByEndpointName, "Not suppressed")</div></div>

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 6,
+    "RequiredSchemaVersion": 7,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 6,
+    "RequiredSchemaVersion": 7,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
### Motivation

- The status page was re-scanning raw `CheckResults` and `StateTransitions` for every load, causing high disk I/O and slow responses at scale.  
- Replace on-demand 24h history scans with a deterministic, persisted rolling summary while keeping raw history as the source of truth.  

### Description

- Add a persisted read model `AssignmentMetrics24h` (per-assignment PK) storing `WindowStartUtc`, `WindowEndUtc`, `UptimeSeconds`, `DowntimeSeconds`, `UnknownSeconds`, `SuppressedSeconds`, `LastRttMs`, `LastSuccessfulCheckUtc`, and `UpdatedAtUtc`.  
- Implement `IAssignmentMetrics24hService` and `AssignmentMetrics24hService` to deterministically compute/refresh summaries from `EndpointStates`, `StateTransitions`, and `CheckResults`, exposing targeted refresh and full rebuild (`RefreshAssignmentAsync`, `RefreshAssignmentsAsync`, `RebuildAllAsync`).  
- Integrate refresh into the authoritative ingestion path by invoking `RefreshAssignmentAsync` from the state-evaluation pipeline after assignment save so affected assignments (including dependency-driven children) are updated during normal processing.  
- Modify the status-page query path to read precomputed summaries via `IAssignmentMetrics24hService` and perform a targeted rebuild on-miss instead of scanning 24h history per request.  
- Add minimal admin maintenance API endpoints (`api/admin/metrics24h`) for summary visibility and targeted/full rebuilds.  
- Update startup/schema support to create the `AssignmentMetrics24h` table and add index hygiene for hot paths (`AssignmentId+CheckedAtUtc`, `AssignmentId+TransitionAtUtc`), and bump required schema version to `7`.  
- Add `docs/performance-metrics-rollup.md` and update `docs/data-model.md` describing the model, update strategy, rebuild/backfill, and limitations (first-phase persists last RTT only and uses a fixed 24h window).  
- Fix wiring/DI by registering `IAssignmentMetrics24hService` and leaving raw-history tables unchanged (raw data remains source of truth).  

Fixes #229

### Testing

- Built the web project successfully with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` (build succeeded).  
- Verified environment/tooling (`dotnet --version` and `pwsh --version`) to validate runtime compatibility with .NET 10.  
- Verified status query path now requests summaries through the new service and triggers a targeted refresh when a summary row is missing (code-path exercised during local inspection and `dotnet build`).  

Notes: no additional unit tests were present for this change class in the repository; the primary automated validation performed here was a successful `dotnet build`. Manual/operational validation (deploy + run against a MySQL instance to validate schema apply, targeted rebuild, and runtime behaviour) is recommended before production rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1db7fbfc832a8dc43c85694a48db)