### PR TITLE
Add separate internal dev build script with auto DEV timestamp versioning

### DIFF
--- a/docs/build-and-release.md
+++ b/docs/build-and-release.md
@@ -1,12 +1,15 @@
 # Build and Release
 
-This project includes a PowerShell script to produce a clean, self-contained release package.
+This project includes PowerShell scripts to produce clean, self-contained packages.
 
-The script:
-- injects version information into the application
-- builds and publishes the app as self-contained
-- packages the app, agent, docs, and sample configs
-- generates a release archive and checksum
+- `scripts/build.ps1` is for **strict release builds**
+- `scripts/build-dev.ps1` is for **internal development/test builds only**
+
+Both scripts:
+- inject version information into the application
+- build and publish the app as self-contained
+- package the app, agent, docs, and sample configs
+- generate an archive and checksum
 
 ---
 
@@ -18,9 +21,11 @@ The script:
 
 ---
 
-## Version Format
+## Release builds (`build.ps1`)
 
-Releases must use the following strict version format:
+### Version format
+
+Release builds require a strict version format:
 
 `Vx.x.x`
 
@@ -35,13 +40,9 @@ Invalid examples:
 - `V1.2`
 - `V1.2.3-beta`
 
-The script will fail if the version format is invalid.
+The release script fails if the format is invalid.
 
----
-
-## Running the build script
-
-From the repository root, run:
+### Run release build
 
 ```powershell
 pwsh ./scripts/build.ps1 -Version V0.1.0
@@ -53,42 +54,86 @@ Optional runtime override:
 pwsh ./scripts/build.ps1 -Version V0.1.0 -Runtime win-x64
 ```
 
----
+### Release output
 
-## Output
-
-The script produces versioned output under:
+The release script produces versioned output under:
 
 `artifacts/releases/`
 
-Primary release archive:
+Primary release archive example:
 
 `PingMonitor-V0.1.0-win-x64.zip`
 
-Release staging folder contents:
+---
+
+## Internal development builds (`build-dev.ps1`)
+
+> This script is for internal dev/test packaging only. Do not use it for production releases.
+
+### Dev version behavior
+
+- Does **not** accept `-Version`
+- Automatically generates a timestamped dev version for in-app display:
+  - `DEV-DD.MM.YY-HH:MM`
+  - Example: `DEV-05.04.26-18:42`
+- Uses filename-safe variant for folder/archive names:
+  - `DEV-DD.MM.YY-HH.MM`
+  - Example: `DEV-05.04.26-18.42`
+
+### Run dev build
+
+```powershell
+pwsh ./scripts/build-dev.ps1
+```
+
+Optional runtime override:
+
+```powershell
+pwsh ./scripts/build-dev.ps1 -Runtime win-x64
+```
+
+### Dev output
+
+The dev script produces versioned output under:
+
+`artifacts/dev-releases/`
+
+Primary dev archive example:
+
+`PingMonitor-DEV-05.04.26-18.42-win-x64.zip`
+
+---
+
+## Package contents (release and dev)
+
+Generated staging folder contents:
 
 - `app/`                → self-contained web application (includes agent runtime assets)
 - `docs/`               → repository documentation
 - `config-samples/`     → sample configuration files
-- `manifest.json`       → release metadata
+- `manifest.json`       → package metadata
 
-Additional generated file in `artifacts/releases/`:
+Additional generated file in artifact root:
 
 - `SHA256.txt`          → checksum for the generated zip
+
+For dev builds, `manifest.json` includes:
+
+- `buildType: "dev"`
 
 ---
 
 ## Notes
 
-- The release is self-contained and does not require a separate .NET runtime.
+- Packages are self-contained and do not require a separate .NET runtime.
 - Version information is injected during the build process.
 - If version injection is missing, the app will display `Internal dev build`.
-- The script validates required files before packaging and will fail if anything is missing.
+- Scripts validate required files before packaging and will fail if anything is missing.
 
 ---
 
 ## Tips
 
-- Always verify the generated zip before publishing.
-- Do not include private configuration files in releases.
-- Keep version numbers consistent with your release history.
+- Always verify the generated zip before publishing or sharing.
+- Do not include private configuration files in packages.
+- Keep release version numbers consistent with your release history.

