### PR TITLE
Decouple raw result flush from downstream assignment processing

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/AdminDatabaseController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminDatabaseController.cs
@@ -210,6 +210,24 @@ public sealed class AdminDatabaseController : Controller
                 LastFlushPersistedCount = runtimeBuffer.LastFlushPersistedCount,
                 LastFlushCompletedAtUtc = runtimeBuffer.LastFlushCompletedAtUtc,
                 LastFlushError = runtimeBuffer.LastFlushError,
+                LastPersistDurationMs = runtimeBuffer.LastPersistDurationMs,
+                LastEnqueuedAssignmentCount = runtimeBuffer.LastEnqueuedAssignmentCount,
+                LastAssignmentsEnqueuedAtUtc = runtimeBuffer.LastAssignmentsEnqueuedAtUtc,
+                AssignmentProcessingQueue = new AssignmentProcessingQueueViewModel
+                {
+                    QueueDepth = runtimeBuffer.AssignmentProcessingQueue.QueueDepth,
+                    PendingAssignmentCount = runtimeBuffer.AssignmentProcessingQueue.PendingAssignmentCount,
+                    TotalEnqueueCount = runtimeBuffer.AssignmentProcessingQueue.TotalEnqueueCount,
+                    CoalescedDuplicateCount = runtimeBuffer.AssignmentProcessingQueue.CoalescedDuplicateCount,
+                    DequeueCount = runtimeBuffer.AssignmentProcessingQueue.DequeueCount,
+                    ProcessedCount = runtimeBuffer.AssignmentProcessingQueue.ProcessedCount,
+                    FailedCount = runtimeBuffer.AssignmentProcessingQueue.FailedCount,
+                    LastEnqueueAtUtc = runtimeBuffer.AssignmentProcessingQueue.LastEnqueueAtUtc,
+                    LastDequeuedAtUtc = runtimeBuffer.AssignmentProcessingQueue.LastDequeuedAtUtc,
+                    LastProcessedAtUtc = runtimeBuffer.AssignmentProcessingQueue.LastProcessedAtUtc,
+                    LastFailureAtUtc = runtimeBuffer.AssignmentProcessingQueue.LastFailureAtUtc,
+                    LastFailureError = runtimeBuffer.AssignmentProcessingQueue.LastFailureError
+                },
                 QueueUtilizationPercent = queueUtilizationPercent,
                 BufferDropRatePercent = bufferDropRatePercent,
                 FlushSuccessRatePercent = flushSuccessRatePercent

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -18,6 +18,8 @@ using PingMonitor.Web.Services.Groups;
 using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.Services.EventLogs;
 using PingMonitor.Web.Services.Metrics;
+using PingMonitor.Web.Services.State;
+using PingMonitor.Web.Services.Background;
 using PingMonitor.Web.Services.StartupGate;
 using PingMonitor.Web.Services.Status;
 using PingMonitor.Web.Services.Security;
@@ -156,6 +158,7 @@ builder.Services.AddScoped<IResultIngestionService, ResultIngestionService>();
 builder.Services.AddSingleton<IBufferedResultIngestionService, BufferedResultIngestionService>();
 builder.Services.AddScoped<IHeartbeatService, AgentHeartbeatService>();
 builder.Services.AddScoped<IStateEvaluationService, StateEvaluationService>();
+builder.Services.AddSingleton<IAssignmentProcessingQueue, AssignmentProcessingQueue>();
 builder.Services.AddScoped<IEventLogService, EventLogService>();
 builder.Services.AddScoped<IEventLogQueryService, EventLogQueryService>();
 builder.Services.AddScoped<ISecurityAuthLogService, SecurityAuthLogService>();
