### PR TITLE
Fix mysqldump path resolution for database backup export

### DIFF
--- a/docs/db-status-and-maintenance.md
+++ b/docs/db-status-and-maintenance.md
@@ -54,6 +54,7 @@ Method in this phase:
 - MySQL logical SQL export using `mysqldump`
 - creates timestamped `.sql` files under server-side `App_Data/DbBackups` by default
 - backup path is not publicly served static content
+- `DatabaseMaintenance:MySqlDumpExecutablePath` can be set to a full executable path (recommended on Windows hosts where MySQL tools are not on `PATH`)
 
 The page lists created backup files (name, UTC time, size) and supports download.
 

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
@@ -142,10 +142,18 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         var safeDatabaseName = string.IsNullOrWhiteSpace(builder.Database) ? "database" : builder.Database.Trim();
         var fileName = $"db-backup-{safeDatabaseName}-{backupTimestamp:yyyyMMdd-HHmmss}.sql";
         var fullPath = Path.Combine(backupDirectory, fileName);
+        var mysqldumpExecutablePath = ResolveMySqlDumpExecutablePath(options.MySqlDumpExecutablePath);
+        if (mysqldumpExecutablePath is null)
+        {
+            return await CreateBackupFailureAsync(
+                "mysqldump executable was not found. Configure DatabaseMaintenance:MySqlDumpExecutablePath with the full executable path.",
+                request.RequestedBy,
+                cancellationToken);
+        }
 
         var processInfo = new ProcessStartInfo
         {
-            FileName = options.MySqlDumpExecutablePath,
+            FileName = mysqldumpExecutablePath,
             WorkingDirectory = backupDirectory,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -230,6 +238,94 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 
             _logger.LogWarning(ex, "Database backup export failed.");
             return await CreateBackupFailureAsync($"Database backup export failed: {ex.Message}", request.RequestedBy, cancellationToken);
+        }
+    }
+
+    private string? ResolveMySqlDumpExecutablePath(string configuredPath)
+    {
+        if (string.IsNullOrWhiteSpace(configuredPath))
+        {
+            return null;
+        }
+
+        var trimmedPath = configuredPath.Trim();
+        if (Path.IsPathRooted(trimmedPath) || trimmedPath.Contains(Path.DirectorySeparatorChar) || trimmedPath.Contains(Path.AltDirectorySeparatorChar))
+        {
+            var rootedPath = Path.IsPathRooted(trimmedPath)
+                ? trimmedPath
+                : Path.GetFullPath(trimmedPath, _webHostEnvironment.ContentRootPath);
+            return File.Exists(rootedPath) ? rootedPath : null;
+        }
+
+        var pathValue = Environment.GetEnvironmentVariable("PATH");
+        if (!string.IsNullOrWhiteSpace(pathValue))
+        {
+            foreach (var pathEntry in pathValue.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var candidate = Path.Combine(pathEntry, trimmedPath);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+
+                if (OperatingSystem.IsWindows())
+                {
+                    var candidateWithExtension = candidate.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+                        ? candidate
+                        : $"{candidate}.exe";
+                    if (File.Exists(candidateWithExtension))
+                    {
+                        return candidateWithExtension;
+                    }
+                }
+            }
+        }
+
+        if (!OperatingSystem.IsWindows())
+        {
+            return null;
+        }
+
+        foreach (var programFilesDirectory in EnumerateWindowsProgramFilesRoots())
+        {
+            if (!Directory.Exists(programFilesDirectory))
+            {
+                continue;
+            }
+
+            var mysqlRoot = Path.Combine(programFilesDirectory, "MySQL");
+            if (!Directory.Exists(mysqlRoot))
+            {
+                continue;
+            }
+
+            var serverDirectories = Directory
+                .EnumerateDirectories(mysqlRoot, "MySQL Server *", SearchOption.TopDirectoryOnly)
+                .OrderByDescending(x => x, StringComparer.OrdinalIgnoreCase);
+            foreach (var serverDirectory in serverDirectories)
+            {
+                var candidate = Path.Combine(serverDirectory, "bin", "mysqldump.exe");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> EnumerateWindowsProgramFilesRoots()
+    {
+        var roots = new[]
+        {
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)
+        };
+
+        foreach (var root in roots.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            yield return root;
         }
     }
 


### PR DESCRIPTION
### Motivation
- The Database Maintenance backup action could fail with a process start error when `mysqldump` was not resolvable from the host `PATH`, producing "The system cannot find the file specified.".
- The change aims to deterministically locate the `mysqldump` executable (or fail fast with an actionable message) rather than letting a low-level process start failure be the only outcome.

### Description
- Add `ResolveMySqlDumpExecutablePath` to resolve a configured executable by accepting absolute/relative paths, probing `PATH` entries, and on Windows probing common `Program Files\MySQL\MySQL Server *\bin\mysqldump.exe` locations.
- Use the resolved path for `ProcessStartInfo.FileName` and return a clear operator-facing failure when the executable cannot be found instead of attempting to start a missing process.
- Document the new guidance in `docs/db-status-and-maintenance.md` recommending `DatabaseMaintenance:MySqlDumpExecutablePath` be set to a full path on Windows hosts where MySQL tools are not on `PATH`.
- This PR links the change to the tracking issue and guidance: `Fixes #274`.

### Testing
- Project build: `~/.dotnet/dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -v minimal` completed successfully (build succeeded).
- No automated unit tests were added or executed for this change; the modification is covered by a deterministic reproduction checklist attached to the issue (fails before change, passes after when `mysqldump` is found or provides actionable error when not).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd502e7f80832a8e97379e131168c2)