### PR TITLE
Integrate default branding SVGs and use icon logo in navbar

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -112,6 +112,30 @@
         font-weight: 700;
     }
 
+    .site-nav-brand {
+        min-width: 44px;
+        width: 44px;
+        padding: .35rem;
+    }
+
+    .site-nav-brand-logo {
+        width: 26px;
+        height: 26px;
+        display: block;
+    }
+
+    .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
+
     .site-nav-shortcut[data-current="true"] {
         border-color: var(--accent);
         box-shadow: inset 0 0 0 1px var(--accent);
@@ -151,7 +175,13 @@
 </style>
 <nav class="site-nav-shell" aria-label="Primary">
     <div class="site-nav" data-site-nav>
-        <a class="site-nav-shortcut" data-current="@(path.Equals("/", StringComparison.OrdinalIgnoreCase) || path.StartsWith("/status", StringComparison.OrdinalIgnoreCase))" href="/status">Home</a>
+        <a class="site-nav-shortcut site-nav-brand"
+           data-current="@(path.Equals("/", StringComparison.OrdinalIgnoreCase) || path.StartsWith("/status", StringComparison.OrdinalIgnoreCase))"
+           href="/status"
+           aria-label="Ping Monitor home">
+            <img class="site-nav-brand-logo" src="/assets/branding/ping-monitor-logo-icon.svg" alt="" />
+            <span class="sr-only">Home</span>
+        </a>
 
         <details data-active="@monitoringOpen">
             <summary aria-controls="nav-menu-monitoring" aria-expanded="false">Monitoring <span aria-hidden="true">▾</span></summary>

--- a/src/WebApp/PingMonitor.Web/wwwroot/assets/branding/ping-monitor-logo-icon.svg
+++ b/src/WebApp/PingMonitor.Web/wwwroot/assets/branding/ping-monitor-logo-icon.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="ring" x1="20" y1="20" x2="160" y2="160" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#22D3EE"/>
+      <stop offset="1" stop-color="#22C55E"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#67E8F9"/>
+      <stop offset="1" stop-color="#4ADE80"/>
+    </linearGradient>
+    <filter id="softGlow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <circle cx="90" cy="90" r="68" stroke="url(#ring)" stroke-width="6" opacity="0.25"/>
+  <circle cx="90" cy="90" r="48" stroke="url(#ring)" stroke-width="6" opacity="0.45"/>
+  <g stroke="#2A4A5A" stroke-width="4" stroke-linecap="round">
+    <path d="M90 90 L45 50"/>
+    <path d="M90 90 L148 60"/>
+    <path d="M90 90 L155 130"/>
+    <path d="M90 90 L70 155"/>
+    <path d="M90 90 L35 105"/>
+  </g>
+  <circle cx="90" cy="90" r="16" fill="#0F172A" stroke="url(#ring)" stroke-width="5"/>
+  <circle cx="45" cy="50" r="8" fill="url(#accent)"/>
+  <circle cx="148" cy="60" r="8" fill="url(#accent)"/>
+  <circle cx="155" cy="130" r="8" fill="url(#accent)"/>
+  <circle cx="70" cy="155" r="8" fill="url(#accent)"/>
+  <circle cx="35" cy="105" r="8" fill="url(#accent)"/>
+  <path stroke="url(#ring)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" filter="url(#softGlow)"
+        d="M38 98 H62 L74 76 L87 122 L106 63 L121 98 H145"/>
+</svg>

--- a/src/WebApp/PingMonitor.Web/wwwroot/assets/branding/ping-monitor-logo.svg
+++ b/src/WebApp/PingMonitor.Web/wwwroot/assets/branding/ping-monitor-logo.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="900" height="220" viewBox="0 0 900 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="ring" x1="20" y1="20" x2="180" y2="180" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#22D3EE"/>
+      <stop offset="1" stop-color="#22C55E"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#67E8F9"/>
+      <stop offset="1" stop-color="#4ADE80"/>
+    </linearGradient>
+    <filter id="softGlow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <style>
+      .brand { font: 700 46px 'Segoe UI', Inter, Arial, sans-serif; fill: #E5EEF8; letter-spacing: 0.2px; }
+      .sub { font: 500 22px 'Segoe UI', Inter, Arial, sans-serif; fill: #9FB3C8; letter-spacing: 0.2px; }
+      .markline { stroke: url(#ring); stroke-width: 8; stroke-linecap: round; stroke-linejoin: round; }
+      .nodeline { stroke: #2A4A5A; stroke-width: 4; stroke-linecap: round; }
+      .node { fill: #0F172A; stroke: url(#ring); stroke-width: 5; }
+      .nodeSolid { fill: url(#accent); }
+    </style>
+  </defs>
+
+  <g transform="translate(20,20)">
+    <circle cx="80" cy="80" r="68" stroke="url(#ring)" stroke-width="6" opacity="0.25"/>
+    <circle cx="80" cy="80" r="48" stroke="url(#ring)" stroke-width="6" opacity="0.45"/>
+    <path class="nodeline" d="M80 80 L35 40 M80 80 L138 50 M80 80 L145 120 M80 80 L60 145 M80 80 L25 95"/>
+    <circle class="node" cx="80" cy="80" r="16"/>
+    <circle class="nodeSolid" cx="35" cy="40" r="8"/>
+    <circle class="nodeSolid" cx="138" cy="50" r="8"/>
+    <circle class="nodeSolid" cx="145" cy="120" r="8"/>
+    <circle class="nodeSolid" cx="60" cy="145" r="8"/>
+    <circle class="nodeSolid" cx="25" cy="95" r="8"/>
+    <path class="markline" filter="url(#softGlow)"
+          d="M28 88 H52 L64 66 L77 112 L96 53 L111 88 H135"/>
+  </g>
+
+  <g transform="translate(220,66)">
+    <text x="0" y="0" class="brand">Ping Monitor</text>
+    <text x="0" y="42" class="sub">by ijyates1992</text>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- Integrate the provided default branding assets into the web UI so the shell/navbar shows the new icon-only logo while keeping the full logo available for fuller-branding surfaces, without changing application behavior.
- Keep layout, navigation and accessibility intact and ensure the logo scales and balances in dark and light modes.

### Description
- Added the provided SVG files to the static assets path at `src/WebApp/PingMonitor.Web/wwwroot/assets/branding/` as `ping-monitor-logo-icon.svg` (icon) and `ping-monitor-logo.svg` (full logo) so both assets are preserved as SVGs.
- Updated the authenticated navbar (`src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml`) to replace the text-only Home shortcut with a compact icon link to `/status` that uses `/assets/branding/ping-monitor-logo-icon.svg` and includes an accessible hidden label via `.sr-only`.
- Added small presentation styles (`.site-nav-brand`, `.site-nav-brand-logo`, `.sr-only`) scoped to the shared nav to preserve spacing, alignment and visual balance in existing light/dark theme tokens, with no changes to navigation logic or app functionality.
- Issue linkage: `Fixes #322`.

### Testing
- Verified presence of the new static assets via repository file checks (`rg`/`find`) and confirmed the updated view file contains the new markup and styles.
- Attempted to run runtime checks but `dotnet` is not available in the execution environment so no build or server-side automated tests were executed.
- UI screenshot capture and live rendering tests were not performed because no browser/screenshot tooling was available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d11a04648c832aaa6a65074d522260)