### PR TITLE
Add section-level auto-refresh for status and endpoint assignments

### DIFF
--- a/docs/auto-refresh.md
+++ b/docs/auto-refresh.md
@@ -1,0 +1,39 @@
+# Auto-refresh (phase 1)
+
+## Scope
+
+Auto-refresh is **section-level only**. The application intentionally avoids full-page refresh/reload.
+
+Phase 1 targets:
+
+- Home (`/status`):
+  - recent events
+  - summary
+  - assignments
+- Manage endpoints (`/endpoints`):
+  - assignments only
+
+## Transport approach
+
+- Use lightweight HTTP `GET` endpoints that return partial HTML for each refreshable section.
+- Poll each section on a fixed interval.
+- Replace only the matching DOM section (`<section ...>`) on success.
+- Do not use SignalR/websockets in phase 1.
+
+## Interval policy
+
+- Status recent events: every **10 seconds**
+- Status summary: every **15 seconds**
+- Status assignments: every **15 seconds**
+- Manage endpoints assignments: every **15 seconds**
+
+Intervals are explicit constants in page scripts so they are easy to tune later.
+
+## UX and stability rules
+
+- Never refresh the whole page.
+- Avoid overlapping refresh runs per section.
+- Fail quietly on transient fetch errors and retry on the next interval.
+- Skip refresh while the tab is hidden.
+- Preserve assignment expand/collapse state on the status page where practical by restoring open assignment IDs after section replacement.
+- Avoid scroll/focus disruption by replacing only target sections and not triggering navigation.

--- a/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/EndpointsController.cs
@@ -55,6 +55,13 @@ public sealed class EndpointsController : Controller
         return View("Index", model);
     }
 
+    [HttpGet("refresh/assignments")]
+    public async Task<IActionResult> RefreshAssignments([FromQuery] string? groupId, CancellationToken cancellationToken)
+    {
+        var model = await _endpointManagementQueryService.GetManagePageAsync(groupId, cancellationToken);
+        return PartialView("_AssignmentsSection", model);
+    }
+
     [Authorize(Roles = ApplicationRoles.Admin)]
     [HttpGet("new")]
     public async Task<IActionResult> New(CancellationToken cancellationToken)

--- a/src/WebApp/PingMonitor.Web/Controllers/StatusController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/StatusController.cs
@@ -22,4 +22,25 @@ public sealed class StatusController : Controller
         var viewModel = await _endpointStatusQueryService.GetStatusPageAsync(state, agent, groupId, search, cancellationToken);
         return View("Index", viewModel);
     }
+
+    [HttpGet("refresh/recent-events")]
+    public async Task<IActionResult> RefreshRecentEvents([FromQuery] string? state, [FromQuery] string? agent, [FromQuery] string? groupId, [FromQuery] string? search, CancellationToken cancellationToken)
+    {
+        var viewModel = await _endpointStatusQueryService.GetStatusPageAsync(state, agent, groupId, search, cancellationToken);
+        return PartialView("_RecentEventsSection", viewModel);
+    }
+
+    [HttpGet("refresh/summary")]
+    public async Task<IActionResult> RefreshSummary([FromQuery] string? state, [FromQuery] string? agent, [FromQuery] string? groupId, [FromQuery] string? search, CancellationToken cancellationToken)
+    {
+        var viewModel = await _endpointStatusQueryService.GetStatusPageAsync(state, agent, groupId, search, cancellationToken);
+        return PartialView("_SummarySection", viewModel);
+    }
+
+    [HttpGet("refresh/assignments")]
+    public async Task<IActionResult> RefreshAssignments([FromQuery] string? state, [FromQuery] string? agent, [FromQuery] string? groupId, [FromQuery] string? search, CancellationToken cancellationToken)
+    {
+        var viewModel = await _endpointStatusQueryService.GetStatusPageAsync(state, agent, groupId, search, cancellationToken);
+        return PartialView("_AssignmentsSection", viewModel);
+    }
 }

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Index.cshtml
@@ -1,17 +1,4 @@
 @model PingMonitor.Web.ViewModels.Endpoints.ManageEndpointsPageViewModel
-@using PingMonitor.Web.Models
-@using PingMonitor.Web.Services.Endpoints
-@{
-    static string StateClass(EndpointStateKind state) => state switch
-    {
-        EndpointStateKind.Up => "state-up",
-        EndpointStateKind.Down => "state-down",
-        EndpointStateKind.Suppressed => "state-suppressed",
-        EndpointStateKind.Degraded => "state-degraded",
-        _ => "state-unknown"
-    };
-    static string FormatRtt(double? value) => value.HasValue ? $"{value.Value:F1} ms" : "No data";
-}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -86,68 +73,52 @@
             </form>
         </section>
 
