### PR TITLE
Add About page and metadata-driven release identity

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/AboutController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AboutController.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Services.ApplicationMetadata;
+using PingMonitor.Web.ViewModels.About;
+
+namespace PingMonitor.Web.Controllers;
+
+[Authorize]
+[Route("about")]
+public sealed class AboutController : Controller
+{
+    private readonly IApplicationMetadataProvider _applicationMetadataProvider;
+
+    public AboutController(IApplicationMetadataProvider applicationMetadataProvider)
+    {
+        _applicationMetadataProvider = applicationMetadataProvider;
+    }
+
+    [HttpGet("")]
+    public IActionResult Index()
+    {
+        var metadata = _applicationMetadataProvider.GetSnapshot();
+        var model = new AboutPageViewModel
+        {
+            ApplicationName = metadata.ApplicationName,
+            Description = metadata.Description,
+            Attribution = metadata.Attribution,
+            Version = metadata.Version,
+            Licence = metadata.Licence,
+            RepositoryUrl = metadata.RepositoryUrl,
+            PreviewNote = metadata.PreviewNote
+        };
+
+        return View("Index", model);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Options/ApplicationMetadataOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/ApplicationMetadataOptions.cs
@@ -1,0 +1,14 @@
+namespace PingMonitor.Web.Options;
+
+public sealed class ApplicationMetadataOptions
+{
+    public const string SectionName = "ApplicationMetadata";
+
+    public string ApplicationName { get; set; } = "Ping Monitor";
+    public string Description { get; set; } = "Control-plane web application for endpoint observability and alerting.";
+    public string Attribution { get; set; } = "by ijyates1992";
+    public string Licence { get; set; } = "Licensed under GNU Affero General Public License v3 (AGPLv3)";
+    public string? RepositoryUrl { get; set; }
+    public string? PreviewNote { get; set; } = "Early preview release";
+    public string? Version { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -26,6 +26,7 @@ using PingMonitor.Web.Services.Security;
 using PingMonitor.Web.Services.SmtpNotifications;
 using PingMonitor.Web.Services.BrowserNotifications;
 using PingMonitor.Web.Services.DatabaseStatus;
+using PingMonitor.Web.Services.ApplicationMetadata;
 using PingMonitor.Web.Services.Diagnostics;
 using PingMonitor.Web.Services.Telegram;
 using PingMonitor.Web.Support;
@@ -45,6 +46,7 @@ builder.Services.Configure<AgentProvisioningOptions>(builder.Configuration.GetSe
 builder.Services.Configure<BackupOptions>(builder.Configuration.GetSection(BackupOptions.SectionName));
 builder.Services.Configure<ResultBufferOptions>(builder.Configuration.GetSection(ResultBufferOptions.SectionName));
 builder.Services.Configure<DatabaseMaintenanceOptions>(builder.Configuration.GetSection(DatabaseMaintenanceOptions.SectionName));
+builder.Services.Configure<ApplicationMetadataOptions>(builder.Configuration.GetSection(ApplicationMetadataOptions.SectionName));
 
 builder.Services.AddSingleton<IDbContextFactory<PingMonitorDbContext>, DynamicPingMonitorDbContextFactory>();
 builder.Services.AddScoped(sp => sp.GetRequiredService<IDbContextFactory<PingMonitorDbContext>>().CreateDbContext());
@@ -185,6 +187,7 @@ builder.Services.AddScoped<DevelopmentAgentSeeder>();
 builder.Services.AddScoped<IAgentPackageBuilder, AgentPackageBuilder>();
 builder.Services.AddScoped<IAgentProvisioningService, AgentProvisioningService>();
 builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsService>();
+builder.Services.AddSingleton<IApplicationMetadataProvider, ApplicationMetadataProvider>();
 builder.Services.AddScoped<IDatabaseStatusQueryService, DatabaseStatusQueryService>();
 builder.Services.AddScoped<IDatabaseMaintenanceService, DatabaseMaintenanceService>();
 builder.Services.AddScoped<INotificationSettingsService, NotificationSettingsService>();

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationMetadata/ApplicationMetadataProvider.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationMetadata/ApplicationMetadataProvider.cs
@@ -1,0 +1,80 @@
+using System.Reflection;
+using Microsoft.Extensions.Options;
+using PingMonitor.Web.Options;
+
+namespace PingMonitor.Web.Services.ApplicationMetadata;
+
+public interface IApplicationMetadataProvider
+{
+    ApplicationMetadataSnapshot GetSnapshot();
+}
+
+public sealed class ApplicationMetadataProvider : IApplicationMetadataProvider
+{
+    private const string InternalDevBuildLabel = "Internal dev build";
+
+    private readonly ApplicationMetadataOptions _options;
+
+    public ApplicationMetadataProvider(IOptions<ApplicationMetadataOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public ApplicationMetadataSnapshot GetSnapshot()
+    {
+        return new ApplicationMetadataSnapshot
+        {
+            ApplicationName = _options.ApplicationName,
+            Description = _options.Description,
+            Attribution = _options.Attribution,
+            Licence = _options.Licence,
+            RepositoryUrl = _options.RepositoryUrl,
+            PreviewNote = _options.PreviewNote,
+            Version = ResolveVersion()
+        };
+    }
+
+    private string ResolveVersion()
+    {
+        if (!string.IsNullOrWhiteSpace(_options.Version))
+        {
+            return _options.Version.Trim();
+        }
+
+        var entryAssembly = Assembly.GetEntryAssembly();
+        if (entryAssembly is null)
+        {
+            return InternalDevBuildLabel;
+        }
+
+        var informationalVersion = entryAssembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion
+            ?.Trim();
+
+        if (!string.IsNullOrWhiteSpace(informationalVersion))
+        {
+            return informationalVersion;
+        }
+
+        var assemblyVersion = entryAssembly.GetName().Version?.ToString()?.Trim();
+        if (string.IsNullOrWhiteSpace(assemblyVersion)
+            || string.Equals(assemblyVersion, "0.0.0.0", StringComparison.Ordinal))
+        {
+            return InternalDevBuildLabel;
+        }
+
+        return assemblyVersion;
+    }
+}
+
+public sealed class ApplicationMetadataSnapshot
+{
+    public string ApplicationName { get; init; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
+    public string Attribution { get; init; } = string.Empty;
+    public string Version { get; init; } = string.Empty;
+    public string Licence { get; init; } = string.Empty;
+    public string? RepositoryUrl { get; init; }
+    public string? PreviewNote { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/About/AboutPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/About/AboutPageViewModel.cs
@@ -1,0 +1,12 @@
+namespace PingMonitor.Web.ViewModels.About;
+
+public sealed class AboutPageViewModel
+{
+    public string ApplicationName { get; init; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
+    public string Attribution { get; init; } = string.Empty;
+    public string Version { get; init; } = string.Empty;
+    public string Licence { get; init; } = string.Empty;
+    public string? RepositoryUrl { get; init; }
+    public string? PreviewNote { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Views/About/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/About/Index.cshtml
@@ -1,0 +1,128 @@
+@model PingMonitor.Web.ViewModels.About.AboutPageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    @await Html.PartialAsync("_ThemeHead")
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>About</title>
+    <style>
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 760px; margin: 0 auto; padding: 1rem; }
+
+        .about-card {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 14px;
+            box-shadow: 0 1px 2px rgba(16,24,40,.08);
+            padding: 1rem;
+            display: grid;
+            gap: 1rem;
+        }
+
+        .about-head {
+            display: flex;
+            align-items: center;
+            gap: .85rem;
+            min-width: 0;
+        }
+
+        .about-logo {
+            width: 48px;
+            height: 48px;
+            flex: 0 0 48px;
+        }
+
+        .about-head h1 {
+            margin: 0;
+            font-size: 1.35rem;
+        }
+
+        .about-subtitle {
+            margin: .15rem 0 0 0;
+            color: var(--muted);
+        }
+
+        .about-note {
+            margin: 0;
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            background: var(--surface-2);
+            padding: .65rem .8rem;
+        }
+
+        .about-meta {
+            display: grid;
+            gap: .75rem;
+            margin: 0;
+        }
+
+        .about-meta > div {
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            background: var(--surface-1);
+            padding: .65rem .8rem;
+        }
+
+        .about-meta dt {
+            font-weight: 700;
+            margin: 0 0 .2rem 0;
+        }
+
+        .about-meta dd {
+            margin: 0;
+            overflow-wrap: anywhere;
+        }
+
+        @@media (min-width: 720px) {
+            .about-card {
+                padding: 1.15rem;
+            }
+
+            .about-meta {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+        }
+    </style>
+</head>
+<body>
+@await Html.PartialAsync("_AuthenticatedNav")
+<main>
+    <section class="about-card" aria-labelledby="about-title">
+        <div class="about-head">
+            <img class="about-logo" src="/assets/branding/ping-monitor-logo-icon.svg" alt="@Model.ApplicationName logo" />
+            <div>
+                <h1 id="about-title">@Model.ApplicationName</h1>
+                <p class="about-subtitle">@Model.Attribution</p>
+            </div>
+        </div>
+
+        <p>@Model.Description</p>
+
+        @if (!string.IsNullOrWhiteSpace(Model.PreviewNote))
+        {
+            <p class="about-note">@Model.PreviewNote</p>
+        }
+
+        <dl class="about-meta">
+            <div>
+                <dt>Version</dt>
+                <dd>@Model.Version</dd>
+            </div>
+            <div>
+                <dt>Licence</dt>
+                <dd>@Model.Licence</dd>
+            </div>
+            @if (!string.IsNullOrWhiteSpace(Model.RepositoryUrl))
+            {
+                <div>
+                    <dt>Project</dt>
+                    <dd><a href="@Model.RepositoryUrl" target="_blank" rel="noopener noreferrer">@Model.RepositoryUrl</a></dd>
+                </div>
+            }
+        </dl>
+    </section>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -21,6 +21,7 @@
     var eventsOpen = IsCurrent(path, "/admin/security");
     var adminOpen = IsCurrent(path, "/admin", "/users", "/settings/notifications");
     var profileOpen = IsCurrent(path, "/profile");
+    var infoOpen = IsCurrent(path, "/about");
 }
 <style>
     .site-nav-shell {
@@ -233,6 +234,14 @@
                 </div>
             </details>
         }
+
+
+        <details data-active="@infoOpen">
+            <summary aria-controls="nav-menu-info" aria-expanded="false">Info <span aria-hidden="true">▾</span></summary>
+            <div class="site-nav-dropdown" id="nav-menu-info">
+                <a class="site-nav-link" data-current="@IsCurrent(path, "/about")" href="/about">About</a>
+            </div>
+        </details>
 
         <details data-active="@profileOpen">
             <summary aria-controls="nav-menu-profile" aria-expanded="false">Profile <span aria-hidden="true">▾</span></summary>

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -61,5 +61,13 @@
   "ForwardedHeaders": {
     "KnownProxies": [],
     "KnownNetworks": []
+  },
+  "ApplicationMetadata": {
+    "ApplicationName": "Ping Monitor",
+    "Description": "Control-plane web application for endpoint observability and alerting.",
+    "Attribution": "by ijyates1992",
+    "Licence": "Licensed under GNU Affero General Public License v3 (AGPLv3)",
+    "RepositoryUrl": "https://github.com/ijyates1992/ping-monitor",
+    "PreviewNote": "Early preview release"
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a clean, discoverable About page for the preview release so the app has a proper release identity for screenshots. 
- Centralise release-facing metadata (name, logo, version, licence, attribution, repo) so values can be overridden at build time and to avoid blank/placeholder version regressions. 
- Keep the page visually consistent with the app and compatible with light/dark themes using shared layout/components.

### Description
- Add an `ApplicationMetadata` options type and an `ApplicationMetadataProvider` that resolves version in this order: `ApplicationMetadata:Version` override, assembly informational version, assembly version (unless `0.0.0.0`), then fallback to "Internal dev build". 
- Add an authenticated `AboutController`, `AboutPageViewModel`, and an `About/Index` view that displays application name, logo, description, attribution, version, licence (AGPLv3), optional preview note, and optional repository link. 
- Register the metadata options/provider in DI and add default metadata values to `appsettings.json`. 
- Add an `Info -> About` entry in the global authenticated navigation so the page is easy to discover. 
- Files added/modified: `Controllers/AboutController.cs`, `ViewModels/About/AboutPageViewModel.cs`, `Views/About/Index.cshtml`, `Options/ApplicationMetadataOptions.cs`, `Services/ApplicationMetadata/ApplicationMetadataProvider.cs`, plus changes to `Program.cs`, `appsettings.json`, and `Views/Shared/_AuthenticatedNav.cshtml`.
- Fixes #328

### Testing
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the project compiled successfully. 
- Ran `dotnet test src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj --no-build` and the test command completed with no failures reported. 
- No automated UI screenshots were captured in this environment (visual verification expected during CI or manual review).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d127951538832a81c94234fb5450f9)