### PR TITLE
Add shared authenticated navigation bar

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,0 +1,46 @@
+# Navigation
+
+## Purpose
+
+The web UI uses a shared **top navigation bar** across authenticated operator pages so navigation is consistent and no longer depends on per-page ad-hoc link sets.
+
+## Main navigation links
+
+The primary navigation contains:
+
+- Dashboard (`/status`)
+- Events / Logs (`/status#recent-events`)
+- Security (`/admin/security`) — admin only
+- Notifications (`/settings/notifications`) — admin only
+- Backups (`/admin/backups`) — admin only
+- Settings (`/admin`) — admin only
+- Profile (`/profile`)
+
+The nav also includes:
+
+- Current signed-in username
+- Profile shortcut
+- Logout action
+
+## Pages that intentionally do not use the main navigation
+
+The main authenticated navigation is intentionally excluded from:
+
+- Startup gate (`/startup-gate`)
+- Login (`/account/login`)
+
+These pages are setup/authentication flows and should remain focused.
+
+## Layout approach
+
+A shared **top nav** partial (`Views/Shared/_MainNavigation.cshtml`) is rendered at the top of authenticated pages.
+
+Behaviour:
+
+- Active-state highlighting based on current path prefix
+- Role-based visibility for admin sections (existing auth roles)
+- Responsive behaviour:
+  - full horizontal links on wider viewports
+  - collapsible menu on narrower viewports
+
+This keeps navigation practical, explicit, and maintainable for day-to-day operations.

--- a/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
@@ -41,6 +41,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
@@ -55,6 +55,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnblockIp.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnblockIp.cshtml
@@ -8,6 +8,7 @@
     <title>Confirm unblock IP</title>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main style="max-width:700px;margin:1rem auto;padding:1rem;font-family:Arial,sans-serif;">
     <h1>Confirm active IP block removal</h1>
     <p>This action clears an active enforcement block immediately and is audited.</p>

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnlockUser.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnlockUser.cshtml
@@ -8,6 +8,7 @@
     <title>Confirm unlock user</title>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main style="max-width:700px;margin:1rem auto;padding:1rem;font-family:Arial,sans-serif;">
     <h1>Confirm manual user unlock</h1>
     <p>This action clears an active Identity lockout immediately and is audited.</p>

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
@@ -49,6 +49,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <section class="card">
         <h1>Security logs and settings</h1>

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Deploy.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Deploy.cshtml
@@ -35,6 +35,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <section class="card stack">
         <h1>Deploy new agent</h1>

--- a/src/WebApp/PingMonitor.Web/Views/Agents/History.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/History.cshtml
@@ -46,6 +46,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
@@ -57,6 +57,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Remove.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Remove.cshtml
@@ -24,6 +24,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <section class="card">
         <h1>Remove agent</h1>

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Edit.cshtml
@@ -32,6 +32,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/History.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/History.cshtml
@@ -46,6 +46,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
@@ -52,6 +52,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/New.cshtml
@@ -44,6 +44,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml
@@ -45,6 +45,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Remove.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Remove.cshtml
@@ -24,6 +24,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <section class="card">
         <h1>Remove endpoint</h1>

--- a/src/WebApp/PingMonitor.Web/Views/Groups/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/Edit.cshtml
@@ -23,6 +23,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <form method="post" asp-controller="Groups" asp-action="Edit" asp-route-id="@Model.GroupId" class="stack">
         @Html.AntiForgeryToken()

--- a/src/WebApp/PingMonitor.Web/Views/Groups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/Index.cshtml
@@ -22,6 +22,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Groups/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/New.cshtml
@@ -23,6 +23,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <form method="post" asp-controller="Groups" asp-action="New" class="stack">
         @Html.AntiForgeryToken()

--- a/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
@@ -18,6 +18,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
@@ -18,6 +18,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
 <div class="stack">
 <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_MainNavigation.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_MainNavigation.cshtml
