### PR TITLE
Reorganize navigation: split notification pages and move endpoint defaults under Admin

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -16,18 +16,23 @@ The authenticated top navigation uses dropdown menus with this structure:
 - **Events / Logs** (Admin only)
   - Recent events → `/status#recent-events`
   - Security logs → `/admin/security#security-logs`
-- **Notifications**
-  - My notification settings → `/profile#notification-preferences`
-  - Notification infrastructure settings → `/settings/notifications` (Admin only)
 - **Admin** (Admin only)
   - Security settings → `/admin/security#security-settings`
   - Configuration backups → `/admin/backups`
   - DB maintenance → `/admin`
+  - Notification infrastructure settings → `/admin/notification-infrastructure-settings`
+  - Default endpoint values → `/admin/default-endpoint-values`
   - User management → `/users`
 - **Profile**
   - My profile → `/profile`
+  - Notification settings → `/profile/notification-settings`
   - Change password → `/profile#change-password`
   - Logout → `POST /account/logout`
+
+## Notification settings ownership
+
+- **Profile > Notification settings** is user-owned and controls per-user notification preferences plus Telegram account linking.
+- **Admin > Notification infrastructure settings** is admin-owned and controls shared SMTP/Telegram transport infrastructure.
 
 ## Duplicate destination rule
 

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminDefaultEndpointValuesController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminDefaultEndpointValuesController.cs
@@ -7,12 +7,12 @@ using PingMonitor.Web.ViewModels.Admin;
 namespace PingMonitor.Web.Controllers;
 
 [Authorize(Roles = ApplicationRoles.Admin)]
