### PR TITLE
Add runtime ingest/drop rate metrics to status page

### DIFF
--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -159,6 +159,7 @@ builder.Services.AddScoped<IAgentAuthenticationService, AgentAuthenticationServi
 builder.Services.AddScoped<IAgentHelloService, AgentHelloService>();
 builder.Services.AddScoped<IAgentConfigurationService, AgentConfigurationService>();
 builder.Services.AddScoped<IResultIngestionService, ResultIngestionService>();
+builder.Services.AddSingleton<IngestRateTracker>();
 builder.Services.AddSingleton<IBufferedResultIngestionService, BufferedResultIngestionService>();
 builder.Services.AddScoped<IHeartbeatService, AgentHeartbeatService>();
 builder.Services.AddScoped<IStateEvaluationService, StateEvaluationService>();

--- a/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultIngestionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultIngestionService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Options;
 using PingMonitor.Web.Options;
+using PingMonitor.Web.Services.Metrics;
 
 namespace PingMonitor.Web.Services.BufferedResults;
 
@@ -9,6 +10,7 @@ internal sealed class BufferedResultIngestionService : IBufferedResultIngestionS
     private readonly Queue<BufferedCheckResult> _queue = new();
     private readonly SemaphoreSlim _signal = new(0);
     private readonly ILogger<BufferedResultIngestionService> _logger;
+    private readonly IngestRateTracker _ingestRateTracker;
     private readonly ResultBufferOptions _options;
     private long _droppedCount;
     private long _totalEnqueueCount;
@@ -25,9 +27,11 @@ internal sealed class BufferedResultIngestionService : IBufferedResultIngestionS
 
     public BufferedResultIngestionService(
         IOptions<ResultBufferOptions> options,
+        IngestRateTracker ingestRateTracker,
         ILogger<BufferedResultIngestionService> logger)
     {
         _logger = logger;
+        _ingestRateTracker = ingestRateTracker;
         _options = options.Value;
     }
 
