### PR TITLE
Align auth and user management pages with shared UI style

### DIFF
--- a/docs/ui-consistency.md
+++ b/docs/ui-consistency.md
@@ -1,0 +1,12 @@
+# UI consistency rules
+
+## Layout boundaries
+
+- Login/auth entry flows (for example `/account/login`) use a simplified unauthenticated shell and do not render the authenticated site navigation.
+- Authenticated operational/admin pages (for example `/users`) render the standard authenticated navigation shell.
+
+## Shared visual language
+
+- Auth and authenticated pages must use the same theme tokens from `_ThemeHead` to preserve light, dark, and system mode behaviour.
+- Forms, buttons, cards, spacing, and tables should use shared reusable classes/partials rather than page-specific one-off inline styling.
+- Identity-related pages should look consistent with the rest of the control-plane UI while preserving existing behavior and safety constraints.

--- a/src/WebApp/PingMonitor.Web/Views/Account/Login.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Account/Login.cshtml
@@ -3,18 +3,45 @@
 <html lang="en">
 <head>
     @await Html.PartialAsync("_ThemeHead")
-    <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Login</title></head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sign in</title>
+    @await Html.PartialAsync("_UiConsistencyStyles")
+</head>
 <body>
-<main style="max-width:420px;margin:2rem auto;font-family:Arial,sans-serif;">
-    <h1>Sign in</h1>
-    @Html.ValidationSummary(false)
-    <form method="post" action="/account/login" style="display:grid;gap:.75rem;">
-        @Html.AntiForgeryToken()
-        <input type="hidden" asp-for="ReturnUrl" />
-        <label>Username <input asp-for="UserName" /></label>
-        <label>Password <input asp-for="Password" type="password" /></label>
-        <button type="submit">Sign in</button>
-    </form>
+<main class="page-shell-auth">
+    <div class="stack">
+        <section class="card stack">
+            <h1 class="section-title">Sign in</h1>
+            <p class="muted">Use your Ping Monitor credentials to access operational status and administration.</p>
+
+            @if (!ViewData.ModelState.IsValid)
+            {
+                <div class="errors" asp-validation-summary="ModelOnly"></div>
+            }
+
+            <form method="post" action="/account/login" class="stack">
+                @Html.AntiForgeryToken()
+                <input type="hidden" asp-for="ReturnUrl" />
+
+                <div class="field-group">
+                    <label asp-for="UserName">Username or email</label>
+                    <input asp-for="UserName" autocomplete="username" />
+                    <div class="field-error"><span asp-validation-for="UserName"></span></div>
+                </div>
+
+                <div class="field-group">
+                    <label asp-for="Password"></label>
+                    <input asp-for="Password" type="password" autocomplete="current-password" />
+                    <div class="field-error"><span asp-validation-for="Password"></span></div>
+                </div>
+
+                <div class="button-row">
+                    <button class="button" type="submit">Sign in</button>
+                </div>
+            </form>
+        </section>
+    </div>
 </main>
 </body>
 </html>

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_UiConsistencyStyles.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_UiConsistencyStyles.cshtml
@@ -1,0 +1,181 @@
+<style>
+    * { box-sizing: border-box; }
+
+    body {
+        margin: 0;
+        font-family: Arial, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+    }
+
+    main {
+        margin: 0 auto;
+        padding: 1rem;
+    }
+
+    .page-shell {
+        max-width: 1180px;
+    }
+
+    .page-shell-narrow {
+        max-width: 820px;
+    }
+
+    .page-shell-auth {
+        max-width: 520px;
+        min-height: calc(100dvh - 2rem);
+        display: flex;
+        align-items: center;
+    }
+
+    .stack {
+        display: grid;
+        gap: 1rem;
+        width: 100%;
+    }
+
+    .card {
+        background: var(--card);
+        border-radius: 14px;
+        box-shadow: 0 1px 2px rgba(16,24,40,.08);
+        padding: 1rem;
+    }
+
+    .section-title {
+        margin: 0;
+    }
+
+    .muted {
+        color: var(--muted);
+    }
+
+    .errors {
+        border: 1px solid #fda29b;
+        background: var(--error-bg);
+        color: #b42318;
+        border-radius: 10px;
+        padding: .8rem;
+    }
+
+    .saved {
+        border: 1px solid #c2f0c2;
+        background: #ebffee;
+        color: #137333;
+        border-radius: 10px;
+        padding: .8rem;
+    }
+
+    .field-group {
+        display: grid;
+        gap: .35rem;
+    }
+
+    .field-grid {
+        display: grid;
+        gap: .75rem;
+    }
+
+    .field-grid-2 {
+        grid-template-columns: 1fr;
+    }
+
+    label,
+    legend {
+        font-weight: 600;
+    }
+
+    input[type="text"],
+    input[type="email"],
+    input[type="password"],
+    select {
+        width: 100%;
+        min-height: 44px;
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: .65rem .7rem;
+        font: inherit;
+    }
+
+    .field-error {
+        color: #b42318;
+        font-size: .9rem;
+    }
+
+    .button-row {
+        display: flex;
+        gap: .75rem;
+        flex-wrap: wrap;
+    }
+
+    .button,
+    .button-secondary {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        border-radius: 10px;
+        padding: .7rem 1rem;
+        font-weight: 600;
+        text-decoration: none;
+        cursor: pointer;
+        font: inherit;
+    }
+
+    .button {
+        border: 0;
+        background: var(--accent);
+        color: var(--accent-contrast);
+    }
+
+    .button-secondary {
+        border: 1px solid var(--border);
+        color: var(--text);
+        background: var(--surface-1);
+    }
+
+    .table-wrap {
+        overflow-x: auto;
+    }
+
+    .table-standard {
+        width: 100%;
+        min-width: 700px;
+        border-collapse: collapse;
+    }
+
+    .table-standard th,
+    .table-standard td {
+        border: 1px solid var(--border);
+        padding: .55rem;
+        text-align: left;
+        vertical-align: top;
+    }
+
+    .check-list {
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: .75rem;
+        max-height: 260px;
+        overflow: auto;
+        display: grid;
+        gap: .5rem;
+    }
+
+    .check-list-item {
+        display: flex;
+        gap: .6rem;
+        align-items: flex-start;
+    }
+
+    .check-list-item input[type="checkbox"] {
+        margin-top: .2rem;
+        width: 1rem;
+        height: 1rem;
+    }
+
+    @@media (min-width: 860px) {
+        .field-grid-2 {
+            grid-template-columns: 1fr 1fr;
+        }
+    }
+</style>