-[Route("admin")]
-public sealed class AdminController : Controller
+[Route("admin/default-endpoint-values")]
+public sealed class AdminDefaultEndpointValuesController : Controller
 {
     private readonly IApplicationSettingsService _applicationSettingsService;
 
-    public AdminController(IApplicationSettingsService applicationSettingsService)
+    public AdminDefaultEndpointValuesController(IApplicationSettingsService applicationSettingsService)
     {
         _applicationSettingsService = applicationSettingsService;
     }
@@ -26,10 +26,8 @@ public sealed class AdminController : Controller
 
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Index([FromForm] AdminSettingsPageViewModel model, CancellationToken cancellationToken)
+    public async Task<IActionResult> Index([FromForm] DefaultEndpointValuesPageViewModel model, CancellationToken cancellationToken)
     {
-        ValidateAbsoluteSiteUrl(model);
-
         if (!ModelState.IsValid)
         {
             return View("Index", model);
@@ -39,31 +37,27 @@ public sealed class AdminController : Controller
         var updated = await _applicationSettingsService.UpdateAsync(
             new UpdateApplicationSettingsCommand
             {
-                SiteUrl = model.SiteUrl,
-                DefaultPingIntervalSeconds = current.DefaultPingIntervalSeconds,
-                DefaultRetryIntervalSeconds = current.DefaultRetryIntervalSeconds,
-                DefaultTimeoutMs = current.DefaultTimeoutMs,
-                DefaultFailureThreshold = current.DefaultFailureThreshold,
-                DefaultRecoveryThreshold = current.DefaultRecoveryThreshold
+                SiteUrl = current.SiteUrl,
+                DefaultPingIntervalSeconds = model.DefaultPingIntervalSeconds,
+                DefaultRetryIntervalSeconds = model.DefaultRetryIntervalSeconds,
+                DefaultTimeoutMs = model.DefaultTimeoutMs,
+                DefaultFailureThreshold = model.DefaultFailureThreshold,
+                DefaultRecoveryThreshold = model.DefaultRecoveryThreshold
             },
             cancellationToken);
 
         return View("Index", ToViewModel(updated, saved: true));
     }
 
-    private void ValidateAbsoluteSiteUrl(AdminSettingsPageViewModel model)
+    private static DefaultEndpointValuesPageViewModel ToViewModel(ApplicationSettingsDto settings, bool saved)
     {
-        if (!Uri.TryCreate(model.SiteUrl?.Trim(), UriKind.Absolute, out _))
+        return new DefaultEndpointValuesPageViewModel
         {
-            ModelState.AddModelError(nameof(AdminSettingsPageViewModel.SiteUrl), "Site URL must be a valid absolute URL.");
-        }
-    }
-
-    private static AdminSettingsPageViewModel ToViewModel(ApplicationSettingsDto settings, bool saved)
-    {
-        return new AdminSettingsPageViewModel
-        {
-            SiteUrl = settings.SiteUrl,
+            DefaultPingIntervalSeconds = settings.DefaultPingIntervalSeconds,
+            DefaultRetryIntervalSeconds = settings.DefaultRetryIntervalSeconds,
+            DefaultTimeoutMs = settings.DefaultTimeoutMs,
+            DefaultFailureThreshold = settings.DefaultFailureThreshold,
+            DefaultRecoveryThreshold = settings.DefaultRecoveryThreshold,
             UpdatedAtUtc = settings.UpdatedAtUtc,
             Saved = saved
         };

--- a/src/WebApp/PingMonitor.Web/Controllers/NotificationSettingsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/NotificationSettingsController.cs
@@ -12,6 +12,7 @@ using System.Net.Mail;
 namespace PingMonitor.Web.Controllers;
 
 [Authorize(Roles = ApplicationRoles.Admin)]
+[Route("admin/notification-infrastructure-settings")]
 [Route("settings/notifications")]
 public sealed class NotificationSettingsController : Controller
 {

--- a/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
@@ -35,6 +35,13 @@ public sealed class ProfileController : Controller
         return View("Index", model);
     }
 
+    [HttpGet("notification-settings")]
+    public async Task<IActionResult> NotificationSettings(CancellationToken cancellationToken)
+    {
+        var model = await BuildModelAsync(cancellationToken);
+        return View("NotificationSettings", model);
+    }
+
     [HttpPost("account")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> UpdateAccount([FromForm] ProfilePageViewModel model, CancellationToken cancellationToken)
@@ -130,6 +137,7 @@ public sealed class ProfileController : Controller
         return View("Index", refreshed);
     }
 
+    [HttpPost("notification-settings")]
     [HttpPost("notifications")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> UpdateNotifications([FromForm] ProfilePageViewModel model, CancellationToken cancellationToken)
@@ -160,7 +168,7 @@ public sealed class ProfileController : Controller
 
         if (!ModelState.IsValid)
         {
-            return View("Index", await BuildModelAsync(cancellationToken, model));
+            return View("NotificationSettings", await BuildModelAsync(cancellationToken, model));
         }
 
         await _userNotificationSettingsService.UpdateAsync(new UpdateUserNotificationSettingsCommand
@@ -193,11 +201,10 @@ public sealed class ProfileController : Controller
 
         var refreshed = await BuildModelAsync(cancellationToken);
         refreshed.NotificationsSaved = true;
-        return View("Index", refreshed);
+        return View("NotificationSettings", refreshed);
     }
 
-
-
+    [HttpPost("notification-settings/telegram/remove")]
     [HttpPost("telegram/remove")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> RemoveTelegramAccount(CancellationToken cancellationToken)
@@ -211,9 +218,10 @@ public sealed class ProfileController : Controller
         await _telegramLinkService.UnlinkAccountAsync(user.Id, cancellationToken);
         var refreshed = await BuildModelAsync(cancellationToken);
         refreshed.TelegramAccountRemoved = true;
-        return View("Index", refreshed);
+        return View("NotificationSettings", refreshed);
     }
 
+    [HttpPost("notification-settings/telegram/generate-code")]
     [HttpPost("telegram/generate-code")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> GenerateTelegramCode(CancellationToken cancellationToken)
@@ -227,7 +235,7 @@ public sealed class ProfileController : Controller
         await _telegramLinkService.GenerateCodeAsync(user.Id, cancellationToken);
         var refreshed = await BuildModelAsync(cancellationToken);
         refreshed.TelegramCodeGenerated = true;
-        return View("Index", refreshed);
+        return View("NotificationSettings", refreshed);
     }
 
     private async Task<ApplicationUser?> RequireUserAsync()
@@ -277,7 +285,7 @@ public sealed class ProfileController : Controller
             NotificationSettingsUpdatedAtUtc = settings.UpdatedAtUtc,
             ActiveTelegramCode = pendingCode?.Code,
             ActiveTelegramCodeExpiresAtUtc = pendingCode?.ExpiresAtUtc,
-            TelegramLinked = telegramAccount is not null && telegramAccount.Verified,
+            TelegramLinked = telegramAccount?.Verified ?? false,
             TelegramLinkedChatId = telegramAccount?.ChatId,
             TelegramLinkedUsername = telegramAccount?.Username,
             TelegramLinkedDisplayName = telegramAccount?.DisplayName,

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/AdminSettingsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/AdminSettingsPageViewModel.cs
@@ -9,26 +9,6 @@ public sealed class AdminSettingsPageViewModel
     [Display(Name = "Site URL")]
     public string SiteUrl { get; set; } = string.Empty;
 
-    [Range(1, int.MaxValue, ErrorMessage = "Default ping interval must be at least 1 second.")]
-    [Display(Name = "Default ping interval (seconds)")]
-    public int DefaultPingIntervalSeconds { get; set; }
-
-    [Range(1, int.MaxValue, ErrorMessage = "Default retry interval must be at least 1 second.")]
-    [Display(Name = "Default retry interval (seconds)")]
-    public int DefaultRetryIntervalSeconds { get; set; }
-
-    [Range(1, int.MaxValue, ErrorMessage = "Default timeout must be at least 1 millisecond.")]
-    [Display(Name = "Default timeout (ms)")]
-    public int DefaultTimeoutMs { get; set; }
-
-    [Range(1, int.MaxValue, ErrorMessage = "Default failure threshold must be at least 1.")]
-    [Display(Name = "Default failure threshold")]
-    public int DefaultFailureThreshold { get; set; }
-
-    [Range(1, int.MaxValue, ErrorMessage = "Default recovery threshold must be at least 1.")]
-    [Display(Name = "Default recovery threshold")]
-    public int DefaultRecoveryThreshold { get; set; }
-
     public bool Saved { get; set; }
 
     public DateTimeOffset UpdatedAtUtc { get; set; }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/DefaultEndpointValuesPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/DefaultEndpointValuesPageViewModel.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PingMonitor.Web.ViewModels.Admin;
+
+public sealed class DefaultEndpointValuesPageViewModel
+{
+    [Range(1, int.MaxValue, ErrorMessage = "Default ping interval must be at least 1 second.")]
+    [Display(Name = "Default ping interval (seconds)")]
+    public int DefaultPingIntervalSeconds { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Default retry interval must be at least 1 second.")]
+    [Display(Name = "Default retry interval (seconds)")]
+    public int DefaultRetryIntervalSeconds { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Default timeout must be at least 1 millisecond.")]
+    [Display(Name = "Default timeout (ms)")]
+    public int DefaultTimeoutMs { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Default failure threshold must be at least 1.")]
+    [Display(Name = "Default failure threshold")]
+    public int DefaultFailureThreshold { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Default recovery threshold must be at least 1.")]
+    [Display(Name = "Default recovery threshold")]
+    public int DefaultRecoveryThreshold { get; set; }
+
+    public bool Saved { get; set; }
+
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
@@ -5,26 +5,14 @@
     @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Admin settings</title>
+    <title>DB maintenance</title>
     <style>
-        :root {
-            color-scheme: light;
-            --bg: #f3f6f8;
-            --card: #ffffff;
-            --text: #102a43;
-            --muted: #52606d;
-            --border: #d9e2ec;
-            --accent: #0f62fe;
-            --success: #137333;
-            --error-bg: #fee4e2;
-            --error-text: #b42318;
-        }
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#ffffff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; --success:#137333; --error-bg:#fee4e2; --error-text:#b42318; }
         * { box-sizing: border-box; }
         body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
         main { max-width: 760px; margin: 0 auto; padding: 1rem; }
         .stack { display: grid; gap: 1rem; }
         .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
-        .field-grid { display: grid; gap: .85rem; }
         label { display: block; font-weight: 600; margin-bottom: .35rem; }
         input { width: 100%; min-height: 48px; padding: .8rem; border: 1px solid var(--border); border-radius: 10px; font-size: 1rem; }
         .button-row { display: flex; gap: .75rem; flex-wrap: wrap; }
@@ -35,9 +23,6 @@
         .errors { border: 1px solid #fda29b; background: var(--error-bg); color: var(--error-text); border-radius: 10px; padding: .8rem; }
         .saved { border: 1px solid #c2f0c2; background: #ebffee; color: var(--success); border-radius: 10px; padding: .8rem; }
         .muted { color: var(--muted); }
-        @@media (min-width: 720px) {
-            .field-grid.two-col { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-        }
     </style>
 </head>
 <body>
@@ -45,14 +30,12 @@
 <main>
     <div class="stack">
         <section class="card">
-            <h1>Admin settings</h1>
-            <p class="muted">Configure application-level settings used by agent provisioning and new endpoint defaults.</p>
+            <h1>DB maintenance</h1>
+            <p class="muted">Configure database-adjacent maintenance settings for the application.</p>
             <div class="button-row">
                 <a class="button-secondary" href="/status">Back to status</a>
-                <a class="button-secondary" href="/profile">My profile</a>
-                <a class="button-secondary" href="/admin/backups">Configuration backups</a>
-                <a class="button-secondary" href="/admin/security">Security logs and settings</a>
-                <a class="button-secondary" href="/settings/notifications">Notification settings</a>
+                <a class="button-secondary" href="/admin/default-endpoint-values">Default endpoint values</a>
+                <a class="button-secondary" href="/admin/notification-infrastructure-settings">Notification infrastructure settings</a>
             </div>
         </section>
 
@@ -71,43 +54,10 @@
 
             <section class="card">
                 <h2>Agent provisioning</h2>
-                <div class="field-grid">
-                    <div>
-                        <label asp-for="SiteUrl"></label>
-                        <input asp-for="SiteUrl" />
-                        <div class="field-error"><span asp-validation-for="SiteUrl"></span></div>
-                    </div>
-                </div>
-            </section>
-
-            <section class="card">
-                <h2>Default endpoint values</h2>
-                <div class="field-grid two-col">
-                    <div>
-                        <label asp-for="DefaultPingIntervalSeconds"></label>
-                        <input asp-for="DefaultPingIntervalSeconds" type="number" min="1" />
-                        <div class="field-error"><span asp-validation-for="DefaultPingIntervalSeconds"></span></div>
-                    </div>
-                    <div>
-                        <label asp-for="DefaultRetryIntervalSeconds"></label>
-                        <input asp-for="DefaultRetryIntervalSeconds" type="number" min="1" />
-                        <div class="field-error"><span asp-validation-for="DefaultRetryIntervalSeconds"></span></div>
-                    </div>
-                    <div>
-                        <label asp-for="DefaultTimeoutMs"></label>
-                        <input asp-for="DefaultTimeoutMs" type="number" min="1" />
-                        <div class="field-error"><span asp-validation-for="DefaultTimeoutMs"></span></div>
-                    </div>
-                    <div>
-                        <label asp-for="DefaultFailureThreshold"></label>
-                        <input asp-for="DefaultFailureThreshold" type="number" min="1" />
-                        <div class="field-error"><span asp-validation-for="DefaultFailureThreshold"></span></div>
-                    </div>
-                    <div>
-                        <label asp-for="DefaultRecoveryThreshold"></label>
-                        <input asp-for="DefaultRecoveryThreshold" type="number" min="1" />
-                        <div class="field-error"><span asp-validation-for="DefaultRecoveryThreshold"></span></div>
-                    </div>
+                <div>
+                    <label asp-for="SiteUrl"></label>
+                    <input asp-for="SiteUrl" />
+                    <div class="field-error"><span asp-validation-for="SiteUrl"></span></div>
                 </div>
                 <p class="muted">Last updated: @Model.UpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</p>
             </section>

--- a/src/WebApp/PingMonitor.Web/Views/AdminDefaultEndpointValues/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminDefaultEndpointValues/Index.cshtml
@@ -1,0 +1,75 @@
+@model PingMonitor.Web.ViewModels.Admin.DefaultEndpointValuesPageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    @await Html.PartialAsync("_ThemeHead")
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Default endpoint values</title>
+    <style>
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; --success:#137333; --error-bg:#fee4e2; --error-text:#b42318; }
+        *{box-sizing:border-box;} body{margin:0;font-family:Arial,sans-serif;background:var(--bg);color:var(--text);} main{max-width:760px;margin:0 auto;padding:1rem;}
+        .stack{display:grid;gap:1rem;} .card{background:var(--card);border-radius:14px;box-shadow:0 1px 2px rgba(16,24,40,.08);padding:1rem;}
+        .field-grid{display:grid;gap:.85rem;} .button-row{display:flex;gap:.75rem;flex-wrap:wrap;}
+        .button,.button-secondary{display:inline-flex;align-items:center;justify-content:center;min-height:48px;padding:.8rem 1rem;border-radius:10px;font-weight:600;text-decoration:none;}
+        .button{border:0;background:var(--accent);color:#fff;cursor:pointer;} .button-secondary{border:1px solid var(--border);color:var(--text);background:#fff;cursor:pointer;}
+        .saved{border:1px solid #c2f0c2;background:#ebffee;color:var(--success);border-radius:10px;padding:.8rem;} .errors{border:1px solid #fda29b;background:var(--error-bg);color:var(--error-text);border-radius:10px;padding:.8rem;}
+        .muted{color:var(--muted);} .field-error{color:var(--error-text);font-size:.9rem;margin-top:.25rem;}
+        input{width:100%;min-height:44px;border:1px solid var(--border);border-radius:8px;padding:.6rem .7rem;font:inherit;}
+        @@media (min-width: 720px) { .field-grid{grid-template-columns:repeat(2,minmax(0,1fr));} }
+    </style>
+</head>
+<body>
+@await Html.PartialAsync("_AuthenticatedNav")
+<main>
+    <div class="stack">
+        <section class="card">
+            <h1>Default endpoint values</h1>
+            <p class="muted">Manage the default values applied when creating new endpoints.</p>
+            <div class="button-row">
+                <a class="button-secondary" href="/admin">Back to DB maintenance</a>
+            </div>
+        </section>
+
+        <form method="post" action="/admin/default-endpoint-values" class="stack">
+            @Html.AntiForgeryToken()
+            @if (Model.Saved) { <div class="saved" role="status">Default endpoint values saved successfully.</div> }
+            @if (!ViewData.ModelState.IsValid) { <div class="errors" asp-validation-summary="ModelOnly"></div> }
+
+            <section class="card">
+                <div class="field-grid">
+                    <div>
+                        <label asp-for="DefaultPingIntervalSeconds"></label>
+                        <input asp-for="DefaultPingIntervalSeconds" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="DefaultPingIntervalSeconds"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="DefaultRetryIntervalSeconds"></label>
+                        <input asp-for="DefaultRetryIntervalSeconds" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="DefaultRetryIntervalSeconds"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="DefaultTimeoutMs"></label>
+                        <input asp-for="DefaultTimeoutMs" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="DefaultTimeoutMs"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="DefaultFailureThreshold"></label>
+                        <input asp-for="DefaultFailureThreshold" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="DefaultFailureThreshold"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="DefaultRecoveryThreshold"></label>
+                        <input asp-for="DefaultRecoveryThreshold" type="number" min="1" />
+                        <div class="field-error"><span asp-validation-for="DefaultRecoveryThreshold"></span></div>
+                    </div>
+                </div>
+                <p class="muted">Last updated: @Model.UpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</p>
+            </section>
+
+            <div class="button-row"><button class="button" type="submit">Save default endpoint values</button></div>
+        </form>
+    </div>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
@@ -5,7 +5,7 @@
     @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Notification infrastructure</title>
+    <title>Notification infrastructure settings</title>
     <style>
         :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; --success:#137333; --error-bg:#fee4e2; --error-text:#b42318; }
         *{box-sizing:border-box;} body{margin:0;font-family:Arial,sans-serif;background:var(--bg);color:var(--text);} main{max-width:760px;margin:0 auto;padding:1rem;}
@@ -22,15 +22,15 @@
 <main>
     <div class="stack">
         <section class="card">
-            <h1>Notification infrastructure</h1>
-            <p class="muted">This page controls notification transport infrastructure (SMTP + Telegram polling settings). Per-user notification preferences moved to each user's <a href="/profile">profile page</a>.</p>
+            <h1>Notification infrastructure settings</h1>
+            <p class="muted">This page controls notification transport infrastructure (SMTP + Telegram polling settings). Per-user notification preferences moved to each user's <a href="/profile/notification-settings">profile page</a>.</p>
             <div class="button-row">
-                <a class="button-secondary" href="/admin">Back to admin settings</a>
+                <a class="button-secondary" href="/admin">Back to DB maintenance</a>
                 <a class="button-secondary" href="/status">Back to status</a>
             </div>
         </section>
 
-        <form method="post" action="/settings/notifications" class="stack">
+        <form method="post" action="/admin/notification-infrastructure-settings" class="stack">
             @Html.AntiForgeryToken()
             @if (Model.Saved) { <div class="saved" role="status">Notification infrastructure settings saved.</div> }
             @if (!ViewData.ModelState.IsValid) { <div class="errors" asp-validation-summary="ModelOnly"></div> }
@@ -78,7 +78,7 @@
                     <div class="field-error"><span asp-validation-for="SmtpFromAddress"></span></div>
                 </div>
                 <div><label asp-for="SmtpFromDisplayName"></label><input asp-for="SmtpFromDisplayName" type="text" /></div>
-                <div class="button-row"><button class="button-secondary" type="submit" formaction="/settings/notifications/smtp-test">Send SMTP test email to my account</button></div>
+                <div class="button-row"><button class="button-secondary" type="submit" formaction="/admin/notification-infrastructure-settings/smtp-test">Send SMTP test email to my account</button></div>
             </section>
 
             <section class="card">

--- a/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
@@ -13,8 +13,8 @@
         .button-row{display:flex;gap:.75rem;flex-wrap:wrap;} .button,.button-secondary{display:inline-flex;align-items:center;justify-content:center;min-height:44px;padding:.7rem 1rem;border-radius:10px;font-weight:600;text-decoration:none;}
         .button{border:0;background:var(--accent);color:#fff;cursor:pointer;} .button-secondary{border:1px solid var(--border);color:var(--text);background:#fff;cursor:pointer;}
         .saved{border:1px solid #c2f0c2;background:#ebffee;color:var(--success);border-radius:10px;padding:.8rem;} .errors{border:1px solid #fda29b;background:var(--error-bg);color:var(--error-text);border-radius:10px;padding:.8rem;}
-        .muted{color:var(--muted);} .field-error{color:var(--error-text);font-size:.9rem;margin-top:.25rem;} .switch-row{display:flex;align-items:center;gap:.75rem;}
-        input[type="text"],input[type="email"],input[type="password"],input[type="time"]{width:100%;min-height:44px;border:1px solid var(--border);border-radius:8px;padding:.6rem .7rem;font:inherit;}
+        .muted{color:var(--muted);} .field-error{color:var(--error-text);font-size:.9rem;margin-top:.25rem;}
+        input[type="text"],input[type="email"],input[type="password"]{width:100%;min-height:44px;border:1px solid var(--border);border-radius:8px;padding:.6rem .7rem;font:inherit;}
     </style>
 </head>
 <body>
@@ -23,8 +23,11 @@
 <div class="stack">
 <section class="card">
     <h1>My profile</h1>
-    <p class="muted">Manage your account details and your own notification preferences.</p>
-    <div class="button-row"><a class="button-secondary" href="/status">Back to status</a></div>
+    <p class="muted">Manage your account details. Notification preferences are on a dedicated page.</p>
+    <div class="button-row">
+        <a class="button-secondary" href="/profile/notification-settings">Notification settings</a>
+        <a class="button-secondary" href="/status">Back to status</a>
+    </div>
 </section>
 @if (!ViewData.ModelState.IsValid) { <div class="errors" asp-validation-summary="ModelOnly"></div> }
 <section class="card stack">
@@ -49,85 +52,7 @@
         <div class="button-row"><button class="button" type="submit">Change password</button></div>
     </form>
 </section>
-<section class="card stack" id="notification-preferences">
-    <h2>Notification preferences</h2>
-    @if (Model.NotificationsSaved) { <div class="saved">Notification preferences saved.</div> }
-    <form method="post" action="/profile/notifications" class="stack">
-        @Html.AntiForgeryToken()
-        <input type="hidden" asp-for="Email" />
-        <input type="hidden" asp-for="BrowserNotificationsPermissionState" id="browserPermissionStateInput" />
-        <h3>Browser</h3>
-        <div class="switch-row"><input asp-for="BrowserNotificationsEnabled" type="checkbox" /><label asp-for="BrowserNotificationsEnabled">Enable browser notifications</label></div>
-        <div class="switch-row"><input asp-for="BrowserNotifyEndpointDown" type="checkbox" /><label asp-for="BrowserNotifyEndpointDown">Endpoint down</label></div>
-        <div class="switch-row"><input asp-for="BrowserNotifyEndpointRecovered" type="checkbox" /><label asp-for="BrowserNotifyEndpointRecovered">Endpoint recovered</label></div>
-        <div class="switch-row"><input asp-for="BrowserNotifyAgentOffline" type="checkbox" /><label asp-for="BrowserNotifyAgentOffline">Agent offline</label></div>
-        <div class="switch-row"><input asp-for="BrowserNotifyAgentOnline" type="checkbox" /><label asp-for="BrowserNotifyAgentOnline">Agent online</label></div>
-
-        <h3>SMTP</h3>
-        <div class="switch-row"><input asp-for="SmtpNotificationsEnabled" type="checkbox" /><label asp-for="SmtpNotificationsEnabled">Enable SMTP notifications to my email</label></div>
-        <div class="switch-row"><input asp-for="SmtpNotifyEndpointDown" type="checkbox" /><label asp-for="SmtpNotifyEndpointDown">Endpoint down</label></div>
-        <div class="switch-row"><input asp-for="SmtpNotifyEndpointRecovered" type="checkbox" /><label asp-for="SmtpNotifyEndpointRecovered">Endpoint recovered</label></div>
-        <div class="switch-row"><input asp-for="SmtpNotifyAgentOffline" type="checkbox" /><label asp-for="SmtpNotifyAgentOffline">Agent offline</label></div>
-        <div class="switch-row"><input asp-for="SmtpNotifyAgentOnline" type="checkbox" /><label asp-for="SmtpNotifyAgentOnline">Agent online</label></div>
-
-
-
-        <h3>Telegram</h3>
-        <div class="switch-row"><input asp-for="TelegramNotificationsEnabled" type="checkbox" /><label asp-for="TelegramNotificationsEnabled">Enable Telegram notifications</label></div>
-        <div class="switch-row"><input asp-for="TelegramNotifyEndpointDown" type="checkbox" /><label asp-for="TelegramNotifyEndpointDown">Endpoint down</label></div>
-        <div class="switch-row"><input asp-for="TelegramNotifyEndpointRecovered" type="checkbox" /><label asp-for="TelegramNotifyEndpointRecovered">Endpoint recovered</label></div>
-        <div class="switch-row"><input asp-for="TelegramNotifyAgentOffline" type="checkbox" /><label asp-for="TelegramNotifyAgentOffline">Agent offline</label></div>
-        <div class="switch-row"><input asp-for="TelegramNotifyAgentOnline" type="checkbox" /><label asp-for="TelegramNotifyAgentOnline">Agent online</label></div>
-
-        <h3>Quiet hours</h3>
-        <div class="switch-row"><input asp-for="QuietHoursEnabled" type="checkbox" /><label asp-for="QuietHoursEnabled">Enable quiet hours</label></div>
-        <div><label asp-for="QuietHoursStartLocalTime">Start</label><input asp-for="QuietHoursStartLocalTime" type="time" /><div class="field-error"><span asp-validation-for="QuietHoursStartLocalTime"></span></div></div>
-        <div><label asp-for="QuietHoursEndLocalTime">End</label><input asp-for="QuietHoursEndLocalTime" type="time" /><div class="field-error"><span asp-validation-for="QuietHoursEndLocalTime"></span></div></div>
-        <div><label asp-for="QuietHoursTimeZoneId">Time zone ID</label><input asp-for="QuietHoursTimeZoneId" type="text" /><div class="field-error"><span asp-validation-for="QuietHoursTimeZoneId"></span></div></div>
-        <div class="switch-row"><input asp-for="QuietHoursSuppressBrowserNotifications" type="checkbox" /><label asp-for="QuietHoursSuppressBrowserNotifications">Suppress browser during quiet hours</label></div>
-        <div class="switch-row"><input asp-for="QuietHoursSuppressSmtpNotifications" type="checkbox" /><label asp-for="QuietHoursSuppressSmtpNotifications">Suppress SMTP during quiet hours</label></div>
-        <div class="switch-row"><input asp-for="QuietHoursSuppressTelegramNotifications" type="checkbox" /><label asp-for="QuietHoursSuppressTelegramNotifications">Suppress Telegram during quiet hours</label></div>
-        <p class="muted">Settings last updated at @Model.NotificationSettingsUpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'").</p>
-        <div class="button-row"><button class="button" type="submit">Save notification preferences</button></div>
-    </form>
-</section>
-
-<section class="card stack">
-    <h2>Telegram account linking</h2>
-    <p class="muted">Generate a verification code, send it to the bot in a private chat, and wait for confirmation.</p>
-    @if (Model.TelegramCodeGenerated) { <div class="saved">A new Telegram link code was generated.</div> }
-    @if (Model.TelegramAccountRemoved) { <div class="saved">Telegram account removed.</div> }
-    @if (!string.IsNullOrWhiteSpace(Model.ActiveTelegramCode))
-    {
-        <p><strong>Active code:</strong> @Model.ActiveTelegramCode (expires @Model.ActiveTelegramCodeExpiresAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'"))</p>
-    }
-    @if (Model.TelegramLinked)
-    {
-        <p><strong>Linked chat:</strong> @Model.TelegramLinkedChatId</p>
-        @if (!string.IsNullOrWhiteSpace(Model.TelegramLinkedUsername)) { <p><strong>Username:</strong> @Model.TelegramLinkedUsername</p> }
-    }
-    <div class="button-row">
-        <form method="post" action="/profile/telegram/generate-code" class="stack">
-            @Html.AntiForgeryToken()
-            <button class="button-secondary" type="submit">Generate link code</button>
-        </form>
-        @if (Model.TelegramLinked)
-        {
-            <form method="post" action="/profile/telegram/remove" class="stack">
-                @Html.AntiForgeryToken()
-                <button class="button-secondary" type="submit">Remove linked Telegram account</button>
-            </form>
-        }
-    </div>
-</section>
-
 </div>
 </main>
-<script>
-(() => {
-const input=document.getElementById('browserPermissionStateInput');
-if (typeof Notification !== 'undefined' && input) { input.value = Notification.permission; }
-})();
-</script>
 </body>
 </html>

--- a/src/WebApp/PingMonitor.Web/Views/Profile/NotificationSettings.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Profile/NotificationSettings.cshtml
@@ -1,0 +1,108 @@
+@model PingMonitor.Web.ViewModels.Profile.ProfilePageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    @await Html.PartialAsync("_ThemeHead")
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Notification settings</title>
+    <style>
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; --success:#137333; --error-bg:#fee4e2; --error-text:#b42318; }
+        *{box-sizing:border-box;} body{margin:0;font-family:Arial,sans-serif;background:var(--bg);color:var(--text);} main{max-width:820px;margin:0 auto;padding:1rem;}
+        .stack{display:grid;gap:1rem;} .card{background:var(--card);border-radius:14px;box-shadow:0 1px 2px rgba(16,24,40,.08);padding:1rem;}
+        .button-row{display:flex;gap:.75rem;flex-wrap:wrap;} .button,.button-secondary{display:inline-flex;align-items:center;justify-content:center;min-height:44px;padding:.7rem 1rem;border-radius:10px;font-weight:600;text-decoration:none;}
+        .button{border:0;background:var(--accent);color:#fff;cursor:pointer;} .button-secondary{border:1px solid var(--border);color:var(--text);background:#fff;cursor:pointer;}
+        .saved{border:1px solid #c2f0c2;background:#ebffee;color:var(--success);border-radius:10px;padding:.8rem;} .errors{border:1px solid #fda29b;background:var(--error-bg);color:var(--error-text);border-radius:10px;padding:.8rem;}
+        .muted{color:var(--muted);} .field-error{color:var(--error-text);font-size:.9rem;margin-top:.25rem;} .switch-row{display:flex;align-items:center;gap:.75rem;}
+        input[type="text"],input[type="time"]{width:100%;min-height:44px;border:1px solid var(--border);border-radius:8px;padding:.6rem .7rem;font:inherit;}
+    </style>
+</head>
+<body>
+@await Html.PartialAsync("_AuthenticatedNav")
+<main>
+<div class="stack">
+<section class="card">
+    <h1>Notification settings</h1>
+    <p class="muted">Manage your personal notification preferences and Telegram account linking.</p>
+    <div class="button-row"><a class="button-secondary" href="/profile">Back to my profile</a></div>
+</section>
+@if (!ViewData.ModelState.IsValid) { <div class="errors" asp-validation-summary="ModelOnly"></div> }
+<section class="card stack">
+    <h2>Notification preferences</h2>
+    @if (Model.NotificationsSaved) { <div class="saved">Notification preferences saved.</div> }
+    <form method="post" action="/profile/notification-settings" class="stack">
+        @Html.AntiForgeryToken()
+        <input type="hidden" asp-for="Email" />
+        <input type="hidden" asp-for="BrowserNotificationsPermissionState" id="browserPermissionStateInput" />
+        <h3>Browser</h3>
+        <div class="switch-row"><input asp-for="BrowserNotificationsEnabled" type="checkbox" /><label asp-for="BrowserNotificationsEnabled">Enable browser notifications</label></div>
+        <div class="switch-row"><input asp-for="BrowserNotifyEndpointDown" type="checkbox" /><label asp-for="BrowserNotifyEndpointDown">Endpoint down</label></div>
+        <div class="switch-row"><input asp-for="BrowserNotifyEndpointRecovered" type="checkbox" /><label asp-for="BrowserNotifyEndpointRecovered">Endpoint recovered</label></div>
+        <div class="switch-row"><input asp-for="BrowserNotifyAgentOffline" type="checkbox" /><label asp-for="BrowserNotifyAgentOffline">Agent offline</label></div>
+        <div class="switch-row"><input asp-for="BrowserNotifyAgentOnline" type="checkbox" /><label asp-for="BrowserNotifyAgentOnline">Agent online</label></div>
+
+        <h3>SMTP</h3>
+        <div class="switch-row"><input asp-for="SmtpNotificationsEnabled" type="checkbox" /><label asp-for="SmtpNotificationsEnabled">Enable SMTP notifications to my email</label></div>
+        <div class="switch-row"><input asp-for="SmtpNotifyEndpointDown" type="checkbox" /><label asp-for="SmtpNotifyEndpointDown">Endpoint down</label></div>
+        <div class="switch-row"><input asp-for="SmtpNotifyEndpointRecovered" type="checkbox" /><label asp-for="SmtpNotifyEndpointRecovered">Endpoint recovered</label></div>
+        <div class="switch-row"><input asp-for="SmtpNotifyAgentOffline" type="checkbox" /><label asp-for="SmtpNotifyAgentOffline">Agent offline</label></div>
+        <div class="switch-row"><input asp-for="SmtpNotifyAgentOnline" type="checkbox" /><label asp-for="SmtpNotifyAgentOnline">Agent online</label></div>
+
+        <h3>Telegram</h3>
+        <div class="switch-row"><input asp-for="TelegramNotificationsEnabled" type="checkbox" /><label asp-for="TelegramNotificationsEnabled">Enable Telegram notifications</label></div>
+        <div class="switch-row"><input asp-for="TelegramNotifyEndpointDown" type="checkbox" /><label asp-for="TelegramNotifyEndpointDown">Endpoint down</label></div>
+        <div class="switch-row"><input asp-for="TelegramNotifyEndpointRecovered" type="checkbox" /><label asp-for="TelegramNotifyEndpointRecovered">Endpoint recovered</label></div>
+        <div class="switch-row"><input asp-for="TelegramNotifyAgentOffline" type="checkbox" /><label asp-for="TelegramNotifyAgentOffline">Agent offline</label></div>
+        <div class="switch-row"><input asp-for="TelegramNotifyAgentOnline" type="checkbox" /><label asp-for="TelegramNotifyAgentOnline">Agent online</label></div>
+
+        <h3>Quiet hours</h3>
+        <div class="switch-row"><input asp-for="QuietHoursEnabled" type="checkbox" /><label asp-for="QuietHoursEnabled">Enable quiet hours</label></div>
+        <div><label asp-for="QuietHoursStartLocalTime">Start</label><input asp-for="QuietHoursStartLocalTime" type="time" /><div class="field-error"><span asp-validation-for="QuietHoursStartLocalTime"></span></div></div>
+        <div><label asp-for="QuietHoursEndLocalTime">End</label><input asp-for="QuietHoursEndLocalTime" type="time" /><div class="field-error"><span asp-validation-for="QuietHoursEndLocalTime"></span></div></div>
+        <div><label asp-for="QuietHoursTimeZoneId">Time zone ID</label><input asp-for="QuietHoursTimeZoneId" type="text" /><div class="field-error"><span asp-validation-for="QuietHoursTimeZoneId"></span></div></div>
+        <div class="switch-row"><input asp-for="QuietHoursSuppressBrowserNotifications" type="checkbox" /><label asp-for="QuietHoursSuppressBrowserNotifications">Suppress browser during quiet hours</label></div>
+        <div class="switch-row"><input asp-for="QuietHoursSuppressSmtpNotifications" type="checkbox" /><label asp-for="QuietHoursSuppressSmtpNotifications">Suppress SMTP during quiet hours</label></div>
+        <div class="switch-row"><input asp-for="QuietHoursSuppressTelegramNotifications" type="checkbox" /><label asp-for="QuietHoursSuppressTelegramNotifications">Suppress Telegram during quiet hours</label></div>
+        <p class="muted">Settings last updated at @Model.NotificationSettingsUpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'").</p>
+        <div class="button-row"><button class="button" type="submit">Save notification preferences</button></div>
+    </form>
+</section>
+
+<section class="card stack">
+    <h2>Telegram account linking</h2>
+    <p class="muted">Generate a verification code, send it to the bot in a private chat, and wait for confirmation.</p>
+    @if (Model.TelegramCodeGenerated) { <div class="saved">A new Telegram link code was generated.</div> }
+    @if (Model.TelegramAccountRemoved) { <div class="saved">Telegram account removed.</div> }
+    @if (!string.IsNullOrWhiteSpace(Model.ActiveTelegramCode))
+    {
+        <p><strong>Active code:</strong> @Model.ActiveTelegramCode (expires @Model.ActiveTelegramCodeExpiresAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'"))</p>
+    }
+    @if (Model.TelegramLinked)
+    {
+        <p><strong>Linked chat:</strong> @Model.TelegramLinkedChatId</p>
+        @if (!string.IsNullOrWhiteSpace(Model.TelegramLinkedUsername)) { <p><strong>Username:</strong> @Model.TelegramLinkedUsername</p> }
+    }
+    <div class="button-row">
+        <form method="post" action="/profile/notification-settings/telegram/generate-code" class="stack">
+            @Html.AntiForgeryToken()
+            <button class="button-secondary" type="submit">Generate link code</button>
+        </form>
+        @if (Model.TelegramLinked)
+        {
+            <form method="post" action="/profile/notification-settings/telegram/remove" class="stack">
+                @Html.AntiForgeryToken()
+                <button class="button-secondary" type="submit">Remove linked Telegram account</button>
+            </form>
+        }
+    </div>
+</section>
+</div>
+</main>
+<script>
+(() => {
+const input=document.getElementById('browserPermissionStateInput');
+if (typeof Notification !== 'undefined' && input) { input.value = Notification.permission; }
+})();
+</script>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -19,8 +19,7 @@
     var monitoringOpen = IsCurrent(path, "/", "/status", "/endpoints", "/groups");
     var agentsOpen = IsCurrent(path, "/agents");
     var eventsOpen = IsCurrent(path, "/admin/security");
-    var notificationsOpen = IsCurrent(path, "/profile", "/settings/notifications");
-    var adminOpen = IsCurrent(path, "/admin", "/users");
+    var adminOpen = IsCurrent(path, "/admin", "/users", "/settings/notifications");
     var profileOpen = IsCurrent(path, "/profile");
 }
 <style>
@@ -163,17 +162,6 @@
             </details>
         }
 
-        <details data-active="@notificationsOpen">
-            <summary aria-controls="nav-menu-notifications" aria-expanded="false">Notifications <span aria-hidden="true">▾</span></summary>
-            <div class="site-nav-dropdown" id="nav-menu-notifications">
-                <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile#notification-preferences">My notification settings</a>
-                @if (isAdmin)
-                {
-                    <a class="site-nav-link" data-current="@IsCurrent(path, "/settings/notifications")" href="/settings/notifications">Notification infrastructure settings</a>
-                }
-            </div>
-        </details>
-
         @if (isAdmin)
         {
             <details data-active="@adminOpen">
@@ -182,6 +170,8 @@
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/admin/security")" href="/admin/security#security-settings">Security settings</a>
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/admin/backups")" href="/admin/backups">Configuration backups</a>
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/admin")" href="/admin">DB maintenance</a>
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/admin/notification-infrastructure-settings", "/settings/notifications")" href="/admin/notification-infrastructure-settings">Notification infrastructure settings</a>
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/admin/default-endpoint-values")" href="/admin/default-endpoint-values">Default endpoint values</a>
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/users")" href="/users">User management</a>
                 </div>
             </details>
@@ -191,6 +181,7 @@
             <summary aria-controls="nav-menu-profile" aria-expanded="false">Profile <span aria-hidden="true">▾</span></summary>
             <div class="site-nav-dropdown" id="nav-menu-profile">
                 <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile">My profile</a>
+                <a class="site-nav-link" data-current="@IsCurrent(path, "/profile/notification-settings")" href="/profile/notification-settings">Notification settings</a>
                 <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile#change-password">Change password</a>
                 <form method="post" action="/account/logout">
                     @Html.AntiForgeryToken()


### PR DESCRIPTION
### Motivation

- Clean up the site information architecture now that global navigation exists by moving user-facing and admin-facing settings to clearer places. 
- Move per-user notification preferences out of the general profile page into a dedicated, user-owned page under `Profile`. 
- Remove the top-level `Notifications` menu and ensure admin notification infrastructure settings and default endpoint values live under `Admin`. 
- Preserve existing notification and endpoint-default behaviors while improving discoverability and reducing nav clutter.

### Description

- Adds a dedicated user notification page at `GET /profile/notification-settings` with its own view `Views/Profile/NotificationSettings.cshtml` and wires `ProfileController` to render/update that view while preserving the existing `IUserNotificationSettingsService` behavior. 
- Moves admin notification infrastructure to `admin/notification-infrastructure-settings` while retaining the legacy `settings/notifications` route for compatibility and updates `NotificationSettingsController` and its view to post to the new admin route. 
- Extracts default endpoint values into a new controller `AdminDefaultEndpointValuesController` at `GET/POST /admin/default-endpoint-values` with `DefaultEndpointValuesPageViewModel` and a new view, and removes default endpoint inputs from the main Admin DB maintenance page while preserving `IApplicationSettingsService` updates. 
- Updates the global nav (`Views/Shared/_AuthenticatedNav.cshtml`) to remove the top-level `Notifications` menu and add Profile and Admin submenu links (`/profile/notification-settings`, `/admin/notification-infrastructure-settings`, `/admin/default-endpoint-values`), and updates `docs/navigation.md` to reflect the final IA; this work is linked to the tracking issue `Fixes #248`. 

### Testing

- Created the GitHub issue and linked the work as required by repo rules (`Fixes #248`).
- Built the web application with .NET SDK `10.0.104` using `dotnet build src/WebApp/PingMonitor.WebApp.slnx`, and the build completed successfully. 
- Verified route/view wiring and navigation changes by inspecting updated controllers and views and searching for the new routes (`/profile/notification-settings`, `/admin/notification-infrastructure-settings`, `/admin/default-endpoint-values`) in the source tree. 
- No other automated runtime tests were added or run as part of this UI/navigation refactor; the change preserves existing service and command contracts to avoid behavioral regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd24e0ab38832aa9fa0c6ac6451596)