### PR TITLE
Require verified email for SMTP notifications (add verification workflow)

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -67,6 +67,14 @@ Initial settings scope is split by ownership:
   - suppress browser notifications during quiet hours
   - suppress SMTP notifications during quiet hours
 
+
+Additional SMTP identity requirements:
+
+- SMTP notifications are delivered only to the authenticated user's current verified email address
+- changing a profile email address resets email verification state until the new address is confirmed
+- profile notification settings must clearly show whether the user email is verified
+- users can request a resend of the email verification message from profile/notification settings
+
 Additional phase 1 per-user Telegram settings:
 
 - Telegram notifications enabled/disabled

--- a/docs/security-logging.md
+++ b/docs/security-logging.md
@@ -148,3 +148,20 @@ Pruning must **not** touch:
 - Confirmation is enforced server-side.
 - Manual prune is destructive and irreversible.
 - Manual prune writes auditable security events (request + completion) including cutoff and deleted row count.
+
+
+## Email verification logging
+
+Email verification flows for authenticated users should emit operator-meaningful audit records without secret leakage.
+
+Expected coverage:
+
+- verification email send requested/sent for current authenticated user
+- email verification completed (success/failure)
+- SMTP notification delivery skipped because recipient email is unverified (rate-limited/log-level appropriate to avoid noise)
+
+Never log:
+
+- raw verification tokens
+- SMTP credentials
+- password material

--- a/src/WebApp/PingMonitor.Web/Controllers/AccountController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AccountController.cs
@@ -2,9 +2,13 @@ using Microsoft.AspNetCore.Authorization;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Models.Identity;
+using PingMonitor.Web.Services.EventLogs;
 using PingMonitor.Web.Services.Security;
+using System.Text;
+using System.Text.Json;
 
 namespace PingMonitor.Web.Controllers;
 
@@ -16,17 +20,23 @@ public sealed class AccountController : Controller
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly ISecurityAuthLogService _securityAuthLogService;
     private readonly ISecurityEnforcementService _securityEnforcementService;
+    private readonly IEventLogService _eventLogService;
+    private readonly ILogger<AccountController> _logger;
 
     public AccountController(
         SignInManager<ApplicationUser> signInManager,
         UserManager<ApplicationUser> userManager,
         ISecurityAuthLogService securityAuthLogService,
-        ISecurityEnforcementService securityEnforcementService)
+        ISecurityEnforcementService securityEnforcementService,
+        IEventLogService eventLogService,
+        ILogger<AccountController> logger)
     {
         _signInManager = signInManager;
         _userManager = userManager;
         _securityAuthLogService = securityAuthLogService;
         _securityEnforcementService = securityEnforcementService;
+        _eventLogService = eventLogService;
+        _logger = logger;
     }
 
     [HttpGet("login")]
@@ -167,6 +177,77 @@ public sealed class AccountController : Controller
         return RedirectToAction(nameof(Login));
     }
 