@@ -213,6 +216,7 @@ builder.Services.AddSingleton<IConfigurationChangeBackupSignal>(sp => sp.GetRequ
 builder.Services.AddHostedService(sp => sp.GetRequiredService<ConfigurationAutoBackupBackgroundService>());
 builder.Services.AddHostedService<AgentStatusTransitionBackgroundService>();
 builder.Services.AddHostedService<BufferedResultFlushBackgroundService>();
+builder.Services.AddHostedService<AssignmentProcessingBackgroundService>();
 builder.Services.AddHostedService<TelegramPollingBackgroundService>();
 
 var app = builder.Build();

--- a/src/WebApp/PingMonitor.Web/Services/Background/AssignmentProcessingBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Background/AssignmentProcessingBackgroundService.cs
@@ -1,0 +1,90 @@
+using PingMonitor.Web.Services.State;
+
+namespace PingMonitor.Web.Services.Background;
+
+internal sealed class AssignmentProcessingBackgroundService : BackgroundService
+{
+    private static readonly TimeSpan IdleDelay = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan FailureBackoff = TimeSpan.FromSeconds(2);
+    private const int MaxBatchSize = 250;
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IAssignmentProcessingQueue _queue;
+    private readonly ILogger<AssignmentProcessingBackgroundService> _logger;
+
+    public AssignmentProcessingBackgroundService(
+        IServiceScopeFactory scopeFactory,
+        IAssignmentProcessingQueue queue,
+        ILogger<AssignmentProcessingBackgroundService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _queue = queue;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await _queue.WaitForSignalAsync(IdleDelay, stoppingToken);
+            await ProcessAvailableAssignmentsAsync(stoppingToken);
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Application shutdown requested. Attempting best-effort assignment processing queue drain.");
+        try
+        {
+            await ProcessAvailableAssignmentsAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Best-effort assignment processing queue drain failed during shutdown.");
+        }
+
+        await base.StopAsync(cancellationToken);
+    }
+
+    private async Task ProcessAvailableAssignmentsAsync(CancellationToken cancellationToken)
+    {
+        while (_queue.HasPendingItems())
+        {
+            var assignmentIds = _queue.DequeueBatch(MaxBatchSize);
+            if (assignmentIds.Count == 0)
+            {
+                break;
+            }
+
+            using var scope = _scopeFactory.CreateScope();
+            var stateEvaluationService = scope.ServiceProvider.GetRequiredService<IStateEvaluationService>();
+
+            var failedAssignments = new List<string>();
+            foreach (var assignmentId in assignmentIds)
+            {
+                try
+                {
+                    await stateEvaluationService.EvaluateAssignmentStateAsync(assignmentId, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    failedAssignments.Add(assignmentId);
+                    _queue.RecordFailure(ex, DateTimeOffset.UtcNow);
+                    _logger.LogError(ex, "Assignment processing failed for assignment {AssignmentId}. Assignment will be retried.", assignmentId);
+                }
+            }
+
+            var processedCount = assignmentIds.Count - failedAssignments.Count;
+            if (processedCount > 0)
+            {
+                _queue.RecordProcessedCount(processedCount, DateTimeOffset.UtcNow);
+            }
+
+            if (failedAssignments.Count > 0)
+            {
+                _queue.EnqueueAssignments(failedAssignments);
+                await Task.Delay(FailureBackoff, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultFlushBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultFlushBackgroundService.cs
@@ -1,9 +1,9 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Options;
 using PingMonitor.Web.Services.Metrics;
+using PingMonitor.Web.Services.State;
 
 namespace PingMonitor.Web.Services.BufferedResults;
 
@@ -12,16 +12,19 @@ internal sealed class BufferedResultFlushBackgroundService : BackgroundService
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IBufferedResultIngestionService _buffer;
     private readonly ResultBufferOptions _options;
+    private readonly IAssignmentProcessingQueue _assignmentProcessingQueue;
     private readonly ILogger<BufferedResultFlushBackgroundService> _logger;
 
     public BufferedResultFlushBackgroundService(
         IServiceScopeFactory scopeFactory,
         IBufferedResultIngestionService buffer,
+        IAssignmentProcessingQueue assignmentProcessingQueue,
         IOptions<ResultBufferOptions> options,
         ILogger<BufferedResultFlushBackgroundService> logger)
     {
         _scopeFactory = scopeFactory;
         _buffer = buffer;
+        _assignmentProcessingQueue = assignmentProcessingQueue;
         _options = options.Value;
         _logger = logger;
     }
@@ -78,12 +81,26 @@ internal sealed class BufferedResultFlushBackgroundService : BackgroundService
 
             try
             {
-                await PersistAndEvaluateAsync(batch, cancellationToken);
-                _buffer.RecordFlushOutcome(batch.Count, batch.Count, DateTimeOffset.UtcNow, null);
+                var flushResult = await PersistAndEnqueueAssignmentsAsync(batch, cancellationToken);
+                _buffer.RecordFlushOutcome(
+                    batch.Count,
+                    batch.Count,
+                    DateTimeOffset.UtcNow,
+                    null,
+                    flushResult.PersistDurationMs,
+                    flushResult.AssignmentEnqueuedCount,
+                    flushResult.LastAssignmentsEnqueuedAtUtc);
             }
             catch (Exception ex)
             {
-                _buffer.RecordFlushOutcome(batch.Count, 0, DateTimeOffset.UtcNow, ex);
+                _buffer.RecordFlushOutcome(
+                    batch.Count,
+                    0,
+                    DateTimeOffset.UtcNow,
+                    ex,
+                    persistDurationMs: 0,
+                    enqueuedAssignmentCount: 0,
+                    lastAssignmentsEnqueuedAtUtc: null);
                 _logger.LogError(ex, "Buffered raw result flush failed for batch size {BatchSize}.", batch.Count);
             }
 
@@ -94,11 +111,10 @@ internal sealed class BufferedResultFlushBackgroundService : BackgroundService
         }
     }
 
-    private async Task PersistAndEvaluateAsync(IReadOnlyList<BufferedCheckResult> batch, CancellationToken cancellationToken)
+    private async Task<FlushResult> PersistAndEnqueueAssignmentsAsync(IReadOnlyList<BufferedCheckResult> batch, CancellationToken cancellationToken)
     {
         using var scope = _scopeFactory.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<PingMonitorDbContext>();
-        var stateEvaluationService = scope.ServiceProvider.GetRequiredService<IStateEvaluationService>();
         var assignmentMetrics24hService = scope.ServiceProvider.GetRequiredService<IAssignmentMetrics24hService>();
 
         var checkResults = batch.Select(item => new CheckResult
@@ -116,8 +132,11 @@ internal sealed class BufferedResultFlushBackgroundService : BackgroundService
             BatchId = item.BatchId
         }).ToArray();
 
+        var persistStartedAtUtc = DateTimeOffset.UtcNow;
         dbContext.CheckResults.AddRange(checkResults);
         await dbContext.SaveChangesAsync(cancellationToken);
+        var persistDurationMs = Math.Max(0, (long)(DateTimeOffset.UtcNow - persistStartedAtUtc).TotalMilliseconds);
+
         await assignmentMetrics24hService.ApplyCheckResultsBatchAsync(checkResults, cancellationToken);
 
         var affectedAssignmentIds = checkResults
@@ -125,21 +144,21 @@ internal sealed class BufferedResultFlushBackgroundService : BackgroundService
             .Distinct(StringComparer.Ordinal)
             .ToArray();
 
-        try
-        {
-            await stateEvaluationService.EvaluateAssignmentsAsync(affectedAssignmentIds, CancellationToken.None);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(
-                ex,
-                "Buffered result flush persisted raw results, but state evaluation failed for assignments: {AssignmentIds}.",
-                affectedAssignmentIds);
-        }
+        var enqueueResult = _assignmentProcessingQueue.EnqueueAssignments(affectedAssignmentIds);
+        var enqueueTimeUtc = DateTimeOffset.UtcNow;
 
         _logger.LogInformation(
-            "Buffered result flush persisted {PersistedCount} raw check results across {AssignmentCount} assignments.",
+            "Buffered result flush persisted {PersistedCount} raw check results across {AssignmentCount} assignments. Enqueued {EnqueuedAssignments} assignments for downstream processing ({CoalescedDuplicates} coalesced duplicates).",
             checkResults.Length,
-            affectedAssignmentIds.Length);
+            affectedAssignmentIds.Length,
+            enqueueResult.EnqueuedCount,
+            enqueueResult.CoalescedDuplicateCount);
+
+        return new FlushResult(
+            PersistDurationMs: persistDurationMs,
+            AssignmentEnqueuedCount: enqueueResult.EnqueuedCount,
+            LastAssignmentsEnqueuedAtUtc: enqueueResult.EnqueuedCount > 0 ? enqueueTimeUtc : null);
     }
+
+    private sealed record FlushResult(long PersistDurationMs, int AssignmentEnqueuedCount, DateTimeOffset? LastAssignmentsEnqueuedAtUtc);
 }

--- a/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultIngestionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultIngestionService.cs
@@ -19,6 +19,9 @@ internal sealed class BufferedResultIngestionService : IBufferedResultIngestionS
     private int _lastFlushAttemptedCount;
     private int _lastFlushPersistedCount;
     private string? _lastFlushError;
+    private long _lastPersistDurationMs;
+    private int _lastEnqueuedAssignmentCount;
+    private DateTimeOffset? _lastAssignmentsEnqueuedAtUtc;
 
     public BufferedResultIngestionService(
         IOptions<ResultBufferOptions> options,
@@ -108,7 +111,10 @@ internal sealed class BufferedResultIngestionService : IBufferedResultIngestionS
                 LastFlushCompletedAtUtc: _lastFlushCompletedAtUtc,
                 LastFlushAttemptedCount: _lastFlushAttemptedCount,
                 LastFlushPersistedCount: _lastFlushPersistedCount,
-                LastFlushError: _lastFlushError);
+                LastFlushError: _lastFlushError,
+                LastPersistDurationMs: _lastPersistDurationMs,
+                LastEnqueuedAssignmentCount: _lastEnqueuedAssignmentCount,
+                LastAssignmentsEnqueuedAtUtc: _lastAssignmentsEnqueuedAtUtc);
         }
     }
 
