### PR TITLE
Fix RTT performance chart to render as a true line series

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml
@@ -184,6 +184,7 @@
 
     const rttLabels = @Html.Raw(JsonSerializer.Serialize(rttLabels));
     const rttValues = @Html.Raw(JsonSerializer.Serialize(rttValues));
+    const rttSeries = rttLabels.map((label, index) => ({ x: label, y: rttValues[index] }));
     const jitterLabels = @Html.Raw(JsonSerializer.Serialize(jitterLabels));
     const jitterValues = @Html.Raw(JsonSerializer.Serialize(jitterValues));
     const failureLabels = @Html.Raw(JsonSerializer.Serialize(failureLabels));
@@ -199,14 +200,20 @@
                 data: {
                     labels: rttLabels,
                     datasets: [{
+                        type: 'line',
                         label: 'RTT (ms)',
-                        data: rttValues,
+                        data: rttSeries,
                         borderColor: '#60a5fa',
-                        backgroundColor: '#60a5fa',
-                        borderWidth: 1,
+                        borderWidth: 1.25,
+                        fill: false,
+                        showLine: true,
+                        stepped: false,
                         tension: 0.15,
-                        pointRadius: 1,
-                        pointHoverRadius: 3
+                        pointRadius: 0,
+                        pointHoverRadius: 2,
+                        pointHitRadius: 8,
+                        pointBackgroundColor: '#60a5fa',
+                        pointBorderColor: '#60a5fa'
                     }]
                 },
                 options: buildBaseOptions('Timestamp (UTC)', 'RTT (ms)', false)


### PR DESCRIPTION
### Motivation
- The RTT series on the endpoint performance page still appeared as vertical spikes/columns despite the surrounding graph layout improvements because dataset-level line rendering was not enforced explicitly.\n
### Description
- Convert RTT data to an explicit `(x, y)` series (`rttSeries`) and bind that to the dataset so timestamps are paired deterministically with values in Chart.js.\n- Update the RTT dataset to enforce true line rendering with dataset-level `type: 'line'`, `showLine: true`, `fill: false`, `stepped: false`, and `tension` for smooth connections.\n- Adjust visual styling to a thin readable stroke and minimal markers using `borderWidth: 1.25`, `pointRadius: 0`, `pointHoverRadius: 2`, and `pointHitRadius: 8`.\n- Preserve existing container/scrolling and single-graph selector behavior by not changing scroller/min-width logic or the outcomes/jitter chart types.\n- File changed: `src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml`.\n- Linked issue: created and linked issue #272 and referenced prior related issues `#269` and `#268` in the PR.

### Testing
- Built the web project with .NET 10: `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` — build succeeded.\n- Confirmed via code inspection that X axis remains timestamp (UTC) and Y axis remains RTT in milliseconds and that the RTT dataset is now an explicit line series.\n- Created GitHub issue `#272` to track the regression and linked it from this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd4d9c7d04832a8266ff5c944e63e0)