--- a/scripts/build-dev.ps1
+++ b/scripts/build-dev.ps1
@@ -1,0 +1,284 @@
+[CmdletBinding()]
+param(
+    [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9.-]*$')]
+    [string]$Runtime = 'win-x64'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host "==> $Message" -ForegroundColor Cyan
+}
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "    $Message"
+}
+
+function Fail-Build {
+    param([string]$Message)
+    Write-Error $Message
+    exit 1
+}
+
+function Invoke-External {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        Fail-Build "Command failed with exit code ${LASTEXITCODE}: $FilePath $($Arguments -join ' ')"
+    }
+}
+
+function Remove-PathIfPresent {
+    param([string]$Path)
+
+    if (Test-Path -LiteralPath $Path) {
+        Remove-Item -LiteralPath $Path -Recurse -Force
+    }
+}
+
+function Copy-DirectoryContents {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SourceDirectory,
+        [Parameter(Mandatory = $true)]
+        [string]$DestinationDirectory
+    )
+
+    New-Item -ItemType Directory -Path $DestinationDirectory -Force | Out-Null
+
+    $entries = Get-ChildItem -LiteralPath $SourceDirectory -Force
+    foreach ($entry in $entries) {
+        $targetPath = Join-Path $DestinationDirectory $entry.Name
+        if ($entry.PSIsContainer) {
+            Copy-Item -LiteralPath $entry.FullName -Destination $targetPath -Recurse -Force
+            continue
+        }
+
+        Copy-Item -LiteralPath $entry.FullName -Destination $targetPath -Force
+    }
+}
+
+$buildTimestamp = Get-Date
+$displayVersion = $buildTimestamp.ToString('dd.MM.yy-HH:mm')
+$fileVersion = $buildTimestamp.ToString('dd.MM.yy-HH.mm')
+$devVersionDisplay = "DEV-$displayVersion"
+$devVersionFileSafe = "DEV-$fileVersion"
+$buildTimestampUtc = [DateTimeOffset]::UtcNow.ToString('o')
+
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $scriptDirectory '..')).Path
+Set-Location $repoRoot
+
+$webProjectPath = Join-Path $repoRoot 'src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj'
+$docsPath = Join-Path $repoRoot 'docs'
+$configSampleSpecs = @(
+    @{ Source = Join-Path $repoRoot 'src/WebApp/PingMonitor.Web/appsettings.json'; Target = 'webapp.appsettings.json' },
+    @{ Source = Join-Path $repoRoot 'src/Agent/.env.example'; Target = 'agent.env.example' }
+)
+
+$releaseRoot = Join-Path $repoRoot 'artifacts/dev-releases'
+$publishRoot = Join-Path $releaseRoot 'publish'
+$packageBaseName = "PingMonitor-$devVersionFileSafe-$Runtime"
+$stagingRoot = Join-Path $releaseRoot $packageBaseName
+$publishOutputPath = Join-Path $publishRoot $Runtime
+$zipPath = Join-Path $releaseRoot "$packageBaseName.zip"
+$checksumPath = Join-Path $releaseRoot 'SHA256.txt'
+$manifestPath = Join-Path $stagingRoot 'manifest.json'
+
+if (-not (Test-Path -LiteralPath $webProjectPath)) {
+    Fail-Build "Expected web project was not found at '$webProjectPath'."
+}
+
+$dotnetCommand = Get-Command dotnet -ErrorAction SilentlyContinue
+if (-not $dotnetCommand) {
+    Fail-Build 'The dotnet CLI is required but was not found on PATH.'
+}
+
+$gitCommand = Get-Command git -ErrorAction SilentlyContinue
+$commitHash = $null
+if ($gitCommand) {
+    $gitStatus = & $gitCommand.Source status --porcelain
+    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace(($gitStatus -join ''))) {
+        Write-Warning 'Git working tree is not clean. Dev artifacts will include uncommitted changes.'
+    }
+
+    $resolvedCommitHash = & $gitCommand.Source rev-parse --short=12 HEAD
+    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($resolvedCommitHash)) {
+        $commitHash = $resolvedCommitHash.Trim()
+    }
+}
+
+Write-Step 'Starting internal dev packaging'
+Write-Info "Repository root: $repoRoot"
+Write-Info "Dev version (display): $devVersionDisplay"
+Write-Info "Dev version (file-safe): $devVersionFileSafe"
+Write-Info "Runtime: $Runtime"
+Write-Info "Package: $packageBaseName"
+
+Write-Step 'Cleaning previous dev build output'
+Remove-PathIfPresent -Path $publishRoot
+Remove-PathIfPresent -Path $stagingRoot
+Remove-PathIfPresent -Path $zipPath
+Remove-PathIfPresent -Path $checksumPath
+New-Item -ItemType Directory -Path $publishRoot -Force | Out-Null
+New-Item -ItemType Directory -Path $releaseRoot -Force | Out-Null
+
+Write-Step 'Restoring and publishing web app (self-contained)'
+Invoke-External -FilePath $dotnetCommand.Source -Arguments @('restore', $webProjectPath)
+Invoke-External -FilePath $dotnetCommand.Source -Arguments @(
+    'publish',
+    $webProjectPath,
+    '--configuration', 'Release',
+    '--runtime', $Runtime,
+    '--self-contained', 'true',
+    '--output', $publishOutputPath,
+    "/p:Version=0.0.0-dev",
+    "/p:AssemblyVersion=0.0.0.0",
+    "/p:FileVersion=0.0.0.0",
+    "/p:InformationalVersion=$devVersionFileSafe",
+    '/p:ContinuousIntegrationBuild=true'
+)
+
+Write-Step 'Validating required source assets'
+if (-not (Test-Path -LiteralPath $docsPath -PathType Container)) {
+    Fail-Build "Required docs folder not found at '$docsPath'."
+}
+
+foreach ($sample in $configSampleSpecs) {
+    if (-not (Test-Path -LiteralPath $sample.Source -PathType Leaf)) {
+        Fail-Build "Required config sample file not found at '$($sample.Source)'."
+    }
+}
+
+Write-Step 'Validating publish output'
+if (-not (Test-Path -LiteralPath $publishOutputPath -PathType Container)) {
+    Fail-Build "Publish output directory was not created at '$publishOutputPath'."
+}
+
+$publishedFiles = Get-ChildItem -LiteralPath $publishOutputPath -Recurse -File
+if ($publishedFiles.Count -eq 0) {
+    Fail-Build "Publish output directory '$publishOutputPath' is empty."
+}
+
+if ($Runtime -like 'win-*') {
+    $expectedExecutablePath = Join-Path $publishOutputPath 'PingMonitor.Web.exe'
+    if (-not (Test-Path -LiteralPath $expectedExecutablePath -PathType Leaf)) {
+        Fail-Build "Expected self-contained executable not found at '$expectedExecutablePath'."
+    }
+}
+
+$requiredAgentAssets = @(
+    'Agent/README.md',
+    'Agent/requirements.txt',
+    'Agent/run-agent.cmd',
+    'Agent/app/main.py'
+)
+
+foreach ($relativeAssetPath in $requiredAgentAssets) {
+    $assetPath = Join-Path $publishOutputPath $relativeAssetPath
+    if (-not (Test-Path -LiteralPath $assetPath -PathType Leaf)) {
+        Fail-Build "Required agent deployment asset missing from publish output: '$relativeAssetPath'."
+    }
+}
+
+Write-Step 'Injecting internal dev version into app metadata source'
+$appSettingsPath = Join-Path $publishOutputPath 'appsettings.json'
+if (-not (Test-Path -LiteralPath $appSettingsPath -PathType Leaf)) {
+    Fail-Build "Published appsettings.json was not found at '$appSettingsPath'."
+}
+
+$appSettings = Get-Content -LiteralPath $appSettingsPath -Raw | ConvertFrom-Json
+if (-not $appSettings.ApplicationMetadata) {
+    $appSettings | Add-Member -NotePropertyName 'ApplicationMetadata' -NotePropertyValue ([PSCustomObject]@{})
+}
+
+if (-not ($appSettings.ApplicationMetadata.PSObject.Properties.Name -contains 'Version')) {
+    $appSettings.ApplicationMetadata | Add-Member -NotePropertyName 'Version' -NotePropertyValue $devVersionDisplay
+} else {
+    $appSettings.ApplicationMetadata.Version = $devVersionDisplay
+}
+$appSettings | ConvertTo-Json -Depth 100 | Set-Content -LiteralPath $appSettingsPath -Encoding UTF8NoBOM
+
+$injectedSettings = Get-Content -LiteralPath $appSettingsPath -Raw | ConvertFrom-Json
+if (-not $injectedSettings.ApplicationMetadata -or $injectedSettings.ApplicationMetadata.Version -ne $devVersionDisplay) {
+    Fail-Build 'Version injection failed. ApplicationMetadata.Version was not updated as expected.'
+}
+
+if (-not $devVersionDisplay.StartsWith('DEV-')) {
+    Fail-Build 'Dev build version safety check failed. Generated version is not clearly marked as DEV-*.'
+}
+
+Write-Step 'Building dev staging layout'
+$appStagingPath = Join-Path $stagingRoot 'app'
+$docsStagingPath = Join-Path $stagingRoot 'docs'
+$configSamplesStagingPath = Join-Path $stagingRoot 'config-samples'
+
+New-Item -ItemType Directory -Path $stagingRoot -Force | Out-Null
+Copy-DirectoryContents -SourceDirectory $publishOutputPath -DestinationDirectory $appStagingPath
+Copy-DirectoryContents -SourceDirectory $docsPath -DestinationDirectory $docsStagingPath
+New-Item -ItemType Directory -Path $configSamplesStagingPath -Force | Out-Null
+foreach ($sample in $configSampleSpecs) {
+    Copy-Item -LiteralPath $sample.Source -Destination (Join-Path $configSamplesStagingPath $sample.Target) -Force
+}
+
+$manifest = [ordered]@{
+    appName = 'Ping Monitor'
+    version = $devVersionDisplay
+    packageVersion = $devVersionFileSafe
+    buildType = 'dev'
+    buildTimestampUtc = $buildTimestampUtc
+    packageFileName = "$packageBaseName.zip"
+    runtime = $Runtime
+    commitHash = $commitHash
+}
+
+$manifest | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $manifestPath -Encoding UTF8NoBOM
+
+if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+    Fail-Build "manifest.json was not created at '$manifestPath'."
+}
+
+if (-not (Test-Path -LiteralPath $appStagingPath -PathType Container)) {
+    Fail-Build "Staging app directory missing at '$appStagingPath'."
+}
+
+if (-not (Test-Path -LiteralPath $docsStagingPath -PathType Container)) {
+    Fail-Build "Staging docs directory missing at '$docsStagingPath'."
+}
+
+if (-not (Test-Path -LiteralPath $configSamplesStagingPath -PathType Container)) {
+    Fail-Build "Staging config-samples directory missing at '$configSamplesStagingPath'."
+}
+
+Write-Step 'Creating dev archive'
+Compress-Archive -Path $stagingRoot -DestinationPath $zipPath -CompressionLevel Optimal
+if (-not (Test-Path -LiteralPath $zipPath -PathType Leaf)) {
+    Fail-Build "Dev archive was not created at '$zipPath'."
+}
+
+Write-Step 'Generating checksum metadata'
+$hashInfo = Get-FileHash -LiteralPath $zipPath -Algorithm SHA256
+"$($hashInfo.Hash)  $($packageBaseName).zip" | Set-Content -LiteralPath $checksumPath -Encoding UTF8NoBOM
+
+if (-not (Test-Path -LiteralPath $checksumPath -PathType Leaf)) {
+    Fail-Build "Checksum file was not created at '$checksumPath'."
+}
+
+Write-Step 'Dev package completed successfully'
+Write-Info "Staging root: $stagingRoot"
+Write-Info "Dev zip: $zipPath"
+Write-Info "Manifest: $manifestPath"
+Write-Info "Checksum: $checksumPath"
+Write-Info "Commit hash: $($commitHash ?? 'unavailable')"
+
+exit 0


