### PR TITLE
Rework authenticated site nav to dropdown IA without duplicate destinations

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,0 +1,47 @@
+# Site navigation (authenticated web app)
+
+This document defines the site-wide authenticated navigation information architecture.
+
+## Top-level categories and submenu items
+
+The authenticated top navigation uses dropdown menus with this structure:
+
+- **Monitoring**
+  - Operational status → `/status`
+  - Manage endpoints → `/endpoints`
+  - Manage groups → `/groups` (Admin only)
+- **Agents** (Admin only)
+  - Manage agents → `/agents`
+  - Deploy new agent → `/agents/deploy`
+- **Events / Logs** (Admin only)
+  - Recent events → `/status#recent-events`
+  - Security logs → `/admin/security#security-logs`
+- **Notifications**
+  - My notification settings → `/profile#notification-preferences`
+  - Notification infrastructure settings → `/settings/notifications` (Admin only)
+- **Admin** (Admin only)
+  - Security settings → `/admin/security#security-settings`
+  - Configuration backups → `/admin/backups`
+  - DB maintenance → `/admin`
+  - User management → `/users`
+- **Profile**
+  - My profile → `/profile`
+  - Change password → `/profile#change-password`
+  - Logout → `POST /account/logout`
+
+## Duplicate destination rule
+
+Duplicate destinations in the site-wide navigation are not allowed.
+
+- No separate top-level Dashboard item is included.
+- Operational status (`/status`) is the single status landing destination.
+- Each menu item must map to a distinct destination path/anchor combination.
+
+## Intentional exclusions from main nav
+
+The full authenticated site nav is intentionally not shown on:
+
+- Startup gate flow (`/startup-gate`)
+- Login/auth entry pages (`/account/login`)
+
+These flows are standalone and are not part of normal authenticated operations navigation.

--- a/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
@@ -41,6 +41,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
@@ -55,6 +55,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnblockIp.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnblockIp.cshtml
@@ -8,6 +8,7 @@
     <title>Confirm unblock IP</title>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main style="max-width:700px;margin:1rem auto;padding:1rem;font-family:Arial,sans-serif;">
     <h1>Confirm active IP block removal</h1>
     <p>This action clears an active enforcement block immediately and is audited.</p>

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnlockUser.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnlockUser.cshtml
@@ -8,6 +8,7 @@
     <title>Confirm unlock user</title>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main style="max-width:700px;margin:1rem auto;padding:1rem;font-family:Arial,sans-serif;">
     <h1>Confirm manual user unlock</h1>
     <p>This action clears an active Identity lockout immediately and is audited.</p>

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
@@ -49,6 +49,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <section class="card">
         <h1>Security logs and settings</h1>
@@ -107,7 +108,7 @@
     </section>
 
     <section class="card">
