### PR TITLE
Clarify navbar theme selector wording to "Dark mode"

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -217,7 +217,7 @@
             </div>
         </details>
 
-        <div class="site-nav-theme" aria-label="Theme selector">
+        <div class="site-nav-theme" aria-label="Dark mode selector">
             @await Html.PartialAsync("_ThemeSelector")
         </div>
     </div>

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_ThemeSelector.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_ThemeSelector.cshtml
@@ -1,6 +1,6 @@
-<div class="theme-selector" aria-label="Theme mode selector">
-    <label for="theme-mode-select">Theme</label>
-    <select id="theme-mode-select" name="theme-mode" aria-label="Theme mode" title="Change theme mode">
+<div class="theme-selector" aria-label="Dark mode selector">
+    <label for="theme-mode-select">Dark mode</label>
+    <select id="theme-mode-select" name="theme-mode" aria-label="Dark mode" title="Change dark mode setting">
         <option value="on">On</option>
         <option value="off">Off</option>
         <option value="system">System</option>


### PR DESCRIPTION
### Motivation

- The compact navbar selector used the generic label "Theme" which is misleading because the control specifically controls dark mode preference, so visible and accessibility text should explicitly read "Dark mode".

### Description

- Updated the shared selector partial `src/WebApp/PingMonitor.Web/Views/Shared/_ThemeSelector.cshtml` to change the visible label, `aria-label`, and `title` from Theme/Theme mode to Dark mode (label: `Theme` → `Dark mode`, container `aria-label`: `Theme mode selector` → `Dark mode selector`, select `aria-label`: `Theme mode` → `Dark mode`, select `title`: `Change theme mode` → `Change dark mode setting`).
- Updated the navbar wrapper `aria-label` in `src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml` from `Theme selector` → `Dark mode selector` for consistent accessibility wording.
- No changes were made to the select option values (`on`, `off`, `system`), JavaScript, persistence, or placement, so behavior remains unchanged.
- Files modified: `src/WebApp/PingMonitor.Web/Views/Shared/_ThemeSelector.cshtml`, `src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml`.

### Testing

- Ran targeted string searches with `rg` to confirm the new wording is present and the option values remain `on`/`off`/`system`, and the checks succeeded.
- Inspected the diff via `git diff` and committed the change with `git commit`, and the commit completed successfully.
- No automated UI or browser layout tests were part of this change; GitHub CLI was not available in the execution environment so issue creation/linkage could not be performed automatically (manual linkage should be added when creating the PR on GitHub).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1128dc924832a9a502a8d55e59cc3)