### PR TITLE
Add per-subsystem DB read/write activity instrumentation to DB Status

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/AdminDatabaseController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminDatabaseController.cs
@@ -171,6 +171,26 @@ public sealed class AdminDatabaseController : Controller
             .ToArray();
 
         var runtimeBuffer = snapshot.ResultBuffer;
+        var dbActivityBySubsystem = snapshot.DbActivityBySubsystem
+            .Select(x => new DatabaseSubsystemActivityViewModel
+            {
+                Subsystem = x.Subsystem,
+                RecentReadCount = x.Recent.ReadCount,
+                LifetimeReadCount = x.Lifetime.ReadCount,
+                RecentWriteCount = x.Recent.WriteCount,
+                LifetimeWriteCount = x.Lifetime.WriteCount,
+                RecentTotalDurationMs = x.Recent.TotalDurationMs,
+                LifetimeTotalDurationMs = x.Lifetime.TotalDurationMs,
+                LifetimeAverageReadDurationMs = x.Lifetime.AverageReadDurationMs,
+                LifetimeAverageWriteDurationMs = x.Lifetime.AverageWriteDurationMs,
+                RecentErrorCount = x.Recent.ReadErrorCount + x.Recent.WriteErrorCount,
+                LifetimeErrorCount = x.Lifetime.ReadErrorCount + x.Lifetime.WriteErrorCount,
+                LastActivityAtUtc = x.LastActivityAtUtc,
+                LastErrorAtUtc = x.LastErrorAtUtc,
+                LifetimeWriteRows = x.Lifetime.WriteRows,
+                LastCommandType = x.LastCommandType
+            })
+            .ToArray();
         var queueUtilizationPercent = runtimeBuffer.ConfiguredMaxQueueSize <= 0
             ? 0
             : (runtimeBuffer.CurrentQueueDepth / (double)runtimeBuffer.ConfiguredMaxQueueSize) * 100;
@@ -194,6 +214,7 @@ public sealed class AdminDatabaseController : Controller
             TotalDataBytes = snapshot.TotalDataBytes,
             TotalIndexBytes = snapshot.TotalIndexBytes,
             Tables = tables,
