### PR TITLE
Render RTT performance chart as true line series

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml
@@ -184,7 +184,6 @@
 
     const rttLabels = @Html.Raw(JsonSerializer.Serialize(rttLabels));
     const rttValues = @Html.Raw(JsonSerializer.Serialize(rttValues));
-    const rttSeries = rttLabels.map((label, index) => ({ x: label, y: rttValues[index] }));
     const jitterLabels = @Html.Raw(JsonSerializer.Serialize(jitterLabels));
     const jitterValues = @Html.Raw(JsonSerializer.Serialize(jitterValues));
     const failureLabels = @Html.Raw(JsonSerializer.Serialize(failureLabels));
@@ -200,18 +199,17 @@
                 data: {
                     labels: rttLabels,
                     datasets: [{
-                        type: 'line',
                         label: 'RTT (ms)',
-                        data: rttSeries,
+                        data: rttValues,
                         borderColor: '#60a5fa',
                         borderWidth: 1.25,
+                        backgroundColor: 'transparent',
                         fill: false,
-                        showLine: true,
-                        stepped: false,
-                        tension: 0.15,
+                        tension: 0.1,
+                        cubicInterpolationMode: 'monotone',
                         pointRadius: 0,
                         pointHoverRadius: 2,
-                        pointHitRadius: 8,
+                        pointHitRadius: 6,
                         pointBackgroundColor: '#60a5fa',
                         pointBorderColor: '#60a5fa'
                     }]


### PR DESCRIPTION
### Motivation
- The RTT panel was rendering with a bar/stem-like appearance instead of a continuous time-series line, reducing readability especially in dark mode. 
- The intent is to keep the improved scroller/scale behavior while converting RTT to a proper line chart with minimal markers and a thin stroke.

### Description
- Switched RTT dataset from object `{x,y}` points to a numeric series by using `data: rttValues` and keeping `labels: rttLabels` in `src/WebApp/PingMonitor.Web/Views/Endpoints/Performance.cshtml`.
- Removed the per-dataset `type` override and any bar-like settings so the chart is driven by the top-level `type: 'line'` only, and added `cubicInterpolationMode: 'monotone'` with `tension: 0.1` for smooth, connected lines.
- Adjusted visual settings to be thin and readable by setting `borderWidth: 1.25`, `backgroundColor: 'transparent'`, `pointRadius: 0`, and reduced hover/hit radii to minimize markers.
- Created issue `#276` to track this work and linked the PR to it for traceability.

### Testing
- Automated build: ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the build completed successfully with no errors. 
- Issue creation via the GitHub API succeeded and the new issue is `#276` to satisfy repository workflow requirements.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd5561dbcc832aae4b3afa20f16fc8)