+    [HttpGet("verify-email")]
+    public async Task<IActionResult> VerifyEmail([FromQuery] string? userId, [FromQuery] string? code, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(code))
+        {
+            return View("VerifyEmail", new VerifyEmailViewModel
+            {
+                Success = false,
+                Message = "Verification link is invalid. Request a new verification email from your profile."
+            });
+        }
+
+        var user = await _userManager.FindByIdAsync(userId);
+        if (user is null)
+        {
+            return View("VerifyEmail", new VerifyEmailViewModel
+            {
+                Success = false,
+                Message = "Verification link is invalid. Request a new verification email from your profile."
+            });
+        }
+
+        string decodedToken;
+        try
+        {
+            decodedToken = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(code));
+        }
+        catch
+        {
+            return View("VerifyEmail", new VerifyEmailViewModel
+            {
+                Success = false,
+                Message = "Verification token is malformed. Request a new verification email from your profile."
+            });
+        }
+
+        var result = await _userManager.ConfirmEmailAsync(user, decodedToken);
+        if (!result.Succeeded)
+        {
+            await _eventLogService.WriteAsync(new EventLogWriteRequest
+            {
+                Category = EventCategory.Security,
+                EventType = "email_verification_confirm_failed",
+                Severity = EventSeverity.Warning,
+                Message = $"Email verification failed for user {user.Id}.",
+                DetailsJson = JsonSerializer.Serialize(new { errors = result.Errors.Select(x => x.Code).ToArray() })
+            }, cancellationToken);
+
+            return View("VerifyEmail", new VerifyEmailViewModel
+            {
+                Success = false,
+                Message = "Verification failed or expired. Request a new verification email from your profile."
+            });
+        }
+
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.Security,
+            EventType = "email_verification_confirmed",
+            Severity = EventSeverity.Info,
+            Message = $"Email verified for user {user.Id}."
+        }, cancellationToken);
+        _logger.LogInformation("Email verification completed for user {UserId}.", user.Id);
+
+        return View("VerifyEmail", new VerifyEmailViewModel
+        {
+            Success = true,
+            Message = "Email verified successfully. SMTP notifications are now eligible for your account."
+        });
+    }
+
     public sealed class LoginViewModel
     {
         [Required]
@@ -177,5 +258,11 @@ public sealed class AccountController : Controller
         public string Password { get; set; } = string.Empty;
 
         public string ReturnUrl { get; set; } = "/status";
+    }
+
+    public sealed class VerifyEmailViewModel
+    {
+        public bool Success { get; set; }
+        public string Message { get; set; } = string.Empty;
     }
 }

--- a/src/WebApp/PingMonitor.Web/Controllers/NotificationSettingsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/NotificationSettingsController.cs
@@ -149,6 +149,12 @@ public sealed class NotificationSettingsController : Controller
             model.SmtpTestMessage = "Current user requires a valid email address for SMTP test.";
             return View("Index", model);
         }
+        if (!user.EmailConfirmed)
+        {
+            model.SmtpTestSent = false;
+            model.SmtpTestMessage = "Current user email address must be verified before SMTP test send.";
+            return View("Index", model);
+        }
 
         var result = await _smtpNotificationSender.SendTestAsync(user.Email, cancellationToken);
         if (result.Success)

--- a/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
@@ -3,10 +3,16 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
 using PingMonitor.Web.Models.Identity;
+using PingMonitor.Web.Models;
 using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.EventLogs;
+using PingMonitor.Web.Services.SmtpNotifications;
 using PingMonitor.Web.Services.Telegram;
 using PingMonitor.Web.ViewModels.Profile;
+using System.Text;
+using System.Text.Json;
 
 namespace PingMonitor.Web.Controllers;
 
@@ -17,15 +23,24 @@ public sealed class ProfileController : Controller
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly IUserNotificationSettingsService _userNotificationSettingsService;
     private readonly ITelegramLinkService _telegramLinkService;
+    private readonly ISmtpNotificationSender _smtpNotificationSender;
+    private readonly IEventLogService _eventLogService;
+    private readonly ILogger<ProfileController> _logger;
 
     public ProfileController(
         UserManager<ApplicationUser> userManager,
         IUserNotificationSettingsService userNotificationSettingsService,
-        ITelegramLinkService telegramLinkService)
+        ITelegramLinkService telegramLinkService,
+        ISmtpNotificationSender smtpNotificationSender,
+        IEventLogService eventLogService,
+        ILogger<ProfileController> logger)
     {
         _userManager = userManager;
         _userNotificationSettingsService = userNotificationSettingsService;
         _telegramLinkService = telegramLinkService;
+        _smtpNotificationSender = smtpNotificationSender;
+        _eventLogService = eventLogService;
+        _logger = logger;
     }
 
     [HttpGet("")]
@@ -74,6 +89,7 @@ public sealed class ProfileController : Controller
             return View("Index", await BuildModelAsync(cancellationToken, model));
         }
 
