### PR TITLE
Fix startup-gate schema apply failure in index existence query

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -652,7 +652,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
     {
         var exists = await dbContext.Database.SqlQueryRaw<int>(
             """
-            SELECT COUNT(1)
+            SELECT COUNT(1) AS Value
             FROM information_schema.statistics
             WHERE table_schema = DATABASE()
               AND table_name = {0}


### PR DESCRIPTION
### Motivation
- The startup-gate schema apply failed on MySQL with `Unknown column 's.Value' in 'field list'` because EF Core composes scalar SQL into a subquery that expects the column alias `Value`.

### Description
- Alias the scalar projection to `Value` in `StartupSchemaService.EnsureIndexExistsAsync` (changed `SELECT COUNT(1)` to `SELECT COUNT(1) AS Value`) so `Database.SqlQueryRaw<int>(...)` maps correctly; Fixes #233.

### Testing
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the build succeeded (0 errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc267145a8832a8d1add7fecc3a49a)