### PR TITLE
Add rolling in-memory 24h assignment window store for hot-path metrics/state updates

### DIFF
--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -192,6 +192,7 @@ builder.Services.AddScoped<IEndpointManagementService, EndpointManagementService
 builder.Services.AddScoped<IEndpointPerformanceQueryService, EndpointPerformanceQueryService>();
 builder.Services.AddScoped<IGroupManagementService, GroupManagementService>();
 builder.Services.AddScoped<IAgentManagementQueryService, AgentManagementQueryService>();
+builder.Services.AddSingleton<IRollingAssignmentWindowStore, RollingAssignmentWindowStore>();
 builder.Services.AddScoped<IAssignmentMetrics24hService, AssignmentMetrics24hService>();
 builder.Services.AddScoped<IAgentMetricsService, AgentMetricsService>();
 builder.Services.AddScoped<IUserAccessScopeService, UserAccessScopeService>();

--- a/src/WebApp/PingMonitor.Web/Services/Metrics/AssignmentMetrics24hService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/AssignmentMetrics24hService.cs
@@ -7,21 +7,13 @@ namespace PingMonitor.Web.Services.Metrics;
 
 internal sealed class AssignmentMetrics24hService : IAssignmentMetrics24hService
 {
-    private static readonly TimeSpan Window = TimeSpan.FromHours(24);
-    private static readonly TimeSpan PruneRetention = TimeSpan.FromHours(48);
     private readonly PingMonitorDbContext _dbContext;
+    private readonly IRollingAssignmentWindowStore _rollingStore;
 
-    private sealed class RttSample
-    {
-        public required int RoundTripMs { get; init; }
-        public required DateTimeOffset CheckedAtUtc { get; init; }
-        public required DateTimeOffset ReceivedAtUtc { get; init; }
-        public required string CheckResultId { get; init; }
-    }
-
-    public AssignmentMetrics24hService(PingMonitorDbContext dbContext)
+    public AssignmentMetrics24hService(PingMonitorDbContext dbContext, IRollingAssignmentWindowStore rollingStore)
     {
         _dbContext = dbContext;
+        _rollingStore = rollingStore;
     }
 
     public async Task<IReadOnlyDictionary<string, AssignmentMetrics24hSummary>> GetSummariesAsync(
@@ -62,34 +54,21 @@ internal sealed class AssignmentMetrics24hService : IAssignmentMetrics24hService
 
     public async Task ApplyCheckResultsBatchAsync(IReadOnlyCollection<CheckResult> checkResults, CancellationToken cancellationToken)
     {
-        var successfulResults = checkResults
-            .Where(x => x.Success && x.RoundTripMs.HasValue)
-            .Select(x => new
-            {
-                x.AssignmentId,
-                MinuteStartUtc = TruncateToMinute(x.CheckedAtUtc)
-            })
-            .Distinct()
+        var assignmentIds = checkResults
+            .Select(x => x.AssignmentId)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x.Trim())
+            .Distinct(StringComparer.Ordinal)
             .ToArray();
 
-        if (successfulResults.Length == 0)
+        if (assignmentIds.Length == 0)
         {
             return;
         }
 
-        foreach (var assignmentMinute in successfulResults)
-        {
-            await RebuildRttBucketAsync(assignmentMinute.AssignmentId, assignmentMinute.MinuteStartUtc, cancellationToken);
-        }
-
-        var assignmentIds = successfulResults
-            .Select(x => x.AssignmentId)
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
-
-        await PruneSupportDataAsync(assignmentIds, DateTimeOffset.UtcNow, cancellationToken);
-        await RecomputeSummariesFromSupportAsync(assignmentIds, DateTimeOffset.UtcNow, cancellationToken);
-        await _dbContext.SaveChangesAsync(cancellationToken);
+        var nowUtc = DateTimeOffset.UtcNow;
+        await _rollingStore.ApplyCheckResultsBatchAsync(checkResults, nowUtc, cancellationToken);
+        await UpsertSnapshotsAsync(assignmentIds, nowUtc, cancellationToken);
     }
 
     public async Task ApplyStateEvaluationAsync(
@@ -101,102 +80,21 @@ internal sealed class AssignmentMetrics24hService : IAssignmentMetrics24hService
         DateTimeOffset evaluatedAtUtc,
         CancellationToken cancellationToken)
     {
-        var activeInterval = await _dbContext.AssignmentStateIntervals
-            .Where(x => x.AssignmentId == assignmentId && x.EndedAtUtc == null)
-            .OrderByDescending(x => x.StartedAtUtc)
-            .FirstOrDefaultAsync(cancellationToken);
+        await _rollingStore.ApplyStateEvaluationAsync(
+            assignmentId,
+            previousState,
+            currentState,
+            transitionAtUtc,
+            stateChangedAtUtc,
+            evaluatedAtUtc,
+            cancellationToken);
 
-        if (transitionAtUtc.HasValue)
-        {
-            if (activeInterval is not null)
-            {
-                if (activeInterval.StartedAtUtc < transitionAtUtc.Value)
-                {
-                    activeInterval.EndedAtUtc = transitionAtUtc.Value;
-                }
-                else
-                {
-                    activeInterval.EndedAtUtc = activeInterval.StartedAtUtc;
-                }
-
-                activeInterval.UpdatedAtUtc = evaluatedAtUtc;
-            }
-            else
-            {
-                var previousStateStartedAtUtc = stateChangedAtUtc > DateTimeOffset.MinValue
-                    ? stateChangedAtUtc
-                    : transitionAtUtc.Value;
-
-                _dbContext.AssignmentStateIntervals.Add(new AssignmentStateInterval
-                {
-                    AssignmentStateIntervalId = Guid.NewGuid().ToString(),
-                    AssignmentId = assignmentId,
-                    State = previousState,
-                    StartedAtUtc = previousStateStartedAtUtc <= transitionAtUtc.Value
-                        ? previousStateStartedAtUtc
-                        : transitionAtUtc.Value,
-                    EndedAtUtc = transitionAtUtc.Value,
-                    UpdatedAtUtc = evaluatedAtUtc
-                });
-            }
-
-            _dbContext.AssignmentStateIntervals.Add(new AssignmentStateInterval
-            {
-                AssignmentStateIntervalId = Guid.NewGuid().ToString(),
-                AssignmentId = assignmentId,
-                State = currentState,
-                StartedAtUtc = transitionAtUtc.Value,
-                EndedAtUtc = null,
-                UpdatedAtUtc = evaluatedAtUtc
-            });
-        }
-        else
-        {
-            var targetStartUtc = stateChangedAtUtc > DateTimeOffset.MinValue
-                ? stateChangedAtUtc
-                : evaluatedAtUtc;
-
-            if (activeInterval is null)
-            {
-                _dbContext.AssignmentStateIntervals.Add(new AssignmentStateInterval
-                {
-                    AssignmentStateIntervalId = Guid.NewGuid().ToString(),
-                    AssignmentId = assignmentId,
-                    State = currentState,
-                    StartedAtUtc = targetStartUtc,
-                    EndedAtUtc = null,
-                    UpdatedAtUtc = evaluatedAtUtc
-                });
-            }
-            else if (activeInterval.State != currentState)
-            {
-                activeInterval.EndedAtUtc = evaluatedAtUtc;
-                activeInterval.UpdatedAtUtc = evaluatedAtUtc;
-
-                _dbContext.AssignmentStateIntervals.Add(new AssignmentStateInterval
-                {
-                    AssignmentStateIntervalId = Guid.NewGuid().ToString(),
-                    AssignmentId = assignmentId,
-                    State = currentState,
-                    StartedAtUtc = targetStartUtc <= evaluatedAtUtc ? targetStartUtc : evaluatedAtUtc,
-                    EndedAtUtc = null,
-                    UpdatedAtUtc = evaluatedAtUtc
-                });
-            }
-            else
-            {
-                activeInterval.UpdatedAtUtc = evaluatedAtUtc;
-            }
-        }
-
-        await PruneSupportDataAsync([assignmentId], evaluatedAtUtc, cancellationToken);
-        await RecomputeSummariesFromSupportAsync([assignmentId], evaluatedAtUtc, cancellationToken);
-        await _dbContext.SaveChangesAsync(cancellationToken);
+        await UpsertSnapshotsAsync([assignmentId], evaluatedAtUtc, cancellationToken);
     }
 
-    public async Task RefreshAssignmentAsync(string assignmentId, CancellationToken cancellationToken)
+    public Task RefreshAssignmentAsync(string assignmentId, CancellationToken cancellationToken)
     {
-        await RefreshAssignmentsAsync([assignmentId], cancellationToken);
+        return RefreshAssignmentsAsync([assignmentId], cancellationToken);
     }
 
     public async Task RefreshAssignmentsAsync(IReadOnlyCollection<string> assignmentIds, CancellationToken cancellationToken)
@@ -208,14 +106,8 @@ internal sealed class AssignmentMetrics24hService : IAssignmentMetrics24hService
         }
 
         var nowUtc = DateTimeOffset.UtcNow;