@@ -58,6 +62,7 @@ internal sealed class BufferedResultIngestionService : IBufferedResultIngestionS
 
         if (droppedInWrite > 0)
         {
+            _ingestRateTracker.RecordDrop(droppedInWrite);
             _logger.LogWarning(
                 "Result buffer overflowed. Dropped {DroppedCount} oldest raw check results to preserve newer telemetry. Queue limit: {MaxQueueSize}.",
                 droppedInWrite,

--- a/src/WebApp/PingMonitor.Web/Services/Metrics/IngestRateTracker.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Metrics/IngestRateTracker.cs
@@ -1,0 +1,104 @@
+namespace PingMonitor.Web.Services.Metrics;
+
+public sealed class IngestRateTracker
+{
+    private const int WindowSizeSeconds = 60;
+    private readonly object _sync = new();
+    private readonly int[] _ingestBuckets = new int[WindowSizeSeconds];
+    private readonly int[] _dropBuckets = new int[WindowSizeSeconds];
+    private long _lastSecond;
+    private int _ingestTotal;
+    private int _dropTotal;
+    private bool _initialized;
+
+    public void RecordIngest(int count)
+    {
+        if (count <= 0)
+        {
+            return;
+        }
+
+        lock (_sync)
+        {
+            var nowSecond = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            AdvanceWindow(nowSecond);
+
+            var bucketIndex = (int)(nowSecond % WindowSizeSeconds);
+            _ingestBuckets[bucketIndex] += count;
+            _ingestTotal += count;
+        }
+    }
+
+    public void RecordDrop(int count)
+    {
+        if (count <= 0)
+        {
+            return;
+        }
+
+        lock (_sync)
+        {
+            var nowSecond = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            AdvanceWindow(nowSecond);
+
+            var bucketIndex = (int)(nowSecond % WindowSizeSeconds);
+            _dropBuckets[bucketIndex] += count;
+            _dropTotal += count;
+        }
+    }
+
+    public int GetIngestPerMinute()
+    {
+        lock (_sync)
+        {
+            AdvanceWindow(DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+            return _ingestTotal;
+        }
+    }
+
+    public int GetDropPerMinute()
+    {
+        lock (_sync)
+        {
+            AdvanceWindow(DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+            return _dropTotal;
+        }
+    }
+
+    private void AdvanceWindow(long nowSecond)
+    {
+        if (!_initialized)
+        {
+            _lastSecond = nowSecond;
+            _initialized = true;
+            return;
+        }
+
+        if (nowSecond <= _lastSecond)
+        {
+            return;
+        }
+
+        var elapsed = nowSecond - _lastSecond;
+        if (elapsed >= WindowSizeSeconds)
+        {
+            Array.Clear(_ingestBuckets);
+            Array.Clear(_dropBuckets);
+            _ingestTotal = 0;
+            _dropTotal = 0;
+            _lastSecond = nowSecond;
+            return;
+        }
+
+        for (var second = _lastSecond + 1; second <= nowSecond; second++)
+        {
+            var bucketIndex = (int)(second % WindowSizeSeconds);
+            _ingestTotal -= _ingestBuckets[bucketIndex];
+            _dropTotal -= _dropBuckets[bucketIndex];
+            _ingestBuckets[bucketIndex] = 0;
+            _dropBuckets[bucketIndex] = 0;
+        }
+
+        _lastSecond = nowSecond;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
@@ -5,6 +5,7 @@ using PingMonitor.Web.Models;
 using PingMonitor.Web.Options;
 using PingMonitor.Web.Services.BufferedResults;
 using PingMonitor.Web.Services.EventLogs;
+using PingMonitor.Web.Services.Metrics;
 using PingMonitor.Web.Support;
 using Microsoft.Extensions.Options;
 
@@ -16,6 +17,7 @@ internal sealed class ResultIngestionService : IResultIngestionService
     private readonly IStateEvaluationService _stateEvaluationService;
     private readonly IBufferedResultIngestionService _bufferedResultIngestionService;
     private readonly IEventLogService _eventLogService;
+    private readonly IngestRateTracker _ingestRateTracker;
     private readonly ILogger<ResultIngestionService> _logger;
     private readonly ResultBufferOptions _resultBufferOptions;
 
@@ -24,6 +26,7 @@ internal sealed class ResultIngestionService : IResultIngestionService
         IStateEvaluationService stateEvaluationService,
         IBufferedResultIngestionService bufferedResultIngestionService,
         IEventLogService eventLogService,
+        IngestRateTracker ingestRateTracker,
         IOptions<ResultBufferOptions> resultBufferOptions,
         ILogger<ResultIngestionService> logger)
     {
@@ -31,6 +34,7 @@ internal sealed class ResultIngestionService : IResultIngestionService
         _stateEvaluationService = stateEvaluationService;
         _bufferedResultIngestionService = bufferedResultIngestionService;
         _eventLogService = eventLogService;
+        _ingestRateTracker = ingestRateTracker;
         _resultBufferOptions = resultBufferOptions.Value;
         _logger = logger;
     }
@@ -162,6 +166,8 @@ internal sealed class ResultIngestionService : IResultIngestionService
                 ReceivedAtUtc = x.ReceivedAtUtc,
                 BatchId = x.BatchId
             }).ToArray();
+
+            _ingestRateTracker.RecordIngest(storedResults.Length);
 
             // Buffering boundary: only raw agent-ingested CheckResults use in-memory buffering.
             // Critical writes (event logs, auth/security/admin/config changes) remain direct DB writes.

--- a/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
@@ -18,8 +18,9 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
     private readonly IUserAccessScopeService _userAccessScopeService;
     private readonly IEventLogQueryService _eventLogQueryService;
     private readonly IDbActivityScope _dbActivityScope;
+    private readonly IngestRateTracker _ingestRateTracker;
 
-    public EndpointStatusQueryService(PingMonitorDbContext dbContext, IAssignmentMetrics24hService assignmentMetrics24hService, IHttpContextAccessor httpContextAccessor, IUserAccessScopeService userAccessScopeService, IEventLogQueryService eventLogQueryService, IDbActivityScope dbActivityScope)
+    public EndpointStatusQueryService(PingMonitorDbContext dbContext, IAssignmentMetrics24hService assignmentMetrics24hService, IHttpContextAccessor httpContextAccessor, IUserAccessScopeService userAccessScopeService, IEventLogQueryService eventLogQueryService, IDbActivityScope dbActivityScope, IngestRateTracker ingestRateTracker)
     {
         _dbContext = dbContext;
         _assignmentMetrics24hService = assignmentMetrics24hService;
@@ -27,6 +28,7 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
         _userAccessScopeService = userAccessScopeService;
         _eventLogQueryService = eventLogQueryService;
         _dbActivityScope = dbActivityScope;
+        _ingestRateTracker = ingestRateTracker;
     }
 
     public async Task<EndpointStatusPageViewModel> GetStatusPageAsync(
@@ -256,6 +258,8 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
                 AvailableAgents = availableAgents,
                 AvailableGroups = availableGroups
             },
+            IngestPerMinute = _ingestRateTracker.GetIngestPerMinute(),
+            DropPerMinute = _ingestRateTracker.GetDropPerMinute(),
             Rows = rowsWithMetrics,
             RecentEvents = await _eventLogQueryService.GetRecentEventsAsync(50, cancellationToken)
         };

--- a/src/WebApp/PingMonitor.Web/ViewModels/Status/EndpointStatusPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Status/EndpointStatusPageViewModel.cs
@@ -6,6 +6,8 @@ namespace PingMonitor.Web.ViewModels.Status;
 public sealed class EndpointStatusPageViewModel
 {
     public EndpointStatusSummaryViewModel Summary { get; init; } = new();
+    public int IngestPerMinute { get; init; }
+    public int DropPerMinute { get; init; }
     public EndpointStatusFiltersViewModel Filters { get; init; } = new();
     public IReadOnlyList<EndpointStatusRowViewModel> Rows { get; init; } = [];
     public IReadOnlyList<RecentEventViewModel> RecentEvents { get; init; } = [];

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -66,6 +66,8 @@
         .state-unknown { color: var(--unknown); background: #eaecf0; }
         .state-degraded { color: var(--degraded); background: #fff7e6; }
         .muted { color: var(--muted); }
+        .activity-list { margin: 0; padding-left: 1.1rem; display: grid; gap: .45rem; }
+        .activity-warning { color: var(--down); font-weight: 700; }
         .row-list { display: grid; gap: .9rem; }
         .status-row {
             border: 1px solid var(--border);
@@ -150,6 +152,14 @@
 
         @await Html.PartialAsync("_RecentEventsSection", Model)
         @await Html.PartialAsync("_SummarySection", Model)
+        
+        <section class="card">
+            <h2>System Activity</h2>
+            <ul class="activity-list">
+                <li>Ingest rate: <strong>@Model.IngestPerMinute</strong> results/min</li>
+                <li class="@(Model.DropPerMinute > 0 ? "activity-warning" : string.Empty)">Drop rate: <strong>@Model.DropPerMinute</strong> results/min</li>
+            </ul>
+        </section>
 
         <section class="card">
             <h2>Filters</h2>


### PR DESCRIPTION
### Motivation

- Provide lightweight, in-memory operational visibility of result activity by exposing ingest and drop rates on the main status page. 
- Metrics must be computed without DB queries, be thread-safe, and use a rolling 60-second window to keep cost and complexity minimal. 

### Description

- Add a singleton `IngestRateTracker` service implementing a fixed-size 60-second per-second ring buffer with thread-safe updates and deterministic window advancement (`src/WebApp/PingMonitor.Web/Services/Metrics/IngestRateTracker.cs`).
- Register the tracker as a singleton in DI (`Program.cs`) and wire `RecordIngest(...)` into the result ingestion path after an accepted batch is materialized in `ResultIngestionService` so accepted volumes are counted per-minute.
- Wire `RecordDrop(...)` into the buffered ingestion overflow handling in `BufferedResultIngestionService` so dropped results due to buffer overflow are counted per-minute.
- Expose `IngestPerMinute` and `DropPerMinute` on the status view model and populate them from the tracker in `EndpointStatusQueryService`, and add a new “System Activity” card to the main status view that highlights non-zero drop rate in a warning colour.
- Files added/modified: added `Services/Metrics/IngestRateTracker.cs`; modified `Program.cs`, `Services/ResultIngestionService.cs`, `Services/BufferedResults/BufferedResultIngestionService.cs`, `Services/Status/EndpointStatusQueryService.cs`, `ViewModels/Status/EndpointStatusPageViewModel.cs`, and `Views/Status/Index.cshtml`.
- Fixes #313

### Testing

- Automated build: installed .NET 10 and used `dotnet` SDK 10.0.104 to run `/tmp/dotnet104/dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully with the web app compiling (0 errors).
- No automated unit or integration tests were added or executed in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d101fcc1a8832ab11d65de0e40b423)