### PR TITLE
Clean up Security logs/settings page styling for dark and light themes

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
@@ -8,12 +8,13 @@
     <title>Security logs and settings</title>
     <style>
         :root {
-            color-scheme: light;
-            --bg: #f3f6f8;
-            --card: #ffffff;
-            --text: #102a43;
-            --muted: #52606d;
-            --border: #d9e2ec;
+            --bg: var(--surface-0);
+            --card: var(--surface-1);
+            --card-alt: var(--surface-2);
+            --text: var(--text-strong);
+            --muted: var(--text-muted);
+            --border: var(--border-default);
+            --focus: var(--accent-default);
             --ok: #166534;
             --bad: #b42318;
             --warn: #9a3412;
@@ -21,29 +22,59 @@
         * { box-sizing: border-box; }
         body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
         main { max-width: 1080px; margin: 0 auto; padding: 1rem; display: grid; gap: 1rem; }
-        .card { background: var(--card); border-radius: 12px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
+        .card { background: var(--card); border: 1px solid var(--border); border-radius: 12px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
         .muted { color: var(--muted); }
         .button-row { display: flex; gap: .6rem; flex-wrap: wrap; }
-        .button-secondary, button { display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: .7rem .95rem; border: 1px solid var(--border); border-radius: 10px; background: white; color: var(--text); text-decoration: none; }
-        .button-primary { background: #0f62fe; color: white; border: 0; }
+        .button-secondary, button { display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: .7rem .95rem; border: 1px solid var(--border); border-radius: 10px; background: var(--card); color: var(--text); text-decoration: none; }
+        .button-primary { background: #0f62fe; color: #fff; border: 0; }
+        button:disabled,
+        .button-secondary[aria-disabled="true"] {
+            opacity: .7;
+            color: var(--muted);
+            border-color: var(--border);
+            cursor: not-allowed;
+        }
         .grid-two { display: grid; gap: .75rem; }
         .field { display: grid; gap: .25rem; }
         label { font-weight: 600; }
         input, select { width: 100%; min-height: 44px; border: 1px solid var(--border); border-radius: 10px; padding: .65rem; }
+        input:focus-visible, select:focus-visible, button:focus-visible, .button-secondary:focus-visible {
+            outline: 2px solid var(--focus);
+            outline-offset: 2px;
+        }
+        input[type="checkbox"] {
+            inline-size: 1rem;
+            block-size: 1rem;
+            min-height: 1rem;
+            margin: .05rem 0 0;
+            accent-color: var(--focus);
+            flex: 0 0 auto;
+        }
+        .checkbox-field {
+            display: flex;
+            align-items: flex-start;
+            gap: .5rem;
+            line-height: 1.4;
+        }
         .field-error { color: var(--bad); font-size: .88rem; }
         .saved { border: 1px solid #c2f0c2; background: #ebffee; color: var(--ok); border-radius: 10px; padding: .7rem; margin-bottom: .6rem; }
         .errors { border: 1px solid #fda29b; background: #fee4e2; color: var(--bad); border-radius: 10px; padding: .7rem; margin-bottom: .6rem; }
+        html[data-theme='dark'] .saved { background: #0f2b1c; border-color: #1f8f4b; color: #7ee2a8; }
+        html[data-theme='dark'] .errors { background: #3a1516; border-color: #d92d20; color: #ffb4af; }
         .table-wrap { overflow-x: auto; }
         table { width: 100%; border-collapse: collapse; min-width: 740px; }
         th, td { border-bottom: 1px solid var(--border); text-align: left; padding: .6rem; vertical-align: top; }
-        .log-box { border: 1px solid var(--border); border-radius: 10px; max-height: 320px; overflow-y: auto; background: #fbfdff; }
+        .log-box { border: 1px solid var(--border); border-radius: 10px; max-height: 320px; overflow-y: auto; background: var(--card-alt); }
         .log-item { padding: .7rem; border-bottom: 1px solid var(--border); font-size: .95rem; border-left: 4px solid transparent; }
         .log-item:last-child { border-bottom: 0; }
         .severity-text-info { color: #166534; font-weight: 700; }
         .severity-text-warning { color: #9a3412; font-weight: 700; }
         .severity-text-error { color: #b42318; font-weight: 700; }
+        html[data-theme='dark'] .severity-text-info { color: #7ee2a8; }
+        html[data-theme='dark'] .severity-text-warning { color: #ffd27a; }
+        html[data-theme='dark'] .severity-text-error { color: #ffb4af; }
         .entry-meta { display: grid; gap: .25rem; }
-        .empty { padding: 1rem; color: var(--muted); }
+        .empty { padding: 1rem; color: var(--muted); background: var(--card); border: 1px dashed var(--border); border-radius: 10px; margin: .75rem; }
         @@media (min-width: 840px) {
             .grid-two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
         }
@@ -170,9 +201,9 @@
                         <div class="field-error"><span asp-validation-for="SettingsForm.UserTemporaryAccountLockoutDurationMinutes"></span></div>
                     </div>
                     <div class="field">
-                        <label>
+                        <label class="checkbox-field">
                             <input asp-for="SettingsForm.SecurityLogRetentionEnabled" type="checkbox" />
-                            Enable security auth log retention
+                            <span>Enable security auth log retention</span>
                         </label>
                     </div>
                     <div class="field">
@@ -181,9 +212,9 @@
                         <div class="field-error"><span asp-validation-for="SettingsForm.SecurityLogRetentionDays"></span></div>
                     </div>
                     <div class="field">
-                        <label>
+                        <label class="checkbox-field">
                             <input asp-for="SettingsForm.SecurityLogAutoPruneEnabled" type="checkbox" />
-                            Enable automatic security auth log prune (not yet implemented)
+                            <span>Enable automatic security auth log prune (not yet implemented)</span>
                         </label>
                     </div>
                 </section>
@@ -347,15 +378,15 @@
                 <div class="field-error"><span asp-validation-for="LogFilterForm.SearchText"></span></div>
             </div>
             <div class="field">
-                <label>
+                <label class="checkbox-field">
                     <input asp-for="LogFilterForm.IncludeSuccessfulUsers" type="checkbox" />
-                    Show successful attempts (users)
+                    <span>Show successful attempts (users)</span>
                 </label>
             </div>
             <div class="field">
-                <label>
+                <label class="checkbox-field">
                     <input asp-for="LogFilterForm.IncludeSuccessfulAgents" type="checkbox" />
-                    Show successful attempts (agents)
+                    <span>Show successful attempts (agents)</span>
                 </label>
             </div>
             <div class="button-row" style="grid-column: 1 / -1;">


### PR DESCRIPTION
### Motivation
- Improve visual clarity and parity between dark and light themes on the Security logs and settings page without changing any runtime behaviour or controls.
- Address oversized checkbox appearance, low-contrast disabled/empty-state elements, and inconsistent log/alert surfaces to make the page readable in both themes.

### Description
- Updated `Views/AdminSecurity/Index.cshtml` to replace page-local color values with the shared theme tokens and to scope styling so changes remain page-specific.
- Normalized control surfaces by adding a bordered `.card`, improved focus outlines, introduced a scoped `.checkbox-field` layout, and constrained `input[type="checkbox"]` sizing to `1rem` while preserving the same checkboxes and bindings.
- Improved log and empty-state presentation by switching `.log-box` background to a theme token, adding a dashed bordered `.empty` block, and tuning severity / saved / error styles for dark-mode legibility.
- Kept all existing form actions, anti-forgery tokens, fields, filters, buttons, and routes unchanged (page-only markup/CSS edits). The modified file is `src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml` and the change is page-specific.

### Testing
- Ran `git diff --check` which returned clean results (success).
- Verified repository status with `git status --short` to confirm the changed file is staged/committed (success).
- Attempted `dotnet --version` in this environment but `dotnet` is not installed so no build/ runtime tests were executed (environment limitation).
- Created issue `#317` to track the change and linked it from the PR description (issue created successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d110fd9d4c832a9e76802eb562d651)