### PR TITLE
Harden startup gate detection for missing required schema tables

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -687,19 +687,10 @@ internal sealed class StartupSchemaService : IStartupSchemaService
     {
         var existingTables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         await using var command = connection.CreateCommand();
-        var parameterNames = new List<string>(RequiredTables.Length);
-        for (var index = 0; index < RequiredTables.Length; index++)
-        {
-            var parameterName = $"@tableName{index}";
-            parameterNames.Add(parameterName);
-            command.Parameters.AddWithValue(parameterName, RequiredTables[index]);
-        }
-
-        command.CommandText = $"""
+        command.CommandText = """
             SELECT table_name
             FROM information_schema.tables
-            WHERE table_schema = DATABASE()
-              AND LOWER(table_name) IN ({string.Join(", ", parameterNames.Select(static parameterName => $"LOWER({parameterName})"))});
+            WHERE table_schema = DATABASE();
             """;
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))


### PR DESCRIPTION
### Motivation
- The startup gate could allow normal startup when some required schema tables were absent (e.g. `AssignmentRttMinuteBuckets`, `AssignmentStateIntervals`), so the gate must deterministically detect missing tables and block normal mode until they are created.

### Description
- Replace the parameterized `IN`-style `information_schema.tables` query with a full schema table listing and an in-memory, case-insensitive comparison against `RequiredTables` in `GetMissingRequiredTablesAsync` to reliably surface missing tables. 
- This change makes any absent required table report `StartupGateSchemaState.Missing` so the startup gate prevents normal startup and local operators can run the schema apply action to create tables. 
- Change is implemented in `src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs` (update to `GetMissingRequiredTablesAsync`).

### Testing
- Created a tracked GitHub issue `#301` to record the bug and reproduction steps (API call to create the issue succeeded). 
- Installed .NET SDK `10.0.104` and ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -v minimal`, which completed successfully. 
- Verified project builds and committed the change (`git commit`) with the message `Harden startup gate required-table detection`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0631abdec832a80cd822a6b3be3dc)