+        user.EmailConfirmed = false;
         user.NormalizedEmail = trimmedEmail.ToUpperInvariant();
         var updateResult = await _userManager.UpdateAsync(user);
         if (!updateResult.Succeeded)
@@ -86,9 +102,37 @@ public sealed class ProfileController : Controller
             return View("Index", await BuildModelAsync(cancellationToken, model));
         }
 
+        var sendResult = await SendVerificationEmailAsync(user, cancellationToken);
         var refreshed = await BuildModelAsync(cancellationToken);
         refreshed.AccountSaved = true;
+        refreshed.EmailVerificationResendSucceeded = sendResult.Success;
+        refreshed.EmailVerificationMessage = sendResult.Message;
         return View("Index", refreshed);
+    }
+
+    [HttpPost("email-verification/resend")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> ResendEmailVerification(CancellationToken cancellationToken)
+    {
+        var user = await RequireUserAsync();
+        if (user is null)
+        {
+            return Challenge();
+        }
+
+        if (user.EmailConfirmed)
+        {
+            var alreadyVerified = await BuildModelAsync(cancellationToken);
+            alreadyVerified.EmailVerificationMessage = "Your email is already verified.";
+            alreadyVerified.EmailVerificationResendSucceeded = true;
+            return View("NotificationSettings", alreadyVerified);
+        }
+
+        var sendResult = await SendVerificationEmailAsync(user, cancellationToken);
+        var refreshed = await BuildModelAsync(cancellationToken);
+        refreshed.EmailVerificationResendSucceeded = sendResult.Success;
+        refreshed.EmailVerificationMessage = sendResult.Message;
+        return View("NotificationSettings", refreshed);
     }
 
     [HttpPost("password")]
@@ -259,6 +303,7 @@ public sealed class ProfileController : Controller
         {
             UserName = user.UserName ?? string.Empty,
             Email = source?.Email ?? user.Email ?? string.Empty,
+            EmailVerified = user.EmailConfirmed,
             BrowserNotificationsEnabled = source?.BrowserNotificationsEnabled ?? settings.BrowserNotificationsEnabled,
             BrowserNotifyEndpointDown = source?.BrowserNotifyEndpointDown ?? settings.BrowserNotifyEndpointDown,
             BrowserNotifyEndpointRecovered = source?.BrowserNotifyEndpointRecovered ?? settings.BrowserNotifyEndpointRecovered,
@@ -291,5 +336,45 @@ public sealed class ProfileController : Controller
             TelegramLinkedDisplayName = telegramAccount?.DisplayName,
             TelegramLinkedAtUtc = telegramAccount?.LinkedAtUtc
         };
+    }
+
+    private async Task<SmtpNotificationSendResult> SendVerificationEmailAsync(ApplicationUser user, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(user.Email) || !MailAddress.TryCreate(user.Email, out _))
+        {
+            return SmtpNotificationSendResult.Failed("A valid email address is required to send verification.");
+        }
+
+        var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+        var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(token));
+        var callbackUrl = Url.Action(
+            action: "VerifyEmail",
+            controller: "Account",
+            values: new { userId = user.Id, code = encodedToken },
+            protocol: Request.Scheme);
+
+        if (string.IsNullOrWhiteSpace(callbackUrl))
+        {
+            return SmtpNotificationSendResult.Failed("Email verification link generation failed.");
+        }
+
+        var result = await _smtpNotificationSender.SendEmailVerificationAsync(user.Email, callbackUrl, cancellationToken);
+        var eventType = result.Success ? "email_verification_email_sent" : "email_verification_email_send_failed";
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.Security,
+            EventType = eventType,
+            Severity = result.Success ? EventSeverity.Info : EventSeverity.Warning,
+            Message = result.Success
+                ? $"Verification email sent for user {user.Id}."
+                : $"Verification email send failed for user {user.Id}.",
+            DetailsJson = result.Success ? null : JsonSerializer.Serialize(new { reason = result.Message })
+        }, cancellationToken);
+
+        _logger.LogInformation(
+            "Email verification resend requested by user {UserId}. Success={Success}",
+            user.Id,
+            result.Success);
+        return result;
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/Identity/UserManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Identity/UserManagementService.cs
@@ -100,10 +100,16 @@ internal sealed class UserManagementService : IUserManagementService
             return new UserManagementResult { Success = false, Found = false, Errors = ["User not found."] };
         }
 
