### PR TITLE
Classify endpoint DOWN and agent OFFLINE events as error severity

### DIFF
--- a/docs/log-severity-ui.md
+++ b/docs/log-severity-ui.md
@@ -25,6 +25,16 @@ For event-log backed views (recent events, endpoint history, agent history):
 
 No message-text parsing is used for severity colour selection.
 
+### Authoritative event severity classification
+
+For endpoint/agent state-change events, the persisted `EventLog.Severity` must follow:
+
+- Endpoint changed to `DOWN` -> `error`
+- Endpoint changed to `UP` (including recovered transitions) -> `info`
+- Agent became `OFFLINE` -> `error`
+- Agent became `ONLINE` -> `info`
+- `warning` is reserved for non-failure conditions (for example `SUPPRESSED`/degraded or other non-critical operational events)
+
 ## Security auth log mapping
 
 `SecurityAuthLog` rows do not store a severity field, so UI severity is derived explicitly:

--- a/src/WebApp/PingMonitor.Web/Services/AgentStatusTransitionBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentStatusTransitionBackgroundService.cs
@@ -87,7 +87,7 @@ internal sealed class AgentStatusTransitionBackgroundService : BackgroundService
                     OccurredAtUtc = now,
                     Category = EventCategory.Agent,
                     EventType = nextStatus == AgentHealthStatus.Stale ? EventType.AgentBecameStale : EventType.AgentBecameOffline,
-                    Severity = EventSeverity.Warning,
+                    Severity = EventSeverity.Error,
                     AgentId = agent.AgentId,
                     Message = nextStatus == AgentHealthStatus.Stale
                         ? $"Agent \"{agent.Name ?? agent.InstanceId}\" became stale."

--- a/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
@@ -170,7 +170,7 @@ internal sealed class StateEvaluationService : IStateEvaluationService
                     OccurredAtUtc = transitionAtUtc,
                     Category = EventCategory.Endpoint,
                     EventType = eventType,
-                    Severity = nextState == EndpointStateKind.Down ? EventSeverity.Warning : EventSeverity.Info,
+                    Severity = nextState == EndpointStateKind.Down ? EventSeverity.Error : EventSeverity.Info,
                     AgentId = assignment.AgentId,
                     EndpointId = assignment.EndpointId,
                     AssignmentId = assignment.AssignmentId,


### PR DESCRIPTION
### Motivation

- Make failure conditions visually and semantically accurate by treating endpoint DOWN and agent OFFLINE/STale events as `error` rather than `warning` so operators see red (critical) for true outages. 
- Do not change the monitoring state machine, event types, or event-generation flow; only update persisted severity classification. 
- Centralise and document the mapping so presentation remains explicit and maintainable (no fragile string parsing in views). 

### Description

- Update authoritative documentation in `docs/log-severity-ui.md` to require: endpoint DOWN → `error`, endpoint UP/recovered → `info`, agent OFFLINE → `error`, agent ONLINE → `info`, and reserve `warning` for non-failure conditions. 
- Persist endpoint state-change events as `EventSeverity.Error` when the next state is `DOWN` by changing the write-site in `src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs`. 
- Persist agent stale/offline transitions as `EventSeverity.Error` by changing the write-site in `src/WebApp/PingMonitor.Web/Services/AgentStatusTransitionBackgroundService.cs`. 
- Kept UI mapping unchanged because views already map `EventLog.Severity` → visual severity/CSS (`error` -> `log-error`, `warning` -> `log-warning`, `info` -> `log-info`) via the centralized projection. 
- Created GitHub issue `#262` to satisfy repository traceability requirements and linked it from the PR. 

### Testing

- Created issue `#262` via the GitHub API successfully for traceability. 
- Installed the .NET 10 SDK specified by `global.json` (`10.0.104`) and ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully with `Build succeeded.` and `0 Error(s)`. 
- Verified via code inspection and projection logic that UI severity mapping remains centralized and will render `error` rows as `log-error`; no runtime UI smoke test was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd3f09d348832aa886f18355fbeba3)