### PR TITLE
Harden startup-gate required-table checks for MySQL table-name mode

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -197,7 +197,8 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await using var connection = new MySqlConnection(connectionString);
         await connection.OpenAsync(cancellationToken);
 
-        var existingTables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var tableNameComparer = await GetTableNameComparerAsync(connection, cancellationToken);
+        var existingTables = new HashSet<string>(tableNameComparer);
         await using (var command = connection.CreateCommand())
         {
             command.CommandText = "SELECT TABLE_NAME FROM information_schema.tables WHERE table_schema = @schema;";
@@ -289,6 +290,23 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             CurrentSchemaVersion = schemaInfo.CurrentSchemaVersion,
             Diagnostics = { "Schema is present and compatible." }
         };
+    }
+
+    private static async Task<StringComparer> GetTableNameComparerAsync(MySqlConnection connection, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT @@lower_case_table_names;";
+
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+        if (result is null || result is DBNull)
+        {
+            return StringComparer.Ordinal;
+        }
+
+        var setting = Convert.ToInt32(result, System.Globalization.CultureInfo.InvariantCulture);
+        return setting == 0
+            ? StringComparer.Ordinal
+            : StringComparer.OrdinalIgnoreCase;
     }
 
     public async Task<StartupSchemaStatus> ApplySchemaAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
### Motivation
- Startup schema inspection previously used a case-insensitive comparison for required table names which can incorrectly treat differently-cased tables as present on case-sensitive MySQL servers and allow startup to continue. 
- The startup gate must fail-safe when required persistence tables are missing while still allowing the local schema-apply action to create the missing tables.

### Description
- Added `GetTableNameComparerAsync(MySqlConnection, CancellationToken)` which reads `@@lower_case_table_names` and returns a `StringComparer` that matches the MySQL server's table-name semantics. 
- `GetStatusAsync` now uses the server-aware comparer when building the `existingTables` set so required-table detection follows the server's case-sensitivity. 
- Left `ApplySchemaAsync` and `EnsureAdditionalTablesAsync` unchanged so the startup-gate still creates any missing tables when the local schema-apply action is used. 
- This change targets `StartupSchemaService` and preserves case-insensitive behavior for MySQL modes where table names are folded.

### Testing
- Installed .NET 10 SDK and PowerShell in the environment and verified `pwsh` and `dotnet` invocations; the SDK reported `10.0.104`. 
- Attempted `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which ran but the restore failed in this environment due to a missing `Microsoft.NETCore.App.Host.ubuntu.24.04-x64` package from configured sources, so a full build could not be completed here. 
- Created issue `#292` to track the regression and included a deterministic reproduction checklist showing how to validate the fix on a case-sensitive MySQL server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d057618998832aa055c48c6ae2e8c7)