### PR TITLE
docs: add build and release packaging guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Supported parameters:
 
 ## Additional documentation
 
+- Build and release packaging guide: `docs/build-and-release.md`
 - Notification setup guide (browser, SMTP, Telegram): `docs/notifications-setup.md`
 
 The script restores and builds the main .NET 10 web project, runs .NET tests when test projects exist, and performs a lightweight Python syntax check for the agent. It does **not** publish or deploy the application.

--- a/docs/build-and-release.md
+++ b/docs/build-and-release.md
@@ -1,0 +1,94 @@
+# Build and Release
+
+This project includes a PowerShell script to produce a clean, self-contained release package.
+
+The script:
+- injects version information into the application
+- builds and publishes the app as self-contained
+- packages the app, agent, docs, and sample configs
+- generates a release archive and checksum
+
+---
+
+## Requirements
+
+- Windows environment
+- PowerShell (`pwsh` or Windows PowerShell)
+- .NET SDK installed (matching project version)
+
+---
+
+## Version Format
+
+Releases must use the following strict version format:
+
+`Vx.x.x`
+
+Examples:
+- `V0.1.0`
+- `V1.2.3`
+- `V10.12.3`
+
+Invalid examples:
+- `v1.2.3`
+- `1.2.3`
+- `V1.2`
+- `V1.2.3-beta`
+
+The script will fail if the version format is invalid.
+
+---
+
+## Running the build script
+
+From the repository root, run:
+
+```powershell
+pwsh ./scripts/build.ps1 -Version V0.1.0
+```
+
+Optional runtime override:
+
+```powershell
+pwsh ./scripts/build.ps1 -Version V0.1.0 -Runtime win-x64
+```
+
+---
+
+## Output
+
+The script produces versioned output under:
+
+`artifacts/releases/`
+
+Primary release archive:
+
+`PingMonitor-V0.1.0-win-x64.zip`
+
+Release staging folder contents:
+
+- `app/`                → self-contained web application (includes agent runtime assets)
+- `docs/`               → repository documentation
+- `config-samples/`     → sample configuration files
+- `manifest.json`       → release metadata
+
+Additional generated file in `artifacts/releases/`:
+
+- `SHA256.txt`          → checksum for the generated zip
+
+---
+
+## Notes
+
+- The release is self-contained and does not require a separate .NET runtime.
+- Version information is injected during the build process.
+- If version injection is missing, the app will display `Internal dev build`.
+- The script validates required files before packaging and will fail if anything is missing.
+
+---
+
+## Tips
+
+- Always verify the generated zip before publishing.
+- Do not include private configuration files in releases.
+- Keep version numbers consistent with your release history.


### PR DESCRIPTION
### Motivation

- Provide clear, copy-pasteable instructions for producing a deterministic, self-contained release package using the existing PowerShell release script. 
- Ensure documentation matches the actual behavior and validation performed by `scripts/build.ps1` (version injection, self-contained publish, staging layout, archive and checksum generation). 

### Description

- Add `docs/build-and-release.md` containing prerequisites, strict `Vx.x.x` version rules with examples, runnable `pwsh ./scripts/build.ps1 -Version V0.1.0` usage examples, expected `artifacts/releases/` output layout, notes, and tips. 
- Update `README.md` to link the new guide from the "Additional documentation" section. 
- Documentation was written to reflect current `scripts/build.ps1` behavior (version regex, publish settings, `appsettings.json` version injection, staging layout, `manifest.json`, zip archive, and `SHA256.txt`). 
- Traceability: this change addresses the release documentation request and links the work to the corresponding issue (Fixes #332). 

### Testing

- Verified the new file exists and contains key copy-paste examples by running `test -f docs/build-and-release.md` and searching for the header and command examples, which succeeded. 
- Confirmed the documentation statements map to script behavior by grepping for the script’s version validation, staging layout, manifest and checksum generation patterns in `scripts/build.ps1`, which succeeded. 
- Verified `README.md` was updated to reference `docs/build-and-release.md` by diffing the README, which showed the added link.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d12ee74c24832a9f908f230767b850)