### PR TITLE
Seed prior-state interval on first transition in AssignmentMetrics24hService

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Metrics/AssignmentMetrics24hService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/AssignmentMetrics24hService.cs
@@ -123,9 +123,10 @@ internal sealed class AssignmentMetrics24hService : IAssignmentMetrics24hService
             }
             else
             {
+                var fallbackPreviousStateStartedAtUtc = transitionAtUtc.Value - Window;
                 var previousStateStartedAtUtc = stateChangedAtUtc > DateTimeOffset.MinValue
                     ? stateChangedAtUtc
-                    : transitionAtUtc.Value;
+                    : fallbackPreviousStateStartedAtUtc;
 
                 _dbContext.AssignmentStateIntervals.Add(new AssignmentStateInterval
                 {


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where a state transition with `transitionAtUtc` but no active interval caused the prior-state segment to be dropped and 24h duration totals to be undercounted (often near-zero) after a first transition or interval-table reset.

### Description
- Updated `AssignmentMetrics24hService.ApplyStateEvaluationAsync` to seed a prior-state interval start using `fallbackPreviousStateStartedAtUtc = transitionAtUtc.Value - Window` when `stateChangedAtUtc` is not available, and kept the existing clamp so `StartedAtUtc` never exceeds `transitionAtUtc.Value`.

### Testing
- Attempted to run a build with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, but it could not be executed in this environment because `dotnet` is not installed, so no automated tests were run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ced2e27290832a9a18c28f6308b4a0)