--- a/src/WebApp/PingMonitor.Web/Views/Users/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/Edit.cshtml
@@ -1,24 +1,87 @@
 @model PingMonitor.Web.ViewModels.Users.UserEditPageViewModel
-<!DOCTYPE html><html><head>
+<!DOCTYPE html>
+<html lang="en">
+<head>
     @await Html.PartialAsync("_ThemeHead")
-    <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Edit User</title></head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Edit user</title>
+    @await Html.PartialAsync("_UiConsistencyStyles")
+</head>
 <body>
 @await Html.PartialAsync("_AuthenticatedNav")
-<main style="font-family:Arial;max-width:980px;margin:1rem auto;">
-<h1>Edit user</h1>
-@Html.ValidationSummary(false)
-<form method="post" style="display:grid;gap:.75rem;">
-@Html.AntiForgeryToken()
-<label>Username <input asp-for="UserName" /></label>
-<label>Email <input asp-for="Email" /></label>
-<label>Role <select asp-for="Role"><option>Admin</option><option>User</option></select></label>
-<label><input asp-for="Enabled" type="checkbox"/> Enabled</label>
-<fieldset><legend>Allowed groups</legend>
-@foreach (var group in Model.AvailableGroups) { <label><input type="checkbox" name="GroupIds" value="@group.Id" checked="@(Model.GroupIds.Contains(group.Id))"/> @group.Name</label><br/> }
-</fieldset>
-<fieldset><legend>Allowed endpoints</legend>
-@foreach (var endpoint in Model.AvailableEndpoints) { <label><input type="checkbox" name="EndpointIds" value="@endpoint.Id" checked="@(Model.EndpointIds.Contains(endpoint.Id))"/> @endpoint.Name</label><br/> }
-</fieldset>
-<button type="submit">Save user</button>
-</form>
-</main></body></html>
+<main class="page-shell-narrow">
+    <div class="stack">
+        <section class="card stack">
+            <h1 class="section-title">Edit user</h1>
+            <p class="muted">Update account access, role, and enabled status.</p>
+            <div class="button-row">
+                <a class="button-secondary" href="/users">Back to users</a>
+            </div>
+        </section>
+
+        @if (!ViewData.ModelState.IsValid)
+        {
+            <div class="errors" asp-validation-summary="ModelOnly"></div>
+        }
+
+        <section class="card stack">
+            <form method="post" class="stack">
+                @Html.AntiForgeryToken()
+
+                <div class="field-grid field-grid-2">
+                    <div class="field-group">
+                        <label asp-for="UserName">Username</label>
+                        <input asp-for="UserName" autocomplete="username" />
+                        <div class="field-error"><span asp-validation-for="UserName"></span></div>
+                    </div>
+                    <div class="field-group">
+                        <label asp-for="Email">Email</label>
+                        <input asp-for="Email" autocomplete="email" />
+                        <div class="field-error"><span asp-validation-for="Email"></span></div>
+                    </div>
+                    <div class="field-group">
+                        <label asp-for="Role">Role</label>
+                        <select asp-for="Role"><option>Admin</option><option>User</option></select>
+                        <div class="field-error"><span asp-validation-for="Role"></span></div>
+                    </div>
+                </div>
+
+                <div class="field-group">
+                    <label class="check-list-item"><input asp-for="Enabled" type="checkbox" /> Enabled</label>
+                </div>
+
+                <div class="field-group">
+                    <fieldset class="stack">
+                        <legend>Allowed groups</legend>
+                        <div class="check-list">
+                            @foreach (var group in Model.AvailableGroups)
+                            {
+                                <label class="check-list-item"><input type="checkbox" name="GroupIds" value="@group.Id" checked="@(Model.GroupIds.Contains(group.Id))" /> @group.Name</label>
+                            }
+                        </div>
+                    </fieldset>
+                </div>
+
+                <div class="field-group">
+                    <fieldset class="stack">
+                        <legend>Allowed endpoints</legend>
+                        <div class="check-list">
+                            @foreach (var endpoint in Model.AvailableEndpoints)
+                            {
+                                <label class="check-list-item"><input type="checkbox" name="EndpointIds" value="@endpoint.Id" checked="@(Model.EndpointIds.Contains(endpoint.Id))" /> @endpoint.Name</label>
+                            }
+                        </div>
+                    </fieldset>
+                </div>
+
+                <div class="button-row">
+                    <button class="button" type="submit">Save user</button>
+                    <a class="button-secondary" href="/users">Cancel</a>
+                </div>
+            </form>
+        </section>
+    </div>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Users/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/Index.cshtml
@@ -1,16 +1,60 @@
 @model PingMonitor.Web.ViewModels.Users.ManageUsersPageViewModel