-        <section class="card">
-            <h2>Assignments</h2>
-            @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
-            {
-                <div class="notice" role="status">@Model.StatusMessage</div>
-            }
-
-            @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
-            {
-                <div class="error" role="alert">@Model.ErrorMessage</div>
-            }
-
-            @if (Model.Rows.Count == 0)
-            {
-                <p class="muted">No endpoint assignments are available.</p>
-            }
-            else
-            {
-                <div class="row-list">
-                    @foreach (var row in Model.Rows)
-                    {
-                        <article class="row">
-                            <div class="row-header">
-                                <div>
-                                    <div><strong>@EndpointIconCatalog.GetSymbol(row.IconKey) @row.EndpointName</strong></div>
-                                    <div class="muted">@row.Target</div>
-                                </div>
-                                <div class="badge @StateClass(row.CurrentState)">@row.CurrentState</div>
-                            </div>
-                            <div class="row-meta">
-                                <div class="meta-item"><span>Assignment ID</span><div>@row.AssignmentId</div></div>
-                                <div class="meta-item"><span>Agent / instance</span><div>@row.AgentDisplay</div></div>
-                                <div class="meta-item"><span>Groups</span><div>@(row.GroupNames.Count == 0 ? "None" : string.Join(", ", row.GroupNames))</div></div>
-                                <div class="meta-item"><span>Dependency parents</span><div>@(row.DependencyEndpointNames.Count == 0 ? "None" : string.Join(", ", row.DependencyEndpointNames))</div></div>
-                                <div class="meta-item"><span>Endpoint enabled</span><div>@(row.EndpointEnabled ? "Enabled" : "Disabled")</div></div>
-                                <div class="meta-item"><span>Assignment enabled</span><div>@(row.AssignmentEnabled ? "Enabled" : "Disabled")</div></div>
-                                <div class="meta-item"><span>Ping interval</span><div>@row.PingIntervalSeconds s</div></div>
-                                <div class="meta-item"><span>Retry interval</span><div>@row.RetryIntervalSeconds s</div></div>
-                                <div class="meta-item"><span>Timeout</span><div>@row.TimeoutMs ms</div></div>
-                                <div class="meta-item"><span>Last RTT (24h)</span><div>@FormatRtt(row.LastRttMs)</div></div>
-                                <div class="meta-item"><span>Average RTT (24h)</span><div>@FormatRtt(row.AverageRttMs)</div></div>
-                                <div class="meta-item"><span>High RTT (24h)</span><div>@FormatRtt(row.HighestRttMs)</div></div>
-                                <div class="meta-item"><span>Low RTT (24h)</span><div>@FormatRtt(row.LowestRttMs)</div></div>
-                                <div class="meta-item"><span>Jitter (24h)</span><div>@FormatRtt(row.JitterMs)</div></div>
-                                <div class="meta-item"><span>Failure threshold</span><div>@row.FailureThreshold</div></div>
-                                <div class="meta-item"><span>Recovery threshold</span><div>@row.RecoveryThreshold</div></div>
-                            </div>
-                            <div class="button-row" style="margin-top:.85rem;">
-                                <a class="button-secondary" href="/endpoints/@row.AssignmentId/performance">View performance</a>
-                                <a class="button-secondary" href="/endpoints/@row.EndpointId/history">View history</a>
-                                @if (User.IsInRole("Admin"))
-                                {
-                                    <a class="button-secondary" href="/endpoints/@row.AssignmentId/edit">Edit assignment</a>
-                                    <a class="button-secondary" href="/endpoints/@row.AssignmentId/remove">Remove endpoint</a>
-                                }
-                            </div>
-                        </article>
-                    }
-                </div>
-            }
-        </section>
+        @await Html.PartialAsync("_AssignmentsSection", Model)
     </div>
 </main>
