### PR TITLE
Fix startup gate required table checks for missing schema tables

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -685,31 +685,29 @@ internal sealed class StartupSchemaService : IStartupSchemaService
 
     private static async Task<string[]> GetMissingRequiredTablesAsync(MySqlConnection connection, CancellationToken cancellationToken)
     {
-        var missingTables = new List<string>();
-        foreach (var requiredTable in RequiredTables)
+        var existingTables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        await using var command = connection.CreateCommand();
+        var parameterNames = new List<string>(RequiredTables.Length);
+        for (var index = 0; index < RequiredTables.Length; index++)
         {
-            if (!await TableExistsAsync(connection, requiredTable, cancellationToken))
-            {
-                missingTables.Add(requiredTable);
-            }
+            var parameterName = $"@tableName{index}";
+            parameterNames.Add(parameterName);
+            command.Parameters.AddWithValue(parameterName, RequiredTables[index]);
         }
 
-        return [.. missingTables];
-    }
-
-    private static async Task<bool> TableExistsAsync(MySqlConnection connection, string tableName, CancellationToken cancellationToken)
-    {
-        await using var command = connection.CreateCommand();
-        command.CommandText = """
-            SELECT 1
+        command.CommandText = $"""
+            SELECT table_name
             FROM information_schema.tables
             WHERE table_schema = DATABASE()
-              AND LOWER(table_name) = LOWER(@tableName)
-            LIMIT 1;
+              AND LOWER(table_name) IN ({string.Join(", ", parameterNames.Select(static parameterName => $"LOWER({parameterName})"))});
             """;
-        command.Parameters.AddWithValue("@tableName", tableName);
-        var result = await command.ExecuteScalarAsync(cancellationToken);
-        return result is not null;
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            existingTables.Add(reader.GetString(0));
+        }
+
+        return [.. RequiredTables.Where(table => !existingTables.Contains(table))];
     }
 
     private static async Task EnsureMetricsIndexesAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -197,20 +197,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await using var connection = new MySqlConnection(connectionString);
         await connection.OpenAsync(cancellationToken);
 
-        var existingTables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        await using (var command = connection.CreateCommand())
-        {
-            command.CommandText = "SELECT TABLE_NAME FROM information_schema.tables WHERE table_schema = @schema;";
-            command.Parameters.AddWithValue("@schema", configuration.DatabaseName);
-
-            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-            while (await reader.ReadAsync(cancellationToken))
-            {
-                existingTables.Add(reader.GetString(0));
-            }
-        }
-
-        var missingTables = RequiredTables.Where(table => !existingTables.Contains(table)).ToArray();
+        var missingTables = await GetMissingRequiredTablesAsync(connection, cancellationToken);
         if (missingTables.Length > 0)
         {
             var status = new StartupSchemaStatus { State = StartupGateSchemaState.Missing };
@@ -694,6 +681,35 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await EnsureAgentColumnsAsync(dbContext, cancellationToken);
         await EnsureMetricsIndexesAsync(dbContext, cancellationToken);
         await MigrateLegacyEndpointDependenciesAsync(dbContext, cancellationToken);
+    }
+
+    private static async Task<string[]> GetMissingRequiredTablesAsync(MySqlConnection connection, CancellationToken cancellationToken)
+    {
+        var missingTables = new List<string>();
+        foreach (var requiredTable in RequiredTables)
+        {
+            if (!await TableExistsAsync(connection, requiredTable, cancellationToken))
+            {
+                missingTables.Add(requiredTable);
+            }
+        }
+
+        return [.. missingTables];
+    }
+
+    private static async Task<bool> TableExistsAsync(MySqlConnection connection, string tableName, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = DATABASE()
+              AND LOWER(table_name) = LOWER(@tableName)
+            LIMIT 1;
+            """;
+        command.Parameters.AddWithValue("@tableName", tableName);
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+        return result is not null;
     }
 
     private static async Task EnsureMetricsIndexesAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)


### PR DESCRIPTION
### Motivation
- The startup gate could incorrectly allow the app to enter normal mode even when required schema tables (e.g. `AssignmentRttMinuteBuckets`, `AssignmentStateIntervals`) were missing.  
- The gate must remain active when any required table is absent while still allowing the schema-apply path to create those missing tables deterministically.

### Description
- Replaced the single information_schema snapshot comparison in `StartupSchemaService.GetStatusAsync` with deterministic per-table existence checks via `GetMissingRequiredTablesAsync` and `TableExistsAsync`.  
- `TableExistsAsync` queries `information_schema.tables` using `table_schema = DATABASE()` and a case-insensitive name comparison (`LOWER(table_name) = LOWER(@tableName)`) to avoid schema selection and casing issues.  
- Missing tables are collected and returned in diagnostics unchanged so the startup-gate remains in `Missing` state until the schema apply path creates the tables.  
- This change is linked to issue `#298` for traceability (deployment repro and acceptance criteria recorded there).

### Testing
- Attempted to run `dotnet --version && dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, but the build could not be executed in this environment because `dotnet` is not installed (command failed).  
- No automated unit/integration tests were executed in this environment; the change is limited to deterministic table-existence checks and preserves the existing schema-apply logic that creates missing tables.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d05de562d4832ab0cd8dd070b83a53)