### PR TITLE
Apply consistent severity-based styling across all logged-item views

### DIFF
--- a/docs/log-severity-ui.md
+++ b/docs/log-severity-ui.md
@@ -1,0 +1,51 @@
+# Log severity UI presentation
+
+This document defines the **UI presentation rule** for logged items across the web app.
+
+It does not change event generation, security enforcement, alerting, or state-machine behavior.
+
+## Site-wide colour mapping
+
+All logged-item views use the same visual severity mapping:
+
+- `log-info` (green): info / up / success
+- `log-warning` (orange): warning
+- `log-error` (red): error / down / failure
+
+These are presentation-only classes used for consistent operator scanning in light and dark themes.
+
+## Event log mapping
+
+For event-log backed views (recent events, endpoint history, agent history):
+
+- UI severity maps directly from `EventLog.Severity`:
+  - `info` -> `log-info`
+  - `warning` -> `log-warning`
+  - `error` -> `log-error`
+
+No message-text parsing is used for severity colour selection.
+
+## Security auth log mapping
+
+`SecurityAuthLog` rows do not store a severity field, so UI severity is derived explicitly:
+
+- Successful authentication attempt -> `log-info`
+- Failed attempt with deny/block/lockout semantics -> `log-error`
+  - `ip_temporarily_blocked`
+  - `ip_permanently_blocked`
+  - `account_locked`
+  - `account_temporarily_locked`
+  - `login_not_allowed`
+  - `disabled_agent`
+  - `revoked_key`
+- Other failed authentication attempts -> `log-warning`
+
+This keeps failed-but-expected validation failures distinct from explicit denial/enforcement failures.
+
+## Views covered
+
+- Status page recent events panel
+- Endpoint history events table
+- Agent history events table
+- Admin security user authentication attempts
+- Admin security agent authentication attempts

--- a/src/WebApp/PingMonitor.Web/Models/LogVisualSeverity.cs
+++ b/src/WebApp/PingMonitor.Web/Models/LogVisualSeverity.cs
@@ -1,0 +1,8 @@
+namespace PingMonitor.Web.Models;
+
+public enum LogVisualSeverity
+{
+    Info = 0,
+    Warning = 1,
+    Error = 2
+}

--- a/src/WebApp/PingMonitor.Web/Services/EventLogs/EventLogQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/EventLogs/EventLogQueryService.cs
@@ -28,6 +28,8 @@ internal sealed class EventLogQueryService : IEventLogQueryService
                 EventType = x.EventType,
                 Severity = x.Severity,
                 Message = x.Message,
+                VisualSeverity = x.VisualSeverity,
+                SeverityCssClass = x.SeverityCssClass,
                 EndpointId = x.EndpointId,
                 EndpointName = x.EndpointName,
                 AgentId = x.AgentId,
@@ -141,6 +143,8 @@ internal sealed class EventLogQueryService : IEventLogQueryService
                 EventType = x.EventType,
                 Severity = x.Severity,
                 Message = x.Message,
+                VisualSeverity = x.VisualSeverity,
+                SeverityCssClass = x.SeverityCssClass,
                 EndpointId = x.EndpointId,
                 EndpointName = x.EndpointName,
                 AgentId = x.AgentId,
@@ -198,21 +202,23 @@ internal sealed class EventLogQueryService : IEventLogQueryService
                 Category = eventLog.EventCategory.ToString(),
                 EventType = eventLog.EventType,
                 Severity = eventLog.Severity.ToString(),
+                VisualSeverity = eventLog.Severity == Models.EventSeverity.Warning
+                    ? Models.LogVisualSeverity.Warning
+                    : eventLog.Severity == Models.EventSeverity.Error
+                        ? Models.LogVisualSeverity.Error
+                        : Models.LogVisualSeverity.Info,
+                SeverityCssClass = eventLog.Severity == Models.EventSeverity.Warning
+                    ? "log-warning"
+                    : eventLog.Severity == Models.EventSeverity.Error
+                        ? "log-error"
+                        : "log-info",
                 Message = eventLog.Message,
                 AgentId = eventLog.AgentId,
                 AgentName = agent != null ? (agent.Name ?? agent.InstanceId) : null,
                 EndpointId = eventLog.EndpointId,
                 EndpointName = endpoint != null ? endpoint.Name : null,
                 AssignmentId = eventLog.AssignmentId,