-        foreach (var assignmentId in normalizedAssignmentIds)
-        {
-            await RebuildRttBucketsFromRawAsync(assignmentId, nowUtc, cancellationToken);
-            await RebuildStateIntervalsFromRawAsync(assignmentId, nowUtc, cancellationToken);
-        }
-
-        await RecomputeSummariesFromSupportAsync(normalizedAssignmentIds, nowUtc, cancellationToken);
-        await _dbContext.SaveChangesAsync(cancellationToken);
+        await _rollingStore.WarmAssignmentsAsync(normalizedAssignmentIds, nowUtc, cancellationToken);
+        await UpsertSnapshotsAsync(normalizedAssignmentIds, nowUtc, cancellationToken);
     }
 
     public async Task RebuildAllAsync(CancellationToken cancellationToken)
@@ -227,162 +119,7 @@ internal sealed class AssignmentMetrics24hService : IAssignmentMetrics24hService
         await RefreshAssignmentsAsync(assignmentIds, cancellationToken);
     }
 
-    private async Task RebuildRttBucketAsync(string assignmentId, DateTimeOffset minuteStartUtc, CancellationToken cancellationToken)
-    {
-        var minuteEndUtc = minuteStartUtc.AddMinutes(1);
-        var samples = await _dbContext.CheckResults.AsNoTracking()
-            .Where(x => x.AssignmentId == assignmentId
-                && x.Success
-                && x.RoundTripMs.HasValue
-                && x.CheckedAtUtc >= minuteStartUtc
-                && x.CheckedAtUtc < minuteEndUtc)
-            .OrderBy(x => x.CheckedAtUtc)
-            .ThenBy(x => x.ReceivedAtUtc)
-            .ThenBy(x => x.CheckResultId)
-            .Select(x => new RttSample
-            {
-                RoundTripMs = x.RoundTripMs!.Value,
-                CheckedAtUtc = x.CheckedAtUtc,
-                ReceivedAtUtc = x.ReceivedAtUtc,
-                CheckResultId = x.CheckResultId
-            })
-            .ToArrayAsync(cancellationToken);
-
-        var existingBucket = await _dbContext.AssignmentRttMinuteBuckets
-            .SingleOrDefaultAsync(x => x.AssignmentId == assignmentId && x.BucketStartUtc == minuteStartUtc, cancellationToken);
-
-        if (samples.Length == 0)
-        {
-            if (existingBucket is not null)
-            {
-                _dbContext.AssignmentRttMinuteBuckets.Remove(existingBucket);
-            }
-
-            return;
-        }
-
-        var orderedRttValues = samples.Select(x => x.RoundTripMs).ToArray();
-        var intraDeltaSum = 0d;
-        for (var index = 1; index < orderedRttValues.Length; index++)
-        {
-            intraDeltaSum += Math.Abs(orderedRttValues[index] - orderedRttValues[index - 1]);
-        }
-
-        if (existingBucket is null)
-        {
-            existingBucket = new AssignmentRttMinuteBucket
-            {
-                AssignmentId = assignmentId,
-                BucketStartUtc = minuteStartUtc
-            };
-
-            _dbContext.AssignmentRttMinuteBuckets.Add(existingBucket);
-        }
-
-        existingBucket.SampleCount = orderedRttValues.Length;
-        existingBucket.SumRttMs = orderedRttValues.Sum(x => (long)x);
-        existingBucket.MinRttMs = orderedRttValues.Min();
-        existingBucket.MaxRttMs = orderedRttValues.Max();
-        existingBucket.FirstRttMs = orderedRttValues[0];
-        existingBucket.LastRttMs = orderedRttValues[^1];
-        existingBucket.FirstSampleUtc = samples[0].CheckedAtUtc;
-        existingBucket.LastSampleUtc = samples[^1].CheckedAtUtc;
-        existingBucket.IntraBucketDeltaSumMs = intraDeltaSum;
-        existingBucket.UpdatedAtUtc = DateTimeOffset.UtcNow;
-    }
-
-    private async Task RebuildRttBucketsFromRawAsync(string assignmentId, DateTimeOffset nowUtc, CancellationToken cancellationToken)
-    {
-        var pruneCutoffUtc = nowUtc - PruneRetention;
-
-        var existingBuckets = await _dbContext.AssignmentRttMinuteBuckets
-            .Where(x => x.AssignmentId == assignmentId)
-            .ToArrayAsync(cancellationToken);
-
-        if (existingBuckets.Length > 0)
-        {
-            _dbContext.AssignmentRttMinuteBuckets.RemoveRange(existingBuckets);
-        }
-
-        var windowSamples = await _dbContext.CheckResults.AsNoTracking()
-            .Where(x => x.AssignmentId == assignmentId
-                && x.Success
-                && x.RoundTripMs.HasValue
-                && x.CheckedAtUtc >= pruneCutoffUtc
-                && x.CheckedAtUtc <= nowUtc)
-            .Select(x => new
-            {
-                x.AssignmentId,
-                MinuteStartUtc = TruncateToMinute(x.CheckedAtUtc)
-            })
-            .Distinct()
-            .ToArrayAsync(cancellationToken);
-
-        foreach (var sample in windowSamples)
-        {
-            await RebuildRttBucketAsync(sample.AssignmentId, sample.MinuteStartUtc, cancellationToken);
-        }
-    }
-
-    private async Task RebuildStateIntervalsFromRawAsync(string assignmentId, DateTimeOffset nowUtc, CancellationToken cancellationToken)
-    {
-        var existingIntervals = await _dbContext.AssignmentStateIntervals
-            .Where(x => x.AssignmentId == assignmentId)
-            .ToArrayAsync(cancellationToken);
-
-        if (existingIntervals.Length > 0)
-        {
-            _dbContext.AssignmentStateIntervals.RemoveRange(existingIntervals);
-        }
-
-        var transitions = await _dbContext.StateTransitions.AsNoTracking()
-            .Where(x => x.AssignmentId == assignmentId)
-            .OrderBy(x => x.TransitionAtUtc)
-            .ToArrayAsync(cancellationToken);
-
-        var endpointState = await _dbContext.EndpointStates.AsNoTracking()
-            .SingleOrDefaultAsync(x => x.AssignmentId == assignmentId, cancellationToken);
-
-        if (transitions.Length == 0)
-        {
-            _dbContext.AssignmentStateIntervals.Add(new AssignmentStateInterval
-            {
-                AssignmentStateIntervalId = Guid.NewGuid().ToString(),
-                AssignmentId = assignmentId,
-                State = endpointState?.CurrentState ?? EndpointStateKind.Unknown,
-                StartedAtUtc = endpointState?.LastStateChangeUtc ?? nowUtc,
-                EndedAtUtc = null,
-                UpdatedAtUtc = nowUtc
-            });
-
-            return;
-        }
-
-        for (var index = 0; index < transitions.Length; index++)
-        {
-            var transition = transitions[index];
-            DateTimeOffset? endedAtUtc = null;
-            if (index < transitions.Length - 1)
-            {
-                endedAtUtc = transitions[index + 1].TransitionAtUtc;
-            }
-
-            _dbContext.AssignmentStateIntervals.Add(new AssignmentStateInterval
-            {
-                AssignmentStateIntervalId = Guid.NewGuid().ToString(),
-                AssignmentId = assignmentId,
-                State = transition.NewState,
-                StartedAtUtc = transition.TransitionAtUtc,
-                EndedAtUtc = endedAtUtc,
-                UpdatedAtUtc = nowUtc
-            });
-        }
-    }
-
-    private async Task RecomputeSummariesFromSupportAsync(
-        IReadOnlyCollection<string> assignmentIds,
-        DateTimeOffset nowUtc,
-        CancellationToken cancellationToken)
+    private async Task UpsertSnapshotsAsync(IReadOnlyCollection<string> assignmentIds, DateTimeOffset nowUtc, CancellationToken cancellationToken)
     {
         var normalizedAssignmentIds = NormalizeAssignmentIds(assignmentIds);
         if (normalizedAssignmentIds.Length == 0)
@@ -390,48 +127,22 @@ internal sealed class AssignmentMetrics24hService : IAssignmentMetrics24hService
             return;
         }
 
