### PR TITLE
Fix startup-gate schema apply failure with MySQL caused by trailing semicolon

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -656,7 +656,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             FROM information_schema.statistics
             WHERE table_schema = DATABASE()
               AND table_name = {0}
-              AND index_name = {1};
+              AND index_name = {1}
             """,
             tableName,
             indexName)


### PR DESCRIPTION
### Motivation
- Prevent startup-gate schema apply from failing on MySQL when EF Core composes `SingleAsync` over a raw SQL query that ended with a semicolon and produced invalid SQL like `; ) AS `s` LIMIT 2`.

### Description
- Removed the trailing semicolon from the composable `SqlQueryRaw<int>` used in `StartupSchemaService.EnsureIndexExistsAsync` (`src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs`) so EF's wrapper queries remain valid for MySQL; Fixes #231.

### Testing
- Installed .NET 10 SDK (10.0.104) and ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc21e58218832aab26cd31bd9124f5)