### PR TITLE
Show configured Telegram bot identity in account-linking instructions

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
@@ -22,7 +22,9 @@ public sealed class ProfileController : Controller
 {
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly IUserNotificationSettingsService _userNotificationSettingsService;
+    private readonly INotificationSettingsService _notificationSettingsService;
     private readonly ITelegramLinkService _telegramLinkService;
+    private readonly ITelegramBotIdentityResolver _telegramBotIdentityResolver;
     private readonly ISmtpNotificationSender _smtpNotificationSender;
     private readonly IEventLogService _eventLogService;
     private readonly ILogger<ProfileController> _logger;
@@ -30,14 +32,18 @@ public sealed class ProfileController : Controller
     public ProfileController(
         UserManager<ApplicationUser> userManager,
         IUserNotificationSettingsService userNotificationSettingsService,
+        INotificationSettingsService notificationSettingsService,
         ITelegramLinkService telegramLinkService,
+        ITelegramBotIdentityResolver telegramBotIdentityResolver,
         ISmtpNotificationSender smtpNotificationSender,
         IEventLogService eventLogService,
         ILogger<ProfileController> logger)
     {
         _userManager = userManager;
         _userNotificationSettingsService = userNotificationSettingsService;
+        _notificationSettingsService = notificationSettingsService;
         _telegramLinkService = telegramLinkService;
+        _telegramBotIdentityResolver = telegramBotIdentityResolver;
         _smtpNotificationSender = smtpNotificationSender;
         _eventLogService = eventLogService;
         _logger = logger;
@@ -297,8 +303,14 @@ public sealed class ProfileController : Controller
         }
 
         var settings = await _userNotificationSettingsService.GetCurrentAsync(user.Id, cancellationToken);
+        var telegramChannelSettings = await _notificationSettingsService.GetTelegramChannelAsync(cancellationToken);
         var pendingCode = await _telegramLinkService.GetActiveCodeAsync(user.Id, cancellationToken);
         var telegramAccount = await _telegramLinkService.GetAccountStatusAsync(user.Id, cancellationToken);
+        var telegramLinkingAvailable = telegramChannelSettings.TelegramEnabled && !string.IsNullOrWhiteSpace(telegramChannelSettings.TelegramBotToken);
+        var telegramBotIdentifier = telegramLinkingAvailable
+            ? await _telegramBotIdentityResolver.ResolveBotIdentifierAsync(telegramChannelSettings.TelegramBotToken!, cancellationToken)
+            : null;
+
         return new ProfilePageViewModel
         {
             UserName = user.UserName ?? string.Empty,
@@ -334,7 +346,9 @@ public sealed class ProfileController : Controller
             TelegramLinkedChatId = telegramAccount?.ChatId,
             TelegramLinkedUsername = telegramAccount?.Username,
             TelegramLinkedDisplayName = telegramAccount?.DisplayName,
-            TelegramLinkedAtUtc = telegramAccount?.LinkedAtUtc
+            TelegramLinkedAtUtc = telegramAccount?.LinkedAtUtc,
+            TelegramLinkingAvailable = telegramLinkingAvailable,
+            TelegramBotIdentifier = telegramBotIdentifier
         };
     }
 

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -196,6 +196,7 @@ builder.Services.AddScoped<INotificationSuppressionService, NotificationSuppress
 builder.Services.AddScoped<ISmtpNotificationSender, SmtpNotificationSender>();
 builder.Services.AddScoped<IBrowserNotificationQueryService, BrowserNotificationQueryService>();
 builder.Services.AddScoped<ITelegramLinkService, TelegramLinkService>();
