### PR TITLE
Show configured Telegram bot identity in account linking instructions

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
@@ -23,6 +23,7 @@ public sealed class ProfileController : Controller
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly IUserNotificationSettingsService _userNotificationSettingsService;
     private readonly ITelegramLinkService _telegramLinkService;
+    private readonly INotificationSettingsService _notificationSettingsService;
     private readonly ISmtpNotificationSender _smtpNotificationSender;
     private readonly IEventLogService _eventLogService;
     private readonly ILogger<ProfileController> _logger;
@@ -31,6 +32,7 @@ public sealed class ProfileController : Controller
         UserManager<ApplicationUser> userManager,
         IUserNotificationSettingsService userNotificationSettingsService,
         ITelegramLinkService telegramLinkService,
+        INotificationSettingsService notificationSettingsService,
         ISmtpNotificationSender smtpNotificationSender,
         IEventLogService eventLogService,
         ILogger<ProfileController> logger)
@@ -38,6 +40,7 @@ public sealed class ProfileController : Controller
         _userManager = userManager;
         _userNotificationSettingsService = userNotificationSettingsService;
         _telegramLinkService = telegramLinkService;
+        _notificationSettingsService = notificationSettingsService;
         _smtpNotificationSender = smtpNotificationSender;
         _eventLogService = eventLogService;
         _logger = logger;
@@ -297,8 +300,11 @@ public sealed class ProfileController : Controller
         }
 
         var settings = await _userNotificationSettingsService.GetCurrentAsync(user.Id, cancellationToken);
+        var telegramChannel = await _notificationSettingsService.GetTelegramChannelAsync(cancellationToken);
         var pendingCode = await _telegramLinkService.GetActiveCodeAsync(user.Id, cancellationToken);
         var telegramAccount = await _telegramLinkService.GetAccountStatusAsync(user.Id, cancellationToken);
+        var telegramLinkingAvailable = telegramChannel.TelegramEnabled && !string.IsNullOrWhiteSpace(telegramChannel.TelegramBotToken);
+        var telegramBotIdentifier = ResolveTelegramBotIdentifier(telegramChannel.TelegramBotToken);
         return new ProfilePageViewModel
         {
             UserName = user.UserName ?? string.Empty,
@@ -334,8 +340,31 @@ public sealed class ProfileController : Controller
             TelegramLinkedChatId = telegramAccount?.ChatId,
             TelegramLinkedUsername = telegramAccount?.Username,
             TelegramLinkedDisplayName = telegramAccount?.DisplayName,
-            TelegramLinkedAtUtc = telegramAccount?.LinkedAtUtc
+            TelegramLinkedAtUtc = telegramAccount?.LinkedAtUtc,
+            TelegramLinkingAvailable = telegramLinkingAvailable,
+            TelegramBotIdentifier = telegramBotIdentifier
         };
+    }
+
+    private static string? ResolveTelegramBotIdentifier(string? telegramBotToken)
+    {
+        if (string.IsNullOrWhiteSpace(telegramBotToken))
+        {
+            return null;
+        }
+
+        var trimmedToken = telegramBotToken.Trim();
+        var delimiterIndex = trimmedToken.IndexOf(':');
+        if (delimiterIndex > 0)
+        {
+            var possibleBotId = trimmedToken[..delimiterIndex];
+            if (possibleBotId.All(char.IsDigit))
+            {
+                return $"bot ID {possibleBotId}";
+            }
+        }
+
+        return "configured Telegram bot";
     }
 
     private async Task<SmtpNotificationSendResult> SendVerificationEmailAsync(ApplicationUser user, CancellationToken cancellationToken)

--- a/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
@@ -55,6 +55,8 @@ public sealed class ProfilePageViewModel
     public DateTimeOffset? TelegramLinkedAtUtc { get; set; }
     public bool TelegramCodeGenerated { get; set; }
     public bool TelegramAccountRemoved { get; set; }
+    public bool TelegramLinkingAvailable { get; set; }
+    public string? TelegramBotIdentifier { get; set; }
     public bool EmailVerificationResendSucceeded { get; set; }
     public string? EmailVerificationMessage { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/Views/Profile/NotificationSettings.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Profile/NotificationSettings.cshtml
@@ -83,7 +83,22 @@
 
 <section class="card stack">
     <h2>Telegram account linking</h2>
-    <p class="muted">Generate a verification code, send it to the bot in a private chat, and wait for confirmation.</p>
+    @if (Model.TelegramLinkingAvailable)
+    {
+        var botIdentifier = Model.TelegramBotIdentifier;
+        if (!string.IsNullOrWhiteSpace(botIdentifier)
+            && !botIdentifier.StartsWith("bot ID ", StringComparison.OrdinalIgnoreCase)
+            && !botIdentifier.StartsWith("@", StringComparison.Ordinal))
+        {
+            botIdentifier = $"@{botIdentifier}";
+        }
+
+        <p class="muted">Generate a verification code, send it to <strong>@botIdentifier</strong> in a private chat, and wait for confirmation.</p>
+    }
+    else
+    {
+        <p class="muted">Telegram account linking is unavailable because Telegram bot settings have not been configured yet.</p>
+    }
     @if (Model.TelegramCodeGenerated) { <div class="saved">A new Telegram link code was generated.</div> }
     @if (Model.TelegramAccountRemoved) { <div class="saved">Telegram account removed.</div> }
     @if (!string.IsNullOrWhiteSpace(Model.ActiveTelegramCode))


### PR DESCRIPTION
### Motivation
- The profile Telegram linking instructions currently say only “the bot” which is unclear to users and can cause confusion when multiple bots exist. 
- The intent is to show a clear, non-secret bot identifier in the linking instructions when Telegram infrastructure is configured, and a clear fallback when it is not.

### Description
- Populate the profile view model with `TelegramLinkingAvailable` and `TelegramBotIdentifier` and resolve bot identity from existing Telegram channel settings without exposing secrets. 
- `ProfileController` now reads channel settings via `INotificationSettingsService.GetTelegramChannelAsync(...)` and derives a safe identifier (e.g. `bot ID <id>` when the token contains a numeric prefix, otherwise `configured Telegram bot`).
- The profile view `NotificationSettings.cshtml` renders conditional copy: when available it reads "Generate a verification code, send it to <bot identifier> in a private chat...", otherwise it shows a clear unavailable message. 
- Files modified: `src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs`, `src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs`, and `src/WebApp/PingMonitor.Web/Views/Profile/NotificationSettings.cshtml`; this change keeps existing linking actions (`GenerateTelegramCode` / `RemoveTelegramAccount`) unchanged and links this PR to the issue with `Fixes #348`.

### Testing
- Built the web project with the .NET SDK using `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which completed successfully. 
- No unit tests were changed or required for this UI-only behavior and no automated UI screenshots were produced in this environment. 
- Manual verification steps: load `/profile/notification-settings` with Telegram configured and not configured to confirm the instruction text behaves as described and no secrets (bot token) are rendered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d27ca6b160832ab12c43c642eb79df)