### PR TITLE
Add missing AspNet Identity tables to required schema list

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -13,7 +13,11 @@ internal sealed class StartupSchemaService : IStartupSchemaService
     [
         "AppSchemaInfo",
         "AspNetRoles",
+        "AspNetRoleClaims",
+        "AspNetUserClaims",
+        "AspNetUserLogins",
         "AspNetUserRoles",
+        "AspNetUserTokens",
         "AspNetUsers",
         "Agents",
         "AgentHeartbeatHistory",


### PR DESCRIPTION
### Motivation
- Ensure the startup schema validation recognizes all ASP.NET Identity tables so schema checks don't report spurious missing tables.

### Description
- Add `AspNetRoleClaims`, `AspNetUserClaims`, `AspNetUserLogins`, and `AspNetUserTokens` to the `RequiredTables` array in `StartupSchemaService`.

### Testing
- Ran the existing automated test suite and the startup schema check; no test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0512c39d4832a8bb758413f800686)