+            DbActivityBySubsystem = dbActivityBySubsystem,
             RuntimeBuffer = new DatabaseStatusRuntimeBufferViewModel
             {
                 BufferingEnabled = runtimeBuffer.BufferingEnabled,

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -26,6 +26,7 @@ using PingMonitor.Web.Services.Security;
 using PingMonitor.Web.Services.SmtpNotifications;
 using PingMonitor.Web.Services.BrowserNotifications;
 using PingMonitor.Web.Services.DatabaseStatus;
+using PingMonitor.Web.Services.Diagnostics;
 using PingMonitor.Web.Services.Telegram;
 using PingMonitor.Web.Support;
 using Microsoft.Extensions.Options;
@@ -47,6 +48,9 @@ builder.Services.Configure<DatabaseMaintenanceOptions>(builder.Configuration.Get
 
 builder.Services.AddSingleton<IDbContextFactory<PingMonitorDbContext>, DynamicPingMonitorDbContextFactory>();
 builder.Services.AddScoped(sp => sp.GetRequiredService<IDbContextFactory<PingMonitorDbContext>>().CreateDbContext());
+builder.Services.AddSingleton<IDbActivityTracker, DbActivityTracker>();
+builder.Services.AddSingleton<IDbActivityScope, DbActivityScope>();
+builder.Services.AddSingleton<DbActivityCommandInterceptor>();
 
 builder.Services
     .AddIdentityCore<ApplicationUser>(options =>

--- a/src/WebApp/PingMonitor.Web/Services/Background/AssignmentProcessingBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Background/AssignmentProcessingBackgroundService.cs
@@ -1,4 +1,5 @@
 using PingMonitor.Web.Services.State;
+using PingMonitor.Web.Services.Diagnostics;
 
 namespace PingMonitor.Web.Services.Background;
 
@@ -58,6 +59,8 @@ internal sealed class AssignmentProcessingBackgroundService : BackgroundService
 
             using var scope = _scopeFactory.CreateScope();
             var stateEvaluationService = scope.ServiceProvider.GetRequiredService<IStateEvaluationService>();
+            var dbActivityScope = scope.ServiceProvider.GetRequiredService<IDbActivityScope>();
+            using var dbScope = dbActivityScope.BeginScope("AssignmentProcessing");
 
             var failedAssignments = new List<string>();
             foreach (var assignmentId in assignmentIds)

--- a/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultFlushBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultFlushBackgroundService.cs
@@ -3,6 +3,7 @@ using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Options;
 using PingMonitor.Web.Services.Metrics;
+using PingMonitor.Web.Services.Diagnostics;
 using PingMonitor.Web.Services.State;
 
 namespace PingMonitor.Web.Services.BufferedResults;
@@ -116,6 +117,8 @@ internal sealed class BufferedResultFlushBackgroundService : BackgroundService
         using var scope = _scopeFactory.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<PingMonitorDbContext>();
         var assignmentMetrics24hService = scope.ServiceProvider.GetRequiredService<IAssignmentMetrics24hService>();
+        var dbActivityScope = scope.ServiceProvider.GetRequiredService<IDbActivityScope>();
+        using var dbScope = dbActivityScope.BeginScope("RawResultFlush");
 
         var checkResults = batch.Select(item => new CheckResult
         {

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseStatusModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseStatusModels.cs
@@ -14,6 +14,7 @@ public sealed class DatabaseStatusSnapshot
     public long TotalIndexBytes { get; init; }
     public IReadOnlyList<DatabaseTableStatusSnapshot> Tables { get; init; } = Array.Empty<DatabaseTableStatusSnapshot>();
     public ResultBufferRuntimeSnapshot ResultBuffer { get; init; } = new();
+    public IReadOnlyList<DatabaseSubsystemActivityStatusSnapshot> DbActivityBySubsystem { get; init; } = Array.Empty<DatabaseSubsystemActivityStatusSnapshot>();
 }
 
 public sealed class DatabaseTableStatusSnapshot
@@ -60,4 +61,28 @@ public sealed class AssignmentProcessingQueueRuntimeSnapshot
     public DateTimeOffset? LastProcessedAtUtc { get; init; }
     public DateTimeOffset? LastFailureAtUtc { get; init; }
     public string? LastFailureError { get; init; }
+}
+
+public sealed class DatabaseSubsystemActivityStatusSnapshot
+{
+    public string Subsystem { get; init; } = string.Empty;
+    public DatabaseSubsystemActivityWindowSnapshot Lifetime { get; init; } = new();
+    public DatabaseSubsystemActivityWindowSnapshot Recent { get; init; } = new();
+    public DateTimeOffset? LastActivityAtUtc { get; init; }
+    public DateTimeOffset? LastErrorAtUtc { get; init; }
+    public string? LastCommandType { get; init; }
+}
+
+public sealed class DatabaseSubsystemActivityWindowSnapshot
+{
+    public long ReadCount { get; init; }
+    public long WriteCount { get; init; }
+    public long ReadErrorCount { get; init; }
+    public long WriteErrorCount { get; init; }
+    public long ReadDurationMs { get; init; }
+    public long WriteDurationMs { get; init; }
+    public long WriteRows { get; init; }
+    public double AverageReadDurationMs { get; init; }
+    public double AverageWriteDurationMs { get; init; }
+    public long TotalDurationMs { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseStatusQueryService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Options;
 using PingMonitor.Web.Services.BufferedResults;
+using PingMonitor.Web.Services.Diagnostics;
 using PingMonitor.Web.Services.State;
 using PingMonitor.Web.Services.StartupGate;
 using System.Data;
@@ -16,23 +17,30 @@ internal sealed class DatabaseStatusQueryService : IDatabaseStatusQueryService
     private readonly IAssignmentProcessingQueue _assignmentProcessingQueue;
     private readonly IOptions<ResultBufferOptions> _resultBufferOptions;
     private readonly IOptions<StartupGateOptions> _startupGateOptions;
+    private readonly IDbActivityTracker _dbActivityTracker;
+    private readonly IDbActivityScope _dbActivityScope;
 
     public DatabaseStatusQueryService(
         PingMonitorDbContext dbContext,
         IBufferedResultIngestionService bufferedResultIngestionService,
         IAssignmentProcessingQueue assignmentProcessingQueue,
         IOptions<ResultBufferOptions> resultBufferOptions,
-        IOptions<StartupGateOptions> startupGateOptions)
+        IOptions<StartupGateOptions> startupGateOptions,
+        IDbActivityTracker dbActivityTracker,
+        IDbActivityScope dbActivityScope)
     {
         _dbContext = dbContext;
         _bufferedResultIngestionService = bufferedResultIngestionService;
         _assignmentProcessingQueue = assignmentProcessingQueue;
         _resultBufferOptions = resultBufferOptions;
         _startupGateOptions = startupGateOptions;
+        _dbActivityTracker = dbActivityTracker;
+        _dbActivityScope = dbActivityScope;
     }
 
     public async Task<DatabaseStatusSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
     {
+        using var dbScope = _dbActivityScope.BeginScope("Admin.DatabaseStatus");
         var connection = _dbContext.Database.GetDbConnection();
         if (connection.State != ConnectionState.Open)
         {
@@ -51,6 +59,41 @@ internal sealed class DatabaseStatusQueryService : IDatabaseStatusQueryService
         var bufferSnapshot = _bufferedResultIngestionService.GetSnapshot();
         var bufferOptions = _resultBufferOptions.Value;
         var assignmentQueueSnapshot = _assignmentProcessingQueue.GetSnapshot();
+        var dbActivity = _dbActivityTracker.GetSnapshot(DateTimeOffset.UtcNow)
+            .Select(x => new DatabaseSubsystemActivityStatusSnapshot
+            {
+                Subsystem = x.Subsystem,
+                Lifetime = new DatabaseSubsystemActivityWindowSnapshot
+                {
+                    ReadCount = x.Lifetime.ReadCount,
+                    WriteCount = x.Lifetime.WriteCount,
+                    ReadErrorCount = x.Lifetime.ReadErrorCount,
+                    WriteErrorCount = x.Lifetime.WriteErrorCount,
+                    ReadDurationMs = x.Lifetime.ReadDurationMs,
+                    WriteDurationMs = x.Lifetime.WriteDurationMs,
+                    WriteRows = x.Lifetime.WriteRows,
+                    AverageReadDurationMs = x.Lifetime.AverageReadDurationMs,
+                    AverageWriteDurationMs = x.Lifetime.AverageWriteDurationMs,
+                    TotalDurationMs = x.Lifetime.TotalDurationMs
+                },
+                Recent = new DatabaseSubsystemActivityWindowSnapshot
+                {
+                    ReadCount = x.Recent.ReadCount,
+                    WriteCount = x.Recent.WriteCount,
+                    ReadErrorCount = x.Recent.ReadErrorCount,
+                    WriteErrorCount = x.Recent.WriteErrorCount,
+                    ReadDurationMs = x.Recent.ReadDurationMs,
+                    WriteDurationMs = x.Recent.WriteDurationMs,
+                    WriteRows = x.Recent.WriteRows,
+                    AverageReadDurationMs = x.Recent.AverageReadDurationMs,
+                    AverageWriteDurationMs = x.Recent.AverageWriteDurationMs,
+                    TotalDurationMs = x.Recent.TotalDurationMs
+                },
+                LastActivityAtUtc = x.LastActivityAtUtc,
+                LastErrorAtUtc = x.LastErrorAtUtc,
+                LastCommandType = x.LastCommandType
+            })
+            .ToArray();
 
         return new DatabaseStatusSnapshot
         {
@@ -65,6 +108,7 @@ internal sealed class DatabaseStatusQueryService : IDatabaseStatusQueryService
             TotalDataBytes = dataBytes,
             TotalIndexBytes = indexBytes,
             Tables = tables,
+            DbActivityBySubsystem = dbActivity,
             ResultBuffer = new ResultBufferRuntimeSnapshot
             {
                 BufferingEnabled = bufferOptions.ResultBufferEnabled,

--- a/src/WebApp/PingMonitor.Web/Services/Diagnostics/DbActivityCommandInterceptor.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Diagnostics/DbActivityCommandInterceptor.cs
@@ -1,0 +1,114 @@
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace PingMonitor.Web.Services.Diagnostics;
+
+internal sealed class DbActivityCommandInterceptor : DbCommandInterceptor
+{
+    private readonly IDbActivityTracker _tracker;
+    private readonly IDbActivityScope _scope;
+
+    public DbActivityCommandInterceptor(IDbActivityTracker tracker, IDbActivityScope scope)
+    {
+        _tracker = tracker;
+        _scope = scope;
+    }
+
+    public override DbDataReader ReaderExecuted(DbCommand command, CommandExecutedEventData eventData, DbDataReader result)
+    {
+        Record(command, eventData.Duration, succeeded: true, rows: null);
+        return result;
+    }
+
+    public override ValueTask<DbDataReader> ReaderExecutedAsync(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        DbDataReader result,
+        CancellationToken cancellationToken = default)
+    {
+        Record(command, eventData.Duration, succeeded: true, rows: null);
+        return ValueTask.FromResult(result);
+    }
+
+    public override object? ScalarExecuted(DbCommand command, CommandExecutedEventData eventData, object? result)
+    {
+        Record(command, eventData.Duration, succeeded: true, rows: null);
+        return result;
+    }
+
+    public override ValueTask<object?> ScalarExecutedAsync(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        object? result,
+        CancellationToken cancellationToken = default)
+    {
+        Record(command, eventData.Duration, succeeded: true, rows: null);
+        return ValueTask.FromResult(result);
+    }
+
+    public override int NonQueryExecuted(DbCommand command, CommandExecutedEventData eventData, int result)
+    {
+        Record(command, eventData.Duration, succeeded: true, rows: result);
+        return result;
+    }
+
+    public override ValueTask<int> NonQueryExecutedAsync(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        int result,
+        CancellationToken cancellationToken = default)
+    {
+        Record(command, eventData.Duration, succeeded: true, rows: result);
+        return ValueTask.FromResult(result);
+    }
+
+    public override void CommandFailed(DbCommand command, CommandErrorEventData eventData)
+    {
+        Record(command, eventData.Duration, succeeded: false, rows: null);
+    }
+
+    public override Task CommandFailedAsync(DbCommand command, CommandErrorEventData eventData, CancellationToken cancellationToken = default)
+    {
+        Record(command, eventData.Duration, succeeded: false, rows: null);
+        return Task.CompletedTask;
+    }
+
+    private void Record(DbCommand command, TimeSpan duration, bool succeeded, int? rows)
+    {
+        var commandType = GetCommandType(command.CommandText);
+        _tracker.Record(new DbActivityRecord
+        {
+            Subsystem = _scope.CurrentSubsystem,
+            ActivityKind = commandType,
+            Duration = duration,
+            Succeeded = succeeded,
+            OccurredAtUtc = DateTimeOffset.UtcNow,
+            Rows = rows,
+            CommandType = commandType.ToString()
+        });
+    }
+
+    private static DbActivityKind GetCommandType(string? commandText)
+    {
+        if (string.IsNullOrWhiteSpace(commandText))
+        {
+            return DbActivityKind.Other;
+        }
+
+        var normalized = commandText.TrimStart();
+        if (normalized.StartsWith("SELECT", StringComparison.OrdinalIgnoreCase))
+        {
+            return DbActivityKind.Read;
+        }
+
+        if (normalized.StartsWith("INSERT", StringComparison.OrdinalIgnoreCase) ||
+            normalized.StartsWith("UPDATE", StringComparison.OrdinalIgnoreCase) ||
+            normalized.StartsWith("DELETE", StringComparison.OrdinalIgnoreCase) ||
+            normalized.StartsWith("REPLACE", StringComparison.OrdinalIgnoreCase))
+        {
+            return DbActivityKind.Write;
+        }
+
+        return DbActivityKind.Other;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Diagnostics/DbActivityScope.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Diagnostics/DbActivityScope.cs
@@ -1,0 +1,45 @@
+using System.Threading;
+
+namespace PingMonitor.Web.Services.Diagnostics;
+
+internal sealed class DbActivityScope : IDbActivityScope
+{
+    private const string UnknownSubsystem = "Unknown";
+    private static readonly AsyncLocal<string?> CurrentScope = new();
+
+    public string CurrentSubsystem => string.IsNullOrWhiteSpace(CurrentScope.Value)
+        ? UnknownSubsystem
+        : CurrentScope.Value!;
+
+    public IDisposable BeginScope(string subsystem)
+    {
+        var previous = CurrentScope.Value;
+        CurrentScope.Value = string.IsNullOrWhiteSpace(subsystem)
+            ? UnknownSubsystem
+            : subsystem.Trim();
+
+        return new ScopeHandle(previous);
+    }
+
+    private sealed class ScopeHandle : IDisposable
+    {
+        private readonly string? _previous;
+        private bool _disposed;
+
+        public ScopeHandle(string? previous)
+        {
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            CurrentScope.Value = _previous;
+            _disposed = true;
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Diagnostics/DbActivityTracker.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Diagnostics/DbActivityTracker.cs
@@ -1,0 +1,188 @@
+using System.Collections.Concurrent;
+
+namespace PingMonitor.Web.Services.Diagnostics;
+
+internal sealed class DbActivityTracker : IDbActivityTracker
+{
+    private static readonly TimeSpan RecentWindow = TimeSpan.FromMinutes(5);
+    private readonly ConcurrentDictionary<string, SubsystemCounter> _counters = new(StringComparer.Ordinal);
+
+    public void Record(DbActivityRecord record)
+    {
+        var subsystem = string.IsNullOrWhiteSpace(record.Subsystem)
+            ? "Unknown"
+            : record.Subsystem.Trim();
+
+        var counter = _counters.GetOrAdd(subsystem, _ => new SubsystemCounter());
+        counter.Record(record);
+    }
+
+    public IReadOnlyList<DbSubsystemActivitySnapshot> GetSnapshot(DateTimeOffset nowUtc)
+    {
+        return _counters
+            .Select(x => x.Value.BuildSnapshot(x.Key, nowUtc))
+            .OrderByDescending(x => x.Recent.TotalDurationMs)
+            .ThenBy(x => x.Subsystem, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private sealed class SubsystemCounter
+    {
+        private readonly object _sync = new();
+        private readonly Dictionary<DateTimeOffset, DbActivityAggregateMutable> _minuteBuckets = [];
+        private readonly DbActivityAggregateMutable _lifetime = new();
+        private DateTimeOffset? _lastActivityAtUtc;
+        private DateTimeOffset? _lastErrorAtUtc;
+        private string? _lastCommandType;
+
+        public void Record(DbActivityRecord record)
+        {
+            if (record.ActivityKind == DbActivityKind.Other)
+            {
+                return;
+            }
+
+            lock (_sync)
+            {
+                _lifetime.Apply(record);
+
+                var minuteBucket = new DateTimeOffset(
+                    record.OccurredAtUtc.Year,
+                    record.OccurredAtUtc.Month,
+                    record.OccurredAtUtc.Day,
+                    record.OccurredAtUtc.Hour,
+                    record.OccurredAtUtc.Minute,
+                    0,
+                    TimeSpan.Zero);
+                if (!_minuteBuckets.TryGetValue(minuteBucket, out var bucket))
+                {
+                    bucket = new DbActivityAggregateMutable();
+                    _minuteBuckets[minuteBucket] = bucket;
+                }
+
+                bucket.Apply(record);
+                _lastActivityAtUtc = _lastActivityAtUtc is null || record.OccurredAtUtc > _lastActivityAtUtc
+                    ? record.OccurredAtUtc
+                    : _lastActivityAtUtc;
+                if (!record.Succeeded)
+                {
+                    _lastErrorAtUtc = _lastErrorAtUtc is null || record.OccurredAtUtc > _lastErrorAtUtc
+                        ? record.OccurredAtUtc
+                        : _lastErrorAtUtc;
+                }
+
+                if (!string.IsNullOrWhiteSpace(record.CommandType))
+                {
+                    _lastCommandType = record.CommandType;
+                }
+            }
+        }
+
+        public DbSubsystemActivitySnapshot BuildSnapshot(string subsystem, DateTimeOffset nowUtc)
+        {
+            lock (_sync)
+            {
+                var cutoff = nowUtc - RecentWindow;
+                var cutoffMinute = new DateTimeOffset(
+                    cutoff.Year,
+                    cutoff.Month,
+                    cutoff.Day,
+                    cutoff.Hour,
+                    cutoff.Minute,
+                    0,
+                    TimeSpan.Zero);
+                var stale = _minuteBuckets.Keys.Where(k => k < cutoffMinute).ToArray();
+                foreach (var key in stale)
+                {
+                    _minuteBuckets.Remove(key);
+                }
+
+                var recent = new DbActivityAggregateMutable();
+                foreach (var pair in _minuteBuckets)
+                {
+                    if (pair.Key >= cutoffMinute)
+                    {
+                        recent.MergeFrom(pair.Value);
+                    }
+                }
+
+                return new DbSubsystemActivitySnapshot
+                {
+                    Subsystem = subsystem,
+                    Lifetime = _lifetime.ToSnapshot(),
+                    Recent = recent.ToSnapshot(),
+                    LastActivityAtUtc = _lastActivityAtUtc,
+                    LastErrorAtUtc = _lastErrorAtUtc,
+                    LastCommandType = _lastCommandType
+                };
+            }
+        }
+    }
+
+    private sealed class DbActivityAggregateMutable
+    {
+        public long ReadCount { get; private set; }
+        public long WriteCount { get; private set; }
+        public long ReadErrorCount { get; private set; }
+        public long WriteErrorCount { get; private set; }
+        public long ReadDurationMs { get; private set; }
+        public long WriteDurationMs { get; private set; }
+        public long WriteRows { get; private set; }
+
+        public void Apply(DbActivityRecord record)
+        {
+            var durationMs = Math.Max(0, (long)record.Duration.TotalMilliseconds);
+            if (record.ActivityKind == DbActivityKind.Read)
+            {
+                ReadCount += 1;
+                ReadDurationMs += durationMs;
+                if (!record.Succeeded)
+                {
+                    ReadErrorCount += 1;
+                }
+
+                return;
+            }
+
+            if (record.ActivityKind == DbActivityKind.Write)
+            {
+                WriteCount += 1;
+                WriteDurationMs += durationMs;
+                if (!record.Succeeded)
+                {
+                    WriteErrorCount += 1;
+                }
+
+                if (record.Rows.HasValue && record.Rows.Value > 0)
+                {
+                    WriteRows += record.Rows.Value;
+                }
+            }
+        }
+
+        public void MergeFrom(DbActivityAggregateMutable other)
+        {
+            ReadCount += other.ReadCount;
+            WriteCount += other.WriteCount;
+            ReadErrorCount += other.ReadErrorCount;
+            WriteErrorCount += other.WriteErrorCount;
+            ReadDurationMs += other.ReadDurationMs;
+            WriteDurationMs += other.WriteDurationMs;
+            WriteRows += other.WriteRows;
+        }
+
+        public DbActivityAggregateSnapshot ToSnapshot()
+        {
+            return new DbActivityAggregateSnapshot
+            {
+                ReadCount = ReadCount,
+                WriteCount = WriteCount,
+                ReadErrorCount = ReadErrorCount,
+                WriteErrorCount = WriteErrorCount,
+                ReadDurationMs = ReadDurationMs,
+                WriteDurationMs = WriteDurationMs,
+                WriteRows = WriteRows
+            };
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Diagnostics/IDbActivityScope.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Diagnostics/IDbActivityScope.cs
@@ -1,0 +1,7 @@
+namespace PingMonitor.Web.Services.Diagnostics;
+
+public interface IDbActivityScope
+{
+    string CurrentSubsystem { get; }
+    IDisposable BeginScope(string subsystem);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Diagnostics/IDbActivityTracker.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Diagnostics/IDbActivityTracker.cs
@@ -1,0 +1,49 @@
+namespace PingMonitor.Web.Services.Diagnostics;
+
+public interface IDbActivityTracker
+{
+    void Record(DbActivityRecord record);
+    IReadOnlyList<DbSubsystemActivitySnapshot> GetSnapshot(DateTimeOffset nowUtc);
+}
+
+public sealed class DbActivityRecord
+{
+    public string Subsystem { get; init; } = "Unknown";
+    public DbActivityKind ActivityKind { get; init; }
+    public TimeSpan Duration { get; init; }
+    public bool Succeeded { get; init; }
+    public DateTimeOffset OccurredAtUtc { get; init; }
+    public int? Rows { get; init; }
+    public string? CommandType { get; init; }
+}
+
+public enum DbActivityKind
+{
+    Read = 1,
+    Write = 2,
+    Other = 3
+}
+
+public sealed class DbSubsystemActivitySnapshot
+{
+    public string Subsystem { get; init; } = string.Empty;
+    public DbActivityAggregateSnapshot Lifetime { get; init; } = new();
+    public DbActivityAggregateSnapshot Recent { get; init; } = new();
+    public DateTimeOffset? LastActivityAtUtc { get; init; }
+    public DateTimeOffset? LastErrorAtUtc { get; init; }
+    public string? LastCommandType { get; init; }
+}
+
+public sealed class DbActivityAggregateSnapshot
+{
+    public long ReadCount { get; init; }
+    public long WriteCount { get; init; }
+    public long ReadErrorCount { get; init; }
+    public long WriteErrorCount { get; init; }
+    public long ReadDurationMs { get; init; }
+    public long WriteDurationMs { get; init; }
+    public long WriteRows { get; init; }
+    public double AverageReadDurationMs => ReadCount <= 0 ? 0 : ReadDurationMs / (double)ReadCount;
+    public double AverageWriteDurationMs => WriteCount <= 0 ? 0 : WriteDurationMs / (double)WriteCount;
+    public long TotalDurationMs => ReadDurationMs + WriteDurationMs;
+}

--- a/src/WebApp/PingMonitor.Web/Services/DynamicPingMonitorDbContextFactory.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DynamicPingMonitorDbContextFactory.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using MySql.EntityFrameworkCore.Extensions;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Options;
+using PingMonitor.Web.Services.Diagnostics;
 using PingMonitor.Web.Services.StartupGate;
 
 namespace PingMonitor.Web.Services;
@@ -10,13 +11,16 @@ internal sealed class DynamicPingMonitorDbContextFactory : IDbContextFactory<Pin
 {
     private readonly IStartupDatabaseConfigurationStore _configurationStore;
     private readonly StartupGateOptions _startupGateOptions;
+    private readonly DbActivityCommandInterceptor _dbActivityCommandInterceptor;
 
     public DynamicPingMonitorDbContextFactory(
         IStartupDatabaseConfigurationStore configurationStore,
-        Microsoft.Extensions.Options.IOptions<StartupGateOptions> startupGateOptions)
+        Microsoft.Extensions.Options.IOptions<StartupGateOptions> startupGateOptions,
+        DbActivityCommandInterceptor dbActivityCommandInterceptor)
     {
         _configurationStore = configurationStore;
         _startupGateOptions = startupGateOptions.Value;
+        _dbActivityCommandInterceptor = dbActivityCommandInterceptor;
     }
 
     public PingMonitorDbContext CreateDbContext()
@@ -31,6 +35,7 @@ internal sealed class DynamicPingMonitorDbContextFactory : IDbContextFactory<Pin
 
         var optionsBuilder = new DbContextOptionsBuilder<PingMonitorDbContext>();
         optionsBuilder.UseMySQL(connectionString);
+        optionsBuilder.AddInterceptors(_dbActivityCommandInterceptor);
         return new PingMonitorDbContext(optionsBuilder.Options);
     }
 

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
@@ -3,6 +3,7 @@ using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Services.Metrics;
 using PingMonitor.Web.Services.Identity;
+using PingMonitor.Web.Services.Diagnostics;
 using PingMonitor.Web.ViewModels.Endpoints;
 
 namespace PingMonitor.Web.Services.Endpoints;
@@ -13,17 +14,20 @@ internal sealed class EndpointManagementQueryService : IEndpointManagementQueryS
     private readonly IAssignmentMetrics24hService _assignmentMetrics24hService;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IUserAccessScopeService _userAccessScopeService;
+    private readonly IDbActivityScope _dbActivityScope;
 
-    public EndpointManagementQueryService(PingMonitorDbContext dbContext, IAssignmentMetrics24hService assignmentMetrics24hService, IHttpContextAccessor httpContextAccessor, IUserAccessScopeService userAccessScopeService)
+    public EndpointManagementQueryService(PingMonitorDbContext dbContext, IAssignmentMetrics24hService assignmentMetrics24hService, IHttpContextAccessor httpContextAccessor, IUserAccessScopeService userAccessScopeService, IDbActivityScope dbActivityScope)
     {
         _dbContext = dbContext;
         _assignmentMetrics24hService = assignmentMetrics24hService;
         _httpContextAccessor = httpContextAccessor;
         _userAccessScopeService = userAccessScopeService;
+        _dbActivityScope = dbActivityScope;
     }
 
     public async Task<ManageEndpointsPageViewModel> GetManagePageAsync(string? groupId, CancellationToken cancellationToken)
     {
+        using var scope = _dbActivityScope.BeginScope("EndpointsPage");
         var normalizedGroupId = string.IsNullOrWhiteSpace(groupId) ? null : groupId.Trim();
         var principal = _httpContextAccessor.HttpContext?.User;
         var isAdmin = principal is not null && await _userAccessScopeService.IsAdminAsync(principal);
@@ -149,6 +153,7 @@ internal sealed class EndpointManagementQueryService : IEndpointManagementQueryS
 
     public async Task<EditEndpointOptionsViewModel> GetEditOptionsAsync(string assignmentId, CancellationToken cancellationToken)
     {
+        using var scope = _dbActivityScope.BeginScope("EndpointsPage");
         var normalizedAssignmentId = assignmentId.Trim();
 
         var endpointId = await _dbContext.MonitorAssignments.AsNoTracking()
@@ -202,6 +207,7 @@ internal sealed class EndpointManagementQueryService : IEndpointManagementQueryS
 
     public async Task<RemoveEndpointDetails?> GetRemoveDetailsAsync(string assignmentId, CancellationToken cancellationToken)
     {
+        using var scope = _dbActivityScope.BeginScope("EndpointsPage");
         var normalizedAssignmentId = assignmentId.Trim();
         if (string.IsNullOrWhiteSpace(normalizedAssignmentId))
         {

--- a/src/WebApp/PingMonitor.Web/Services/Metrics/AssignmentMetrics24hService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/AssignmentMetrics24hService.cs
@@ -2,6 +2,7 @@ using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.Diagnostics;
 
 namespace PingMonitor.Web.Services.Metrics;
 
@@ -9,17 +10,20 @@ internal sealed class AssignmentMetrics24hService : IAssignmentMetrics24hService
 {
     private readonly PingMonitorDbContext _dbContext;
     private readonly IRollingAssignmentWindowStore _rollingStore;
+    private readonly IDbActivityScope _dbActivityScope;
 
-    public AssignmentMetrics24hService(PingMonitorDbContext dbContext, IRollingAssignmentWindowStore rollingStore)
+    public AssignmentMetrics24hService(PingMonitorDbContext dbContext, IRollingAssignmentWindowStore rollingStore, IDbActivityScope dbActivityScope)
     {
         _dbContext = dbContext;
         _rollingStore = rollingStore;
+        _dbActivityScope = dbActivityScope;
     }
 
     public async Task<IReadOnlyDictionary<string, AssignmentMetrics24hSummary>> GetSummariesAsync(
         IReadOnlyCollection<string> assignmentIds,
         CancellationToken cancellationToken)
     {
+        using var scope = _dbActivityScope.BeginScope("AssignmentMetrics24h");
         var normalizedAssignmentIds = NormalizeAssignmentIds(assignmentIds);
         if (normalizedAssignmentIds.Length == 0)
         {
@@ -54,6 +58,7 @@ internal sealed class AssignmentMetrics24hService : IAssignmentMetrics24hService
 
     public async Task ApplyCheckResultsBatchAsync(IReadOnlyCollection<CheckResult> checkResults, CancellationToken cancellationToken)
     {
+        using var scope = _dbActivityScope.BeginScope("AssignmentMetrics24h");
         var assignmentIds = checkResults
             .Select(x => x.AssignmentId)
             .Where(x => !string.IsNullOrWhiteSpace(x))
@@ -80,6 +85,7 @@ internal sealed class AssignmentMetrics24hService : IAssignmentMetrics24hService
         DateTimeOffset evaluatedAtUtc,
         CancellationToken cancellationToken)
     {
+        using var scope = _dbActivityScope.BeginScope("AssignmentMetrics24h");
         await _rollingStore.ApplyStateEvaluationAsync(
             assignmentId,
             previousState,
@@ -99,6 +105,7 @@ internal sealed class AssignmentMetrics24hService : IAssignmentMetrics24hService
 
     public async Task RefreshAssignmentsAsync(IReadOnlyCollection<string> assignmentIds, CancellationToken cancellationToken)
     {
+        using var scope = _dbActivityScope.BeginScope("AssignmentMetrics24h");
         var normalizedAssignmentIds = NormalizeAssignmentIds(assignmentIds);
         if (normalizedAssignmentIds.Length == 0)
         {
@@ -112,6 +119,7 @@ internal sealed class AssignmentMetrics24hService : IAssignmentMetrics24hService
 
     public async Task RebuildAllAsync(CancellationToken cancellationToken)
     {
+        using var scope = _dbActivityScope.BeginScope("AssignmentMetrics24h");
         var assignmentIds = await _dbContext.MonitorAssignments.AsNoTracking()
             .Select(x => x.AssignmentId)
             .ToArrayAsync(cancellationToken);

--- a/src/WebApp/PingMonitor.Web/Services/Metrics/RollingAssignmentWindowStore.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/RollingAssignmentWindowStore.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.Diagnostics;
 
 namespace PingMonitor.Web.Services.Metrics;
 
@@ -60,6 +61,8 @@ internal sealed class RollingAssignmentWindowStore : IRollingAssignmentWindowSto
         }
 
         using var scope = _scopeFactory.CreateScope();
+        var dbActivityScope = scope.ServiceProvider.GetRequiredService<IDbActivityScope>();
+        using var dbScope = dbActivityScope.BeginScope("RollingWindowHydration");
         var dbContext = scope.ServiceProvider.GetRequiredService<PingMonitorDbContext>();
         var latest = await dbContext.CheckResults.AsNoTracking()
             .Where(x => x.AssignmentId == normalizedAssignmentId)
@@ -186,6 +189,8 @@ internal sealed class RollingAssignmentWindowStore : IRollingAssignmentWindowSto
         var windowStartUtc = nowUtc - Window;
 
         using var scope = _scopeFactory.CreateScope();
+        var dbActivityScope = scope.ServiceProvider.GetRequiredService<IDbActivityScope>();
+        using var dbScope = dbActivityScope.BeginScope("RollingWindowHydration");
         var dbContext = scope.ServiceProvider.GetRequiredService<PingMonitorDbContext>();
 
         var samples = await dbContext.CheckResults.AsNoTracking()

--- a/src/WebApp/PingMonitor.Web/Services/SmtpNotifications/SmtpNotificationSender.cs
+++ b/src/WebApp/PingMonitor.Web/Services/SmtpNotifications/SmtpNotificationSender.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.Diagnostics;
 
 namespace PingMonitor.Web.Services.SmtpNotifications;
 
@@ -14,18 +15,21 @@ internal sealed class SmtpNotificationSender : ISmtpNotificationSender
     private readonly IUserNotificationSettingsService _userNotificationSettingsService;
     private readonly INotificationSuppressionService _notificationSuppressionService;
     private readonly ILogger<SmtpNotificationSender> _logger;
+    private readonly IDbActivityScope _dbActivityScope;
 
     public SmtpNotificationSender(
         PingMonitorDbContext dbContext,
         INotificationSettingsService notificationSettingsService,
         IUserNotificationSettingsService userNotificationSettingsService,
         INotificationSuppressionService notificationSuppressionService,
+        IDbActivityScope dbActivityScope,
         ILogger<SmtpNotificationSender> logger)
     {
         _dbContext = dbContext;
         _notificationSettingsService = notificationSettingsService;
         _userNotificationSettingsService = userNotificationSettingsService;
         _notificationSuppressionService = notificationSuppressionService;
+        _dbActivityScope = dbActivityScope;
         _logger = logger;
     }
 
@@ -64,6 +68,7 @@ internal sealed class SmtpNotificationSender : ISmtpNotificationSender
 
     public async Task<SmtpNotificationSendResult> SendForEventAsync(EventLog eventLog, CancellationToken cancellationToken)
     {
+        using var scope = _dbActivityScope.BeginScope("Notifications.Smtp");
         var mapped = MapEvent(eventLog);
         if (mapped is null)
         {

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -4,6 +4,7 @@ using MySqlConnector;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Options;
+using PingMonitor.Web.Services.Diagnostics;
 
 namespace PingMonitor.Web.Services.StartupGate;
 
@@ -167,21 +168,25 @@ internal sealed class StartupSchemaService : IStartupSchemaService
     private readonly IStartupDatabaseConfigurationStore _configurationStore;
     private readonly StartupGateOptions _options;
     private readonly ILogger<StartupSchemaService> _logger;
+    private readonly IDbActivityScope _dbActivityScope;
 
     public StartupSchemaService(
         IDbContextFactory<PingMonitorDbContext> dbContextFactory,
         IStartupDatabaseConfigurationStore configurationStore,
         IOptions<StartupGateOptions> options,
+        IDbActivityScope dbActivityScope,
         ILogger<StartupSchemaService> logger)
     {
         _dbContextFactory = dbContextFactory;
         _configurationStore = configurationStore;
         _options = options.Value;
+        _dbActivityScope = dbActivityScope;
         _logger = logger;
     }
 
     public async Task<StartupSchemaStatus> GetStatusAsync(CancellationToken cancellationToken)
     {
+        using var scope = _dbActivityScope.BeginScope("StartupSchema");
         var configuration = await _configurationStore.LoadAsync(cancellationToken);
         var password = await _configurationStore.LoadPasswordAsync(cancellationToken);
         if (configuration is null || !configuration.IsComplete || string.IsNullOrWhiteSpace(password))
@@ -293,6 +298,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
 
     public async Task<StartupSchemaStatus> ApplySchemaAsync(CancellationToken cancellationToken)
     {
+        using var scope = _dbActivityScope.BeginScope("StartupSchema");
         _logger.LogInformation("Startup gate schema apply requested.");
 
         await using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);

--- a/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
@@ -2,6 +2,7 @@ using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Services.EventLogs;
 using PingMonitor.Web.Services.Metrics;
+using PingMonitor.Web.Services.Diagnostics;
 using PingMonitor.Web.Services.State;
 using System.Text.Json;
 
@@ -16,6 +17,7 @@ internal sealed class StateEvaluationService : IStateEvaluationService
     private readonly IAssignmentTopologyCache _topologyCache;
     private readonly IAssignmentCurrentStateCache _currentStateCache;
     private readonly IRollingAssignmentWindowStore _rollingAssignmentWindowStore;
+    private readonly IDbActivityScope _dbActivityScope;
 
     public StateEvaluationService(
         PingMonitorDbContext dbContext,
@@ -24,7 +26,8 @@ internal sealed class StateEvaluationService : IStateEvaluationService
         IAssignmentMetrics24hService assignmentMetrics24hService,
         IAssignmentTopologyCache topologyCache,
         IAssignmentCurrentStateCache currentStateCache,
-        IRollingAssignmentWindowStore rollingAssignmentWindowStore)
+        IRollingAssignmentWindowStore rollingAssignmentWindowStore,
+        IDbActivityScope dbActivityScope)
     {
         _dbContext = dbContext;
         _logger = logger;
@@ -33,6 +36,7 @@ internal sealed class StateEvaluationService : IStateEvaluationService
         _topologyCache = topologyCache;
         _currentStateCache = currentStateCache;
         _rollingAssignmentWindowStore = rollingAssignmentWindowStore;
+        _dbActivityScope = dbActivityScope;
     }
 
     public async Task EvaluateAssignmentsAsync(IEnumerable<string> assignmentIds, CancellationToken cancellationToken)
@@ -74,6 +78,7 @@ internal sealed class StateEvaluationService : IStateEvaluationService
 
     private async Task<IReadOnlyCollection<string>> EvaluateInternalAsync(string assignmentId, CancellationToken cancellationToken)
     {
+        using var scope = _dbActivityScope.BeginScope("StateEvaluation");
         var assignmentContext = await _topologyCache.GetAssignmentContextAsync(assignmentId, cancellationToken);
         if (assignmentContext is null)
         {

--- a/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
@@ -5,6 +5,7 @@ using PingMonitor.Web.Services.Endpoints;
 using PingMonitor.Web.Services.Metrics;
 using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.Services.EventLogs;
+using PingMonitor.Web.Services.Diagnostics;
 using PingMonitor.Web.ViewModels.Status;
 
 namespace PingMonitor.Web.Services.Status;
@@ -16,14 +17,16 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IUserAccessScopeService _userAccessScopeService;
     private readonly IEventLogQueryService _eventLogQueryService;
+    private readonly IDbActivityScope _dbActivityScope;
 
-    public EndpointStatusQueryService(PingMonitorDbContext dbContext, IAssignmentMetrics24hService assignmentMetrics24hService, IHttpContextAccessor httpContextAccessor, IUserAccessScopeService userAccessScopeService, IEventLogQueryService eventLogQueryService)
+    public EndpointStatusQueryService(PingMonitorDbContext dbContext, IAssignmentMetrics24hService assignmentMetrics24hService, IHttpContextAccessor httpContextAccessor, IUserAccessScopeService userAccessScopeService, IEventLogQueryService eventLogQueryService, IDbActivityScope dbActivityScope)
     {
         _dbContext = dbContext;
         _assignmentMetrics24hService = assignmentMetrics24hService;
         _httpContextAccessor = httpContextAccessor;
         _userAccessScopeService = userAccessScopeService;
         _eventLogQueryService = eventLogQueryService;
+        _dbActivityScope = dbActivityScope;
     }
 
     public async Task<EndpointStatusPageViewModel> GetStatusPageAsync(
@@ -33,6 +36,7 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
         string? search,
         CancellationToken cancellationToken)
     {
+        using var scope = _dbActivityScope.BeginScope("StatusPage");
         var nowUtc = DateTimeOffset.UtcNow;
         var normalizedState = Normalize(state);
 

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramNotificationSender.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramNotificationSender.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.Diagnostics;
 
 namespace PingMonitor.Web.Services.Telegram;
 
@@ -12,6 +13,7 @@ internal sealed class TelegramNotificationSender : ITelegramNotificationSender
     private readonly IUserNotificationSettingsService _userNotificationSettingsService;
     private readonly INotificationSuppressionService _notificationSuppressionService;
     private readonly ILogger<TelegramNotificationSender> _logger;
+    private readonly IDbActivityScope _dbActivityScope;
     private readonly HttpClient _httpClient = new();
 
     public TelegramNotificationSender(
@@ -19,17 +21,20 @@ internal sealed class TelegramNotificationSender : ITelegramNotificationSender
         INotificationSettingsService notificationSettingsService,
         IUserNotificationSettingsService userNotificationSettingsService,
         INotificationSuppressionService notificationSuppressionService,
+        IDbActivityScope dbActivityScope,
         ILogger<TelegramNotificationSender> logger)
     {
         _dbContext = dbContext;
         _notificationSettingsService = notificationSettingsService;
         _userNotificationSettingsService = userNotificationSettingsService;
         _notificationSuppressionService = notificationSuppressionService;
+        _dbActivityScope = dbActivityScope;
         _logger = logger;
     }
 
     public async Task<TelegramNotificationSendResult> SendForEventAsync(EventLog eventLog, CancellationToken cancellationToken)
     {
+        using var scope = _dbActivityScope.BeginScope("Notifications.Telegram");
         var mapped = MapEvent(eventLog);
         if (mapped is null)
         {

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/DatabaseStatusPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/DatabaseStatusPageViewModel.cs
@@ -16,6 +16,7 @@ public sealed class DatabaseStatusPageViewModel
     public long TotalDataBytes { get; init; }
     public long TotalIndexBytes { get; init; }
     public IReadOnlyList<DatabaseStatusTableViewModel> Tables { get; init; } = Array.Empty<DatabaseStatusTableViewModel>();
+    public IReadOnlyList<DatabaseSubsystemActivityViewModel> DbActivityBySubsystem { get; init; } = Array.Empty<DatabaseSubsystemActivityViewModel>();
     public DatabaseStatusRuntimeBufferViewModel RuntimeBuffer { get; init; } = new();
 }
 
@@ -62,6 +63,25 @@ public sealed class DatabaseStatusRuntimeBufferViewModel
     public double BufferDropRatePercent { get; init; }
     public double FlushSuccessRatePercent { get; init; }
     public string CacheHitRateNote { get; init; } = "No request/result cache hit-rate metric is currently instrumented.";
+}
+
+public sealed class DatabaseSubsystemActivityViewModel
+{
+    public string Subsystem { get; init; } = string.Empty;
+    public long RecentReadCount { get; init; }
+    public long LifetimeReadCount { get; init; }
+    public long RecentWriteCount { get; init; }
+    public long LifetimeWriteCount { get; init; }
+    public long RecentTotalDurationMs { get; init; }
+    public long LifetimeTotalDurationMs { get; init; }
+    public double LifetimeAverageReadDurationMs { get; init; }
+    public double LifetimeAverageWriteDurationMs { get; init; }
+    public long RecentErrorCount { get; init; }
+    public long LifetimeErrorCount { get; init; }
+    public DateTimeOffset? LastActivityAtUtc { get; init; }
+    public DateTimeOffset? LastErrorAtUtc { get; init; }
+    public long LifetimeWriteRows { get; init; }
+    public string? LastCommandType { get; init; }
 }
 
 public sealed class AssignmentProcessingQueueViewModel

--- a/src/WebApp/PingMonitor.Web/Views/AdminDatabase/Status.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminDatabase/Status.cshtml
@@ -53,6 +53,44 @@
         </section>
 
         <section class="card">
+            <h2>DB activity by subsystem</h2>
+            <p class="muted">In-memory application-level read/write pressure, with recent 5-minute and lifetime totals.</p>
+            <div class="table-wrap">
+                <table>
+                    <thead>
+                    <tr>
+                        <th>Subsystem</th>
+                        <th>Reads (recent / lifetime)</th>
+                        <th>Writes (recent / lifetime)</th>
+                        <th>Total DB time ms (recent / lifetime)</th>
+                        <th>Avg read ms</th>
+                        <th>Avg write ms</th>
+                        <th>Errors (recent / lifetime)</th>
+                        <th>Write rows</th>
+                        <th>Last activity (UTC)</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @foreach (var row in Model.DbActivityBySubsystem)
+                    {
+                        <tr>
+                            <td>@row.Subsystem</td>
+                            <td>@row.RecentReadCount / @row.LifetimeReadCount</td>
+                            <td>@row.RecentWriteCount / @row.LifetimeWriteCount</td>
+                            <td>@row.RecentTotalDurationMs / @row.LifetimeTotalDurationMs</td>
+                            <td>@row.LifetimeAverageReadDurationMs.ToString("0.##")</td>
+                            <td>@row.LifetimeAverageWriteDurationMs.ToString("0.##")</td>
+                            <td>@row.RecentErrorCount / @row.LifetimeErrorCount</td>
+                            <td>@row.LifetimeWriteRows</td>
+                            <td>@(row.LastActivityAtUtc is null ? "n/a" : DisplayFormatting.FormatUtcDateTime(row.LastActivityAtUtc.Value))</td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <section class="card">
             <h2>DB buffer status</h2>
             <p class="muted">Runtime metrics for in-memory buffering of agent-ingested raw check results.</p>
             <div class="overview-grid">


### PR DESCRIPTION
### Motivation
- Provide low-overhead, application-level observability of database pressure so read/write hotspots can be attributed to application subsystems. 
- Surface both recent (rolling 5-minute) and lifetime read/write counts, durations and errors on the existing DB Status page to speed future diagnosis.

### Description
- Added a lightweight in-memory diagnostics stack: `IDbActivityTracker`/`DbActivityTracker` for minute-bucketed 5-minute rolling totals + lifetime aggregates, and `IDbActivityScope`/`DbActivityScope` (AsyncLocal) for ambient subsystem scoping. (new files under `Services/Diagnostics`).
- Instrumented EF Core at the command boundary via `DbActivityCommandInterceptor` and registered the interceptor in the dynamic `DbContext` factory so all DB commands are measured centrally. (interceptor DI registered in `Program.cs` and added via `optionsBuilder.AddInterceptors(...)`).
- Applied ambient subsystem scopes at key entry points (not every helper) and propagated scope selection to the interceptor; extended existing database status snapshot/viewmodel/view to include subsystem metrics and added a table to the Admin DB Status page. Files added/updated include: `Services/Diagnostics/*`, `Services/DatabaseStatus/*`, `ViewModels/Admin/DatabaseStatusPageViewModel.cs`, `Controllers/AdminDatabaseController.cs`, `Views/AdminDatabase/Status.cshtml`, `Program.cs`, `DynamicPingMonitorDbContextFactory.cs`, and several major service entry points where scopes were introduced.
- Subsystem scope names introduced: `RawResultFlush`, `AssignmentProcessing`, `StateEvaluation`, `RollingWindowHydration`, `AssignmentMetrics24h`, `Notifications.Smtp`, `Notifications.Telegram`, `StatusPage`, `EndpointsPage`, `Admin.DatabaseStatus`, `StartupSchema`, and `Unknown` (fallback).
- Limitations: SQL classification is intentionally simple (SQL text prefix: `SELECT` => read; `INSERT/UPDATE/DELETE/REPLACE` => write; others => ignored), minute-bucket rolling window is approximate by design, and read row counts are not tracked (writes track rows when available).

### Testing
- Installed .NET 10 SDK and ran a full project build: `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` succeeded (SDK 10.0.104 installed and build passed).
- Verified the EF interceptor is wired into the `DbContextOptions` (inspected `DynamicPingMonitorDbContextFactory`) and that major services/pages create subsystem scopes (code inspection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d07c6c2818832ab60273b40b7fb91f)