-                RowKind = eventLog.EventCategory == Models.EventCategory.Endpoint &&
-                          eventLog.EventType == Models.EventType.EndpointStateChanged &&
-                          EF.Functions.Like(eventLog.Message, "Endpoint \"%\" went down.%")
-                    ? RecentEventRowKind.EndpointDown
-                    : eventLog.EventCategory == Models.EventCategory.Endpoint &&
-                      eventLog.EventType == Models.EventType.EndpointStateChanged &&
-                      EF.Functions.Like(eventLog.Message, "Endpoint \"%\" recovered%")
-                        ? RecentEventRowKind.EndpointRecovery
-                        : RecentEventRowKind.Default
+                RowKind = RecentEventRowKind.Default
             };
     }
 
@@ -229,6 +235,8 @@ internal sealed class EventLogQueryService : IEventLogQueryService
         public string EventType { get; init; } = string.Empty;
         public string Severity { get; init; } = string.Empty;
         public string Message { get; init; } = string.Empty;
+        public Models.LogVisualSeverity VisualSeverity { get; init; } = Models.LogVisualSeverity.Info;
+        public string SeverityCssClass { get; init; } = "log-info";
         public string? AgentId { get; init; }
         public string? AgentName { get; init; }
         public string? EndpointId { get; init; }

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityAuthLogQueryModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityAuthLogQueryModels.cs
@@ -8,6 +8,8 @@ public sealed class SecurityAuthLogListItem
     public required string SubjectIdentifier { get; init; }
     public string? SourceIpAddress { get; init; }
     public required bool Success { get; init; }
+    public LogVisualSeverity VisualSeverity { get; init; } = LogVisualSeverity.Info;
+    public string SeverityCssClass { get; init; } = "log-info";
     public string? FailureReason { get; init; }
     public string? UserId { get; init; }
     public string? AgentId { get; init; }

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityAuthLogQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityAuthLogQueryService.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
+using PingMonitor.Web.Support;
 
 namespace PingMonitor.Web.Services.Security;
 
@@ -37,18 +38,35 @@ internal sealed class SecurityAuthLogQueryService : ISecurityAuthLogQueryService
         var rows = await dbQuery
             .OrderByDescending(x => x.OccurredAtUtc)
             .Take(effectiveLimit)
-            .Select(x => new SecurityAuthLogListItem
+            .Select(x => new
             {
-                OccurredAtUtc = x.OccurredAtUtc,
-                SubjectIdentifier = x.SubjectIdentifier,
-                SourceIpAddress = x.SourceIpAddress,
-                Success = x.Success,
-                FailureReason = x.FailureReason,
-                UserId = x.UserId,
-                AgentId = x.AgentId
+                x.OccurredAtUtc,
+                x.SubjectIdentifier,
+                x.SourceIpAddress,
+                x.Success,
+                x.FailureReason,
+                x.UserId,
+                x.AgentId
             })
             .ToListAsync(cancellationToken);
 
-        return rows;
+        return rows
+            .Select(x =>
+            {
+                var visualSeverity = LogSeverityPresentation.FromSecurityAuthAttempt(x.Success, x.FailureReason);
+                return new SecurityAuthLogListItem
+                {
+                    OccurredAtUtc = x.OccurredAtUtc,
+                    SubjectIdentifier = x.SubjectIdentifier,
+                    SourceIpAddress = x.SourceIpAddress,
+                    Success = x.Success,
+                    VisualSeverity = visualSeverity,
+                    SeverityCssClass = LogSeverityPresentation.ToCssClass(visualSeverity),
+                    FailureReason = x.FailureReason,
+                    UserId = x.UserId,
+                    AgentId = x.AgentId
+                };
+            })
+            .ToList();
     }
 }

