### PR TITLE
Clarify Admin submenu label for /admin destination

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
@@ -5,7 +5,7 @@
     @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>DB maintenance</title>
+    <title>Admin settings</title>
     <style>
         :root { color-scheme: light; --bg:#f3f6f8; --card:#ffffff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; --success:#137333; --error-bg:#fee4e2; --error-text:#b42318; }
         * { box-sizing: border-box; }
@@ -30,7 +30,7 @@
 <main>
     <div class="stack">
         <section class="card">
-            <h1>DB maintenance</h1>
+            <h1>Admin settings</h1>
             <p class="muted">Configure database-adjacent maintenance settings for the application.</p>
             <div class="button-row">
                 <a class="button-secondary" href="/status">Back to status</a>

--- a/src/WebApp/PingMonitor.Web/Views/AdminDefaultEndpointValues/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminDefaultEndpointValues/Index.cshtml
@@ -27,7 +27,7 @@
             <h1>Default endpoint values</h1>
             <p class="muted">Manage the default values applied when creating new endpoints.</p>
             <div class="button-row">
-                <a class="button-secondary" href="/admin">Back to DB maintenance</a>
+                <a class="button-secondary" href="/admin">Back to Admin settings</a>
             </div>
         </section>
 

--- a/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
@@ -25,7 +25,7 @@
             <h1>Notification infrastructure settings</h1>
             <p class="muted">This page controls notification transport infrastructure (SMTP + Telegram polling settings). Per-user notification preferences moved to each user's <a href="/profile/notification-settings">profile page</a>.</p>
             <div class="button-row">
-                <a class="button-secondary" href="/admin">Back to DB maintenance</a>
+                <a class="button-secondary" href="/admin">Back to Admin settings</a>
                 <a class="button-secondary" href="/status">Back to status</a>
             </div>
         </section>

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -169,7 +169,7 @@
                 <div class="site-nav-dropdown" id="nav-menu-admin">
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/admin/security")" href="/admin/security#security-settings">Security settings</a>
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/admin/backups")" href="/admin/backups">Configuration backups</a>
-                    <a class="site-nav-link" data-current="@IsCurrent(path, "/admin")" href="/admin">DB maintenance</a>
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/admin")" href="/admin">Admin settings</a>
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/admin/notification-infrastructure-settings", "/settings/notifications")" href="/admin/notification-infrastructure-settings">Notification infrastructure settings</a>
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/admin/default-endpoint-values")" href="/admin/default-endpoint-values">Default endpoint values</a>
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/users")" href="/users">User management</a>


### PR DESCRIPTION
### Motivation
- The Admin submenu item was labeled "DB Maintenance" but routed to the `/admin` Admin settings page, which is misleading because there is no dedicated DB Maintenance page yet. 
- This is a UI-only correctness fix to avoid user confusion without changing routing or behavior. 
- The change follows repository issue/PR traceability requirements by linking the work to an issue. 

### Description
- Rename the Admin submenu label from `DB maintenance` to `Admin settings` in `src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml` while keeping the `href="/admin"` unchanged. 
- Update the `/admin` page title and main heading in `src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml` to `Admin settings` so the destination matches the menu label. 
- Update adjacent back-link wording that points to `/admin` in `src/WebApp/PingMonitor.Web/Views/AdminDefaultEndpointValues/Index.cshtml` and `src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml` to `Back to Admin settings` for consistency. 
- This PR is associated with and closes the created issue `#250` (Fixes #250). 

### Testing
- Built the web app with .NET 10 using `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which succeeded with SDK `10.0.104`. 
- Verified with a deterministic search (`rg -n "DB maintenance|Admin settings" src/WebApp/PingMonitor.Web -S`) that remaining UI labels that route to `/admin` now use `Admin settings` and no `DB maintenance` labels remain in the web app views.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd29579204832a8edeee55cb5ab3c0)