+builder.Services.AddScoped<ITelegramBotIdentityResolver, TelegramBotIdentityResolver>();
 builder.Services.AddScoped<ITelegramMessageProcessor, TelegramMessageProcessor>();
 builder.Services.AddScoped<ITelegramPollingService, TelegramPollingService>();
 builder.Services.AddScoped<ITelegramNotificationSender, TelegramNotificationSender>();

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/ITelegramBotIdentityResolver.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/ITelegramBotIdentityResolver.cs
@@ -1,0 +1,6 @@
+namespace PingMonitor.Web.Services.Telegram;
+
+public interface ITelegramBotIdentityResolver
+{
+    Task<string?> ResolveBotIdentifierAsync(string botToken, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramBotIdentityResolver.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramBotIdentityResolver.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+
+namespace PingMonitor.Web.Services.Telegram;
+
+internal sealed class TelegramBotIdentityResolver : ITelegramBotIdentityResolver
+{
+    private readonly ILogger<TelegramBotIdentityResolver> _logger;
+    private readonly HttpClient _httpClient = new();
+
+    public TelegramBotIdentityResolver(ILogger<TelegramBotIdentityResolver> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<string?> ResolveBotIdentifierAsync(string botToken, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(botToken))
+        {
+            return null;
+        }
+
+        var trimmedToken = botToken.Trim();
+        var fallbackBotId = TryExtractBotId(trimmedToken);
+        var fallbackIdentifier = fallbackBotId is not null
+            ? $"bot ID {fallbackBotId}"
+            : "configured Telegram bot";
+
+        var url = $"https://api.telegram.org/bot{trimmedToken}/getMe";
+        try
+        {
+            using var response = await _httpClient.GetAsync(url, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Telegram getMe returned status code {StatusCode}. Falling back to configured bot identifier.", (int)response.StatusCode);
+                return fallbackIdentifier;
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+            if (!document.RootElement.TryGetProperty("result", out var result) || result.ValueKind != JsonValueKind.Object)
+            {
+                return fallbackIdentifier;
+            }
+
+            var username = result.TryGetProperty("username", out var usernameElement) ? usernameElement.GetString() : null;
+            if (!string.IsNullOrWhiteSpace(username))
+            {
+                return username.StartsWith('@') ? username : $"@{username}";
+            }
+
+            return fallbackIdentifier;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Telegram getMe request failed while resolving bot identity. Falling back to configured bot identifier.");
+            return fallbackIdentifier;
+        }
+    }
+
+    private static string? TryExtractBotId(string token)
+    {
+        var separatorIndex = token.IndexOf(':');
+        if (separatorIndex <= 0)
+        {
+            return null;
+        }
+
+        var candidate = token[..separatorIndex];
+        foreach (var character in candidate)
+        {
+            if (!char.IsDigit(character))
+            {
+                return null;
+            }
+        }
+
+        return candidate;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
@@ -55,6 +55,8 @@ public sealed class ProfilePageViewModel
     public DateTimeOffset? TelegramLinkedAtUtc { get; set; }
     public bool TelegramCodeGenerated { get; set; }
     public bool TelegramAccountRemoved { get; set; }
+    public bool TelegramLinkingAvailable { get; set; }
+    public string? TelegramBotIdentifier { get; set; }
     public bool EmailVerificationResendSucceeded { get; set; }
     public string? EmailVerificationMessage { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/Views/Profile/NotificationSettings.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Profile/NotificationSettings.cshtml
@@ -83,7 +83,21 @@
 
 <section class="card stack">
     <h2>Telegram account linking</h2>
-    <p class="muted">Generate a verification code, send it to the bot in a private chat, and wait for confirmation.</p>
+    @if (Model.TelegramLinkingAvailable)
+    {
+        if (!string.IsNullOrWhiteSpace(Model.TelegramBotIdentifier))
+        {
+            <p class="muted">Generate a verification code, send it to <strong>@Model.TelegramBotIdentifier</strong> in a private chat, and wait for confirmation.</p>
+        }
+        else
+        {
+            <p class="muted">Generate a verification code, send it to the configured Telegram bot in a private chat, and wait for confirmation.</p>
+        }
+    }
+    else
+    {
+        <p class="muted">Telegram account linking is unavailable because Telegram bot settings have not been configured yet.</p>
+    }
     @if (Model.TelegramCodeGenerated) { <div class="saved">A new Telegram link code was generated.</div> }
     @if (Model.TelegramAccountRemoved) { <div class="saved">Telegram account removed.</div> }
     @if (!string.IsNullOrWhiteSpace(Model.ActiveTelegramCode))


### PR DESCRIPTION
### Motivation
- The Telegram account-linking instructions were ambiguous because they asked users to send a code to "the bot" without naming which bot is configured, forcing admins/users to inspect settings to learn the bot identity. 
- The intent is to improve UX by clearly showing a safe, user-friendly bot identifier (prefer `@username`) when Telegram infrastructure is configured, and to show a clear unavailable message when it is not.

### Description
- Added a lightweight bot identity resolver service (`ITelegramBotIdentityResolver` + `TelegramBotIdentityResolver`) that calls the Telegram Bot API `getMe` to prefer `@username` and falls back to a non-secret identifier derived from the token (numeric bot ID prefix) or a generic label when username resolution fails. 
- Updated `ProfileController.BuildModelAsync` to fetch Telegram channel settings, determine linking availability (`TelegramEnabled` + token present), resolve a display-safe bot identifier, and pass `TelegramLinkingAvailable` and `TelegramBotIdentifier` into the profile view model. 
- Extended `ProfilePageViewModel` with `TelegramLinkingAvailable` and `TelegramBotIdentifier`, and updated the `/profile/notification-settings` Razor view to show either the resolved `@BotUsername`, a safe fallback text, or a clear "linking is unavailable" message when Telegram is not configured. 
- Registered the resolver in DI and kept all existing linking flow endpoints and behavior unchanged; no secrets (bot token) are rendered in the UI. 
- Fixes the related issue: closes #351.

### Testing
- Performed code search/inspection to confirm new symbols and view changes with `rg`/`sed` and verified the modified files are present and wired into the controller and DI. (succeeded)
- Committed the changes and created the issue referenced by this work (issue #351). (succeeded)
- Attempted to run `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` in the current execution environment but `dotnet` was not available, so a full build/CI run could not be executed here; a local or CI build is expected and should be run before merge. (failed in this environment)
- No automated unit/integration tests were executed in this environment; please run the repository's test/build pipeline (including `dotnet build` and any test suites) in CI to validate compilation and behavior prior to merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2b709c2e4832a94ab3ccf561395eb)