--- a/src/WebApp/PingMonitor.Web/Support/LogSeverityPresentation.cs
+++ b/src/WebApp/PingMonitor.Web/Support/LogSeverityPresentation.cs
@@ -1,0 +1,53 @@
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Support;
+
+public static class LogSeverityPresentation
+{
+    public static LogVisualSeverity FromEventSeverity(EventSeverity severity)
+    {
+        return severity switch
+        {
+            EventSeverity.Info => LogVisualSeverity.Info,
+            EventSeverity.Warning => LogVisualSeverity.Warning,
+            EventSeverity.Error => LogVisualSeverity.Error,
+            _ => LogVisualSeverity.Info
+        };
+    }
+
+    public static LogVisualSeverity FromSecurityAuthAttempt(bool success, string? failureReason)
+    {
+        if (success)
+        {
+            return LogVisualSeverity.Info;
+        }
+
+        if (string.IsNullOrWhiteSpace(failureReason))
+        {
+            return LogVisualSeverity.Warning;
+        }
+
+        return failureReason.Trim().ToLowerInvariant() switch
+        {
+            "ip_temporarily_blocked" => LogVisualSeverity.Error,
+            "ip_permanently_blocked" => LogVisualSeverity.Error,
+            "account_locked" => LogVisualSeverity.Error,
+            "account_temporarily_locked" => LogVisualSeverity.Error,
+            "login_not_allowed" => LogVisualSeverity.Error,
+            "disabled_agent" => LogVisualSeverity.Error,
+            "revoked_key" => LogVisualSeverity.Error,
+            _ => LogVisualSeverity.Warning
+        };
+    }
+
+    public static string ToCssClass(LogVisualSeverity severity)
+    {
+        return severity switch
+        {
+            LogVisualSeverity.Info => "log-info",
+            LogVisualSeverity.Warning => "log-warning",
+            LogVisualSeverity.Error => "log-error",
+            _ => "log-info"
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/EventLogs/EventLogHistoryPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/EventLogs/EventLogHistoryPageViewModel.cs
@@ -1,3 +1,5 @@
+using PingMonitor.Web.Models;
+
 namespace PingMonitor.Web.ViewModels.EventLogs;
 
 public sealed class EventLogHistoryPageViewModel
@@ -29,6 +31,8 @@ public sealed class EventLogHistoryRowViewModel
     public string Category { get; init; } = string.Empty;
     public string EventType { get; init; } = string.Empty;
     public string Severity { get; init; } = string.Empty;
+    public LogVisualSeverity VisualSeverity { get; init; } = LogVisualSeverity.Info;
+    public string SeverityCssClass { get; init; } = "log-info";
     public string Message { get; init; } = string.Empty;
     public string? EndpointId { get; init; }
     public string? EndpointName { get; init; }
@@ -54,6 +58,8 @@ public sealed class RecentEventViewModel
     public string Category { get; init; } = string.Empty;
     public string EventType { get; init; } = string.Empty;
     public string Severity { get; init; } = string.Empty;
+    public LogVisualSeverity VisualSeverity { get; init; } = LogVisualSeverity.Info;
+    public string SeverityCssClass { get; init; } = "log-info";
     public string Message { get; init; } = string.Empty;
     public string? EndpointId { get; init; }
     public string? EndpointName { get; init; }

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
@@ -37,10 +37,11 @@
         table { width: 100%; border-collapse: collapse; min-width: 740px; }
         th, td { border-bottom: 1px solid var(--border); text-align: left; padding: .6rem; vertical-align: top; }
         .log-box { border: 1px solid var(--border); border-radius: 10px; max-height: 320px; overflow-y: auto; background: #fbfdff; }
-        .log-item { padding: .7rem; border-bottom: 1px solid var(--border); font-size: .95rem; }
+        .log-item { padding: .7rem; border-bottom: 1px solid var(--border); font-size: .95rem; border-left: 4px solid transparent; }
         .log-item:last-child { border-bottom: 0; }
-        .status-ok { color: var(--ok); font-weight: 700; }
-        .status-bad { color: var(--bad); font-weight: 700; }
+        .severity-text-info { color: #166534; font-weight: 700; }
+        .severity-text-warning { color: #9a3412; font-weight: 700; }
+        .severity-text-error { color: #b42318; font-weight: 700; }
         .entry-meta { display: grid; gap: .25rem; }
         .empty { padding: 1rem; color: var(--muted); }
         @@media (min-width: 840px) {
@@ -374,12 +375,12 @@
             {
                 @foreach (var entry in Model.UserAttempts)
                 {
-                    <div class="log-item">
+                    <div class="log-item @entry.SeverityCssClass">
                         <div class="entry-meta">
                             <div><strong>@entry.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</strong></div>
                             <div>Subject: @entry.SubjectIdentifier</div>
                             <div>Source IP: @(string.IsNullOrWhiteSpace(entry.SourceIpAddress) ? "n/a" : entry.SourceIpAddress)</div>
-                            <div>Status: <span class="@(entry.Success ? "status-ok" : "status-bad")">@(entry.Success ? "SUCCESS" : "FAILED")</span></div>
+                            <div>Status: <span class="@(entry.VisualSeverity == PingMonitor.Web.Models.LogVisualSeverity.Error ? "severity-text-error" : entry.VisualSeverity == PingMonitor.Web.Models.LogVisualSeverity.Warning ? "severity-text-warning" : "severity-text-info")">@(entry.Success ? "SUCCESS" : "FAILED")</span></div>
                             @if (!string.IsNullOrWhiteSpace(entry.FailureReason))
                             {
                                 <div>Failure reason: @entry.FailureReason</div>
@@ -402,12 +403,12 @@
             {
                 @foreach (var entry in Model.AgentAttempts)
                 {
-                    <div class="log-item">
+                    <div class="log-item @entry.SeverityCssClass">
                         <div class="entry-meta">
                             <div><strong>@entry.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</strong></div>
                             <div>Subject: @entry.SubjectIdentifier</div>
                             <div>Source IP: @(string.IsNullOrWhiteSpace(entry.SourceIpAddress) ? "n/a" : entry.SourceIpAddress)</div>
-                            <div>Status: <span class="@(entry.Success ? "status-ok" : "status-bad")">@(entry.Success ? "SUCCESS" : "FAILED")</span></div>
+                            <div>Status: <span class="@(entry.VisualSeverity == PingMonitor.Web.Models.LogVisualSeverity.Error ? "severity-text-error" : entry.VisualSeverity == PingMonitor.Web.Models.LogVisualSeverity.Warning ? "severity-text-warning" : "severity-text-info")">@(entry.Success ? "SUCCESS" : "FAILED")</span></div>
                             @if (!string.IsNullOrWhiteSpace(entry.FailureReason))
                             {
                                 <div>Failure reason: @entry.FailureReason</div>

--- a/src/WebApp/PingMonitor.Web/Views/Agents/History.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/History.cshtml
@@ -123,11 +123,11 @@
                         <tbody>
                             @foreach (var row in Model.Rows)
                             {
-                                <tr>
+                                <tr class="@row.SeverityCssClass">
                                     <td>@FormatDate(row.OccurredAtUtc)</td>
                                     <td>@row.EventType</td>
                                     <td>@row.Category</td>
-                                    <td>@row.Severity</td>
+                                    <td><strong>@row.Severity</strong></td>
                                     <td>@row.Message</td>
                                     <td>@FormatRelated(row.EndpointId, row.EndpointName, row.AgentId, row.AgentName)</td>
                                 </tr>

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/History.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/History.cshtml
@@ -123,11 +123,11 @@
                         <tbody>
                             @foreach (var row in Model.Rows)
                             {
-                                <tr>
+                                <tr class="@row.SeverityCssClass">
                                     <td>@FormatDate(row.OccurredAtUtc)</td>
                                     <td>@row.EventType</td>
                                     <td>@row.Category</td>
-                                    <td>@row.Severity</td>
+                                    <td><strong>@row.Severity</strong></td>
                                     <td>@row.Message</td>
                                     <td>@FormatRelated(row.EndpointId, row.EndpointName, row.AgentId, row.AgentName)</td>
                                 </tr>

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_ThemeHead.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_ThemeHead.cshtml
@@ -176,14 +176,34 @@
         color: var(--text) !important;
     }
 
-    html[data-theme='dark'] .event-row-down,
-    html[data-theme='dark'] .state-down {
-        background: #3a1516 !important;
+
+    .log-info {
+        background: var(--success-soft);
+        border-left: 4px solid #1f8f4b !important;
     }
 
-    html[data-theme='dark'] .event-row-recovery,
+    .log-warning {
+        background: var(--warning-soft);
+        border-left: 4px solid #dc6803 !important;
+    }
+
+    .log-error {
+        background: var(--error-soft);
+        border-left: 4px solid #d92d20 !important;
+    }
+
+    html[data-theme='dark'] .log-info,
     html[data-theme='dark'] .state-up {
         background: #123221 !important;
+    }
+
+    html[data-theme='dark'] .log-warning {
+        background: #3a2c12 !important;
+    }
+
+    html[data-theme='dark'] .log-error,
+    html[data-theme='dark'] .state-down {
+        background: #3a1516 !important;
     }
 
     html[data-theme='dark'] .state-suppressed {

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -112,8 +112,6 @@
         .event-row:last-child { border-bottom: 0; }
         .event-row-clickable { cursor: pointer; }
         .event-row-clickable:focus-visible { outline: 3px solid var(--accent); outline-offset: -3px; }
-        .event-row-down { background: #fdecec; }
-        .event-row-recovery { background: #e8f6ec; }
         .nowrap { white-space: nowrap; }
         @@media (min-width: 720px) {
             .page-header {

--- a/src/WebApp/PingMonitor.Web/Views/Status/_RecentEventsSection.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/_RecentEventsSection.cshtml
@@ -1,12 +1,6 @@
 @model PingMonitor.Web.ViewModels.Status.EndpointStatusPageViewModel
 @using PingMonitor.Web.Models
 @{
-    static string EventRowClass(PingMonitor.Web.ViewModels.EventLogs.RecentEventRowKind rowKind) => rowKind switch
-    {
-        PingMonitor.Web.ViewModels.EventLogs.RecentEventRowKind.EndpointDown => "event-row event-row-down",
-        PingMonitor.Web.ViewModels.EventLogs.RecentEventRowKind.EndpointRecovery => "event-row event-row-recovery",
-        _ => "event-row"
-    };
     static string? GetRecentEventDestination(PingMonitor.Web.ViewModels.EventLogs.RecentEventViewModel recentEvent)
     {
         var hasEndpoint = !string.IsNullOrWhiteSpace(recentEvent.EndpointId);
@@ -55,9 +49,10 @@
             @foreach (var recentEvent in Model.RecentEvents)
             {
                 var destination = GetRecentEventDestination(recentEvent);
+                var severityClassName = recentEvent.SeverityCssClass;
                 var rowClassName = destination is null
-                    ? EventRowClass(recentEvent.RowKind)
-                    : $"{EventRowClass(recentEvent.RowKind)} event-row-clickable";
+                    ? $"event-row {severityClassName}"
+                    : $"event-row {severityClassName} event-row-clickable";
 
                 if (destination is null)
                 {


### PR DESCRIPTION
### Motivation
- Operators need a consistent, site-wide visual language so logged items (events and auth attempts) are immediately distinguishable by severity without changing underlying event or security semantics. 
- Recent-events already had special-case up/down colouring; this change centralises and generalises that behaviour for all log views.
- Keep presentation explicit and maintainable, with MySQL/.NET-safe server-side mapping rather than fragile view string-matching.

### Description
- Add a small presentation model `LogVisualSeverity` and helper `LogSeverityPresentation` to produce a reusable `VisualSeverity` and `SeverityCssClass` for log rows. 
- Extend event/security query projections and view models to include `VisualSeverity` + `SeverityCssClass`, and map `EventLog.Severity` and `SecurityAuthLog` rows to `log-info`/`log-warning`/`log-error` explicitly. 
- Apply shared CSS classes (`log-info`, `log-warning`, `log-error`) in `_ThemeHead` and update the Recent Events panel, Endpoint/Agent history tables and Admin security auth panels to use the shared severity classes while preserving click/navigation and accessibility behaviour. 
- Add documentation `docs/log-severity-ui.md` describing the site-wide mapping and choices. (Fixes #258)

### Testing
- Built the web app: `dotnet build src/WebApp/PingMonitor.WebApp.slnx` — build succeeded with zero errors. 
- Verified server-side mapping by exercising the query projections locally (unit/build-time inspection) and confirmed `VisualSeverity`/`SeverityCssClass` are produced for recent events and auth log queries. 
- Created GitHub issue #258 before implementation and linked the work to that issue; no UI screenshots were produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd3607fef4832a9f9c4d8e6818f12b)