+<script>
+(() => {
+    const refreshIntervalMs = 15000;
+    let inFlight = false;
+    const query = window.location.search ?? '';
+    const refreshUrl = `/endpoints/refresh/assignments${query}`;
+
+    async function refreshAssignmentsSection() {
+        if (inFlight || document.hidden) {
+            return;
+        }
+
+        const currentSection = document.getElementById('manage-assignments-section');
+        if (!currentSection) {
+            return;
+        }
+
+        inFlight = true;
+        try {
+            const response = await fetch(refreshUrl, { method: 'GET', credentials: 'same-origin', headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+            if (!response.ok) {
+                return;
+            }
+
+            const html = await response.text();
+            const parser = new DOMParser();
+            const documentFragment = parser.parseFromString(html, 'text/html');
+            const nextSection = documentFragment.getElementById('manage-assignments-section');
+            if (!nextSection) {
+                return;
+            }
+
+            currentSection.replaceWith(nextSection);
+        } catch {
+            // Keep retrying on the next interval.
+        } finally {
+            inFlight = false;
+        }
+    }
+
+    refreshAssignmentsSection();
+    window.setInterval(refreshAssignmentsSection, refreshIntervalMs);
+})();
+</script>
 </body>
 </html>

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/_AssignmentsSection.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/_AssignmentsSection.cshtml
@@ -1,0 +1,75 @@
+@model PingMonitor.Web.ViewModels.Endpoints.ManageEndpointsPageViewModel
+@using PingMonitor.Web.Models
+@using PingMonitor.Web.Services.Endpoints
+@{
+    static string StateClass(EndpointStateKind state) => state switch
+    {
+        EndpointStateKind.Up => "state-up",
+        EndpointStateKind.Down => "state-down",
+        EndpointStateKind.Suppressed => "state-suppressed",
+        EndpointStateKind.Degraded => "state-degraded",
+        _ => "state-unknown"
+    };
+    static string FormatRtt(double? value) => value.HasValue ? $"{value.Value:F1} ms" : "No data";
+}
+<section class="card" id="manage-assignments-section" data-refresh-section="manage-assignments">
+    <h2>Assignments</h2>
+    @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
+    {
+        <div class="notice" role="status">@Model.StatusMessage</div>
+    }
+
+    @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
+    {
+        <div class="error" role="alert">@Model.ErrorMessage</div>
+    }
+
+    @if (Model.Rows.Count == 0)
+    {
+        <p class="muted">No endpoint assignments are available.</p>
+    }
+    else
+    {
+        <div class="row-list">
+            @foreach (var row in Model.Rows)
+            {
+                <article class="row">
+                    <div class="row-header">
+                        <div>
+                            <div><strong>@EndpointIconCatalog.GetSymbol(row.IconKey) @row.EndpointName</strong></div>
+                            <div class="muted">@row.Target</div>
+                        </div>
+                        <div class="badge @StateClass(row.CurrentState)">@row.CurrentState</div>
+                    </div>
+                    <div class="row-meta">
+                        <div class="meta-item"><span>Assignment ID</span><div>@row.AssignmentId</div></div>
+                        <div class="meta-item"><span>Agent / instance</span><div>@row.AgentDisplay</div></div>
+                        <div class="meta-item"><span>Groups</span><div>@(row.GroupNames.Count == 0 ? "None" : string.Join(", ", row.GroupNames))</div></div>
+                        <div class="meta-item"><span>Dependency parents</span><div>@(row.DependencyEndpointNames.Count == 0 ? "None" : string.Join(", ", row.DependencyEndpointNames))</div></div>
+                        <div class="meta-item"><span>Endpoint enabled</span><div>@(row.EndpointEnabled ? "Enabled" : "Disabled")</div></div>
+                        <div class="meta-item"><span>Assignment enabled</span><div>@(row.AssignmentEnabled ? "Enabled" : "Disabled")</div></div>
+                        <div class="meta-item"><span>Ping interval</span><div>@row.PingIntervalSeconds s</div></div>
+                        <div class="meta-item"><span>Retry interval</span><div>@row.RetryIntervalSeconds s</div></div>
+                        <div class="meta-item"><span>Timeout</span><div>@row.TimeoutMs ms</div></div>
+                        <div class="meta-item"><span>Last RTT (24h)</span><div>@FormatRtt(row.LastRttMs)</div></div>
+                        <div class="meta-item"><span>Average RTT (24h)</span><div>@FormatRtt(row.AverageRttMs)</div></div>
+                        <div class="meta-item"><span>High RTT (24h)</span><div>@FormatRtt(row.HighestRttMs)</div></div>
+                        <div class="meta-item"><span>Low RTT (24h)</span><div>@FormatRtt(row.LowestRttMs)</div></div>
+                        <div class="meta-item"><span>Jitter (24h)</span><div>@FormatRtt(row.JitterMs)</div></div>
+                        <div class="meta-item"><span>Failure threshold</span><div>@row.FailureThreshold</div></div>
+                        <div class="meta-item"><span>Recovery threshold</span><div>@row.RecoveryThreshold</div></div>
+                    </div>
+                    <div class="button-row" style="margin-top:.85rem;">
+                        <a class="button-secondary" href="/endpoints/@row.AssignmentId/performance">View performance</a>
+                        <a class="button-secondary" href="/endpoints/@row.EndpointId/history">View history</a>
+                        @if (User.IsInRole("Admin"))
+                        {
+                            <a class="button-secondary" href="/endpoints/@row.AssignmentId/edit">Edit assignment</a>
+                            <a class="button-secondary" href="/endpoints/@row.AssignmentId/remove">Remove endpoint</a>
+                        }
+                    </div>
+                </article>
+            }
+        </div>
+    }
+</section>

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -1,65 +1,5 @@
 @model PingMonitor.Web.ViewModels.Status.EndpointStatusPageViewModel
-@using PingMonitor.Web.Models
-@using PingMonitor.Web.Services.Endpoints
 @{
-    static string FormatDate(DateTimeOffset? value) => value.HasValue ? value.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") : "No checks yet";
-    static string FormatDependencies(IReadOnlyList<string> endpointIds, IReadOnlyList<string> endpointNames, string emptyText) => endpointIds.Count == 0
-        ? emptyText
-        : endpointNames.Count == 0
-            ? string.Join(", ", endpointIds)
-            : string.Join(", ", endpointNames);
-    static string FormatDependency(string? endpointId, string? endpointName, string emptyText) => string.IsNullOrWhiteSpace(endpointId) ? emptyText : string.IsNullOrWhiteSpace(endpointName) ? $"{endpointId} (name unavailable)" : endpointName;
-    static string FormatPercent(double? value) => value.HasValue ? $"{value.Value:F1}%" : "Unknown";
-    static string FormatRtt(double? value) => value.HasValue ? $"{value.Value:F1} ms" : "No data";
-    static string EventRowClass(PingMonitor.Web.ViewModels.EventLogs.RecentEventRowKind rowKind) => rowKind switch
-    {
-        PingMonitor.Web.ViewModels.EventLogs.RecentEventRowKind.EndpointDown => "event-row event-row-down",
-        PingMonitor.Web.ViewModels.EventLogs.RecentEventRowKind.EndpointRecovery => "event-row event-row-recovery",
-        _ => "event-row"
-    };
-    static string? GetRecentEventDestination(PingMonitor.Web.ViewModels.EventLogs.RecentEventViewModel recentEvent)
-    {
-        var hasEndpoint = !string.IsNullOrWhiteSpace(recentEvent.EndpointId);
-        var hasAgent = !string.IsNullOrWhiteSpace(recentEvent.AgentId);
-
-        if (!hasEndpoint && !hasAgent)
-        {
-            return null;
-        }
-
-        var isEndpointCategory = string.Equals(recentEvent.Category, EventCategory.Endpoint.ToString(), StringComparison.Ordinal);
-        var isAgentCategory = string.Equals(recentEvent.Category, EventCategory.Agent.ToString(), StringComparison.Ordinal);
-
-        if (hasEndpoint && hasAgent)
-        {
-            if (isEndpointCategory)
-            {
-                return $"/endpoints/{recentEvent.EndpointId}/history";
-            }
-
-            if (isAgentCategory)
-            {
-                return $"/agents/{recentEvent.AgentId}/history";
-            }
-
-            return $"/endpoints/{recentEvent.EndpointId}/history";
-        }
-
-        if (hasEndpoint)
-        {
-            return $"/endpoints/{recentEvent.EndpointId}/history";
-        }
-
-        return $"/agents/{recentEvent.AgentId}/history";
-    }
-    static string StateClass(EndpointStateKind state) => state switch
-    {
-        EndpointStateKind.Up => "state-up",
-        EndpointStateKind.Down => "state-down",
-        EndpointStateKind.Suppressed => "state-suppressed",
-        EndpointStateKind.Degraded => "state-degraded",
-        _ => "state-unknown"
-    };
 }
 <!DOCTYPE html>
 <html lang="en">
@@ -210,72 +150,8 @@
             </div>
         </section>
 
-        <section class="card" id="recent-events">
-            <h2>Recent events</h2>
-            @if (Model.RecentEvents.Count == 0)
-            {
-                <p class="muted">No events recorded yet.</p>
-            }
-            else
-            {
-                <div class="recent-events">
-                    @foreach (var recentEvent in Model.RecentEvents)
-                    {
-                        var destination = GetRecentEventDestination(recentEvent);
-                        var rowClassName = destination is null
-                            ? EventRowClass(recentEvent.RowKind)
-                            : $"{EventRowClass(recentEvent.RowKind)} event-row-clickable";
-
-                        if (destination is null)
-                        {
-                            <div class="@rowClassName">
-                                <div><strong>@recentEvent.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</strong> · @recentEvent.EventType (@recentEvent.Category)</div>
-                                <div>@recentEvent.Message</div>
-                                <div class="muted">
-                                    @if (!string.IsNullOrWhiteSpace(recentEvent.EndpointId))
-                                    {
-                                        <span>Endpoint: @(string.IsNullOrWhiteSpace(recentEvent.EndpointName) ? recentEvent.EndpointId : recentEvent.EndpointName)</span>
-                                    }
-                                    @if (!string.IsNullOrWhiteSpace(recentEvent.AgentId))
-                                    {
-                                        <span> · Agent: @(string.IsNullOrWhiteSpace(recentEvent.AgentName) ? recentEvent.AgentId : recentEvent.AgentName)</span>
-                                    }
-                                </div>
-                            </div>
-                        }
-                        else
-                        {
-                            <a class="@rowClassName" href="@destination" aria-label="Open details for @recentEvent.EventType event at @recentEvent.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")">
-                                <div><strong>@recentEvent.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</strong> · @recentEvent.EventType (@recentEvent.Category)</div>
-                                <div>@recentEvent.Message</div>
-                                <div class="muted">
-                                    @if (!string.IsNullOrWhiteSpace(recentEvent.EndpointId))
-                                    {
-                                        <span>Endpoint: @(string.IsNullOrWhiteSpace(recentEvent.EndpointName) ? recentEvent.EndpointId : recentEvent.EndpointName)</span>
-                                    }
-                                    @if (!string.IsNullOrWhiteSpace(recentEvent.AgentId))
-                                    {
-                                        <span> · Agent: @(string.IsNullOrWhiteSpace(recentEvent.AgentName) ? recentEvent.AgentId : recentEvent.AgentName)</span>
-                                    }
-                                </div>
-                            </a>
-                        }
-                    }
-                </div>
-            }
-        </section>
-
-        <section class="card">
-            <h2>Summary</h2>
-            <div class="summary-grid">
-                <div class="summary-item"><div class="muted">Total assignments</div><strong>@Model.Summary.TotalAssignments</strong></div>
-                <div class="summary-item"><div class="muted">UP</div><strong>@Model.Summary.UpCount</strong></div>
-                <div class="summary-item"><div class="muted">DOWN</div><strong>@Model.Summary.DownCount</strong></div>
-                <div class="summary-item"><div class="muted">SUPPRESSED</div><strong>@Model.Summary.SuppressedCount</strong></div>
-                <div class="summary-item"><div class="muted">UNKNOWN</div><strong>@Model.Summary.UnknownCount</strong></div>
-                <div class="summary-item"><div class="muted">DEGRADED</div><strong>@Model.Summary.DegradedCount</strong></div>
-            </div>
-        </section>
+        @await Html.PartialAsync("_RecentEventsSection", Model)
+        @await Html.PartialAsync("_SummarySection", Model)
 
         <section class="card">
             <h2>Filters</h2>
@@ -323,89 +199,7 @@
             </form>
         </section>
 
-        <section class="card">
-            <h2>Assignments</h2>
-            @if (Model.Rows.Count == 0)
-            {
-                <div class="empty">
-                    <p><strong>No assignments match the current view.</strong></p>
-                    <p class="muted">If assignments have not been created yet, they will appear here once the server has configuration records. Assignments with no current state snapshot are still shown as UNKNOWN when present.</p>
-                </div>
-            }
-            else
-            {
-                <div class="row-list">
-                    @foreach (var row in Model.Rows)
-                    {
-                        <article class="status-row @row.StatusCssClass">
-                            <details class="status-details">
-                                <summary>
-                                    <div class="row-header">
-                                        <div class="summary-chevron" aria-hidden="true">▶</div>
-                                        <div class="row-header-main">
-                                            <h2>@EndpointIconCatalog.GetSymbol(row.IconKey) @row.EndpointName</h2>
-                                            <div class="row-header-subtitle">@row.Target</div>
-                                        </div>
-                                        <div class="summary-grid-row">
-                                            <div class="summary-item-compact">
-                                                <span>State duration</span>
-                                                <strong>@row.CurrentStateDurationDisplay</strong>
-                                            </div>
-                                            <div class="summary-item-compact">
-                                                <span>Uptime (24h)</span>
-                                                <strong>@FormatPercent(row.UptimePercent)</strong>
-                                            </div>
-                                            <div class="summary-item-compact">
-                                                <span>Last RTT</span>
-                                                <strong>@FormatRtt(row.LastRttMs)</strong>
-                                            </div>
-                                            <div class="summary-item-compact">
-                                                <span>Agent</span>
-                                                <strong>@row.AgentInstanceId</strong>
-                                            </div>
-                                        </div>
-                                        <div class="badge @StateClass(row.CurrentState)">@row.CurrentState</div>
-                                    </div>
-                                </summary>
-                                <div class="status-details-body">
-                                    <div class="row-detail-intro">
-                                        <div>
-                                            <h2>@EndpointIconCatalog.GetSymbol(row.IconKey) @row.EndpointName</h2>
-                                            <div class="muted">@row.Target</div>
-                                        </div>
-                                        <div class="badge @StateClass(row.CurrentState)">@row.CurrentState</div>
-                                    </div>
-
-                                    <div class="row-meta">
-                                        <div class="meta-item"><span>Agent / instance</span><div>@row.AgentName <span class="muted">(@row.AgentInstanceId)</span></div></div>
-                                        <div class="meta-item"><span>Check type</span><div>@row.CheckType</div></div>
-                                        <div class="meta-item"><span>Last check</span><div class="nowrap">@FormatDate(row.LastCheckUtc)</div></div>
-                                        <div class="meta-item"><span>Last state change</span><div class="nowrap">@FormatDate(row.LastStateChangeUtc)</div></div>
-                                        <div class="meta-item"><span>Current state duration</span><div>@row.CurrentStateDurationDisplay</div></div>
-                                        <div class="meta-item"><span>Consecutive failures</span><div>@row.ConsecutiveFailureCount</div></div>
-                                        <div class="meta-item"><span>Consecutive successes</span><div>@row.ConsecutiveSuccessCount</div></div>
-                                        <div class="meta-item"><span>Endpoint uptime (24h)</span><div>@FormatPercent(row.UptimePercent)</div></div>
-                                        <div class="meta-item"><span>Last RTT (24h)</span><div>@FormatRtt(row.LastRttMs)</div></div>
-                                        <div class="meta-item"><span>Groups</span><div>@(row.GroupNames.Count == 0 ? "None" : string.Join(", ", row.GroupNames))</div></div>
-                                        <div class="meta-item"><span>Dependency parents</span><div>@FormatDependencies(row.ParentEndpointIds, row.ParentEndpointNames, "None")</div></div>
-                                        <div class="meta-item"><span>Suppressed by</span><div>@FormatDependency(row.SuppressedByEndpointId, row.SuppressedByEndpointName, "Not suppressed")</div></div>
-                                        <div class="meta-item"><span>Assignment enabled</span><div>@(row.AssignmentEnabled ? "Enabled" : "Disabled")</div></div>
-                                        <div class="meta-item"><span>Endpoint enabled</span><div>@(row.EndpointEnabled ? "Enabled" : "Disabled")</div></div>
-                                        <div class="meta-item"><span>Assignment ID</span><div>@row.AssignmentId</div></div>
-                                        <div class="meta-item"><span>Endpoint ID</span><div>@row.EndpointId</div></div>
-                                    </div>
-                                    <div class="inline-actions">
-                                        <a class="button-secondary" href="/endpoints/@row.AssignmentId/performance">View performance</a>
-                                        <a class="button-secondary" href="/endpoints/@row.EndpointId/history">Endpoint history</a>
-                                        <a class="button-secondary" href="/agents/@row.AgentId/history">Agent history</a>
-                                    </div>
-                                </div>
-                            </details>
-                        </article>
-                    }
-                </div>
-            }
-        </section>
+        @await Html.PartialAsync("_AssignmentsSection", Model)
     </div>
 </main>
 <script>
@@ -500,6 +294,89 @@
 
     pollBrowserNotifications();
     window.setInterval(pollBrowserNotifications, pollIntervalMs);
+})();
+
+(() => {
+    const eventsIntervalMs = 10000;
+    const summaryIntervalMs = 15000;
+    const assignmentsIntervalMs = 15000;
+    const inFlight = new Map();
+
+    const query = window.location.search ?? '';
+    const eventsUrl = `/status/refresh/recent-events${query}`;
+    const summaryUrl = `/status/refresh/summary${query}`;
+    const assignmentsUrl = `/status/refresh/assignments${query}`;
+
+    function getExpandedAssignmentIds() {
+        return Array.from(document.querySelectorAll('#assignments-section details.status-details[open][data-assignment-id]'))
+            .map((element) => element.getAttribute('data-assignment-id'))
+            .filter((value) => typeof value === 'string' && value.length > 0);
+    }
+
+    function restoreExpandedAssignmentIds(ids) {
+        if (!Array.isArray(ids) || ids.length === 0) {
+            return;
+        }
+
+        for (const assignmentId of ids) {
+            const selector = `#assignments-section details.status-details[data-assignment-id="${CSS.escape(assignmentId)}"]`;
+            const details = document.querySelector(selector);
+            if (details) {
+                details.open = true;
+            }
+        }
+    }
+
+    async function refreshSection(key, url, sectionId, options) {
+        if (inFlight.get(key) === true) {
+            return;
+        }
+
+        const currentSection = document.getElementById(sectionId);
+        if (!currentSection || document.hidden) {
+            return;
+        }
+
+        inFlight.set(key, true);
+        try {
+            const response = await fetch(url, { method: 'GET', credentials: 'same-origin', headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+            if (!response.ok) {
+                return;
+            }
+
+            const html = await response.text();
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(html, 'text/html');
+            const nextSection = doc.getElementById(sectionId);
+            if (!nextSection) {
+                return;
+            }
+
+            const preservedAssignmentIds = options?.captureState ? options.captureState() : [];
+            currentSection.replaceWith(nextSection);
+            if (options?.restoreState) {
+                options.restoreState(preservedAssignmentIds);
+            }
+        } catch {
+            // Keep polling quiet on transient failures.
+        } finally {
+            inFlight.set(key, false);
+        }
+    }
+
+    refreshSection('recent-events', eventsUrl, 'recent-events-section');
+    refreshSection('summary', summaryUrl, 'summary-section');
+    refreshSection('assignments', assignmentsUrl, 'assignments-section', {
+        captureState: getExpandedAssignmentIds,
+        restoreState: restoreExpandedAssignmentIds
+    });
+
+    window.setInterval(() => refreshSection('recent-events', eventsUrl, 'recent-events-section'), eventsIntervalMs);
+    window.setInterval(() => refreshSection('summary', summaryUrl, 'summary-section'), summaryIntervalMs);
+    window.setInterval(() => refreshSection('assignments', assignmentsUrl, 'assignments-section', {
+        captureState: getExpandedAssignmentIds,
+        restoreState: restoreExpandedAssignmentIds
+    }), assignmentsIntervalMs);
 })();
 </script>
 </body>

--- a/src/WebApp/PingMonitor.Web/Views/Status/_AssignmentsSection.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/_AssignmentsSection.cshtml
@@ -1,0 +1,105 @@
+@model PingMonitor.Web.ViewModels.Status.EndpointStatusPageViewModel
+@using PingMonitor.Web.Models
+@using PingMonitor.Web.Services.Endpoints
+@{
+    static string FormatDate(DateTimeOffset? value) => value.HasValue ? value.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") : "No checks yet";
+    static string FormatDependencies(IReadOnlyList<string> endpointIds, IReadOnlyList<string> endpointNames, string emptyText) => endpointIds.Count == 0
+        ? emptyText
+        : endpointNames.Count == 0
+            ? string.Join(", ", endpointIds)
+            : string.Join(", ", endpointNames);
+    static string FormatDependency(string? endpointId, string? endpointName, string emptyText) => string.IsNullOrWhiteSpace(endpointId) ? emptyText : string.IsNullOrWhiteSpace(endpointName) ? $"{endpointId} (name unavailable)" : endpointName;
+    static string FormatPercent(double? value) => value.HasValue ? $"{value.Value:F1}%" : "Unknown";
+    static string FormatRtt(double? value) => value.HasValue ? $"{value.Value:F1} ms" : "No data";
+    static string StateClass(EndpointStateKind state) => state switch
+    {
+        EndpointStateKind.Up => "state-up",
+        EndpointStateKind.Down => "state-down",
+        EndpointStateKind.Suppressed => "state-suppressed",
+        EndpointStateKind.Degraded => "state-degraded",
+        _ => "state-unknown"
+    };
+}
+<section class="card" id="assignments-section" data-refresh-section="assignments">
+    <h2>Assignments</h2>
+    @if (Model.Rows.Count == 0)
+    {
+        <div class="empty">
+            <p><strong>No assignments match the current view.</strong></p>
+            <p class="muted">If assignments have not been created yet, they will appear here once the server has configuration records. Assignments with no current state snapshot are still shown as UNKNOWN when present.</p>
+        </div>
+    }
+    else
+    {
+        <div class="row-list">
+            @foreach (var row in Model.Rows)
+            {
+                <article class="status-row @row.StatusCssClass">
+                    <details class="status-details" data-assignment-id="@row.AssignmentId">
+                        <summary>
+                            <div class="row-header">
+                                <div class="summary-chevron" aria-hidden="true">▶</div>
+                                <div class="row-header-main">
+                                    <h2>@EndpointIconCatalog.GetSymbol(row.IconKey) @row.EndpointName</h2>
+                                    <div class="row-header-subtitle">@row.Target</div>
+                                </div>
+                                <div class="summary-grid-row">
+                                    <div class="summary-item-compact">
+                                        <span>State duration</span>
+                                        <strong>@row.CurrentStateDurationDisplay</strong>
+                                    </div>
+                                    <div class="summary-item-compact">
+                                        <span>Uptime (24h)</span>
+                                        <strong>@FormatPercent(row.UptimePercent)</strong>
+                                    </div>
+                                    <div class="summary-item-compact">
+                                        <span>Last RTT</span>
+                                        <strong>@FormatRtt(row.LastRttMs)</strong>
+                                    </div>
+                                    <div class="summary-item-compact">
+                                        <span>Agent</span>
+                                        <strong>@row.AgentInstanceId</strong>
+                                    </div>
+                                </div>
+                                <div class="badge @StateClass(row.CurrentState)">@row.CurrentState</div>
+                            </div>
+                        </summary>
+                        <div class="status-details-body">
+                            <div class="row-detail-intro">
+                                <div>
+                                    <h2>@EndpointIconCatalog.GetSymbol(row.IconKey) @row.EndpointName</h2>
+                                    <div class="muted">@row.Target</div>
+                                </div>
+                                <div class="badge @StateClass(row.CurrentState)">@row.CurrentState</div>
+                            </div>
+
+                            <div class="row-meta">
+                                <div class="meta-item"><span>Agent / instance</span><div>@row.AgentName <span class="muted">(@row.AgentInstanceId)</span></div></div>
+                                <div class="meta-item"><span>Check type</span><div>@row.CheckType</div></div>
+                                <div class="meta-item"><span>Last check</span><div class="nowrap">@FormatDate(row.LastCheckUtc)</div></div>
+                                <div class="meta-item"><span>Last state change</span><div class="nowrap">@FormatDate(row.LastStateChangeUtc)</div></div>
+                                <div class="meta-item"><span>Current state duration</span><div>@row.CurrentStateDurationDisplay</div></div>
+                                <div class="meta-item"><span>Consecutive failures</span><div>@row.ConsecutiveFailureCount</div></div>
+                                <div class="meta-item"><span>Consecutive successes</span><div>@row.ConsecutiveSuccessCount</div></div>
+                                <div class="meta-item"><span>Endpoint uptime (24h)</span><div>@FormatPercent(row.UptimePercent)</div></div>
+                                <div class="meta-item"><span>Last RTT (24h)</span><div>@FormatRtt(row.LastRttMs)</div></div>
+                                <div class="meta-item"><span>Groups</span><div>@(row.GroupNames.Count == 0 ? "None" : string.Join(", ", row.GroupNames))</div></div>
+                                <div class="meta-item"><span>Dependency parents</span><div>@FormatDependencies(row.ParentEndpointIds, row.ParentEndpointNames, "None")</div></div>
+                                <div class="meta-item"><span>Suppressed by</span><div>@FormatDependency(row.SuppressedByEndpointId, row.SuppressedByEndpointName, "Not suppressed")</div></div>
+                                <div class="meta-item"><span>Assignment enabled</span><div>@(row.AssignmentEnabled ? "Enabled" : "Disabled")</div></div>
+                                <div class="meta-item"><span>Endpoint enabled</span><div>@(row.EndpointEnabled ? "Enabled" : "Disabled")</div></div>
+                                <div class="meta-item"><span>Assignment ID</span><div>@row.AssignmentId</div></div>
+                                <div class="meta-item"><span>Endpoint ID</span><div>@row.EndpointId</div></div>
+                            </div>
+                            <div class="inline-actions">
+                                <a class="button-secondary" href="/endpoints/@row.AssignmentId/performance">View performance</a>
+                                <a class="button-secondary" href="/endpoints/@row.EndpointId/history">Endpoint history</a>
+                                <a class="button-secondary" href="/agents/@row.AgentId/history">Agent history</a>
+                            </div>
+                        </div>
+                    </details>
+                </article>
+            }
+        </div>
+    }
+</section>

--- a/src/WebApp/PingMonitor.Web/Views/Status/_RecentEventsSection.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/_RecentEventsSection.cshtml
@@ -1,0 +1,99 @@
+@model PingMonitor.Web.ViewModels.Status.EndpointStatusPageViewModel
+@using PingMonitor.Web.Models
+@{
+    static string EventRowClass(PingMonitor.Web.ViewModels.EventLogs.RecentEventRowKind rowKind) => rowKind switch
+    {
+        PingMonitor.Web.ViewModels.EventLogs.RecentEventRowKind.EndpointDown => "event-row event-row-down",
+        PingMonitor.Web.ViewModels.EventLogs.RecentEventRowKind.EndpointRecovery => "event-row event-row-recovery",
+        _ => "event-row"
+    };
+    static string? GetRecentEventDestination(PingMonitor.Web.ViewModels.EventLogs.RecentEventViewModel recentEvent)
+    {
+        var hasEndpoint = !string.IsNullOrWhiteSpace(recentEvent.EndpointId);
+        var hasAgent = !string.IsNullOrWhiteSpace(recentEvent.AgentId);
+
+        if (!hasEndpoint && !hasAgent)
+        {
+            return null;
+        }
+
+        var isEndpointCategory = string.Equals(recentEvent.Category, EventCategory.Endpoint.ToString(), StringComparison.Ordinal);
+        var isAgentCategory = string.Equals(recentEvent.Category, EventCategory.Agent.ToString(), StringComparison.Ordinal);
+
+        if (hasEndpoint && hasAgent)
+        {
+            if (isEndpointCategory)
+            {
+                return $"/endpoints/{recentEvent.EndpointId}/history";
+            }
+
+            if (isAgentCategory)
+            {
+                return $"/agents/{recentEvent.AgentId}/history";
+            }
+
+            return $"/endpoints/{recentEvent.EndpointId}/history";
+        }
+
+        if (hasEndpoint)
+        {
+            return $"/endpoints/{recentEvent.EndpointId}/history";
+        }
+
+        return $"/agents/{recentEvent.AgentId}/history";
+    }
+}
+<section class="card" id="recent-events-section" data-refresh-section="recent-events">
+    <h2>Recent events</h2>
+    @if (Model.RecentEvents.Count == 0)
+    {
+        <p class="muted">No events recorded yet.</p>
+    }
+    else
+    {
+        <div class="recent-events">
+            @foreach (var recentEvent in Model.RecentEvents)
+            {
+                var destination = GetRecentEventDestination(recentEvent);
+                var rowClassName = destination is null
+                    ? EventRowClass(recentEvent.RowKind)
+                    : $"{EventRowClass(recentEvent.RowKind)} event-row-clickable";
+
+                if (destination is null)
+                {
+                    <div class="@rowClassName">
+                        <div><strong>@recentEvent.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</strong> · @recentEvent.EventType (@recentEvent.Category)</div>
+                        <div>@recentEvent.Message</div>
+                        <div class="muted">
+                            @if (!string.IsNullOrWhiteSpace(recentEvent.EndpointId))
+                            {
+                                <span>Endpoint: @(string.IsNullOrWhiteSpace(recentEvent.EndpointName) ? recentEvent.EndpointId : recentEvent.EndpointName)</span>
+                            }
+                            @if (!string.IsNullOrWhiteSpace(recentEvent.AgentId))
+                            {
+                                <span> · Agent: @(string.IsNullOrWhiteSpace(recentEvent.AgentName) ? recentEvent.AgentId : recentEvent.AgentName)</span>
+                            }
+                        </div>
+                    </div>
+                }
+                else
+                {
+                    <a class="@rowClassName" href="@destination" aria-label="Open details for @recentEvent.EventType event at @recentEvent.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")">
+                        <div><strong>@recentEvent.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</strong> · @recentEvent.EventType (@recentEvent.Category)</div>
+                        <div>@recentEvent.Message</div>
+                        <div class="muted">
+                            @if (!string.IsNullOrWhiteSpace(recentEvent.EndpointId))
+                            {
+                                <span>Endpoint: @(string.IsNullOrWhiteSpace(recentEvent.EndpointName) ? recentEvent.EndpointId : recentEvent.EndpointName)</span>
+                            }
+                            @if (!string.IsNullOrWhiteSpace(recentEvent.AgentId))
+                            {
+                                <span> · Agent: @(string.IsNullOrWhiteSpace(recentEvent.AgentName) ? recentEvent.AgentId : recentEvent.AgentName)</span>
+                            }
+                        </div>
+                    </a>
+                }
+            }
+        </div>
+    }
+</section>

--- a/src/WebApp/PingMonitor.Web/Views/Status/_SummarySection.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/_SummarySection.cshtml
@@ -1,0 +1,12 @@
+@model PingMonitor.Web.ViewModels.Status.EndpointStatusPageViewModel
+<section class="card" id="summary-section" data-refresh-section="summary">
+    <h2>Summary</h2>
+    <div class="summary-grid">
+        <div class="summary-item"><div class="muted">Total assignments</div><strong>@Model.Summary.TotalAssignments</strong></div>
+        <div class="summary-item"><div class="muted">UP</div><strong>@Model.Summary.UpCount</strong></div>
+        <div class="summary-item"><div class="muted">DOWN</div><strong>@Model.Summary.DownCount</strong></div>
+        <div class="summary-item"><div class="muted">SUPPRESSED</div><strong>@Model.Summary.SuppressedCount</strong></div>
+        <div class="summary-item"><div class="muted">UNKNOWN</div><strong>@Model.Summary.UnknownCount</strong></div>
+        <div class="summary-item"><div class="muted">DEGRADED</div><strong>@Model.Summary.DegradedCount</strong></div>
+    </div>
+</section>


### PR DESCRIPTION
### Motivation
- Provide lightweight, targeted auto-refresh for key operational UI areas while explicitly avoiding full-page reloads or realtime frameworks.  
- Phase‑1 scope focuses on section-level updates only: status page (recent events, summary, assignments) and manage endpoints (assignments).  
- Preserve user context (expanded assignment details) and minimise visual disruption during updates.  
- Traceability: work is tracked in issue `#256` (created before implementation). 

### Description
- Adds HTTP GET refresh endpoints that return partial HTML for each refreshable section on the status controller (`/status/refresh/recent-events`, `/status/refresh/summary`, `/status/refresh/assignments`) and the endpoints controller (`/endpoints/refresh/assignments`).
- Extracts refreshable blocks into focused partial views to reuse existing query logic and avoid rebuilding full pages (`_RecentEventsSection`, `_SummarySection`, `_AssignmentsSection` for status and `_AssignmentsSection` for manage endpoints). 
- Adds minimal, isolated client-side polling logic per page that: polls per-section endpoints on explicit intervals, prevents overlapping in-flight requests, skips while the browser tab is hidden, handles transient failures quietly, and replaces only the target section DOM node. 
- Preserves assignment expand/collapse state on the status page by capturing open assignment IDs before replacement and restoring them after update. 
- Documents phase‑1 policy and UX rules in `docs/auto-refresh.md` and sets default intervals (recent events: 10s; summary & assignments: 15s). 
- Implementation intentionally avoids SignalR/websockets and any full-page reload behavior.  
- Fixes: `#256`.

### Testing
- Created GitHub issue `#256` via API prior to implementation for traceability and the API call succeeded. 
- Built the web app with .NET 10 (`dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`) and the build succeeded (no warnings/errors). 
- Ran lightweight runtime checks: partial endpoints return HTML fragments when rendered via the views included in this change (manual verification during development). 
- No unit or integration tests were added in this change; build is the automated validation performed and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd322c4ef4832aa82ea69752b8b0eb)