### PR TITLE
Add direct Home shortcut to authenticated primary navigation

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -80,6 +80,7 @@
         z-index: 50;
     }
 
+    .site-nav-shortcut,
     .site-nav-link,
     .site-nav-logout {
         display: flex;
@@ -97,11 +98,27 @@
         cursor: pointer;
     }
 
+    .site-nav-shortcut {
+        border: 1px solid var(--border);
+        background: var(--surface-1);
+        min-width: 110px;
+        justify-content: center;
+        font-weight: 700;
+    }
+
+    .site-nav-shortcut[data-current="true"] {
+        border-color: var(--accent);
+        box-shadow: inset 0 0 0 1px var(--accent);
+        background: var(--surface-2);
+    }
+
     .site-nav-link[data-current="true"] {
         background: var(--surface-2);
         font-weight: 700;
     }
 
+    .site-nav-shortcut:hover,
+    .site-nav-shortcut:focus-visible,
     .site-nav-link:hover,
     .site-nav-link:focus-visible,
     .site-nav-logout:hover,
@@ -128,6 +145,8 @@
 </style>
 <nav class="site-nav-shell" aria-label="Primary">
     <div class="site-nav" data-site-nav>
+        <a class="site-nav-shortcut" data-current="@(path.Equals("/", StringComparison.OrdinalIgnoreCase) || path.StartsWith("/status", StringComparison.OrdinalIgnoreCase))" href="/status">Home</a>
+
         <details data-active="@monitoringOpen">
             <summary aria-controls="nav-menu-monitoring" aria-expanded="false">Monitoring <span aria-hidden="true">▾</span></summary>
             <div class="site-nav-dropdown" id="nav-menu-monitoring">


### PR DESCRIPTION
### Motivation
- Provide a one-click entry to the main operational status page so users can return to the overview without opening dropdowns.
- Keep the existing category/dropdown structure unchanged while improving frequent navigation, especially on mobile.

### Description
- Added a top-level `Home` shortcut link in `src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml` that routes directly to `/status` and is placed before the existing dropdowns so it is accessible without opening menus. 
- Implemented dedicated styling for the shortcut (`.site-nav-shortcut`) including hover/focus and an active state driven by an explicit path check for `/` or `/status` so it highlights correctly when the operational status page is open. 
- Left all existing dropdown menus and links intact; this change is purely a navigation usability improvement and is linked to the created issue `#252` (Fixes #252).

### Testing
- Ran a full web build with the .NET 10 SDK using `dotnet build` and the web project built successfully (no errors).
- Performed a code-level verification that the shortcut `href` points to `/status` and the active-state predicate matches `/` and `/status` so the visual active styling will apply when on the status page.
- No automated UI/browser screenshot tests were run in this environment; visual verification is recommended during review to confirm spacing and behavior across themes and narrow widths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2b0ad034832a8ab9eb829e26ca30)