### PR TITLE
Enforce single-open submenu in authenticated nav with hover-to-switch and global close

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -128,10 +128,10 @@
     }
 </style>
 <nav class="site-nav-shell" aria-label="Primary">
-    <div class="site-nav">
+    <div class="site-nav" data-site-nav>
         <details data-active="@monitoringOpen">
-            <summary>Monitoring <span aria-hidden="true">▾</span></summary>
-            <div class="site-nav-dropdown">
+            <summary aria-controls="nav-menu-monitoring" aria-expanded="false">Monitoring <span aria-hidden="true">▾</span></summary>
+            <div class="site-nav-dropdown" id="nav-menu-monitoring">
                 <a class="site-nav-link" data-current="@IsCurrent(path, "/", "/status")" href="/status">Operational status</a>
                 <a class="site-nav-link" data-current="@IsCurrent(path, "/endpoints")" href="/endpoints">Manage endpoints</a>
                 @if (isAdmin)
@@ -144,8 +144,8 @@
         @if (isAdmin)
         {
             <details data-active="@agentsOpen">
-                <summary>Agents <span aria-hidden="true">▾</span></summary>
-                <div class="site-nav-dropdown">
+                <summary aria-controls="nav-menu-agents" aria-expanded="false">Agents <span aria-hidden="true">▾</span></summary>
+                <div class="site-nav-dropdown" id="nav-menu-agents">
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/agents")" href="/agents">Manage agents</a>
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/agents/deploy")" href="/agents/deploy">Deploy new agent</a>
                 </div>
@@ -155,8 +155,8 @@
         @if (isAdmin)
         {
             <details data-active="@eventsOpen">
-                <summary>Events / Logs <span aria-hidden="true">▾</span></summary>
-                <div class="site-nav-dropdown">
+                <summary aria-controls="nav-menu-events" aria-expanded="false">Events / Logs <span aria-hidden="true">▾</span></summary>
+                <div class="site-nav-dropdown" id="nav-menu-events">
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/status")" href="/status#recent-events">Recent events</a>
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/admin/security")" href="/admin/security#security-logs">Security logs</a>
                 </div>
@@ -164,8 +164,8 @@
         }
 
         <details data-active="@notificationsOpen">
-            <summary>Notifications <span aria-hidden="true">▾</span></summary>
-            <div class="site-nav-dropdown">
+            <summary aria-controls="nav-menu-notifications" aria-expanded="false">Notifications <span aria-hidden="true">▾</span></summary>
+            <div class="site-nav-dropdown" id="nav-menu-notifications">
                 <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile#notification-preferences">My notification settings</a>
                 @if (isAdmin)
                 {
@@ -177,8 +177,8 @@
         @if (isAdmin)
         {
             <details data-active="@adminOpen">
-                <summary>Admin <span aria-hidden="true">▾</span></summary>
-                <div class="site-nav-dropdown">
+                <summary aria-controls="nav-menu-admin" aria-expanded="false">Admin <span aria-hidden="true">▾</span></summary>
+                <div class="site-nav-dropdown" id="nav-menu-admin">
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/admin/security")" href="/admin/security#security-settings">Security settings</a>
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/admin/backups")" href="/admin/backups">Configuration backups</a>
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/admin")" href="/admin">DB maintenance</a>
@@ -188,8 +188,8 @@
         }
 
         <details data-active="@profileOpen">
-            <summary>Profile <span aria-hidden="true">▾</span></summary>
-            <div class="site-nav-dropdown">
+            <summary aria-controls="nav-menu-profile" aria-expanded="false">Profile <span aria-hidden="true">▾</span></summary>
+            <div class="site-nav-dropdown" id="nav-menu-profile">
                 <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile">My profile</a>
                 <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile#change-password">Change password</a>
                 <form method="post" action="/account/logout">
@@ -200,3 +200,75 @@
         </details>
     </div>
 </nav>
+<script>
+    (() => {
+        const nav = document.querySelector('[data-site-nav]');
+        if (!nav) {
+            return;
+        }
+
+        const menus = Array.from(nav.querySelectorAll('details'));
+
+        const syncAria = () => {
+            for (const menu of menus) {
+                const summary = menu.querySelector('summary');
+                if (!summary) {
+                    continue;
+                }
+
+                summary.setAttribute('aria-expanded', menu.open ? 'true' : 'false');
+            }
+        };
+
+        const closeAll = () => {
+            for (const menu of menus) {
+                menu.open = false;
+            }
+
+            syncAria();
+        };
+
+        const closeOthers = (activeMenu) => {
+            for (const menu of menus) {
+                if (menu !== activeMenu) {
+                    menu.open = false;
+                }
+            }
+        };
+
+        for (const menu of menus) {
+            menu.addEventListener('toggle', () => {
+                if (menu.open) {
+                    closeOthers(menu);
+                }
+
+                syncAria();
+            });
+
+            menu.addEventListener('mouseenter', () => {
+                const openMenu = menus.find((candidate) => candidate.open);
+                if (!openMenu || openMenu === menu) {
+                    return;
+                }
+
+                openMenu.open = false;
+                menu.open = true;
+                syncAria();
+            });
+        }
+
+        document.addEventListener('click', (event) => {
+            if (!nav.contains(event.target)) {
+                closeAll();
+            }
+        });
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                closeAll();
+            }
+        });
+
+        syncAria();
+    })();
+</script>


### PR DESCRIPTION
### Motivation
- The current `<details>`-based authenticated navigation allows multiple submenus to remain open, producing a cluttered and awkward UI.  
- The change centralizes submenu open/close state to ensure only one submenu is visible at a time while preserving existing structure and routes.  
- Keep behavior simple, maintain keyboard accessibility, and avoid altering styling, destinations, or responsive/dark-mode behavior.

### Description
- Added `data-site-nav` to the nav container and `aria-controls`/`id` pairs on each submenu plus synchronized `aria-expanded` on each `summary`.  
- Injected a small nav-scoped script that centrally manages all `<details>` menus: it enforces a single-open invariant by closing sibling menus on `toggle`.  
- Implemented hover-to-switch: when any submenu is already open, `mouseenter` on another top-level item closes the current submenu and opens the hovered one; hovering does not open menus from a fully closed state.  
- Added global close handlers so clicking outside the nav or pressing `Escape` closes all open submenus, and preserved native click-to-toggle behavior for each `summary`.

### Testing
- Ran repository consistency checks with `git diff --check` which passed and committed the updated file.  
- Created issue `#244` to track the change and added labels programmatically; the issue was created successfully.  
- Could not run the web app or browser-based UI tests in this environment because the `.NET` SDK / browser tooling is not installed, so full runtime/browser verification was not executed.  
- Included a deterministic reproduction checklist in the PR (open one submenu, open another, verify single-open; hover-to-switch when open; outside click/Escape closes) to serve as a regression-proof checklist for CI/manual validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd1e2fb2a4832a9a579e925ac543eb)