### PR TITLE
docs: add collapsible README overview screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,29 @@ Agents collect facts. The server decides meaning.
 
 ---
 
+## 📊 Overview
+
+<img src="docs/images/status.jpeg" width="900">
+<p><em>Real-time operational status across all monitored endpoints.</em></p>
+
+<details>
+<summary>View more screenshots</summary>
+
+### 📈 Endpoint Performance
+<img src="docs/images/performance.jpeg" width="900">
+<p><em>Detailed endpoint performance trends for latency and reliability analysis.</em></p>
+
+### 🔔 Notifications
+<img src="docs/images/notifications.jpeg" width="900">
+<p><em>Centralized alert and notification history for rapid operational response.</em></p>
+
+### 🔐 Security & Protection
+<img src="docs/images/security.jpeg" width="900">
+<p><em>Security controls and safeguards to protect monitoring access and data.</em></p>
+</details>
+
+---
+
 ## Key Features
 
 ### Endpoint Monitoring


### PR DESCRIPTION
### Motivation
- Reduce README visual weight by showing one primary hero screenshot and hiding supplementary screenshots behind a collapsible block so the page remains concise and readable on GitHub.

### Description
- Added a new `## 📊 Overview` section before `## Key Features` that shows a visible hero image using `<img src="docs/images/status.jpeg" width="900">` with an italic caption and includes a `<details><summary>View more screenshots</summary>` block containing `Endpoint Performance`, `Notifications`, and `Security & Protection` sections each with sized HTML `<img src="docs/images/*.jpeg" width="900">` tags and italic captions, using `docs/images/*.jpeg` paths and no markdown image syntax; Fixes #340.

### Testing
- Performed repository checks and git operations: `rg` to search README for duplicates, `git diff -- README.md` to verify the diff, and `git commit` to record the change, all commands completed successfully and no automated unit tests were modified or required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d141010d94832ab601a9be68c1a395)