@@ -124,7 +130,14 @@ internal sealed class BufferedResultIngestionService : IBufferedResultIngestionS
         }
     }
 
-    public void RecordFlushOutcome(int attemptedCount, int persistedCount, DateTimeOffset completedAtUtc, Exception? error)
+    public void RecordFlushOutcome(
+        int attemptedCount,
+        int persistedCount,
+        DateTimeOffset completedAtUtc,
+        Exception? error,
+        long persistDurationMs,
+        int enqueuedAssignmentCount,
+        DateTimeOffset? lastAssignmentsEnqueuedAtUtc)
     {
         lock (_sync)
         {
@@ -139,6 +152,9 @@ internal sealed class BufferedResultIngestionService : IBufferedResultIngestionS
             _lastFlushAttemptedCount = attemptedCount;
             _lastFlushPersistedCount = persistedCount;
             _lastFlushError = error?.Message;
+            _lastPersistDurationMs = persistDurationMs;
+            _lastEnqueuedAssignmentCount = enqueuedAssignmentCount;
+            _lastAssignmentsEnqueuedAtUtc = lastAssignmentsEnqueuedAtUtc;
         }
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/BufferedResults/IBufferedResultIngestionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BufferedResults/IBufferedResultIngestionService.cs
@@ -8,7 +8,14 @@ public interface IBufferedResultIngestionService
     IReadOnlyList<BufferedCheckResult> DequeueBatch(int maxBatchSize);
     BufferedResultBufferSnapshot GetSnapshot();
     Task<bool> WaitForSignalAsync(TimeSpan timeout, CancellationToken cancellationToken);
-    void RecordFlushOutcome(int attemptedCount, int persistedCount, DateTimeOffset completedAtUtc, Exception? error);
+    void RecordFlushOutcome(
+        int attemptedCount,
+        int persistedCount,
+        DateTimeOffset completedAtUtc,
+        Exception? error,
+        long persistDurationMs,
+        int enqueuedAssignmentCount,
+        DateTimeOffset? lastAssignmentsEnqueuedAtUtc);
 }
 
 public sealed record BufferedResultBufferSnapshot(
@@ -21,4 +28,7 @@ public sealed record BufferedResultBufferSnapshot(
     DateTimeOffset? LastFlushCompletedAtUtc,
     int LastFlushAttemptedCount,
     int LastFlushPersistedCount,
-    string? LastFlushError);
+    string? LastFlushError,
+    long LastPersistDurationMs,
+    int LastEnqueuedAssignmentCount,
+    DateTimeOffset? LastAssignmentsEnqueuedAtUtc);

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseStatusModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseStatusModels.cs
@@ -40,4 +40,24 @@ public sealed class ResultBufferRuntimeSnapshot
     public int LastFlushPersistedCount { get; init; }
     public DateTimeOffset? LastFlushCompletedAtUtc { get; init; }
     public string? LastFlushError { get; init; }