-        var windowStartUtc = nowUtc - Window;
+        var snapshots = await _rollingStore.GetSnapshotsAsync(normalizedAssignmentIds, nowUtc, cancellationToken);
 
-        var existingRows = await ApplyAssignmentFilter(
+        var rows = await ApplyAssignmentFilter(
                 _dbContext.AssignmentMetrics24h,
                 x => x.AssignmentId,
                 normalizedAssignmentIds)
             .ToDictionaryAsync(x => x.AssignmentId, cancellationToken);
 
-        var rttBuckets = await ApplyAssignmentFilter(
-                _dbContext.AssignmentRttMinuteBuckets.AsNoTracking(),
-                x => x.AssignmentId,
-                normalizedAssignmentIds)
-            .Where(x => x.LastSampleUtc >= windowStartUtc && x.FirstSampleUtc <= nowUtc)
-            .OrderBy(x => x.BucketStartUtc)
-            .ToArrayAsync(cancellationToken);
-
-        var intervals = await ApplyAssignmentFilter(
-                _dbContext.AssignmentStateIntervals.AsNoTracking(),
-                x => x.AssignmentId,
-                normalizedAssignmentIds)
-            .Where(x => x.StartedAtUtc <= nowUtc
-                && (x.EndedAtUtc == null || x.EndedAtUtc >= windowStartUtc))
-            .OrderBy(x => x.StartedAtUtc)
-            .ToArrayAsync(cancellationToken);
-
-        var rttByAssignment = rttBuckets
-            .GroupBy(x => x.AssignmentId, StringComparer.Ordinal)
-            .ToDictionary(x => x.Key, x => x.ToArray(), StringComparer.Ordinal);
-
-        var intervalsByAssignment = intervals
-            .GroupBy(x => x.AssignmentId, StringComparer.Ordinal)
-            .ToDictionary(x => x.Key, x => x.ToArray(), StringComparer.Ordinal);
-
         foreach (var assignmentId in normalizedAssignmentIds)
         {
-            rttByAssignment.TryGetValue(assignmentId, out var assignmentBuckets);
-            intervalsByAssignment.TryGetValue(assignmentId, out var assignmentIntervals);
+            if (!snapshots.TryGetValue(assignmentId, out var snapshot))
+            {
+                continue;
+            }
 
-            var rttSummary = CalculateRttSummaryFromBuckets(assignmentBuckets ?? []);
-            var durationSummary = CalculateDurationsFromIntervals(assignmentIntervals ?? [], windowStartUtc, nowUtc);
-
-            if (!existingRows.TryGetValue(assignmentId, out var row))
+            if (!rows.TryGetValue(assignmentId, out var row))
             {
                 row = new AssignmentMetrics24h
                 {
@@ -441,156 +152,22 @@ internal sealed class AssignmentMetrics24hService : IAssignmentMetrics24hService
                 _dbContext.AssignmentMetrics24h.Add(row);
             }
 
-            row.WindowStartUtc = windowStartUtc;
-            row.WindowEndUtc = nowUtc;
-            row.UptimeSeconds = durationSummary.UptimeSeconds;
-            row.DowntimeSeconds = durationSummary.DowntimeSeconds;
-            row.UnknownSeconds = durationSummary.UnknownSeconds;
-            row.SuppressedSeconds = durationSummary.SuppressedSeconds;
-            row.LastRttMs = rttSummary.LastRttMs;
-            row.HighestRttMs = rttSummary.HighestRttMs;
-            row.LowestRttMs = rttSummary.LowestRttMs;
-            row.AverageRttMs = rttSummary.AverageRttMs;
-            row.JitterMs = rttSummary.JitterMs;
-            row.LastSuccessfulCheckUtc = rttSummary.LastSuccessfulCheckUtc;
-            row.UpdatedAtUtc = nowUtc;
-        }
-    }
-
-    private static AssignmentDurationSummary CalculateDurationsFromIntervals(
-        IReadOnlyList<AssignmentStateInterval> intervals,
-        DateTimeOffset windowStartUtc,
-        DateTimeOffset windowEndUtc)
-    {
-        if (windowEndUtc <= windowStartUtc)
-        {
-            return AssignmentDurationSummary.Empty;
+            row.WindowStartUtc = snapshot.WindowStartUtc;
+            row.WindowEndUtc = snapshot.WindowEndUtc;
+            row.UptimeSeconds = snapshot.UpDurationSeconds24h;
+            row.DowntimeSeconds = snapshot.DownDurationSeconds24h;
+            row.UnknownSeconds = snapshot.UnknownDurationSeconds24h;
+            row.SuppressedSeconds = snapshot.SuppressedDurationSeconds24h;
+            row.LastRttMs = snapshot.LastRttMs;
+            row.HighestRttMs = snapshot.HighestRttMs;
+            row.LowestRttMs = snapshot.LowestRttMs;
+            row.AverageRttMs = snapshot.AverageRttMs;
+            row.JitterMs = snapshot.JitterMs;
+            row.LastSuccessfulCheckUtc = snapshot.LastSuccessfulCheckUtc;
+            row.UpdatedAtUtc = snapshot.UpdatedUtc;
         }
 
-        var durationsByState = new Dictionary<EndpointStateKind, TimeSpan>
-        {
-            [EndpointStateKind.Up] = TimeSpan.Zero,
-            [EndpointStateKind.Degraded] = TimeSpan.Zero,
-            [EndpointStateKind.Down] = TimeSpan.Zero,
-            [EndpointStateKind.Unknown] = TimeSpan.Zero,
-            [EndpointStateKind.Suppressed] = TimeSpan.Zero
-        };
-
-        foreach (var interval in intervals)
-        {
-            var effectiveStartUtc = interval.StartedAtUtc < windowStartUtc ? windowStartUtc : interval.StartedAtUtc;
-            var intervalEndUtc = interval.EndedAtUtc ?? windowEndUtc;
-            var effectiveEndUtc = intervalEndUtc > windowEndUtc ? windowEndUtc : intervalEndUtc;
-            if (effectiveEndUtc <= effectiveStartUtc)
-            {
-                continue;
-            }
-
-            durationsByState[interval.State] += effectiveEndUtc - effectiveStartUtc;
-        }
-
-        return new AssignmentDurationSummary(
-            UptimeSeconds: ToWholeSeconds(durationsByState[EndpointStateKind.Up] + durationsByState[EndpointStateKind.Degraded]),
-            DowntimeSeconds: ToWholeSeconds(durationsByState[EndpointStateKind.Down]),
-            UnknownSeconds: ToWholeSeconds(durationsByState[EndpointStateKind.Unknown]),
-            SuppressedSeconds: ToWholeSeconds(durationsByState[EndpointStateKind.Suppressed]));
-    }
-
-    private static AssignmentRttSummary CalculateRttSummaryFromBuckets(IReadOnlyList<AssignmentRttMinuteBucket> buckets)
-    {
-        if (buckets.Count == 0)
-        {
-            return AssignmentRttSummary.Empty;
-        }
-
-        var ordered = buckets
-            .OrderBy(x => x.BucketStartUtc)
-            .ThenBy(x => x.LastSampleUtc)
-            .ToArray();
-
-        var totalSamples = 0;
-        long totalRttMs = 0;
-        int? minRttMs = null;
-        int? maxRttMs = null;
-        double deltaSumMs = 0d;
-
-        for (var index = 0; index < ordered.Length; index++)
-        {
-            var bucket = ordered[index];
-            totalSamples += bucket.SampleCount;
-            totalRttMs += bucket.SumRttMs;
-            minRttMs = !minRttMs.HasValue ? bucket.MinRttMs : Math.Min(minRttMs.Value, bucket.MinRttMs);
-            maxRttMs = !maxRttMs.HasValue ? bucket.MaxRttMs : Math.Max(maxRttMs.Value, bucket.MaxRttMs);
-            deltaSumMs += bucket.IntraBucketDeltaSumMs;
-
-            if (index > 0)
-            {
-                var previous = ordered[index - 1];
-                deltaSumMs += Math.Abs(bucket.FirstRttMs - previous.LastRttMs);
-            }
-        }
-
-        var lastBucket = ordered[^1];
-        var averageRtt = totalSamples > 0 ? totalRttMs / (double)totalSamples : (double?)null;
-        var jitterMs = totalSamples >= 2 ? deltaSumMs / (totalSamples - 1) : (double?)null;
-
-        return new AssignmentRttSummary(
-            LastRttMs: lastBucket.LastRttMs,
-            HighestRttMs: maxRttMs,
-            LowestRttMs: minRttMs,
-            AverageRttMs: averageRtt,
-            JitterMs: jitterMs,
-            LastSuccessfulCheckUtc: lastBucket.LastSampleUtc);
-    }
-
-    private async Task PruneSupportDataAsync(IReadOnlyCollection<string> assignmentIds, DateTimeOffset nowUtc, CancellationToken cancellationToken)
-    {
-        var normalizedAssignmentIds = NormalizeAssignmentIds(assignmentIds);
-        if (normalizedAssignmentIds.Length == 0)
-        {
-            return;
-        }
-
-        var pruneCutoffUtc = nowUtc - PruneRetention;
-
-        var staleBuckets = await ApplyAssignmentFilter(
-                _dbContext.AssignmentRttMinuteBuckets,
-                x => x.AssignmentId,
-                normalizedAssignmentIds)
-            .Where(x => x.BucketStartUtc < pruneCutoffUtc)
-            .ToArrayAsync(cancellationToken);
-
-        if (staleBuckets.Length > 0)
-        {
-            _dbContext.AssignmentRttMinuteBuckets.RemoveRange(staleBuckets);
-        }
-
-        var staleIntervals = await ApplyAssignmentFilter(
-                _dbContext.AssignmentStateIntervals,
-                x => x.AssignmentId,
-                normalizedAssignmentIds)
-            .Where(x => x.EndedAtUtc.HasValue && x.EndedAtUtc.Value < pruneCutoffUtc)
-            .ToArrayAsync(cancellationToken);
-
-        if (staleIntervals.Length > 0)
-        {
-            _dbContext.AssignmentStateIntervals.RemoveRange(staleIntervals);
-        }
-    }
-
-    private static DateTimeOffset TruncateToMinute(DateTimeOffset value)
-    {
-        return new DateTimeOffset(value.Year, value.Month, value.Day, value.Hour, value.Minute, 0, TimeSpan.Zero);
-    }
-
-    private static long ToWholeSeconds(TimeSpan duration)
-    {
-        if (duration <= TimeSpan.Zero)
-        {
-            return 0;
-        }
-
-        return (long)Math.Floor(duration.TotalSeconds);
+        await _dbContext.SaveChangesAsync(cancellationToken);
     }
 
     private static double? ComputeUptimePercent(long uptimeSeconds, DateTimeOffset windowStartUtc, DateTimeOffset windowEndUtc)
@@ -639,25 +216,5 @@ internal sealed class AssignmentMetrics24hService : IAssignmentMetrics24hService
 
         var predicate = Expression.Lambda<Func<T, bool>>(filterExpression, parameter);
         return query.Where(predicate);
-    }
-
-    private readonly record struct AssignmentDurationSummary(
-        long UptimeSeconds,
-        long DowntimeSeconds,
-        long UnknownSeconds,
-        long SuppressedSeconds)
-    {
-        public static AssignmentDurationSummary Empty => new(0, 0, 0, 0);
-    }
-
-    private readonly record struct AssignmentRttSummary(
-        int? LastRttMs,
-        int? HighestRttMs,
-        int? LowestRttMs,
-        double? AverageRttMs,
-        double? JitterMs,
-        DateTimeOffset? LastSuccessfulCheckUtc)
-    {
-        public static AssignmentRttSummary Empty => new(null, null, null, null, null, null);
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/Metrics/IRollingAssignmentWindowStore.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/IRollingAssignmentWindowStore.cs
@@ -1,0 +1,44 @@
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.Metrics;
+
+public interface IRollingAssignmentWindowStore
+{
+    Task ApplyCheckResultsBatchAsync(IReadOnlyCollection<CheckResult> checkResults, DateTimeOffset nowUtc, CancellationToken cancellationToken);
+
+    Task ApplyStateEvaluationAsync(
+        string assignmentId,
+        EndpointStateKind previousState,
+        EndpointStateKind currentState,
+        DateTimeOffset? transitionAtUtc,
+        DateTimeOffset stateChangedAtUtc,
+        DateTimeOffset evaluatedAtUtc,
+        CancellationToken cancellationToken);
+
+    Task<AssignmentWindowSnapshot> GetSnapshotAsync(string assignmentId, DateTimeOffset nowUtc, CancellationToken cancellationToken);
+
+    Task<IReadOnlyDictionary<string, AssignmentWindowSnapshot>> GetSnapshotsAsync(
+        IReadOnlyCollection<string> assignmentIds,
+        DateTimeOffset nowUtc,
+        CancellationToken cancellationToken);
+
+    Task WarmAssignmentsAsync(IReadOnlyCollection<string> assignmentIds, DateTimeOffset nowUtc, CancellationToken cancellationToken);
+}
+
+public sealed class AssignmentWindowSnapshot
+{
+    public required string AssignmentId { get; init; }
+    public required DateTimeOffset WindowStartUtc { get; init; }
+    public required DateTimeOffset WindowEndUtc { get; init; }
+    public required int? LastRttMs { get; init; }
+    public required int? HighestRttMs { get; init; }
+    public required int? LowestRttMs { get; init; }
+    public required double? AverageRttMs { get; init; }
+    public required double? JitterMs { get; init; }
+    public required DateTimeOffset? LastSuccessfulCheckUtc { get; init; }
+    public required long UpDurationSeconds24h { get; init; }
+    public required long DownDurationSeconds24h { get; init; }
+    public required long UnknownDurationSeconds24h { get; init; }
+    public required long SuppressedDurationSeconds24h { get; init; }
+    public required DateTimeOffset UpdatedUtc { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Metrics/RollingAssignmentWindowStore.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/RollingAssignmentWindowStore.cs
@@ -1,0 +1,557 @@
+using System.Collections.Concurrent;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.Metrics;
+
+internal sealed class RollingAssignmentWindowStore : IRollingAssignmentWindowStore
+{
+    private static readonly TimeSpan Window = TimeSpan.FromHours(24);
+    private readonly ConcurrentDictionary<string, AssignmentWindow> _windows = new(StringComparer.Ordinal);
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public RollingAssignmentWindowStore(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public async Task ApplyCheckResultsBatchAsync(IReadOnlyCollection<CheckResult> checkResults, DateTimeOffset nowUtc, CancellationToken cancellationToken)
+    {
+        var successfulByAssignment = checkResults
+            .Where(x => x.Success && x.RoundTripMs.HasValue && !string.IsNullOrWhiteSpace(x.AssignmentId))
+            .GroupBy(x => x.AssignmentId.Trim(), StringComparer.Ordinal);
+
+        foreach (var group in successfulByAssignment)
+        {
+            var window = await GetWindowAsync(group.Key, nowUtc, cancellationToken);
+            var ordered = group
+                .Select(x => new RttSamplePoint(x.CheckedAtUtc, x.RoundTripMs!.Value))
+                .OrderBy(x => x.CheckedAtUtc)
+                .ToArray();
+
+            await window.WithLockAsync(() =>
+            {
+                foreach (var sample in ordered)
+                {
+                    window.AppendRttSample(sample, nowUtc - Window);
+                }
+            }, cancellationToken);
+        }
+    }
+
+    public async Task ApplyStateEvaluationAsync(
+        string assignmentId,
+        EndpointStateKind previousState,
+        EndpointStateKind currentState,
+        DateTimeOffset? transitionAtUtc,
+        DateTimeOffset stateChangedAtUtc,
+        DateTimeOffset evaluatedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(assignmentId))
+        {
+            return;
+        }
+
+        var normalizedAssignmentId = assignmentId.Trim();
+        var window = await GetWindowAsync(normalizedAssignmentId, evaluatedAtUtc, cancellationToken);
+
+        await window.WithLockAsync(() =>
+        {
+            if (transitionAtUtc.HasValue)
+            {
+                var previousStartedAtUtc = stateChangedAtUtc > DateTimeOffset.MinValue
+                    ? stateChangedAtUtc
+                    : transitionAtUtc.Value;
+
+                window.EnsureState(previousState, previousStartedAtUtc);
+                window.AppendStateTransition(currentState, transitionAtUtc.Value);
+            }
+            else
+            {
+                var currentStartedAtUtc = stateChangedAtUtc > DateTimeOffset.MinValue
+                    ? stateChangedAtUtc
+                    : evaluatedAtUtc;
+
+                window.EnsureState(currentState, currentStartedAtUtc);
+            }
+
+            window.PruneStateWindow(evaluatedAtUtc - Window);
+        }, cancellationToken);
+    }
+
+    public async Task<AssignmentWindowSnapshot> GetSnapshotAsync(string assignmentId, DateTimeOffset nowUtc, CancellationToken cancellationToken)
+    {
+        var window = await GetWindowAsync(assignmentId, nowUtc, cancellationToken);
+        return await window.WithLockAsync(() => window.BuildSnapshot(nowUtc - Window, nowUtc), cancellationToken);
+    }
+
+    public async Task<IReadOnlyDictionary<string, AssignmentWindowSnapshot>> GetSnapshotsAsync(
+        IReadOnlyCollection<string> assignmentIds,
+        DateTimeOffset nowUtc,
+        CancellationToken cancellationToken)
+    {
+        var result = new Dictionary<string, AssignmentWindowSnapshot>(StringComparer.Ordinal);
+
+        foreach (var assignmentId in NormalizeAssignmentIds(assignmentIds))
+        {
+            result[assignmentId] = await GetSnapshotAsync(assignmentId, nowUtc, cancellationToken);
+        }
+
+        return result;
+    }
+
+    public async Task WarmAssignmentsAsync(IReadOnlyCollection<string> assignmentIds, DateTimeOffset nowUtc, CancellationToken cancellationToken)
+    {
+        foreach (var assignmentId in NormalizeAssignmentIds(assignmentIds))
+        {
+            _ = await GetWindowAsync(assignmentId, nowUtc, cancellationToken);
+        }
+    }
+
+    private async Task<AssignmentWindow> GetWindowAsync(string assignmentId, DateTimeOffset nowUtc, CancellationToken cancellationToken)
+    {
+        var normalizedAssignmentId = assignmentId.Trim();
+        var window = _windows.GetOrAdd(normalizedAssignmentId, id => new AssignmentWindow(id));
+
+        if (window.IsHydrated)
+        {
+            return window;
+        }
+
+        await window.WithLockAsync(async () =>
+        {
+            if (window.IsHydrated)
+            {
+                return;
+            }
+
+            await HydrateWindowAsync(window, nowUtc, cancellationToken);
+            window.IsHydrated = true;
+        }, cancellationToken);
+
+        return window;
+    }
+
+    private async Task HydrateWindowAsync(AssignmentWindow window, DateTimeOffset nowUtc, CancellationToken cancellationToken)
+    {
+        var windowStartUtc = nowUtc - Window;
+
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<PingMonitorDbContext>();
+
+        var samples = await dbContext.CheckResults.AsNoTracking()
+            .Where(x => x.AssignmentId == window.AssignmentId
+                && x.Success
+                && x.RoundTripMs.HasValue
+                && x.CheckedAtUtc >= windowStartUtc
+                && x.CheckedAtUtc <= nowUtc)
+            .OrderBy(x => x.CheckedAtUtc)
+            .ThenBy(x => x.ReceivedAtUtc)
+            .ThenBy(x => x.CheckResultId)
+            .Select(x => new RttSamplePoint(x.CheckedAtUtc, x.RoundTripMs!.Value))
+            .ToArrayAsync(cancellationToken);
+
+        var transitionsInWindow = await dbContext.StateTransitions.AsNoTracking()
+            .Where(x => x.AssignmentId == window.AssignmentId
+                && x.TransitionAtUtc >= windowStartUtc
+                && x.TransitionAtUtc <= nowUtc)
+            .OrderBy(x => x.TransitionAtUtc)
+            .Select(x => new StateTransitionPoint(x.TransitionAtUtc, x.NewState))
+            .ToArrayAsync(cancellationToken);
+
+        var latestBeforeWindow = await dbContext.StateTransitions.AsNoTracking()
+            .Where(x => x.AssignmentId == window.AssignmentId
+                && x.TransitionAtUtc < windowStartUtc)
+            .OrderByDescending(x => x.TransitionAtUtc)
+            .Select(x => new StateTransitionPoint(x.TransitionAtUtc, x.NewState))
+            .Take(1)
+            .ToArrayAsync(cancellationToken);
+
+        var endpointState = await dbContext.EndpointStates.AsNoTracking()
+            .SingleOrDefaultAsync(x => x.AssignmentId == window.AssignmentId, cancellationToken);
+
+        window.Reset();
+
+        foreach (var sample in samples)
+        {
+            window.AppendRttSample(sample, windowStartUtc);
+        }
+
+        if (latestBeforeWindow.Length > 0)
+        {
+            window.AddHydratedTransition(latestBeforeWindow[0]);
+        }
+        else if (endpointState is not null)
+        {
+            var stateSinceUtc = endpointState.LastStateChangeUtc ?? windowStartUtc;
+            window.AddHydratedTransition(new StateTransitionPoint(stateSinceUtc, endpointState.CurrentState));
+        }
+
+        foreach (var transition in transitionsInWindow)
+        {
+            window.AddHydratedTransition(transition);
+        }
+
+        window.PruneStateWindow(windowStartUtc);
+    }
+
+    private static string[] NormalizeAssignmentIds(IReadOnlyCollection<string> assignmentIds)
+    {
+        return assignmentIds
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private readonly record struct RttSamplePoint(DateTimeOffset CheckedAtUtc, int RttMs);
+    private readonly record struct StateTransitionPoint(DateTimeOffset TransitionAtUtc, EndpointStateKind State);
+
+    private sealed class AssignmentWindow
+    {
+        private readonly SemaphoreSlim _gate = new(1, 1);
+        private readonly LinkedList<RttSamplePoint> _rttSamples = [];
+        private readonly LinkedList<StateTransitionPoint> _stateTransitions = [];
+        private long _rttSum;
+        private int? _rttMin;
+        private int? _rttMax;
+        private bool _rttMinDirty;
+        private bool _rttMaxDirty;
+        private double _rttDeltaSum;
+
+        public AssignmentWindow(string assignmentId)
+        {
+            AssignmentId = assignmentId;
+        }
+
+        public string AssignmentId { get; }
+        public bool IsHydrated { get; set; }
+
+        public void Reset()
+        {
+            _rttSamples.Clear();
+            _stateTransitions.Clear();
+            _rttSum = 0;
+            _rttMin = null;
+            _rttMax = null;
+            _rttMinDirty = false;
+            _rttMaxDirty = false;
+            _rttDeltaSum = 0;
+        }
+
+        public async Task WithLockAsync(Action action, CancellationToken cancellationToken)
+        {
+            await _gate.WaitAsync(cancellationToken);
+            try
+            {
+                action();
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        public async Task<T> WithLockAsync<T>(Func<T> action, CancellationToken cancellationToken)
+        {
+            await _gate.WaitAsync(cancellationToken);
+            try
+            {
+                return action();
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        public async Task WithLockAsync(Func<Task> action, CancellationToken cancellationToken)
+        {
+            await _gate.WaitAsync(cancellationToken);
+            try
+            {
+                await action();
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        public void AppendRttSample(RttSamplePoint sample, DateTimeOffset windowStartUtc)
+        {
+            var tail = _rttSamples.Last?.Value;
+            _rttSamples.AddLast(sample);
+            _rttSum += sample.RttMs;
+
+            _rttMin = !_rttMin.HasValue ? sample.RttMs : Math.Min(_rttMin.Value, sample.RttMs);
+            _rttMax = !_rttMax.HasValue ? sample.RttMs : Math.Max(_rttMax.Value, sample.RttMs);
+
+            if (tail.HasValue)
+            {
+                _rttDeltaSum += Math.Abs(sample.RttMs - tail.Value.RttMs);
+            }
+
+            PruneRttWindow(windowStartUtc);
+        }
+
+        public void AddHydratedTransition(StateTransitionPoint transition)
+        {
+            if (_stateTransitions.Last is not null && _stateTransitions.Last.Value.TransitionAtUtc == transition.TransitionAtUtc)
+            {
+                _stateTransitions.Last.Value = transition;
+                return;
+            }
+
+            if (_stateTransitions.Last is not null && _stateTransitions.Last.Value.State == transition.State)
+            {
+                return;
+            }
+
+            _stateTransitions.AddLast(transition);
+        }
+
+        public void EnsureState(EndpointStateKind state, DateTimeOffset stateSinceUtc)
+        {
+            if (_stateTransitions.Count == 0)
+            {
+                _stateTransitions.AddLast(new StateTransitionPoint(stateSinceUtc, state));
+                return;
+            }
+
+            if (_stateTransitions.Last!.Value.State != state)
+            {
+                _stateTransitions.AddLast(new StateTransitionPoint(stateSinceUtc, state));
+            }
+        }
+
+        public void AppendStateTransition(EndpointStateKind newState, DateTimeOffset transitionAtUtc)
+        {
+            if (_stateTransitions.Last is not null && _stateTransitions.Last.Value.TransitionAtUtc == transitionAtUtc)
+            {
+                _stateTransitions.Last.Value = new StateTransitionPoint(transitionAtUtc, newState);
+                return;
+            }
+
+            if (_stateTransitions.Last is not null && _stateTransitions.Last.Value.State == newState)
+            {
+                return;
+            }
+
+            _stateTransitions.AddLast(new StateTransitionPoint(transitionAtUtc, newState));
+        }
+
+        public void PruneStateWindow(DateTimeOffset windowStartUtc)
+        {
+            while (_stateTransitions.Count >= 2)
+            {
+                var oldest = _stateTransitions.First!;
+                var second = oldest.Next!;
+                if (second.Value.TransitionAtUtc >= windowStartUtc)
+                {
+                    break;
+                }
+
+                _stateTransitions.RemoveFirst();
+            }
+        }
+
+        public AssignmentWindowSnapshot BuildSnapshot(DateTimeOffset windowStartUtc, DateTimeOffset nowUtc)
+        {
+            PruneRttWindow(windowStartUtc);
+            PruneStateWindow(windowStartUtc);
+            EnsureRttBounds();
+
+            var rttCount = _rttSamples.Count;
+            var lastRtt = _rttSamples.Last?.Value.RttMs;
+            var lastSuccessUtc = _rttSamples.Last?.Value.CheckedAtUtc;
+            var averageRtt = rttCount > 0 ? _rttSum / (double)rttCount : (double?)null;
+            var jitter = rttCount >= 2 ? _rttDeltaSum / (rttCount - 1) : (double?)null;
+
+            var durations = CalculateStateDurations(windowStartUtc, nowUtc);
+
+            return new AssignmentWindowSnapshot
+            {
+                AssignmentId = AssignmentId,
+                WindowStartUtc = windowStartUtc,
+                WindowEndUtc = nowUtc,
+                LastRttMs = lastRtt,
+                HighestRttMs = _rttMax,
+                LowestRttMs = _rttMin,
+                AverageRttMs = averageRtt,
+                JitterMs = jitter,
+                LastSuccessfulCheckUtc = lastSuccessUtc,
+                UpDurationSeconds24h = durations.UpSeconds,
+                DownDurationSeconds24h = durations.DownSeconds,
+                UnknownDurationSeconds24h = durations.UnknownSeconds,
+                SuppressedDurationSeconds24h = durations.SuppressedSeconds,
+                UpdatedUtc = nowUtc
+            };
+        }
+
+        private void PruneRttWindow(DateTimeOffset windowStartUtc)
+        {
+            while (_rttSamples.First is not null && _rttSamples.First.Value.CheckedAtUtc < windowStartUtc)
+            {
+                var oldest = _rttSamples.First;
+                var next = oldest!.Next;
+
+                _rttSum -= oldest.Value.RttMs;
+
+                if (_rttMin.HasValue && oldest.Value.RttMs == _rttMin.Value)
+                {
+                    _rttMinDirty = true;
+                }
+
+                if (_rttMax.HasValue && oldest.Value.RttMs == _rttMax.Value)
+                {
+                    _rttMaxDirty = true;
+                }
+
+                if (next is not null)
+                {
+                    _rttDeltaSum -= Math.Abs(next.Value.RttMs - oldest.Value.RttMs);
+                }
+
+                _rttSamples.RemoveFirst();
+            }
+
+            if (_rttSamples.Count == 0)
+            {
+                _rttSum = 0;
+                _rttMin = null;
+                _rttMax = null;
+                _rttMinDirty = false;
+                _rttMaxDirty = false;
+                _rttDeltaSum = 0;
+            }
+        }
+
+        private void EnsureRttBounds()
+        {
+            if (_rttSamples.Count == 0)
+            {
+                _rttMin = null;
+                _rttMax = null;
+                _rttMinDirty = false;
+                _rttMaxDirty = false;
+                return;
+            }
+
+            if (_rttMinDirty)
+            {
+                _rttMin = _rttSamples.Min(x => x.RttMs);
+                _rttMinDirty = false;
+            }
+
+            if (_rttMaxDirty)
+            {
+                _rttMax = _rttSamples.Max(x => x.RttMs);
+                _rttMaxDirty = false;
+            }
+        }
+
+        private StateDurationSummary CalculateStateDurations(DateTimeOffset windowStartUtc, DateTimeOffset windowEndUtc)
+        {
+            if (windowEndUtc <= windowStartUtc)
+            {
+                return StateDurationSummary.Empty;
+            }
+
+            if (_stateTransitions.Count == 0)
+            {
+                var seconds = ToWholeSeconds(windowEndUtc - windowStartUtc);
+                return new StateDurationSummary(0, 0, seconds, 0);
+            }
+
+            var ordered = _stateTransitions
+                .Where(x => x.TransitionAtUtc <= windowEndUtc)
+                .OrderBy(x => x.TransitionAtUtc)
+                .ToArray();
+
+            if (ordered.Length == 0)
+            {
+                var seconds = ToWholeSeconds(windowEndUtc - windowStartUtc);
+                return new StateDurationSummary(0, 0, seconds, 0);
+            }
+
+            var currentState = EndpointStateKind.Unknown;
+            var cursorUtc = windowStartUtc;
+
+            var anchor = ordered.LastOrDefault(x => x.TransitionAtUtc <= windowStartUtc);
+            if (anchor != default)
+            {
+                currentState = anchor.State;
+            }
+
+            var up = 0L;
+            var down = 0L;
+            var unknown = 0L;
+            var suppressed = 0L;
+
+            foreach (var transition in ordered)
+            {
+                if (transition.TransitionAtUtc <= windowStartUtc)
+                {
+                    continue;
+                }
+
+                if (transition.TransitionAtUtc > windowEndUtc)
+                {
+                    break;
+                }
+
+                AddDuration(currentState, transition.TransitionAtUtc - cursorUtc, ref up, ref down, ref unknown, ref suppressed);
+                cursorUtc = transition.TransitionAtUtc;
+                currentState = transition.State;
+            }
+
+            AddDuration(currentState, windowEndUtc - cursorUtc, ref up, ref down, ref unknown, ref suppressed);
+            return new StateDurationSummary(up, down, unknown, suppressed);
+        }
+
+        private static void AddDuration(
+            EndpointStateKind state,
+            TimeSpan duration,
+            ref long up,
+            ref long down,
+            ref long unknown,
+            ref long suppressed)
+        {
+            var seconds = ToWholeSeconds(duration);
+            if (seconds <= 0)
+            {
+                return;
+            }
+
+            switch (state)
+            {
+                case EndpointStateKind.Up:
+                case EndpointStateKind.Degraded:
+                    up += seconds;
+                    break;
+                case EndpointStateKind.Down:
+                    down += seconds;
+                    break;
+                case EndpointStateKind.Suppressed:
+                    suppressed += seconds;
+                    break;
+                default:
+                    unknown += seconds;
+                    break;
+            }
+        }
+
+        private static long ToWholeSeconds(TimeSpan span)
+        {
+            return span <= TimeSpan.Zero ? 0 : (long)Math.Floor(span.TotalSeconds);
+        }
+
+        private readonly record struct StateDurationSummary(long UpSeconds, long DownSeconds, long UnknownSeconds, long SuppressedSeconds)
+        {
+            public static StateDurationSummary Empty => new(0, 0, 0, 0);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce hot-path DB reads during result flush/state evaluation by keeping a compact 24-hour per-assignment working set in memory. 
- Preserve the DB as the durable cold-path source of truth and provide a deterministic rebuild/hydration path. 
- Keep per-assignment isolation so different assignments do not block each other and avoid reusing the existing ingest buffer for this responsibility.

### Description
- Add `IRollingAssignmentWindowStore` and `AssignmentWindowSnapshot` to define the rolling-window contract and snapshot shape that maps to `AssignmentMetrics24h`.
- Implement `RollingAssignmentWindowStore` with a `ConcurrentDictionary<string, AssignmentWindow>` and per-assignment `SemaphoreSlim` locks; each `AssignmentWindow` maintains a compact RTT deque and a state-transition deque with incremental aggregates (sum, min/max with dirty-recompute, delta-sum for exact jitter) and anchor retention for exact 24h duration calculation. (new files: `Services/Metrics/IRollingAssignmentWindowStore.cs`, `Services/Metrics/RollingAssignmentWindowStore.cs`)
- Refactor `AssignmentMetrics24hService` hot path to use the rolling store: `ApplyCheckResultsBatchAsync` updates the in-memory RTT window and `ApplyStateEvaluationAsync` updates the in-memory state window, and both upsert `AssignmentMetrics24h` from in-memory snapshots instead of rescanning 24h raw history. Cold-path `Refresh*`/`RebuildAll` warm/hydrate the rolling store from DB. (updated file: `Services/Metrics/AssignmentMetrics24hService.cs`)
- Register the rolling store in DI as a singleton and keep existing integrations (buffered flush and state evaluation) intact so the normal flow now writes raw results to DB, updates the rolling store, and then persists snapshot summaries. (updated file: `Program.cs`)
- Preserve exact jitter semantics and exact 24h state-duration calculation by maintaining consecutive-sample delta sums and retaining the last transition before the window start as an anchor so snapshots compute durations deterministically.

### Testing
- Built the web app: `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the build succeeded without warnings or errors. (Succeeded)
- Validated hot-path wiring via repository search that the buffered flush and state evaluation now call the new rolling-store-backed metric APIs (`ApplyCheckResultsBatchAsync`, `ApplyStateEvaluationAsync`) and `AssignmentMetrics24hService` no longer rescans 24h raw-history tables in the normal per-batch hot path. (Verified via `rg` search) 
- Confirmed lazy cold-path hydration exists in `RollingAssignmentWindowStore.HydrateWindowAsync` and `Refresh*`/`RebuildAll` warm the store from DB. (Verified)

Files added/updated
- Added: `src/WebApp/PingMonitor.Web/Services/Metrics/IRollingAssignmentWindowStore.cs` and `src/WebApp/PingMonitor.Web/Services/Metrics/RollingAssignmentWindowStore.cs`.
- Updated: `src/WebApp/PingMonitor.Web/Services/Metrics/AssignmentMetrics24hService.cs` and `src/WebApp/PingMonitor.Web/Program.cs`.

Issue linkage
- Fixes #286

Risks / follow-ups
- In-memory window eviction for very long-inactive assignments (memory pruning) can be added later; current design uses lazy hydration and opportunistic pruning on append.
- `StateEvaluationService` still performs a small latest-result read; further decoupling could yield additional throughput improvements if needed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ced6047f30832ab352f09012746cab)