### PR DESCRIPTION
### Motivation
- Provide a dedicated, safe internal development packaging flow that is distinct from the strict release process so internal builds cannot be mistaken for formal releases.
- Automatically generate a clear, timestamped DEV version for in‑app display and use a filename-safe variant for packages to make each dev build easily identifiable.
- Keep release semantics unchanged and avoid exposing the release `-Version` validation to internal builds.

### Description
- Add `scripts/build-dev.ps1` implementing an internal-only packaging flow that does not accept `-Version`, auto-generates `DEV-DD.MM.YY-HH:MM` for in-app display and `DEV-DD.MM.YY-HH.MM` for filenames, injects the display version into `appsettings.json`, publishes a self-contained app, stages `app/`, `docs/`, `config-samples/`, writes `manifest.json` (including `buildType: "dev"`), generates `SHA256.txt`, and produces a zip under `artifacts/dev-releases/` (package name example: `PingMonitor-DEV-05.04.26-18.42-win-x64.zip`).
- Update `docs/build-and-release.md` to document the new `build-dev.ps1` behavior and to distinguish release builds (`scripts/build.ps1` with strict `Vx.x.x` validation) from internal dev builds.
- Ensure safety measures so dev packages are clearly labeled and separate from releases by using a different output root, filename conventions, and a DEV prefix verification before packaging.
- Files added/modified: added `scripts/build-dev.ps1` and modified `docs/build-and-release.md`; this change addresses issue `#344` (Fixes #344).

### Testing
- Static/script validation: verified `scripts/build-dev.ps1` exists, its parameter surface does not include `-Version`, and the dev version strings (`devVersionDisplay` and `devVersionFileSafe`) are generated from the current timestamp; these checks succeeded.
- Content validation: grepped and inspected the updated docs and script to confirm doc text and manifest field `buildType: "dev"` were added; this verification succeeded.
- Commit/packaging readiness: staged and committed the new files in the repository to confirm no local file errors; this step succeeded.
- Tooling run limitation: attempted to run `pwsh`/`dotnet` checks in the environment but `pwsh`/`dotnet` were not installed, so a full publish/package execution could not be performed here; that validation is therefore pending in an environment with PowerShell and .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2499a6030832aa953ad888b8e6755)