### PR TITLE
Harden auth/API boundaries before public deployment

### DIFF
--- a/docs/security-settings.md
+++ b/docs/security-settings.md
@@ -106,6 +106,14 @@ Manual and automatic block/unblock actions are persisted as security IP block re
 Manual user unlock actions (success and rejected attempts) are event logged with operator identity context when available.
 Settings updates are also event logged.
 
+## Reverse proxy header trust requirements
+
+Authentication IP-based protections (temporary/permanent IP block and failed-attempt thresholding) depend on accurate source IP resolution.
+
+- Only trust `X-Forwarded-*` headers from explicitly configured proxy IPs/networks.
+- Do not run with unrestricted forwarded-header trust in public deployments.
+- If no trusted proxies are configured, forwarded headers should remain limited to default local proxy trust only.
+
 ## Security auth log prune controls
 
 - Security page exposes current retention values, computed cutoff, and current eligible auth-log count.

--- a/docs/startup-gate.md
+++ b/docs/startup-gate.md
@@ -131,6 +131,8 @@ Local access is allowed to:
 - apply schema changes  
 - create initial admin user  
 
+When the app is deployed behind a reverse proxy, forwarded headers must be trusted only from explicitly configured proxy IPs/networks. Do not trust arbitrary `X-Forwarded-*` values from the public internet, because local-vs-remote startup-gate enforcement depends on resolved client address integrity.
+
 ---
 
 ### Remote access (untrusted)

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminMetricsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminMetricsController.cs
@@ -37,6 +37,7 @@ public sealed class AdminMetricsController : ControllerBase
     }
 
     [HttpPost("rebuild/{assignmentId}")]
+    [ValidateAntiForgeryToken]
     public async Task<IActionResult> RebuildAssignment([FromRoute] string assignmentId, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(assignmentId))
@@ -49,6 +50,7 @@ public sealed class AdminMetricsController : ControllerBase
     }
 
     [HttpPost("rebuild-all")]
+    [ValidateAntiForgeryToken]
     public async Task<IActionResult> RebuildAll(CancellationToken cancellationToken)
     {
         await _assignmentMetrics24hService.RebuildAllAsync(cancellationToken);

--- a/src/WebApp/PingMonitor.Web/Controllers/DevelopmentStateDiagnosticsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/DevelopmentStateDiagnosticsController.cs
@@ -1,12 +1,15 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Contracts.Diagnostics;
 using PingMonitor.Web.Data;
+using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.Models;
 
 namespace PingMonitor.Web.Controllers;
 
 [ApiController]
+[Authorize(Roles = ApplicationRoles.Admin)]
 [Route("internal/dev/state")]
 public sealed class DevelopmentStateDiagnosticsController : ControllerBase
 {

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using MySql.EntityFrameworkCore.Extensions;
+using System.Net;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models.Identity;
 using PingMonitor.Web.Options;
@@ -108,8 +109,43 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
         ForwardedHeaders.XForwardedFor |
         ForwardedHeaders.XForwardedProto |
         ForwardedHeaders.XForwardedHost;
-    options.KnownIPNetworks.Clear();
-    options.KnownProxies.Clear();
+    options.ForwardLimit = 1;
+    options.RequireHeaderSymmetry = true;
+
+    var knownProxies = builder.Configuration.GetSection("ForwardedHeaders:KnownProxies").Get<string[]>() ?? [];
+    var knownNetworks = builder.Configuration.GetSection("ForwardedHeaders:KnownNetworks").Get<string[]>() ?? [];
+
+    if (knownProxies.Length > 0 || knownNetworks.Length > 0)
+    {
+        options.KnownIPNetworks.Clear();
+        options.KnownProxies.Clear();
+
+        foreach (var proxy in knownProxies)
+        {
+            if (!IPAddress.TryParse(proxy?.Trim(), out var parsedProxy))
+            {
+                throw new InvalidOperationException($"Invalid ForwardedHeaders:KnownProxies entry '{proxy}'.");
+            }
+
+            options.KnownProxies.Add(parsedProxy);
+        }
+
+        foreach (var network in knownNetworks)
+        {
+            var normalized = network?.Trim();
+            if (string.IsNullOrWhiteSpace(normalized))
+            {
+                continue;
+            }
+
+            if (!System.Net.IPNetwork.TryParse(normalized, out var parsedNetwork))
+            {
+                throw new InvalidOperationException($"Invalid ForwardedHeaders:KnownNetworks entry '{network}'. Use CIDR format (for example 10.0.0.0/8).");
+            }
+
+            options.KnownIPNetworks.Add(parsedNetwork);
+        }
+    }
 });
 
 builder.Services.AddScoped<IAgentApiKeyHasher, AgentApiKeyHasher>();

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -57,5 +57,9 @@
   "DatabaseMaintenance": {
     "BackupStoragePath": "App_Data/DbBackups",
     "MySqlDumpExecutablePath": "mysqldump"
+  },
+  "ForwardedHeaders": {
+    "KnownProxies": [],
+    "KnownNetworks": []
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure the startup-gate and IP-based auth protections cannot be bypassed by spoofed `X-Forwarded-*` headers when the app is placed behind a reverse proxy.  
- Close CSRF exposure on admin state-changing APIs that were POST endpoints callable from an authenticated browser session.  
- Reduce information/authorization exposure for development-only diagnostics by restricting who can access internal state endpoints.

### Description
- Added strict forwarded-header handling in `Program.cs`: set `ForwardLimit = 1`, `RequireHeaderSymmetry = true`, and require explicit `ForwardedHeaders:KnownProxies` or `ForwardedHeaders:KnownNetworks` configuration with CIDR parsing and fail-fast validation (invalid entries throw on startup).  
- Added `ForwardedHeaders` defaults to `appsettings.json` to surface the new configuration keys.  
- Added `[ValidateAntiForgeryToken]` to admin metrics POST actions in `AdminMetricsController` to mitigate CSRF on privileged rebuild endpoints.  
- Restricted the development diagnostics endpoint by requiring admin role in `DevelopmentStateDiagnosticsController` so only admins can call internal state diagnostics even in development mode.  
- Updated docs to require explicit trusted-proxy configuration for reverse-proxy deployments and to call out forwarded-header trust requirements in `docs/startup-gate.md` and `docs/security-settings.md`.  
- This PR is tracked by Issue #278 (the security hardening task) and includes the code and docs changes referenced above (Fixes #278).

### Testing
- Created tracking issue `#278` via the GitHub API to follow this work and confirm the issue workflow (issue creation succeeded).  
- Verified the .NET SDK installation step used during validation by running the official `dotnet-install.sh` for the required SDK version.  
- Performed a deterministic build check with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the project built successfully with zero errors after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd60776ffc832ab6e8f9efdbcaf481)