### PR TITLE
Fix MySQL status-page visibility filter type mapping exception

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Status/EndpointStatusQueryService.cs
@@ -7,6 +7,7 @@ using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.Services.EventLogs;
 using PingMonitor.Web.Services.Diagnostics;
 using PingMonitor.Web.ViewModels.Status;
+using System.Linq.Expressions;
 
 namespace PingMonitor.Web.Services.Status;
 
@@ -55,7 +56,7 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
         var assignments = _dbContext.MonitorAssignments.AsNoTracking();
         if (visibleEndpointIds is not null)
         {
-            assignments = assignments.Where(assignment => visibleEndpointIds.Contains(assignment.EndpointId));
+            assignments = ApplyVisibleEndpointFilter(assignments, visibleEndpointIds);
         }
 
         var baseQuery =
@@ -264,6 +265,29 @@ internal sealed class EndpointStatusQueryService : IEndpointStatusQueryService
             Rows = rowsWithMetrics,
             RecentEvents = await _eventLogQueryService.GetRecentEventsAsync(50, cancellationToken)
         };
+    }
+
+    private static IQueryable<MonitorAssignment> ApplyVisibleEndpointFilter(
+        IQueryable<MonitorAssignment> assignments,
+        IReadOnlyCollection<string> visibleEndpointIds)
+    {
+        if (visibleEndpointIds.Count == 0)
+        {
+            return assignments.Where(static _ => false);
+        }
+
+        var parameter = Expression.Parameter(typeof(MonitorAssignment), "assignment");
+        var endpointId = Expression.Property(parameter, nameof(MonitorAssignment.EndpointId));
+        Expression? combinedPredicate = null;
+
+        foreach (var visibleEndpointId in visibleEndpointIds)
+        {
+            var equals = Expression.Equal(endpointId, Expression.Constant(visibleEndpointId));
+            combinedPredicate = combinedPredicate is null ? equals : Expression.OrElse(combinedPredicate, equals);
+        }
+
+        var lambda = Expression.Lambda<Func<MonitorAssignment, bool>>(combinedPredicate!, parameter);
+        return assignments.Where(lambda);
     }
 
     private static string? Normalize(string? value)


### PR DESCRIPTION
### Motivation
- The status page could throw `System.InvalidOperationException: Expression '@visibleEndpointIds' in the SQL tree does not have a type mapping assigned.` when a non-admin user's visibility set was applied, breaking `/` rendering. 
- The failure is caused by passing a primitive collection into a LINQ `Contains` predicate which the MySQL EF provider failed to translate, so a provider-safe query form is required.

### Description
- Replace `assignments.Where(assignment => visibleEndpointIds.Contains(assignment.EndpointId))` with a provider-safe predicate builder implemented as `ApplyVisibleEndpointFilter`, which expands the allowed endpoint IDs into explicit equality `OR` predicates using `System.Linq.Expressions`.
- The new method returns `WHERE false` for empty visibility sets to preserve fail-safe behavior where scoped users see nothing when they have no endpoints.
- This change targets the query path in `EndpointStatusQueryService.GetStatusPageAsync` and preserves existing semantics for admin and scoped users.  
- Fixes #346 and includes a deterministic before/after checklist for regression proof in the PR metadata.

### Testing
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the build succeeded (output: `PingMonitor.Web -> .../bin/Debug/net10.0/PingMonitor.Web.dll`).
- Verified the project compiles with the installed .NET SDK matching `global.json` (`10.0.104`).
- No unit tests were added or executed in this change; the build is the automated validation performed and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d252d84a6c832a8e3244c797494d10)