+        var trimmedEmail = command.Email.Trim();
+        var emailChanged = !string.Equals(user.Email, trimmedEmail, StringComparison.OrdinalIgnoreCase);
         user.UserName = command.UserName.Trim();
-        user.Email = command.Email.Trim();
+        user.Email = trimmedEmail;
+        if (emailChanged)
+        {
+            user.EmailConfirmed = false;
+        }
         user.NormalizedUserName = command.UserName.Trim().ToUpperInvariant();
-        user.NormalizedEmail = command.Email.Trim().ToUpperInvariant();
+        user.NormalizedEmail = trimmedEmail.ToUpperInvariant();
         user.LockoutEnabled = true;
         user.LockoutEnd = command.Enabled ? null : DateTimeOffset.MaxValue;
 

--- a/src/WebApp/PingMonitor.Web/Services/SmtpNotifications/ISmtpNotificationSender.cs
+++ b/src/WebApp/PingMonitor.Web/Services/SmtpNotifications/ISmtpNotificationSender.cs
@@ -5,5 +5,6 @@ namespace PingMonitor.Web.Services.SmtpNotifications;
 public interface ISmtpNotificationSender
 {
     Task<SmtpNotificationSendResult> SendTestAsync(string recipientAddress, CancellationToken cancellationToken);
+    Task<SmtpNotificationSendResult> SendEmailVerificationAsync(string recipientAddress, string verificationLink, CancellationToken cancellationToken);
     Task<SmtpNotificationSendResult> SendForEventAsync(EventLog eventLog, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/Services/SmtpNotifications/SmtpNotificationSender.cs
+++ b/src/WebApp/PingMonitor.Web/Services/SmtpNotifications/SmtpNotificationSender.cs
@@ -36,6 +36,29 @@ internal sealed class SmtpNotificationSender : ISmtpNotificationSender
             body: "SMTP notifications are working.",
             eventKey: "smtp_test",
             recipients: [recipientAddress],
+            requireSmtpNotificationChannelEnabled: true,
+            cancellationToken);
+    }
+
+    public async Task<SmtpNotificationSendResult> SendEmailVerificationAsync(string recipientAddress, string verificationLink, CancellationToken cancellationToken)
+    {
+        var body = string.Join(
+            Environment.NewLine,
+            [
+                "Verify your Ping Monitor email address.",
+                "SMTP notifications are sent only to verified email addresses.",
+                string.Empty,
+                $"Verification link: {verificationLink}",
+                string.Empty,
+                "If you did not request this, you can ignore this email."
+            ]);
+
+        return await SendEmailAsync(
+            subject: "Ping Monitor: Verify your email address",
+            body: body,
+            eventKey: "email_verification",
+            recipients: [recipientAddress],
+            requireSmtpNotificationChannelEnabled: false,
             cancellationToken);
     }
 
@@ -54,7 +77,7 @@ internal sealed class SmtpNotificationSender : ISmtpNotificationSender
         }
 
         var body = BuildEventBody(eventLog);