-<!DOCTYPE html><html><head>
+<!DOCTYPE html>
+<html lang="en">
+<head>
     @await Html.PartialAsync("_ThemeHead")
-    <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Users</title></head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>User management</title>
+    @await Html.PartialAsync("_UiConsistencyStyles")
+</head>
 <body>
 @await Html.PartialAsync("_AuthenticatedNav")
-<main style="font-family:Arial;max-width:980px;margin:1rem auto;">
-<h1>Manage users</h1>
-@if (!string.IsNullOrWhiteSpace(Model.StatusMessage)) { <p>@Model.StatusMessage</p> }
-<p><a href="/users/new">Create user</a> | <a href="/status">Status</a></p>
-<table style="width:100%"><thead><tr><th>User</th><th>Email</th><th>Role</th><th>Enabled</th><th></th></tr></thead><tbody>
-@foreach (var user in Model.Users) {
-<tr><td>@user.UserName</td><td>@user.Email</td><td>@user.Role</td><td>@(user.Enabled?"Yes":"No")</td><td><a href="/users/@user.UserId/edit">Edit</a></td></tr>
-}
-</tbody></table>
-</main></body></html>
+<main class="page-shell">
+    <div class="stack">
+        <section class="card stack">
+            <h1 class="section-title">Manage users</h1>
+            <p class="muted">Create and maintain user accounts, role access, and enabled state.</p>
+            <div class="button-row">
+                <a class="button" href="/users/new">Create user</a>
+                <a class="button-secondary" href="/status">Back to status</a>
+            </div>
+        </section>
+
+        @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
+        {
+            <div class="saved">@Model.StatusMessage</div>
+        }
+
+        <section class="card stack">
+            <h2 class="section-title">Users</h2>
+            <div class="table-wrap">
+                <table class="table-standard">
+                    <thead>
+                        <tr>
+                            <th>User</th>
+                            <th>Email</th>
+                            <th>Role</th>
+                            <th>Enabled</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    @foreach (var user in Model.Users)
+                    {
+                        <tr>
+                            <td>@user.UserName</td>
+                            <td>@user.Email</td>
+                            <td>@user.Role</td>
+                            <td>@(user.Enabled ? "Yes" : "No")</td>
+                            <td><a class="button-secondary" href="/users/@user.UserId/edit">Edit</a></td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    </div>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Users/New.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Users/New.cshtml
@@ -1,26 +1,93 @@
 @model PingMonitor.Web.ViewModels.Users.UserEditPageViewModel
-@{ ViewData["Title"] = "New User"; }
-<!DOCTYPE html><html><head>
+@{ ViewData["Title"] = "Create user"; }
+<!DOCTYPE html>
+<html lang="en">
+<head>
     @await Html.PartialAsync("_ThemeHead")
-    <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>@ViewData["Title"]</title></head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>@ViewData["Title"]</title>
+    @await Html.PartialAsync("_UiConsistencyStyles")
+</head>
 <body>
 @await Html.PartialAsync("_AuthenticatedNav")
-<main style="font-family:Arial;max-width:980px;margin:1rem auto;">
-<h1>Create user</h1>
-@Html.ValidationSummary(false)
-<form method="post" style="display:grid;gap:.75rem;">
-@Html.AntiForgeryToken()
-<label>Username <input asp-for="UserName" /></label>
-<label>Email <input asp-for="Email" /></label>
-<label>Password <input asp-for="Password" type="password" /></label>
-<label>Role <select asp-for="Role"><option>Admin</option><option>User</option></select></label>
-<label><input asp-for="Enabled" type="checkbox"/> Enabled</label>
-<fieldset><legend>Allowed groups</legend>
-@foreach (var group in Model.AvailableGroups) { <label><input type="checkbox" name="GroupIds" value="@group.Id" checked="@(Model.GroupIds.Contains(group.Id))"/> @group.Name</label><br/> }
-</fieldset>
-<fieldset><legend>Allowed endpoints</legend>
-@foreach (var endpoint in Model.AvailableEndpoints) { <label><input type="checkbox" name="EndpointIds" value="@endpoint.Id" checked="@(Model.EndpointIds.Contains(endpoint.Id))"/> @endpoint.Name</label><br/> }
-</fieldset>
-<button type="submit">Create user</button>
-</form>
-</main></body></html>
+<main class="page-shell-narrow">
+    <div class="stack">
+        <section class="card stack">
+            <h1 class="section-title">Create user</h1>
+            <p class="muted">Provision a new user and set access scope before first sign-in.</p>
+            <div class="button-row">
+                <a class="button-secondary" href="/users">Back to users</a>
+            </div>
+        </section>
+
+        @if (!ViewData.ModelState.IsValid)
+        {
+            <div class="errors" asp-validation-summary="ModelOnly"></div>
+        }
+
+        <section class="card stack">
+            <form method="post" class="stack">
+                @Html.AntiForgeryToken()
+
+                <div class="field-grid field-grid-2">
+                    <div class="field-group">
+                        <label asp-for="UserName">Username</label>
+                        <input asp-for="UserName" autocomplete="username" />
+                        <div class="field-error"><span asp-validation-for="UserName"></span></div>
+                    </div>
+                    <div class="field-group">
+                        <label asp-for="Email">Email</label>
+                        <input asp-for="Email" autocomplete="email" />
+                        <div class="field-error"><span asp-validation-for="Email"></span></div>
+                    </div>
+                    <div class="field-group">
+                        <label asp-for="Password">Password</label>
+                        <input asp-for="Password" type="password" autocomplete="new-password" />
+                        <div class="field-error"><span asp-validation-for="Password"></span></div>
+                    </div>
+                    <div class="field-group">
+                        <label asp-for="Role">Role</label>
+                        <select asp-for="Role"><option>Admin</option><option>User</option></select>
+                        <div class="field-error"><span asp-validation-for="Role"></span></div>
+                    </div>
+                </div>
+
+                <div class="field-group">
+                    <label class="check-list-item"><input asp-for="Enabled" type="checkbox" /> Enabled</label>
+                </div>
+
+                <div class="field-group">
+                    <fieldset class="stack">
+                        <legend>Allowed groups</legend>
+                        <div class="check-list">
+                            @foreach (var group in Model.AvailableGroups)
+                            {
+                                <label class="check-list-item"><input type="checkbox" name="GroupIds" value="@group.Id" checked="@(Model.GroupIds.Contains(group.Id))" /> @group.Name</label>
+                            }
+                        </div>
+                    </fieldset>
+                </div>
+
+                <div class="field-group">
+                    <fieldset class="stack">
+                        <legend>Allowed endpoints</legend>
+                        <div class="check-list">
+                            @foreach (var endpoint in Model.AvailableEndpoints)
+                            {
+                                <label class="check-list-item"><input type="checkbox" name="EndpointIds" value="@endpoint.Id" checked="@(Model.EndpointIds.Contains(endpoint.Id))" /> @endpoint.Name</label>
+                            }
+                        </div>
+                    </fieldset>
+                </div>
+
+                <div class="button-row">
+                    <button class="button" type="submit">Create user</button>
+                    <a class="button-secondary" href="/users">Cancel</a>
+                </div>
+            </form>
+        </section>
+    </div>
+</main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- The login/auth pages and scaffolded user-management views used default, inconsistent styling that diverged from the main app visual language and reduced polish while leaving behavior unchanged.
- Changes must preserve authentication and user-management semantics, keep unauthenticated pages outside the authenticated nav shell, and follow the repository UI/theme tokens and platform constraints.

### Description

- Add a shared Razor partial `Views/Shared/_UiConsistencyStyles.cshtml` that centralizes reusable page-shell, card, form, button, table, and checklist styling using existing theme tokens for light/dark/system compatibility.
- Replace the old login view with `Views/Account/Login.cshtml` that includes the shared styles and renders a centered unauthenticated card layout (`page-shell-auth`) while preserving form posting, validation, and return-url behavior and explicitly omitting the authenticated nav.
- Update user-management pages `Views/Users/Index.cshtml`, `Views/Users/New.cshtml`, and `Views/Users/Edit.cshtml` to use the authenticated shell (`_AuthenticatedNav`) and the shared styling including consistent cards, form grids, buttons, checklists, and a standard table presentation.
- Add `docs/ui-consistency.md` documenting the layout boundary rules (unauthenticated auth flows vs authenticated admin pages) and the requirement to reuse shared style tokens/classes.

### Testing

- Ran `dotnet --version` which reported `10.0.104` to verify the environment targets .NET 10.
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the project restored and built successfully with `Build succeeded.` and `0 Warning(s) / 0 Error(s)`.
- No behavior tests were changed; this PR is layout/style-only and the `dotnet build` smoke check verified the views compile into the project.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd3d1d66d4832a9b0423a7001a2f4f)