### PR TITLE
Fix MySQL endpoint visibility filter translation on status page

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
@@ -46,7 +46,7 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
         var isAdmin = principal is not null && await _userAccessScopeService.IsAdminAsync(principal);
         var visibleEndpointIds = isAdmin || principal is null
             ? null
-            : await _userAccessScopeService.GetVisibleEndpointIdsAsync(principal, cancellationToken);
+            : (await _userAccessScopeService.GetVisibleEndpointIdsAsync(principal, cancellationToken)).ToArray();
         var normalizedAgent = Normalize(agent);
         var normalizedGroupId = Normalize(groupId);
         var normalizedSearch = Normalize(search);


### PR DESCRIPTION
### Motivation
- The status page query can throw a MySQL EF translation/type-mapping error when a scoped (non-admin) user's visible endpoint set is used directly in a LINQ `Contains`, producing `Expression "@visibleEndpointIds" in the SQL tree does not have a type mapping assigned.`

### Description
- Materialize the scoped visibility collection to a `string[]` in `EndpointStatusQueryService.GetStatusPageAsync` (`GetVisibleEndpointIdsAsync(...).ToArray()`), making the `Contains` predicate provider-safe while preserving existing filtering semantics and linking this change to issue #336.

### Testing
- Installed the matching .NET SDK (10.0.104), ran `dotnet restore` and `dotnet build` on `src/WebApp/PingMonitor.Web`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1357a9240832aa5d3cd42450964f6)