-        <h2>Authentication protection settings</h2>
+        <h2 id="security-settings">Authentication protection settings</h2>
         @if (Model.SettingsSaved)
         {
             <div class="saved" role="status">Security settings saved successfully.</div>
@@ -326,7 +327,7 @@
     </section>
 
     <section class="card">
-        <h2>Authentication log filters</h2>
+        <h2 id="security-logs">Authentication log filters</h2>
         <p class="muted">All log filters use UTC values and apply to both user and agent authentication panels.</p>
         <form method="get" action="/admin/security" class="grid-two" style="margin-bottom: .8rem;">
             <div class="field">

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Deploy.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Deploy.cshtml
@@ -35,6 +35,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <section class="card stack">
         <h1>Deploy new agent</h1>

--- a/src/WebApp/PingMonitor.Web/Views/Agents/History.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/History.cshtml
@@ -46,6 +46,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
@@ -57,6 +57,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Remove.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Remove.cshtml
@@ -24,6 +24,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <section class="card">
         <h1>Remove agent</h1>

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Edit.cshtml
@@ -32,6 +32,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/History.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/History.cshtml
@@ -46,6 +46,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
@@ -52,6 +52,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/New.cshtml
@@ -44,6 +44,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml
@@ -45,6 +45,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Remove.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Remove.cshtml
@@ -24,6 +24,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <section class="card">
         <h1>Remove endpoint</h1>

--- a/src/WebApp/PingMonitor.Web/Views/Groups/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/Edit.cshtml
@@ -23,6 +23,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <form method="post" asp-controller="Groups" asp-action="Edit" asp-route-id="@Model.GroupId" class="stack">
         @Html.AntiForgeryToken()

--- a/src/WebApp/PingMonitor.Web/Views/Groups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/Index.cshtml
@@ -22,6 +22,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Groups/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/New.cshtml
@@ -23,6 +23,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <form method="post" asp-controller="Groups" asp-action="New" class="stack">
         @Html.AntiForgeryToken()

--- a/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
@@ -18,6 +18,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <div class="stack">
         <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
@@ -18,6 +18,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
 <div class="stack">
 <section class="card">
@@ -36,7 +37,7 @@
         <div class="button-row"><button class="button" type="submit">Save account details</button></div>
     </form>
 </section>
-<section class="card stack">
+<section class="card stack" id="change-password">
     <h2>Change password</h2>
     @if (Model.PasswordSaved) { <div class="saved">Password changed.</div> }
     <form method="post" action="/profile/password" class="stack">
@@ -48,7 +49,7 @@
         <div class="button-row"><button class="button" type="submit">Change password</button></div>
     </form>
 </section>
-<section class="card stack">
+<section class="card stack" id="notification-preferences">
     <h2>Notification preferences</h2>
     @if (Model.NotificationsSaved) { <div class="saved">Notification preferences saved.</div> }
     <form method="post" action="/profile/notifications" class="stack">

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -1,0 +1,202 @@
+@using PingMonitor.Web.Services.Identity
+@{
+    var path = Context?.Request?.Path.Value ?? string.Empty;
+    var isAdmin = User.IsInRole(ApplicationRoles.Admin);
+
+    static bool IsCurrent(string path, params string[] prefixes)
+    {
+        foreach (var prefix in prefixes)
+        {
+            if (path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    var monitoringOpen = IsCurrent(path, "/", "/status", "/endpoints", "/groups");
+    var agentsOpen = IsCurrent(path, "/agents");
+    var eventsOpen = IsCurrent(path, "/admin/security");
+    var notificationsOpen = IsCurrent(path, "/profile", "/settings/notifications");
+    var adminOpen = IsCurrent(path, "/admin", "/users");
+    var profileOpen = IsCurrent(path, "/profile");
+}
+<style>
+    .site-nav-shell {
+        border-bottom: 1px solid var(--border);
+        background: var(--card);
+        padding: .6rem 1rem;
+    }
+
+    .site-nav {
+        max-width: 1180px;
+        margin: 0 auto;
+        display: flex;
+        gap: .5rem;
+        flex-wrap: wrap;
+        align-items: stretch;
+    }
+
+    .site-nav details {
+        position: relative;
+        min-width: 160px;
+    }
+
+    .site-nav summary {
+        list-style: none;
+        cursor: pointer;
+        border: 1px solid var(--border);
+        background: var(--surface-1);
+        color: var(--text);
+        border-radius: 10px;
+        min-height: 44px;
+        padding: .55rem .8rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        font-weight: 600;
+        gap: .5rem;
+    }
+
+    .site-nav summary::-webkit-details-marker {
+        display: none;
+    }
+
+    .site-nav details[data-active="true"] > summary {
+        border-color: var(--accent);
+        box-shadow: inset 0 0 0 1px var(--accent);
+    }
+
+    .site-nav-dropdown {
+        margin-top: .35rem;
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        background: var(--surface-1);
+        padding: .35rem;
+        min-width: 220px;
+        display: grid;
+        gap: .2rem;
+        z-index: 50;
+    }
+
+    .site-nav-link,
+    .site-nav-logout {
+        display: flex;
+        align-items: center;
+        min-height: 42px;
+        border-radius: 8px;
+        padding: .45rem .6rem;
+        text-decoration: none;
+        color: var(--text);
+        border: 0;
+        background: transparent;
+        width: 100%;
+        text-align: left;
+        font: inherit;
+        cursor: pointer;
+    }
+
+    .site-nav-link[data-current="true"] {
+        background: var(--surface-2);
+        font-weight: 700;
+    }
+
+    .site-nav-link:hover,
+    .site-nav-link:focus-visible,
+    .site-nav-logout:hover,
+    .site-nav-logout:focus-visible {
+        outline: none;
+        background: var(--surface-2);
+    }
+
+    .site-nav-logout {
+        color: #b42318;
+    }
+
+    @@media (min-width: 860px) {
+        .site-nav details {
+            min-width: 180px;
+        }
+
+        .site-nav details[open] .site-nav-dropdown {
+            position: absolute;
+            left: 0;
+            top: 100%;
+        }
+    }
+</style>
+<nav class="site-nav-shell" aria-label="Primary">
+    <div class="site-nav">
+        <details data-active="@monitoringOpen">
+            <summary>Monitoring <span aria-hidden="true">▾</span></summary>
+            <div class="site-nav-dropdown">
+                <a class="site-nav-link" data-current="@IsCurrent(path, "/", "/status")" href="/status">Operational status</a>
+                <a class="site-nav-link" data-current="@IsCurrent(path, "/endpoints")" href="/endpoints">Manage endpoints</a>
+                @if (isAdmin)
+                {
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/groups")" href="/groups">Manage groups</a>
+                }
+            </div>
+        </details>
+
+        @if (isAdmin)
+        {
+            <details data-active="@agentsOpen">
+                <summary>Agents <span aria-hidden="true">▾</span></summary>
+                <div class="site-nav-dropdown">
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/agents")" href="/agents">Manage agents</a>
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/agents/deploy")" href="/agents/deploy">Deploy new agent</a>
+                </div>
+            </details>
+        }
+
+        @if (isAdmin)
+        {
+            <details data-active="@eventsOpen">
+                <summary>Events / Logs <span aria-hidden="true">▾</span></summary>
+                <div class="site-nav-dropdown">
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/status")" href="/status#recent-events">Recent events</a>
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/admin/security")" href="/admin/security#security-logs">Security logs</a>
+                </div>
+            </details>
+        }
+
+        <details data-active="@notificationsOpen">
+            <summary>Notifications <span aria-hidden="true">▾</span></summary>
+            <div class="site-nav-dropdown">
+                <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile#notification-preferences">My notification settings</a>
+                @if (isAdmin)
+                {
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/settings/notifications")" href="/settings/notifications">Notification infrastructure settings</a>
+                }
+            </div>
+        </details>
+
+        @if (isAdmin)
+        {
+            <details data-active="@adminOpen">
+                <summary>Admin <span aria-hidden="true">▾</span></summary>
+                <div class="site-nav-dropdown">
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/admin/security")" href="/admin/security#security-settings">Security settings</a>
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/admin/backups")" href="/admin/backups">Configuration backups</a>
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/admin")" href="/admin">DB maintenance</a>
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/users")" href="/users">User management</a>
+                </div>
+            </details>
+        }
+
+        <details data-active="@profileOpen">
+            <summary>Profile <span aria-hidden="true">▾</span></summary>
+            <div class="site-nav-dropdown">
+                <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile">My profile</a>
+                <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile#change-password">Change password</a>
+                <form method="post" action="/account/logout">
+                    @Html.AntiForgeryToken()
+                    <button class="site-nav-logout" type="submit">Logout</button>
+                </form>
+            </div>
+        </details>
+    </div>
+</nav>

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -195,6 +195,7 @@
     </style>
 </head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main>
     <div class="stack">
         <section class="card">
@@ -222,7 +223,7 @@
             </div>
         </section>
 
-        <section class="card">
+        <section class="card" id="recent-events">
             <h2>Recent events</h2>
             @if (Model.RecentEvents.Count == 0)
             {

--- a/src/WebApp/PingMonitor.Web/Views/Users/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/Edit.cshtml
@@ -3,6 +3,7 @@
     @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Edit User</title></head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main style="font-family:Arial;max-width:980px;margin:1rem auto;">
 <h1>Edit user</h1>
 @Html.ValidationSummary(false)

--- a/src/WebApp/PingMonitor.Web/Views/Users/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/Index.cshtml
@@ -3,6 +3,7 @@
     @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Users</title></head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main style="font-family:Arial;max-width:980px;margin:1rem auto;">
 <h1>Manage users</h1>
 @if (!string.IsNullOrWhiteSpace(Model.StatusMessage)) { <p>@Model.StatusMessage</p> }

--- a/src/WebApp/PingMonitor.Web/Views/Users/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/New.cshtml
@@ -4,6 +4,7 @@
     @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>@ViewData["Title"]</title></head>
 <body>
+@await Html.PartialAsync("_AuthenticatedNav")
 <main style="font-family:Arial;max-width:980px;margin:1rem auto;">
 <h1>Create user</h1>
 @Html.ValidationSummary(false)


### PR DESCRIPTION
### Motivation
- Replace the previous ad-hoc navigation with a single, predictable site-wide navigation that uses top-level dropdowns and avoids duplicate destinations. 
- Provide clear role-aware visibility for admin-only functionality and keep standalone flows (startup/login) outside the authenticated nav. 
- Document the information architecture to prevent future divergence and accidental duplicate links. 

### Description
- Added a shared authenticated navigation partial `src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml` implementing the required top-level categories (Monitoring, Agents, Events / Logs, Notifications, Admin, Profile) with responsive `<details>`-based dropdowns and simple CSS for desktop and narrow widths. 
- Injected the shared partial into authenticated page views and intentionally left `/account/login` and `/startup-gate` untouched; updated many view files to include `@await Html.PartialAsync("_AuthenticatedNav")` where appropriate. 
- Introduced page/section anchors and targeted links to avoid duplicate destinations (for example `Security settings` → `/admin/security#security-settings` and `Security logs` → `/admin/security#security-logs`, and `Recent events` → `/status#recent-events`), and added `docs/navigation.md` documenting the IA and duplicate-destination rule. 
- Kept role-aware visibility using existing role checks (`ApplicationRoles.Admin`) so admin-only menus are only shown to admin users, and omitted submenu items that do not map to existing pages (e.g., no global Performance graphs link). 

### Testing
- Created GitHub issue #242 before implementation and linked the work to it. 
- Built the web project with .NET 10 SDK (used SDK `10.0.104`) via `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which succeeded. 
- Ran an automated destination-extraction check against the new `_AuthenticatedNav.cshtml` to verify there are no duplicate `href`/`action` targets, which passed after adding distinct anchors. 
- Verified that the shared nav is present on authenticated pages and excluded from login and startup-gate pages by scanning views for the inserted partial; no automated unit tests were changed or required for this UI IA change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd19804f8c832aac00cb73c1400375)