### PR TITLE
Move 3‑state theme selector into global navbar and remove status-page panel

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -38,6 +38,12 @@
         align-items: stretch;
     }
 
+    .site-nav-theme {
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+    }
+
     .site-nav details {
         position: relative;
         min-width: 160px;
@@ -210,6 +216,10 @@
                 </form>
             </div>
         </details>
+
+        <div class="site-nav-theme" aria-label="Theme selector">
+            @await Html.PartialAsync("_ThemeSelector")
+        </div>
     </div>
 </nav>
 <script>

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_ThemeSelector.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_ThemeSelector.cshtml
@@ -1,57 +1,39 @@
-<div class="theme-selector" aria-label="Dark mode selector">
-    <label for="theme-mode-select" title="On = always dark; Off = always light; System = follows your OS/browser preference.">Dark mode</label>
-    <select id="theme-mode-select" name="theme-mode" aria-describedby="theme-mode-help" title="On = always dark; Off = always light; System = follows your OS/browser preference.">
+<div class="theme-selector" aria-label="Theme mode selector">
+    <label for="theme-mode-select">Theme</label>
+    <select id="theme-mode-select" name="theme-mode" aria-label="Theme mode" title="Change theme mode">
         <option value="on">On</option>
         <option value="off">Off</option>
         <option value="system">System</option>
     </select>
-    <span id="theme-mode-help" class="theme-selector-muted">On = always dark · Off = always light · System = follows OS/browser</span>
-    <span id="theme-mode-effective" class="theme-selector-muted"></span>
 </div>
 <style>
     .theme-selector {
         display: flex;
-        align-items: flex-start;
-        gap: .5rem .6rem;
-        flex-wrap: wrap;
-        justify-content: flex-start;
-        width: fit-content;
-        max-width: 100%;
-        padding: .6rem .75rem;
+        align-items: center;
+        gap: .4rem;
+        padding: .35rem .45rem;
         border: 1px solid var(--border);
-        border-radius: 10px;
-        background: var(--card);
+        border-radius: 8px;
+        background: var(--surface-1);
         color: var(--text);
-        box-shadow: 0 1px 3px rgba(16, 24, 40, .2);
-        font-family: Arial, sans-serif;
-        font-size: .9rem;
+        font-size: .85rem;
     }
 
-    .theme-selector label { font-weight: 600; margin: 0; }
+    .theme-selector label {
+        font-weight: 700;
+        margin: 0;
+        line-height: 1;
+    }
 
     .theme-selector select {
         border: 1px solid var(--border);
-        border-radius: 8px;
-        background: var(--card);
+        border-radius: 6px;
+        background: var(--surface-1);
         color: var(--text);
-        min-height: 34px;
-        padding: .25rem .4rem;
-        font-size: .9rem;
+        min-height: 30px;
+        padding: .2rem .3rem;
+        font-size: .85rem;
         width: auto;
-    }
-
-    .theme-selector-muted {
-        color: var(--muted);
-        font-size: .8rem;
-        white-space: normal;
-        overflow-wrap: anywhere;
-        flex-basis: 100%;
-    }
-
-    @@media (min-width: 720px) {
-        .theme-selector {
-            justify-content: flex-end;
-        }
     }
 </style>
 <script>
@@ -121,10 +103,12 @@
         document.documentElement.setAttribute('data-theme-mode', mode);
         document.documentElement.setAttribute('data-theme', effectiveTheme);
 
-        if (mode === 'system') {
-            effective.textContent = 'Using ' + effectiveTheme;
-        } else {
-            effective.textContent = '';
+        if (effective) {
+            if (mode === 'system') {
+                effective.textContent = 'Using ' + effectiveTheme;
+            } else {
+                effective.textContent = '';
+            }
         }
     }
 

--- a/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/Index.cshtml
@@ -43,12 +43,6 @@
         .page-header-main h1 {
             margin-top: 0;
         }
-        .page-header-theme {
-            flex: 1 1 280px;
-            min-width: 0;
-            display: flex;
-            justify-content: flex-start;
-        }
         .summary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
         .summary-item { border: 1px solid var(--border); border-radius: 12px; padding: .85rem; }
         .summary-item strong { display: block; font-size: 1.4rem; margin-top: .25rem; }
@@ -119,10 +113,6 @@
             .page-header {
                 flex-wrap: nowrap;
             }
-            .page-header-theme {
-                flex: 0 1 auto;
-                justify-content: flex-end;
-            }
             .summary-grid { grid-template-columns: repeat(6, minmax(0, 1fr)); }
             .filter-grid { grid-template-columns: 1fr 220px 220px 220px; align-items: end; }
             .status-details > summary { padding: .95rem 1rem; }
@@ -143,9 +133,6 @@
                 <div class="page-header-main">
                     <h1>Operational endpoint status</h1>
                     <p class="muted">Current assignment-scoped status derived by the server state engine. Missing state rows are shown as <strong>UNKNOWN</strong> until trusted server-side state exists.</p>
-                </div>
-                <div class="page-header-theme">
-                    @await Html.PartialAsync("_ThemeSelector")
                 </div>
             </div>
         </section>


### PR DESCRIPTION
### Motivation
- The large theme panel on the status page consumes significant header space and is not available on other pages. 
- The theme control is a 3-state selector (On / Off / System) and needs to be globally accessible and compact. 
- Preserve existing persistence and system-following behaviour while improving navbar ergonomics and consistency.

### Description
- Render the compact theme control from the shared authenticated navigation partial by adding a right-aligned `.site-nav-theme` slot in `Views/Shared/_AuthenticatedNav.cshtml` and including `@await Html.PartialAsync("_ThemeSelector")` there. 
- Refactor the theme UI into a compact navbar-friendly selector in `Views/Shared/_ThemeSelector.cshtml` (smaller CSS, label `Theme`, native `<select>` with `On/Off/System`, ARIA/title attributes). 
- Remove the large theme panel and its layout CSS from `Views/Status/Index.cshtml` so the status header no longer contains the embedded selector. 
- Preserve exact behaviour and persistence: the same `pingmonitor.themeMode` localStorage key and `pm_theme_mode` cookie fallback remain in use, and `System` mode still uses `prefers-color-scheme` with a change listener. 
- Issue linkage: Fixes #315.

### Testing
- Attempted `dotnet --version` as an environment check, which failed because `dotnet` is not installed in this runtime (automated check: failed). 
- Attempted `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` to validate compilation, which failed due to `dotnet` not being available in the environment (automated build: failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d10e727d50832a9f664beec8563dc6)