### PR TITLE
Remove redundant navigation shortcuts from Operational Status page

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -208,19 +208,6 @@
                     @await Html.PartialAsync("_ThemeSelector")
                 </div>
             </div>
-            <div class="button-row">
-                <a class="button-secondary" href="/endpoints">Endpoints</a>
-                <a class="button-secondary" href="/profile">My profile</a>
-                @if (User.IsInRole("Admin"))
-                {
-                    <a class="button" href="/agents">Manage agents</a>
-                    <a class="button-secondary" href="/agents/deploy">Deploy new agent</a>
-                    <a class="button-secondary" href="/groups">Manage groups</a>
-                    <a class="button-secondary" href="/endpoints/new">Add new endpoint</a>
-                    <a class="button-secondary" href="/admin">Admin settings</a>
-                    <a class="button-secondary" href="/users">Manage users</a>
-                }
-            </div>
         </section>
 
         <section class="card" id="recent-events">


### PR DESCRIPTION
### Motivation

- The site-wide authenticated navigation bar now exposes destinations previously duplicated by a page-level shortcut row on the operational status page, so the per-page navigation created visual clutter and risked divergence. 
- The intent is to remove navigation-only shortcuts while preserving true page-local actions and keeping the page visually balanced.
- Follow repository workflow by creating an issue to track the change before implementation (`#246`).

### Description

- Removed the legacy shortcut button row from the Operational Status page hero section in `src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml`, deleting links for `Endpoints`, `My profile`, `Manage agents`, `Deploy new agent`, `Manage groups`, `Add new endpoint`, `Admin settings`, and `Manage users` which are now reachable via the global nav. 
- Preserved the page-local filter action buttons (`Apply filters` / `Clear filters`) because they are contextual controls for the current view rather than site navigation. 
- Ensured no layout gaps remain by keeping the page header/hero markup and theme selector intact and relying on the shared `_AuthenticatedNav` partial as the canonical navigation surface.

### Testing

- Created issue `#246` to record the work and scope using `gh issue create`, which succeeded. 
- Built the web app using .NET SDK `10.0.104` with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully with zero errors. 
- Verified the removal and absence of duplicate links using repository search commands (grep/ripgrep) and inspected `src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml` to confirm the removed destinations remain available via the global nav.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd211062c4832aa5683c25edf50a68)