### PR TITLE
Follow-up: ensure ApplySchema creates required ASP.NET Identity tables

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -559,6 +559,49 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 KEY `IX_AssignmentStateIntervals_AssignmentId_EndedAtUtc` (`AssignmentId`, `EndedAtUtc`)
             );
             """;
+        const string createAspNetRoleClaimsSql = """
+            CREATE TABLE IF NOT EXISTS `AspNetRoleClaims` (
+                `Id` int NOT NULL AUTO_INCREMENT,
+                `RoleId` varchar(255) NOT NULL,
+                `ClaimType` longtext NULL,
+                `ClaimValue` longtext NULL,
+                PRIMARY KEY (`Id`),
+                KEY `IX_AspNetRoleClaims_RoleId` (`RoleId`),
+                CONSTRAINT `FK_AspNetRoleClaims_AspNetRoles_RoleId` FOREIGN KEY (`RoleId`) REFERENCES `AspNetRoles` (`Id`) ON DELETE CASCADE
+            );
+            """;
+        const string createAspNetUserClaimsSql = """
+            CREATE TABLE IF NOT EXISTS `AspNetUserClaims` (
+                `Id` int NOT NULL AUTO_INCREMENT,
+                `UserId` varchar(255) NOT NULL,
+                `ClaimType` longtext NULL,
+                `ClaimValue` longtext NULL,
+                PRIMARY KEY (`Id`),
+                KEY `IX_AspNetUserClaims_UserId` (`UserId`),
+                CONSTRAINT `FK_AspNetUserClaims_AspNetUsers_UserId` FOREIGN KEY (`UserId`) REFERENCES `AspNetUsers` (`Id`) ON DELETE CASCADE
+            );
+            """;
+        const string createAspNetUserLoginsSql = """
+            CREATE TABLE IF NOT EXISTS `AspNetUserLogins` (
+                `LoginProvider` varchar(255) NOT NULL,
+                `ProviderKey` varchar(255) NOT NULL,
+                `ProviderDisplayName` longtext NULL,
+                `UserId` varchar(255) NOT NULL,
+                PRIMARY KEY (`LoginProvider`, `ProviderKey`),
+                KEY `IX_AspNetUserLogins_UserId` (`UserId`),
+                CONSTRAINT `FK_AspNetUserLogins_AspNetUsers_UserId` FOREIGN KEY (`UserId`) REFERENCES `AspNetUsers` (`Id`) ON DELETE CASCADE
+            );
+            """;
+        const string createAspNetUserTokensSql = """
+            CREATE TABLE IF NOT EXISTS `AspNetUserTokens` (
+                `UserId` varchar(255) NOT NULL,
+                `LoginProvider` varchar(255) NOT NULL,
+                `Name` varchar(255) NOT NULL,
+                `Value` longtext NULL,
+                PRIMARY KEY (`UserId`, `LoginProvider`, `Name`),
+                CONSTRAINT `FK_AspNetUserTokens_AspNetUsers_UserId` FOREIGN KEY (`UserId`) REFERENCES `AspNetUsers` (`Id`) ON DELETE CASCADE
+            );
+            """;
 
         const string createEventLogsSql = """
             CREATE TABLE IF NOT EXISTS `EventLogs` (
@@ -670,6 +713,10 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await dbContext.Database.ExecuteSqlRawAsync(createAssignmentMetrics24hSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createAssignmentRttMinuteBucketsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createAssignmentStateIntervalsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createAspNetRoleClaimsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createAspNetUserClaimsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createAspNetUserLoginsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createAspNetUserTokensSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createEventLogsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createSecurityAuthLogsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createApplicationSettingsSql, cancellationToken);


### PR DESCRIPTION
### Motivation
- A prior change added several ASP.NET Identity tables to the `RequiredTables` list in `StartupSchemaService`, which caused `GetStatusAsync` to report `Missing` for those tables on existing databases where `EnsureCreatedAsync` will not add missing tables.
- The startup-gate recovery path must be able to create those tables automatically so existing installations are not permanently blocked.

### Description
- Add explicit MySQL `CREATE TABLE IF NOT EXISTS` statements for the Identity tables `AspNetRoleClaims`, `AspNetUserClaims`, `AspNetUserLogins`, and `AspNetUserTokens` as new SQL constants in `StartupSchemaService`.
- Execute the new statements from `EnsureAdditionalTablesAsync` via `dbContext.Database.ExecuteSqlRawAsync(...)` so `ApplySchemaAsync` will create the tables on non-empty databases where `EnsureCreatedAsync` is insufficient.
- Changes are contained to `src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs` and keep the startup schema-apply flow deterministic and MySQL-oriented.

### Testing
- Attempted to run a local build with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, but the environment does not have the `dotnet` SDK installed so the build could not be executed (`dotnet: command not found`).
- Verified the source changes and diff show the new SQL constants and that `EnsureAdditionalTablesAsync` now invokes them; no automated test run was possible in this environment due to the missing SDK.

Refs #291

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d060a185d0832aa8d5e36420be935f)