-        return await SendEmailAsync(mapped.Value.Subject, body, eventLog.EventType, eligibleRecipientAddresses, cancellationToken);
+        return await SendEmailAsync(mapped.Value.Subject, body, eventLog.EventType, eligibleRecipientAddresses, requireSmtpNotificationChannelEnabled: true, cancellationToken);
     }
 
     private async Task<SmtpNotificationSendResult> SendEmailAsync(
@@ -62,10 +85,11 @@ internal sealed class SmtpNotificationSender : ISmtpNotificationSender
         string body,
         string eventKey,
         IReadOnlyList<string> recipients,
+        bool requireSmtpNotificationChannelEnabled,
         CancellationToken cancellationToken)
     {
         var settings = await _notificationSettingsService.GetSmtpChannelAsync(cancellationToken);
-        if (!settings.SmtpNotificationsEnabled)
+        if (requireSmtpNotificationChannelEnabled && !settings.SmtpNotificationsEnabled)
         {
             return SmtpNotificationSendResult.Skip("SMTP notifications are disabled.");
         }
@@ -151,7 +175,7 @@ internal sealed class SmtpNotificationSender : ISmtpNotificationSender
     {
         var users = await _dbContext.Users
             .Where(x => !string.IsNullOrWhiteSpace(x.Email))
-            .Select(x => new { x.Id, x.Email })
+            .Select(x => new { x.Id, x.Email, x.EmailConfirmed })
             .ToArrayAsync(cancellationToken);
 
         var recipients = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -166,6 +190,12 @@ internal sealed class SmtpNotificationSender : ISmtpNotificationSender
             var suppressionDecision = _notificationSuppressionService.IsSmtpNotificationSuppressed(userSettings);
             if (suppressionDecision.IsSuppressed)
             {
+                continue;
+            }
+
+            if (!user.EmailConfirmed)
+            {
+                _logger.LogDebug("Skipping SMTP notification eligibility for user {UserId} because email is unverified.", user.Id);
                 continue;
             }
 

--- a/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
@@ -9,6 +9,7 @@ public sealed class ProfilePageViewModel
     [Required]
     [EmailAddress]
     public string Email { get; set; } = string.Empty;
+    public bool EmailVerified { get; set; }
 
     [DataType(DataType.Password)]
     public string CurrentPassword { get; set; } = string.Empty;
@@ -54,4 +55,6 @@ public sealed class ProfilePageViewModel
     public DateTimeOffset? TelegramLinkedAtUtc { get; set; }
     public bool TelegramCodeGenerated { get; set; }
     public bool TelegramAccountRemoved { get; set; }
+    public bool EmailVerificationResendSucceeded { get; set; }
+    public string? EmailVerificationMessage { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/Views/Account/VerifyEmail.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Account/VerifyEmail.cshtml
@@ -1,0 +1,36 @@
+@model PingMonitor.Web.Controllers.AccountController.VerifyEmailViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    @await Html.PartialAsync("_ThemeHead")
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Email verification</title>
+    <style>
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --success:#137333; --error:#b42318; }
+        *{box-sizing:border-box;} body{margin:0;font-family:Arial,sans-serif;background:var(--bg);color:var(--text);} main{max-width:720px;margin:0 auto;padding:1rem;}
+        .card{background:var(--card);border-radius:14px;box-shadow:0 1px 2px rgba(16,24,40,.08);padding:1rem;display:grid;gap:.75rem;}
+        .status-success{color:var(--success);} .status-error{color:var(--error);} .button-secondary{display:inline-flex;align-items:center;justify-content:center;min-height:44px;padding:.7rem 1rem;border-radius:10px;border:1px solid var(--border);color:var(--text);background:#fff;text-decoration:none;font-weight:600;}
+        .muted{color:var(--muted);}
+    </style>
+</head>
+<body>
+<main>
+    <section class="card">
+        <h1>Email verification</h1>
+        @if (Model.Success)
+        {
+            <p class="status-success"><strong>Success:</strong> @Model.Message</p>
+        }
+        else
+        {
+            <p class="status-error"><strong>Unable to verify:</strong> @Model.Message</p>
+        }
+        <p class="muted">You can sign in and open your profile notification settings to resend verification if needed.</p>
+        <div>
+            <a class="button-secondary" href="/account/login">Go to login</a>
+        </div>
+    </section>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
@@ -33,10 +33,16 @@
 <section class="card stack">
     <h2>Account details</h2>
     @if (Model.AccountSaved) { <div class="saved">Email updated.</div> }
+    @if (!string.IsNullOrWhiteSpace(Model.EmailVerificationMessage)) { <div class="saved">@Model.EmailVerificationMessage</div> }
     <form method="post" action="/profile/account" class="stack">
         @Html.AntiForgeryToken()
         <div><label>Username</label><input value="@Model.UserName" type="text" readonly /></div>
         <div><label asp-for="Email"></label><input asp-for="Email" type="email" /><div class="field-error"><span asp-validation-for="Email"></span></div></div>
+        <p class="muted">Email verification status: <strong>@(Model.EmailVerified ? "Verified" : "Unverified")</strong>.</p>
+        @if (!Model.EmailVerified)
+        {
+            <p class="muted">SMTP notifications are delivered only after email verification succeeds.</p>
+        }
         <div class="button-row"><button class="button" type="submit">Save account details</button></div>
     </form>
 </section>

--- a/src/WebApp/PingMonitor.Web/Views/Profile/NotificationSettings.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Profile/NotificationSettings.cshtml
@@ -24,6 +24,19 @@
 <section class="card">
     <h1>Notification settings</h1>
     <p class="muted">Manage your personal notification preferences and Telegram account linking.</p>
+    <p class="muted">Email: <strong>@Model.Email</strong> · Verification: <strong>@(Model.EmailVerified ? "Verified" : "Unverified")</strong></p>
+    @if (!Model.EmailVerified)
+    {
+        <p class="muted">SMTP notifications require a verified email address.</p>
+        <form method="post" action="/profile/email-verification/resend">
+            @Html.AntiForgeryToken()
+            <button class="button-secondary" type="submit">Resend verification email</button>
+        </form>
+    }
+    @if (!string.IsNullOrWhiteSpace(Model.EmailVerificationMessage))
+    {
+        <div class="saved">@Model.EmailVerificationMessage</div>
+    }
     <div class="button-row"><a class="button-secondary" href="/profile">Back to my profile</a></div>
 </section>
 @if (!ViewData.ModelState.IsValid) { <div class="errors" asp-validation-summary="ModelOnly"></div> }


### PR DESCRIPTION
### Motivation
- Prevent SMTP notifications being sent to unverified or changed addresses by tying delivery eligibility to a verified user email.
- Provide an explicit, auditable verification workflow so operators can trust notification recipients and avoid misdelivery.
- Update authoritative docs to reflect the verification requirement and logging expectations before changing runtime behavior.

### Description
- Added an ASP.NET Identity-based email verification workflow that generates confirmation tokens, sends a verification email, and exposes an anonymous confirmation endpoint at `/account/verify-email` with a user-facing result page.
- Exposed an authenticated resend action at `/profile/email-verification/resend`, and made profile/email update reset `EmailConfirmed` so new addresses are unverified until confirmed.
- Extended the SMTP sender to send verification emails via existing SMTP infrastructure and changed recipient resolution so event emails are only sent when the user `EmailConfirmed` is true while preserving per-user toggles and suppression/quiet-hours logic.
- Surface verification status and resend affordance in the profile and notification settings UI and add operational event logging for send/confirm/failure events without logging tokens or secrets.
- Documentation updates were applied to `docs/notifications.md` and `docs/security-logging.md` to require verified emails for SMTP delivery and to describe verification-related logging.

### Testing
- Created the tracking GitHub issue via the API (issue #266) successfully before implementation to satisfy repository traceability requirements.
- Updated docs and committed the changes successfully as an initial docs-first step.
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` targeting .NET 10, and the build completed successfully after ensuring the matching SDK was available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd45b5133c832aa28cfd009cfcf2c5)