@@ -1,0 +1,87 @@
+@{
+    var path = Context?.Request?.Path.Value ?? string.Empty;
+    var isAdmin = User.IsInRole("Admin");
+    var userName = User?.Identity?.Name ?? "User";
+
+    static bool IsActive(string requestPath, params string[] prefixes)
+    {
+        foreach (var prefix in prefixes)
+        {
+            if (requestPath.Equals(prefix, StringComparison.OrdinalIgnoreCase) ||
+                requestPath.StartsWith(prefix + "/", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    var navItems = new List<(string Label, string Href, bool Active, bool Visible)>
+    {
+        ("Dashboard", "/status", IsActive(path, "/", "/status"), true),
+        ("Events / Logs", "/status#recent-events", IsActive(path, "/status", "/endpoints", "/agents"), true),
+        ("Security", "/admin/security", IsActive(path, "/admin/security"), isAdmin),
+        ("Notifications", "/settings/notifications", IsActive(path, "/settings/notifications"), isAdmin),
+        ("Backups", "/admin/backups", IsActive(path, "/admin/backups"), isAdmin),
+        ("Settings", "/admin", IsActive(path, "/admin"), isAdmin),
+        ("Profile", "/profile", IsActive(path, "/profile"), true)
+    };
+}
+<style>
+    .pm-nav { background: var(--card, #fff); border-bottom: 1px solid var(--border, #d9e2ec); position: sticky; top: 0; z-index: 40; }
+    .pm-nav-wrap { max-width: 1180px; margin: 0 auto; padding: .6rem .9rem; display: grid; gap: .6rem; }
+    .pm-nav-top { display:flex; align-items:center; justify-content:space-between; gap:.75rem; }
+    .pm-brand { font-weight:700; color: var(--text, #102a43); text-decoration:none; }
+    .pm-user { color: var(--muted, #52606d); font-size:.92rem; display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; }
+    .pm-user form { margin:0; }
+    .pm-link-list { display:flex; gap:.5rem; flex-wrap:wrap; }
+    .pm-link { text-decoration:none; color: var(--text, #102a43); border:1px solid transparent; border-radius:10px; padding:.48rem .7rem; font-weight:600; min-height:42px; display:inline-flex; align-items:center; }
+    .pm-link:hover, .pm-link:focus-visible { border-color: var(--border, #d9e2ec); background: var(--bg, #f3f6f8); outline:none; }
+    .pm-link.active { border-color: var(--accent, #0f62fe); color: var(--accent, #0f62fe); background: rgba(15, 98, 254, 0.12); }
+    .pm-logout { background:none; border:1px solid var(--border, #d9e2ec); border-radius:9px; padding:.35rem .65rem; min-height:36px; font-weight:600; cursor:pointer; color: var(--text, #102a43); }
+    .pm-nav-menu { display:none; }
+    @@media (max-width: 760px) {
+        .pm-nav-links { display:none; }
+        .pm-nav-menu { display:block; }
+        .pm-nav-menu details summary { list-style:none; border:1px solid var(--border, #d9e2ec); border-radius:10px; padding:.55rem .7rem; font-weight:600; cursor:pointer; }
+        .pm-nav-menu details summary::-webkit-details-marker { display:none; }
+        .pm-nav-menu-list { margin-top:.55rem; display:grid; gap:.4rem; }
+    }
+</style>
+<nav class="pm-nav" aria-label="Primary navigation">
+    <div class="pm-nav-wrap">
+        <div class="pm-nav-top">
+            <a class="pm-brand" href="/status">Ping Monitor</a>
+            <div class="pm-user">
+                <span>@userName</span>
+                <a class="pm-link" href="/profile">Profile</a>
+                <form method="post" action="/account/logout">
+                    @Html.AntiForgeryToken()
+                    <button class="pm-logout" type="submit">Log out</button>
+                </form>
+            </div>
+        </div>
+
+        <div class="pm-nav-links">
+            <div class="pm-link-list">
+                @foreach (var item in navItems.Where(item => item.Visible))
+                {
+                    <a class="pm-link @(item.Active ? "active" : string.Empty)" href="@item.Href" aria-current="@(item.Active ? "page" : null)">@item.Label</a>
+                }
+            </div>
+        </div>
+
+        <div class="pm-nav-menu">
+            <details>
+                <summary>Menu</summary>
+                <div class="pm-nav-menu-list">
+                    @foreach (var item in navItems.Where(item => item.Visible))
+                    {
+                        <a class="pm-link @(item.Active ? "active" : string.Empty)" href="@item.Href" aria-current="@(item.Active ? "page" : null)">@item.Label</a>
+                    }
+                </div>
+            </details>
+        </div>
+    </div>
+</nav>

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -195,6 +195,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Users/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/Edit.cshtml
@@ -3,6 +3,7 @@
     @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Edit User</title></head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main style="font-family:Arial;max-width:980px;margin:1rem auto;">
 <h1>Edit user</h1>
 @Html.ValidationSummary(false)

--- a/src/WebApp/PingMonitor.Web/Views/Users/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/Index.cshtml
@@ -3,6 +3,7 @@
     @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Users</title></head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main style="font-family:Arial;max-width:980px;margin:1rem auto;">
 <h1>Manage users</h1>
 @if (!string.IsNullOrWhiteSpace(Model.StatusMessage)) { <p>@Model.StatusMessage</p> }

--- a/src/WebApp/PingMonitor.Web/Views/Users/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/New.cshtml
@@ -4,6 +4,7 @@
     @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>@ViewData["Title"]</title></head>
 <body>
+@await Html.PartialAsync("_MainNavigation")
 <main style="font-family:Arial;max-width:980px;margin:1rem auto;">
 <h1>Create user</h1>
 @Html.ValidationSummary(false)


### PR DESCRIPTION
### Motivation

- Provide a consistent, site-wide navigation for the authenticated web app so pages no longer rely on ad-hoc per-page link sets while keeping the UI practical and operable.
- Preserve safety and focus for setup/auth flows by intentionally excluding startup gate and login pages from the main nav and follow mobile-first UI and platform constraints.

### Description

- Add a shared top navigation partial at `Views/Shared/_MainNavigation.cshtml` with primary links (Dashboard, Events / Logs, Security, Notifications, Backups, Settings, Profile), username/profile shortcut, logout action, active-state highlighting, role-aware visibility for admin links, and a responsive collapse for narrow viewports. 
- Render the new partial at the top of authenticated views under `src/WebApp/PingMonitor.Web/Views/*/*.cshtml` while keeping `Views/StartupGate/Index.cshtml` and `Views/Account/Login.cshtml` intentionally unchanged (no main nav). 
- Keep role checks explicit using the existing auth model (`User.IsInRole("Admin")`) for admin-only items and avoid introducing a separate permission system. 
- Add `docs/navigation.md` describing purpose, included links, exclusions, layout approach, and behavior, and create GitHub issue #239 to track the work (this PR links to it; Fixes #239). 

### Testing

- Installed the required .NET 10 SDK and built the web project using `DOTNET_ROOT=/tmp/dotnet10 PATH=/tmp/dotnet10:$PATH dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully. 
- Verified Razor compilation and resolved a template CSS `@media` syntax interaction so the project builds with zero errors. 
- No automated UI/browser tests were run in this environment; verification performed is limited to project build and static file changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd12df7164832a84872286fe47cbc7)