+    public long LastPersistDurationMs { get; init; }
+    public int LastEnqueuedAssignmentCount { get; init; }
+    public DateTimeOffset? LastAssignmentsEnqueuedAtUtc { get; init; }
+    public AssignmentProcessingQueueRuntimeSnapshot AssignmentProcessingQueue { get; init; } = new();
+}
+
+public sealed class AssignmentProcessingQueueRuntimeSnapshot
+{
+    public int QueueDepth { get; init; }
+    public int PendingAssignmentCount { get; init; }
+    public long TotalEnqueueCount { get; init; }
+    public long CoalescedDuplicateCount { get; init; }
+    public long DequeueCount { get; init; }
+    public long ProcessedCount { get; init; }
+    public long FailedCount { get; init; }
+    public DateTimeOffset? LastEnqueueAtUtc { get; init; }
+    public DateTimeOffset? LastDequeuedAtUtc { get; init; }
+    public DateTimeOffset? LastProcessedAtUtc { get; init; }
+    public DateTimeOffset? LastFailureAtUtc { get; init; }
+    public string? LastFailureError { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseStatusQueryService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Options;
 using PingMonitor.Web.Services.BufferedResults;
+using PingMonitor.Web.Services.State;
 using PingMonitor.Web.Services.StartupGate;
 using System.Data;
 
@@ -12,17 +13,20 @@ internal sealed class DatabaseStatusQueryService : IDatabaseStatusQueryService
 {
     private readonly PingMonitorDbContext _dbContext;
     private readonly IBufferedResultIngestionService _bufferedResultIngestionService;
+    private readonly IAssignmentProcessingQueue _assignmentProcessingQueue;
     private readonly IOptions<ResultBufferOptions> _resultBufferOptions;
     private readonly IOptions<StartupGateOptions> _startupGateOptions;
 
     public DatabaseStatusQueryService(
         PingMonitorDbContext dbContext,
         IBufferedResultIngestionService bufferedResultIngestionService,
+        IAssignmentProcessingQueue assignmentProcessingQueue,
         IOptions<ResultBufferOptions> resultBufferOptions,
         IOptions<StartupGateOptions> startupGateOptions)
     {
         _dbContext = dbContext;
         _bufferedResultIngestionService = bufferedResultIngestionService;
+        _assignmentProcessingQueue = assignmentProcessingQueue;
         _resultBufferOptions = resultBufferOptions;
         _startupGateOptions = startupGateOptions;
     }
@@ -46,6 +50,7 @@ internal sealed class DatabaseStatusQueryService : IDatabaseStatusQueryService
         var indexBytes = tables.Sum(x => x.IndexBytes);
         var bufferSnapshot = _bufferedResultIngestionService.GetSnapshot();
         var bufferOptions = _resultBufferOptions.Value;
+        var assignmentQueueSnapshot = _assignmentProcessingQueue.GetSnapshot();
 
         return new DatabaseStatusSnapshot
         {
@@ -75,7 +80,25 @@ internal sealed class DatabaseStatusQueryService : IDatabaseStatusQueryService
                 LastFlushAttemptedCount = bufferSnapshot.LastFlushAttemptedCount,
                 LastFlushPersistedCount = bufferSnapshot.LastFlushPersistedCount,
                 LastFlushCompletedAtUtc = bufferSnapshot.LastFlushCompletedAtUtc,
-                LastFlushError = bufferSnapshot.LastFlushError
+                LastFlushError = bufferSnapshot.LastFlushError,
+                LastPersistDurationMs = bufferSnapshot.LastPersistDurationMs,
+                LastEnqueuedAssignmentCount = bufferSnapshot.LastEnqueuedAssignmentCount,
+                LastAssignmentsEnqueuedAtUtc = bufferSnapshot.LastAssignmentsEnqueuedAtUtc,
+                AssignmentProcessingQueue = new AssignmentProcessingQueueRuntimeSnapshot
+                {
+                    QueueDepth = assignmentQueueSnapshot.QueueDepth,
+                    PendingAssignmentCount = assignmentQueueSnapshot.PendingAssignmentCount,
+                    TotalEnqueueCount = assignmentQueueSnapshot.TotalEnqueueCount,
+                    CoalescedDuplicateCount = assignmentQueueSnapshot.CoalescedDuplicateCount,
+                    DequeueCount = assignmentQueueSnapshot.DequeueCount,
+                    ProcessedCount = assignmentQueueSnapshot.ProcessedCount,
+                    FailedCount = assignmentQueueSnapshot.FailedCount,
+                    LastEnqueueAtUtc = assignmentQueueSnapshot.LastEnqueueAtUtc,
+                    LastDequeuedAtUtc = assignmentQueueSnapshot.LastDequeuedAtUtc,
+                    LastProcessedAtUtc = assignmentQueueSnapshot.LastProcessedAtUtc,
+                    LastFailureAtUtc = assignmentQueueSnapshot.LastFailureAtUtc,
+                    LastFailureError = assignmentQueueSnapshot.LastFailureError
+                }
             }
         };
     }

--- a/src/WebApp/PingMonitor.Web/Services/State/AssignmentProcessingQueue.cs
+++ b/src/WebApp/PingMonitor.Web/Services/State/AssignmentProcessingQueue.cs
@@ -1,0 +1,162 @@
+namespace PingMonitor.Web.Services.State;
+
+internal sealed class AssignmentProcessingQueue : IAssignmentProcessingQueue
+{
+    private readonly object _sync = new();
+    private readonly Queue<string> _queue = new();
+    private readonly HashSet<string> _pending = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim _signal = new(0);
+
+    private long _totalEnqueueCount;
+    private long _coalescedDuplicateCount;
+    private long _dequeueCount;
+    private long _processedCount;
+    private long _failedCount;
+    private DateTimeOffset? _lastEnqueueAtUtc;
+    private DateTimeOffset? _lastDequeuedAtUtc;
+    private DateTimeOffset? _lastProcessedAtUtc;
+    private DateTimeOffset? _lastFailureAtUtc;
+    private string? _lastFailureError;
+
+    public AssignmentProcessingQueueEnqueueResult EnqueueAssignments(IReadOnlyCollection<string> assignmentIds)
+    {
+        if (assignmentIds.Count == 0)
+        {
+            return new AssignmentProcessingQueueEnqueueResult(0, 0);
+        }
+
+        var enqueued = 0;
+        var coalesced = 0;
+        var nowUtc = DateTimeOffset.UtcNow;
+
+        lock (_sync)
+        {
+            foreach (var assignmentId in assignmentIds)
+            {
+                if (string.IsNullOrWhiteSpace(assignmentId))
+                {
+                    continue;
+                }
+
+                var normalizedAssignmentId = assignmentId.Trim();
+                _totalEnqueueCount++;
+
+                if (_pending.Add(normalizedAssignmentId))
+                {
+                    _queue.Enqueue(normalizedAssignmentId);
+                    enqueued++;
+                }
+                else
+                {
+                    _coalescedDuplicateCount++;
+                    coalesced++;
+                }
+            }
+
+            if (enqueued > 0)
+            {
+                _lastEnqueueAtUtc = nowUtc;
+            }
+        }
+
+        if (enqueued > 0)
+        {
+            _signal.Release();
+        }
+
+        return new AssignmentProcessingQueueEnqueueResult(enqueued, coalesced);
+    }
+
+    public IReadOnlyList<string> DequeueBatch(int maxBatchSize)
+    {
+        if (maxBatchSize <= 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var batch = new List<string>(maxBatchSize);
+        var nowUtc = DateTimeOffset.UtcNow;
+
+        lock (_sync)
+        {
+            while (_queue.Count > 0 && batch.Count < maxBatchSize)
+            {
+                var assignmentId = _queue.Dequeue();
+                _pending.Remove(assignmentId);
+                batch.Add(assignmentId);
+            }
+
+            if (batch.Count > 0)
+            {
+                _dequeueCount += batch.Count;
+                _lastDequeuedAtUtc = nowUtc;
+            }
+        }
+
+        return batch;
+    }
+
+    public bool HasPendingItems()
+    {
+        lock (_sync)
+        {
+            return _queue.Count > 0;
+        }
+    }
+
+    public async Task<bool> WaitForSignalAsync(TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _signal.WaitAsync(timeout, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+    }
+
+    public void RecordProcessedCount(int processedCount, DateTimeOffset processedAtUtc)
+    {
+        if (processedCount <= 0)
+        {
+            return;
+        }
+
+        lock (_sync)
+        {
+            _processedCount += processedCount;
+            _lastProcessedAtUtc = processedAtUtc;
+        }
+    }
+
+    public void RecordFailure(Exception exception, DateTimeOffset failedAtUtc)
+    {
+        lock (_sync)
+        {
+            _failedCount++;
+            _lastFailureAtUtc = failedAtUtc;
+            _lastFailureError = exception.Message;
+        }
+    }
+
+    public AssignmentProcessingQueueSnapshot GetSnapshot()
+    {
+        lock (_sync)
+        {
+            return new AssignmentProcessingQueueSnapshot(
+                QueueDepth: _queue.Count,
+                PendingAssignmentCount: _pending.Count,
+                TotalEnqueueCount: _totalEnqueueCount,
+                CoalescedDuplicateCount: _coalescedDuplicateCount,
+                DequeueCount: _dequeueCount,
+                ProcessedCount: _processedCount,
+                FailedCount: _failedCount,
+                LastEnqueueAtUtc: _lastEnqueueAtUtc,
+                LastDequeuedAtUtc: _lastDequeuedAtUtc,
+                LastProcessedAtUtc: _lastProcessedAtUtc,
+                LastFailureAtUtc: _lastFailureAtUtc,
+                LastFailureError: _lastFailureError);
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/State/IAssignmentProcessingQueue.cs
+++ b/src/WebApp/PingMonitor.Web/Services/State/IAssignmentProcessingQueue.cs
@@ -1,0 +1,28 @@
+namespace PingMonitor.Web.Services.State;
+
+public interface IAssignmentProcessingQueue
+{
+    AssignmentProcessingQueueEnqueueResult EnqueueAssignments(IReadOnlyCollection<string> assignmentIds);
+    IReadOnlyList<string> DequeueBatch(int maxBatchSize);
+    bool HasPendingItems();
+    Task<bool> WaitForSignalAsync(TimeSpan timeout, CancellationToken cancellationToken);
+    void RecordProcessedCount(int processedCount, DateTimeOffset processedAtUtc);
+    void RecordFailure(Exception exception, DateTimeOffset failedAtUtc);
+    AssignmentProcessingQueueSnapshot GetSnapshot();
+}
+
+public sealed record AssignmentProcessingQueueEnqueueResult(int EnqueuedCount, int CoalescedDuplicateCount);
+
+public sealed record AssignmentProcessingQueueSnapshot(
+    int QueueDepth,
+    int PendingAssignmentCount,
+    long TotalEnqueueCount,
+    long CoalescedDuplicateCount,
+    long DequeueCount,
+    long ProcessedCount,
+    long FailedCount,
+    DateTimeOffset? LastEnqueueAtUtc,
+    DateTimeOffset? LastDequeuedAtUtc,
+    DateTimeOffset? LastProcessedAtUtc,
+    DateTimeOffset? LastFailureAtUtc,
+    string? LastFailureError);

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/DatabaseStatusPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/DatabaseStatusPageViewModel.cs
@@ -54,10 +54,30 @@ public sealed class DatabaseStatusRuntimeBufferViewModel
     public int LastFlushPersistedCount { get; init; }
     public DateTimeOffset? LastFlushCompletedAtUtc { get; init; }
     public string? LastFlushError { get; init; }
+    public long LastPersistDurationMs { get; init; }
+    public int LastEnqueuedAssignmentCount { get; init; }
+    public DateTimeOffset? LastAssignmentsEnqueuedAtUtc { get; init; }
+    public AssignmentProcessingQueueViewModel AssignmentProcessingQueue { get; init; } = new();
     public double QueueUtilizationPercent { get; init; }
     public double BufferDropRatePercent { get; init; }
     public double FlushSuccessRatePercent { get; init; }
     public string CacheHitRateNote { get; init; } = "No request/result cache hit-rate metric is currently instrumented.";
+}
+
+public sealed class AssignmentProcessingQueueViewModel
+{
+    public int QueueDepth { get; init; }
+    public int PendingAssignmentCount { get; init; }
+    public long TotalEnqueueCount { get; init; }
+    public long CoalescedDuplicateCount { get; init; }
+    public long DequeueCount { get; init; }
+    public long ProcessedCount { get; init; }
+    public long FailedCount { get; init; }
+    public DateTimeOffset? LastEnqueueAtUtc { get; init; }
+    public DateTimeOffset? LastDequeuedAtUtc { get; init; }
+    public DateTimeOffset? LastProcessedAtUtc { get; init; }
+    public DateTimeOffset? LastFailureAtUtc { get; init; }
+    public string? LastFailureError { get; init; }
 }
 
 public sealed class DatabasePruneForm

--- a/src/WebApp/PingMonitor.Web/Views/AdminDatabase/Status.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminDatabase/Status.cshtml
@@ -63,7 +63,10 @@
                 <div class="metric"><div class="label">Configured max batch size</div><div class="value">@Model.RuntimeBuffer.ConfiguredMaxBatchSize</div></div>
                 <div class="metric"><div class="label">Configured flush interval</div><div class="value">@Model.RuntimeBuffer.ConfiguredFlushIntervalSeconds sec</div></div>
                 <div class="metric"><div class="label">Last flush time (UTC)</div><div class="value">@(Model.RuntimeBuffer.LastFlushCompletedAtUtc is null ? "n/a" : DisplayFormatting.FormatUtcDateTime(Model.RuntimeBuffer.LastFlushCompletedAtUtc.Value))</div></div>
+                <div class="metric"><div class="label">Last persist duration</div><div class="value">@Model.RuntimeBuffer.LastPersistDurationMs ms</div></div>
                 <div class="metric"><div class="label">Last flush result</div><div class="value">@Model.RuntimeBuffer.LastFlushPersistedCount / @Model.RuntimeBuffer.LastFlushAttemptedCount persisted</div></div>
+                <div class="metric"><div class="label">Assignments enqueued (last flush)</div><div class="value">@Model.RuntimeBuffer.LastEnqueuedAssignmentCount</div></div>
+                <div class="metric"><div class="label">Last assignment enqueue time (UTC)</div><div class="value">@(Model.RuntimeBuffer.LastAssignmentsEnqueuedAtUtc is null ? "n/a" : DisplayFormatting.FormatUtcDateTime(Model.RuntimeBuffer.LastAssignmentsEnqueuedAtUtc.Value))</div></div>
                 <div class="metric"><div class="label">Dropped-result count</div><div class="value">@Model.RuntimeBuffer.DroppedResultCount</div></div>
                 <div class="metric"><div class="label">Drop rate</div><div class="value">@Model.RuntimeBuffer.BufferDropRatePercent.ToString("0.##")%</div></div>
                 <div class="metric"><div class="label">Flush success rate</div><div class="value">@Model.RuntimeBuffer.FlushSuccessRatePercent.ToString("0.##")%</div></div>
@@ -74,6 +77,25 @@
                 <p class="muted">Last flush error details: @Model.RuntimeBuffer.LastFlushError</p>
             }
             <p class="muted">@Model.RuntimeBuffer.CacheHitRateNote</p>
+        </section>
+
+        <section class="card">
+            <h2>Downstream assignment processing</h2>
+            <p class="muted">Runtime metrics for asynchronous state/metrics processing queued after raw result persistence.</p>
+            <div class="overview-grid">
+                <div class="metric"><div class="label">Queue depth</div><div class="value">@Model.RuntimeBuffer.AssignmentProcessingQueue.QueueDepth</div></div>
+                <div class="metric"><div class="label">Pending assignment count</div><div class="value">@Model.RuntimeBuffer.AssignmentProcessingQueue.PendingAssignmentCount</div></div>
+                <div class="metric"><div class="label">Total enqueue count</div><div class="value">@Model.RuntimeBuffer.AssignmentProcessingQueue.TotalEnqueueCount</div></div>
+                <div class="metric"><div class="label">Coalesced duplicates</div><div class="value">@Model.RuntimeBuffer.AssignmentProcessingQueue.CoalescedDuplicateCount</div></div>
+                <div class="metric"><div class="label">Processed count</div><div class="value">@Model.RuntimeBuffer.AssignmentProcessingQueue.ProcessedCount</div></div>
+                <div class="metric"><div class="label">Failed count</div><div class="value">@Model.RuntimeBuffer.AssignmentProcessingQueue.FailedCount</div></div>
+                <div class="metric"><div class="label">Last processed (UTC)</div><div class="value">@(Model.RuntimeBuffer.AssignmentProcessingQueue.LastProcessedAtUtc is null ? "n/a" : DisplayFormatting.FormatUtcDateTime(Model.RuntimeBuffer.AssignmentProcessingQueue.LastProcessedAtUtc.Value))</div></div>
+                <div class="metric"><div class="label">Last failure (UTC)</div><div class="value">@(Model.RuntimeBuffer.AssignmentProcessingQueue.LastFailureAtUtc is null ? "n/a" : DisplayFormatting.FormatUtcDateTime(Model.RuntimeBuffer.AssignmentProcessingQueue.LastFailureAtUtc.Value))</div></div>
+            </div>
+            @if (!string.IsNullOrWhiteSpace(Model.RuntimeBuffer.AssignmentProcessingQueue.LastFailureError))
+            {
+                <p class="muted">Last assignment-processing error: @Model.RuntimeBuffer.AssignmentProcessingQueue.LastFailureError</p>
+            }
         </section>
 
         <section class="card">


### PR DESCRIPTION
### Motivation
- Prevent the raw ingest buffer from being throttled by synchronous state evaluation so raw `CheckResult` durability can proceed at DB insert speed.
- Allow downstream state evaluation and metrics work to run asynchronously and coalesced per-assignment to tolerate bursts and improve throughput.

### Description
- Split the ingest pipeline into two stages by adding a coalescing assignment queue (`IAssignmentProcessingQueue` / `AssignmentProcessingQueue`) and a dedicated background worker (`AssignmentProcessingBackgroundService`) to run state evaluation for affected assignments.
- Refactored `BufferedResultFlushBackgroundService` so it now persists raw `CheckResult` batches, records persist duration, identifies affected assignment IDs, and enqueues them for downstream processing instead of calling `IStateEvaluationService` synchronously.
- Extended `IBufferedResultIngestionService`/runtime snapshot to include `LastPersistDurationMs`, `LastEnqueuedAssignmentCount`, and `LastAssignmentsEnqueuedAtUtc`, and surfaced downstream queue diagnostics in `DatabaseStatusQueryService`, controller mapping and the DB admin UI.
- Registered the new queue and background worker in `Program.cs` and added safe retry/metrics instrumentation: coalescing duplicate enqueues, processed/failed counters, last error timestamps, and best-effort drain on shutdown.

### Testing
- Built the web app with .NET 10 (`/tmp/dotnet/dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`) and the build succeeded with SDK `10.0.104`.
- Verified by automated text searches that `BufferedResultFlushBackgroundService` no longer resolves or calls `IStateEvaluationService` and that `IAssignmentProcessingQueue` / `AssignmentProcessingBackgroundService` are present and registered in DI using `rg` queries; all checks passed.
- No unit tests were added in this change; integration/behavioural validation performed via build and static verification steps above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d02dc6d6f8832abf7b07bd4d9a756b)