### PR TITLE
Database backups: add upload, restore (with pre-restore), and delete to DB maintenance

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/AdminDatabaseController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminDatabaseController.cs
@@ -141,6 +141,112 @@ public sealed class AdminDatabaseController : Controller
         return RedirectToAction(nameof(Maintenance));
     }
 
+    [HttpPost("backup/upload")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UploadBackup([FromForm(Name = "UploadForm")] DatabaseBackupUploadForm uploadForm, CancellationToken cancellationToken)
+    {
+        if (uploadForm.BackupFile is null || uploadForm.BackupFile.Length <= 0)
+        {
+            ModelState.AddModelError($"{nameof(DatabaseBackupUploadForm)}.{nameof(DatabaseBackupUploadForm.BackupFile)}", "Select a database backup file to upload.");
+            var invalidModel = await BuildMaintenanceModelAsync(new DatabasePruneForm(), null, null, null, cancellationToken);
+            return View("Maintenance", invalidModel);
+        }
+
+        await using var stream = uploadForm.BackupFile.OpenReadStream();
+        var result = await _databaseMaintenanceService.UploadBackupAsync(
+            new DatabaseBackupUploadRequest
+            {
+                OriginalFileName = uploadForm.BackupFile.FileName,
+                Content = stream,
+                RequestedBy = GetOperatorIdentity()
+            },
+            cancellationToken);
+
+        TempData["DbBackupStatus"] = result.Succeeded
+            ? $"Database backup upload completed: {result.FileName} ({result.FileSizeBytes} bytes)."
+            : $"Database backup upload failed: {result.Message}";
+
+        return RedirectToAction(nameof(Maintenance));
+    }
+
+    [HttpPost("backup/restore")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RestoreBackup([FromForm(Name = "RestoreForm")] DatabaseBackupRestoreForm restoreForm, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(restoreForm.FileId))
+        {
+            TempData["DbBackupStatus"] = "Database backup restore failed: select a DATABASE backup file.";
+            return RedirectToAction(nameof(Maintenance));
+        }
+
+        if (!string.Equals(restoreForm.ConfirmationText?.Trim(), DatabaseBackupRestoreRequest.ConfirmationKeyword, StringComparison.Ordinal))
+        {
+            ModelState.AddModelError($"{nameof(DatabaseBackupRestoreForm)}.{nameof(DatabaseBackupRestoreForm.ConfirmationText)}", $"Type {DatabaseBackupRestoreRequest.ConfirmationKeyword} to confirm restore.");
+            var invalidModel = await BuildMaintenanceModelAsync(new DatabasePruneForm(), null, null, null, cancellationToken);
+            return View("Maintenance", invalidModel);
+        }
+
+        try
+        {
+            var result = await _databaseMaintenanceService.RestoreBackupAsync(
+                new DatabaseBackupRestoreRequest
+                {
+                    FileId = restoreForm.FileId,
+                    ConfirmationText = restoreForm.ConfirmationText ?? string.Empty,
+                    RequestedBy = GetOperatorIdentity()
+                },
+                cancellationToken);
+
+            TempData["DbBackupStatus"] = result.Succeeded
+                ? $"Database backup restored from {result.RestoredFileName}. Pre-restore backup: {result.PreRestoreBackupFileName ?? "(none)"}."
+                : $"Database backup restore failed: {result.Message}";
+        }
+        catch (FileNotFoundException)
+        {
+            TempData["DbBackupStatus"] = "Database backup restore failed: selected backup file was not found.";
+        }
+
+        return RedirectToAction(nameof(Maintenance));
+    }
+
+    [HttpPost("backup/delete")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteBackup([FromForm(Name = "DeleteForm")] DatabaseBackupDeleteForm deleteForm, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(deleteForm.FileId))
+        {
+            TempData["DbBackupStatus"] = "Database backup delete failed: select a DATABASE backup file.";
+            return RedirectToAction(nameof(Maintenance));
+        }
+
+        if (!deleteForm.ConfirmDelete)
+        {
+            TempData["DbBackupStatus"] = "Database backup delete canceled: confirmation was not provided.";
+            return RedirectToAction(nameof(Maintenance));
+        }
+
+        try
+        {
+            var result = await _databaseMaintenanceService.DeleteBackupAsync(
+                new DatabaseBackupDeleteRequest
+                {
+                    FileId = deleteForm.FileId,
+                    ConfirmDelete = deleteForm.ConfirmDelete,
+                    RequestedBy = GetOperatorIdentity()
+                },
+                cancellationToken);
+            TempData["DbBackupStatus"] = result.Succeeded
+                ? $"Database backup deleted: {result.FileName}."
+                : $"Database backup delete failed: {result.Message}";
+        }
+        catch (FileNotFoundException)
+        {
+            TempData["DbBackupStatus"] = "Database backup delete failed: selected backup file was not found.";
+        }
+
+        return RedirectToAction(nameof(Maintenance));
+    }
+
     [HttpGet("backup/download")]
     public IActionResult DownloadBackup([FromQuery] string fileId)
     {
@@ -272,12 +378,17 @@ public sealed class AdminDatabaseController : Controller
             PruneStatusMessage = pruneStatusMessage,
             BackupStatusMessage = backupStatusMessage,
             BackupForm = new DatabaseBackupForm(),
+            UploadForm = new DatabaseBackupUploadForm(),
+            RestoreForm = new DatabaseBackupRestoreForm(),
+            DeleteForm = new DatabaseBackupDeleteForm(),
             Backups = backups.Select(x => new DatabaseBackupRowViewModel
             {
                 FileName = x.FileName,
                 FileId = x.FileId,
                 CreatedAtUtc = x.CreatedAtUtc,
-                SizeBytes = x.FileSizeBytes
+                SizeBytes = x.FileSizeBytes,
+                MetadataSummary = x.MetadataSummary,
+                BackupSource = x.BackupSource
             }).ToArray()
         };
     }

--- a/src/WebApp/PingMonitor.Web/Models/EventType.cs
+++ b/src/WebApp/PingMonitor.Web/Models/EventType.cs
@@ -28,4 +28,9 @@ public static class EventType
     public const string DatabaseBackupStarted = "database_backup_started";
     public const string DatabaseBackupCompleted = "database_backup_completed";
     public const string DatabaseBackupFailed = "database_backup_failed";
+    public const string DatabaseBackupUploadCompleted = "database_backup_upload_completed";
+    public const string DatabaseBackupRestoreStarted = "database_backup_restore_started";
+    public const string DatabaseBackupRestoreCompleted = "database_backup_restore_completed";
+    public const string DatabaseBackupRestoreFailed = "database_backup_restore_failed";
+    public const string DatabaseBackupDeleted = "database_backup_deleted";
 }

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceModels.cs
@@ -45,6 +45,55 @@ public sealed class DatabaseBackupCreateRequest
     public string? RequestedBy { get; init; }
 }
 
+public sealed class DatabaseBackupUploadRequest
+{
+    public string OriginalFileName { get; init; } = string.Empty;
+    public Stream Content { get; init; } = Stream.Null;
+    public string? RequestedBy { get; init; }
+}
+
+public sealed class DatabaseBackupUploadResult
+{
+    public bool Succeeded { get; init; }
+    public string Message { get; init; } = string.Empty;
+    public string? FileName { get; init; }
+    public DateTimeOffset? UploadedAtUtc { get; init; }
+    public long? FileSizeBytes { get; init; }
+}
+
+public sealed class DatabaseBackupRestoreRequest
+{
+    public const string ConfirmationKeyword = "RESTORE";
+
+    public string FileId { get; init; } = string.Empty;
+    public string ConfirmationText { get; init; } = string.Empty;
+    public string? RequestedBy { get; init; }
+}
+
+public sealed class DatabaseBackupRestoreResult
+{
+    public bool Succeeded { get; init; }
+    public string Message { get; init; } = string.Empty;
+    public string? RestoredFileName { get; init; }
+    public DateTimeOffset? RestoredFileCreatedAtUtc { get; init; }
+    public bool PreRestoreBackupCreated { get; init; }
+    public string? PreRestoreBackupFileName { get; init; }
+}
+
+public sealed class DatabaseBackupDeleteRequest
+{
+    public string FileId { get; init; } = string.Empty;
+    public bool ConfirmDelete { get; init; }
+    public string? RequestedBy { get; init; }
+}
+
+public sealed class DatabaseBackupDeleteResult
+{
+    public bool Succeeded { get; init; }
+    public string Message { get; init; } = string.Empty;
+    public string? FileName { get; init; }
+}
+
 public sealed class DatabaseBackupCreateResult
 {
     public bool Succeeded { get; init; }
@@ -62,4 +111,6 @@ public sealed class DatabaseBackupFileSnapshot
     public DateTimeOffset CreatedAtUtc { get; init; }
     public long FileSizeBytes { get; init; }
     public string FullPath { get; init; } = string.Empty;
+    public string MetadataSummary { get; init; } = string.Empty;
+    public string BackupSource { get; init; } = string.Empty;
 }

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using MySqlConnector;
@@ -14,6 +16,8 @@ namespace PingMonitor.Web.Services.DatabaseStatus;
 
 internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 {
+    private const int MaxUploadBytes = 100 * 1024 * 1024;
+
     private readonly PingMonitorDbContext _dbContext;
     private readonly IEventLogService _eventLogService;
     private readonly IOptions<DatabaseMaintenanceOptions> _options;
@@ -142,7 +146,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         var safeDatabaseName = string.IsNullOrWhiteSpace(builder.Database) ? "database" : builder.Database.Trim();
         var fileName = $"db-backup-{safeDatabaseName}-{backupTimestamp:yyyyMMdd-HHmmss}.sql";
         var fullPath = Path.Combine(backupDirectory, fileName);
-        var mysqldumpExecutablePath = ResolveMySqlDumpExecutablePath(options.MySqlDumpExecutablePath);
+        var mysqldumpExecutablePath = ResolveExecutablePath(options.MySqlDumpExecutablePath, "mysqldump");
         if (mysqldumpExecutablePath is null)
         {
             return await CreateBackupFailureAsync(
@@ -241,41 +245,332 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         }
     }
 
-    private string? ResolveMySqlDumpExecutablePath(string configuredPath)
+    public async Task<DatabaseBackupUploadResult> UploadBackupAsync(DatabaseBackupUploadRequest request, CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(configuredPath))
+        if (request.Content is null || request.Content == Stream.Null)
         {
-            return null;
+            throw new InvalidOperationException("Database backup upload file is required.");
         }
 
-        var trimmedPath = configuredPath.Trim();
-        if (Path.IsPathRooted(trimmedPath) || trimmedPath.Contains(Path.DirectorySeparatorChar) || trimmedPath.Contains(Path.AltDirectorySeparatorChar))
+        var backupDirectory = GetBackupDirectory(_options.Value.BackupStoragePath);
+        Directory.CreateDirectory(backupDirectory);
+
+        var safeOriginalName = SanitizeFileName(request.OriginalFileName);
+        if (string.IsNullOrWhiteSpace(safeOriginalName))
         {
-            var rootedPath = Path.IsPathRooted(trimmedPath)
-                ? trimmedPath
-                : Path.GetFullPath(trimmedPath, _webHostEnvironment.ContentRootPath);
-            return File.Exists(rootedPath) ? rootedPath : null;
+            return new DatabaseBackupUploadResult { Succeeded = false, Message = "Backup file name is invalid." };
         }
 
-        var pathValue = Environment.GetEnvironmentVariable("PATH");
-        if (!string.IsNullOrWhiteSpace(pathValue))
+        if (!safeOriginalName.EndsWith(".sql", StringComparison.OrdinalIgnoreCase))
         {
-            foreach (var pathEntry in pathValue.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            return new DatabaseBackupUploadResult { Succeeded = false, Message = "Only .sql database backup files are accepted." };
+        }
+
+        await using var uploadBuffer = new MemoryStream();
+        await request.Content.CopyToAsync(uploadBuffer, cancellationToken);
+        if (uploadBuffer.Length <= 0)
+        {
+            return new DatabaseBackupUploadResult { Succeeded = false, Message = "Backup file is empty." };
+        }
+
+        if (uploadBuffer.Length > MaxUploadBytes)
+        {
+            return new DatabaseBackupUploadResult { Succeeded = false, Message = $"Backup file exceeds the {MaxUploadBytes / (1024 * 1024)} MB upload limit." };
+        }
+
+        var contentBytes = uploadBuffer.ToArray();
+        var validationMessage = ValidateSqlBackupContent(contentBytes);
+        if (validationMessage is not null)
+        {
+            return new DatabaseBackupUploadResult { Succeeded = false, Message = validationMessage };
+        }
+
+        var uploadedAtUtc = DateTimeOffset.UtcNow;
+        var storedFileName = BuildStoredUploadFileName(safeOriginalName, uploadedAtUtc);
+        var fullPath = Path.Combine(backupDirectory, storedFileName);
+        EnsurePathIsWithinDirectory(backupDirectory, fullPath);
+
+        await File.WriteAllBytesAsync(fullPath, contentBytes, cancellationToken);
+        var fileInfo = new FileInfo(fullPath);
+
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.System,
+            EventType = EventType.DatabaseBackupUploadCompleted,
+            Severity = EventSeverity.Warning,
+            Message = $"Database backup upload completed. File: {storedFileName}.",
+            DetailsJson = JsonSerializer.Serialize(new
             {
-                var candidate = Path.Combine(pathEntry, trimmedPath);
-                if (File.Exists(candidate))
-                {
-                    return candidate;
-                }
+                storedFileName,
+                originalFileName = request.OriginalFileName,
+                uploadedAtUtc,
+                fileSizeBytes = fileInfo.Length,
+                requestedBy = request.RequestedBy
+            })
+        }, cancellationToken);
 
-                if (OperatingSystem.IsWindows())
+        return new DatabaseBackupUploadResult
+        {
+            Succeeded = true,
+            Message = "Database backup upload completed successfully.",
+            FileName = storedFileName,
+            UploadedAtUtc = uploadedAtUtc,
+            FileSizeBytes = fileInfo.Length
+        };
+    }
+
+    public async Task<DatabaseBackupRestoreResult> RestoreBackupAsync(DatabaseBackupRestoreRequest request, CancellationToken cancellationToken)
+    {
+        if (!string.Equals(request.ConfirmationText?.Trim(), DatabaseBackupRestoreRequest.ConfirmationKeyword, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Type {DatabaseBackupRestoreRequest.ConfirmationKeyword} to confirm restore.");
+        }
+
+        var backupPath = ResolveBackupDownloadPath(request.FileId);
+        var backupFileInfo = new FileInfo(backupPath);
+        var contentBytes = await File.ReadAllBytesAsync(backupPath, cancellationToken);
+        var validationMessage = ValidateSqlBackupContent(contentBytes);
+        if (validationMessage is not null)
+        {
+            await _eventLogService.WriteAsync(new EventLogWriteRequest
+            {
+                Category = EventCategory.System,
+                EventType = EventType.DatabaseBackupRestoreFailed,
+                Severity = EventSeverity.Error,
+                Message = "Database backup restore rejected: validation failed.",
+                DetailsJson = JsonSerializer.Serialize(new
                 {
-                    var candidateWithExtension = candidate.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
-                        ? candidate
-                        : $"{candidate}.exe";
-                    if (File.Exists(candidateWithExtension))
+                    request.FileId,
+                    fileName = backupFileInfo.Name,
+                    validationMessage,
+                    requestedBy = request.RequestedBy
+                })
+            }, cancellationToken);
+
+            return new DatabaseBackupRestoreResult
+            {
+                Succeeded = false,
+                Message = validationMessage,
+                RestoredFileName = backupFileInfo.Name,
+                RestoredFileCreatedAtUtc = new DateTimeOffset(backupFileInfo.LastWriteTimeUtc, TimeSpan.Zero),
+                PreRestoreBackupCreated = false
+            };
+        }
+
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.System,
+            EventType = EventType.DatabaseBackupRestoreStarted,
+            Severity = EventSeverity.Warning,
+            Message = $"Database backup restore started. File: {backupFileInfo.Name}.",
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                request.FileId,
+                fileName = backupFileInfo.Name,
+                fileSizeBytes = backupFileInfo.Length,
+                requestedBy = request.RequestedBy
+            })
+        }, cancellationToken);
+
+        var preRestoreBackup = await CreateBackupAsync(
+            new DatabaseBackupCreateRequest { RequestedBy = request.RequestedBy },
+            cancellationToken);
+        if (!preRestoreBackup.Succeeded)
+        {
+            await _eventLogService.WriteAsync(new EventLogWriteRequest
+            {
+                Category = EventCategory.System,
+                EventType = EventType.DatabaseBackupRestoreFailed,
+                Severity = EventSeverity.Error,
+                Message = "Database backup restore aborted because pre-restore backup failed.",
+                DetailsJson = JsonSerializer.Serialize(new
+                {
+                    request.FileId,
+                    fileName = backupFileInfo.Name,
+                    preRestoreBackupMessage = preRestoreBackup.Message,
+                    requestedBy = request.RequestedBy
+                })
+            }, cancellationToken);
+
+            return new DatabaseBackupRestoreResult
+            {
+                Succeeded = false,
+                Message = $"Restore was aborted because pre-restore backup failed: {preRestoreBackup.Message}",
+                RestoredFileName = backupFileInfo.Name,
+                RestoredFileCreatedAtUtc = new DateTimeOffset(backupFileInfo.LastWriteTimeUtc, TimeSpan.Zero),
+                PreRestoreBackupCreated = false
+            };
+        }
+
+        var dbConnectionString = _dbContext.Database.GetConnectionString();
+        if (string.IsNullOrWhiteSpace(dbConnectionString))
+        {
+            return await CreateRestoreFailureAsync("Database connection string is unavailable.", backupFileInfo, request, true, preRestoreBackup.FileName, cancellationToken);
+        }
+
+        var builder = new MySqlConnectionStringBuilder(dbConnectionString);
+        var mysqlExecutablePath = ResolveExecutablePath(null, "mysql");
+        if (mysqlExecutablePath is null)
+        {
+            return await CreateRestoreFailureAsync("mysql executable was not found. Ensure mysql client is installed and available in PATH.", backupFileInfo, request, true, preRestoreBackup.FileName, cancellationToken);
+        }
+
+        var processInfo = new ProcessStartInfo
+        {
+            FileName = mysqlExecutablePath,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        processInfo.ArgumentList.Add("--host");
+        processInfo.ArgumentList.Add(builder.Server);
+        processInfo.ArgumentList.Add("--port");
+        processInfo.ArgumentList.Add(builder.Port.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        processInfo.ArgumentList.Add("--user");
+        processInfo.ArgumentList.Add(builder.UserID);
+        processInfo.ArgumentList.Add(builder.Database);
+        processInfo.Environment["MYSQL_PWD"] = builder.Password;
+
+        try
+        {
+            using var process = Process.Start(processInfo);
+            if (process is null)
+            {
+                return await CreateRestoreFailureAsync("Unable to start mysql restore process.", backupFileInfo, request, true, preRestoreBackup.FileName, cancellationToken);
+            }
+
+            await process.StandardInput.BaseStream.WriteAsync(contentBytes, cancellationToken);
+            await process.StandardInput.BaseStream.FlushAsync(cancellationToken);
+            process.StandardInput.Close();
+            var stderr = await process.StandardError.ReadToEndAsync(cancellationToken);
+            await process.WaitForExitAsync(cancellationToken);
+
+            if (process.ExitCode != 0)
+            {
+                return await CreateRestoreFailureAsync($"mysql restore exited with code {process.ExitCode}. {TrimDiagnostic(stderr)}", backupFileInfo, request, true, preRestoreBackup.FileName, cancellationToken);
+            }
+
+            await _eventLogService.WriteAsync(new EventLogWriteRequest
+            {
+                Category = EventCategory.System,
+                EventType = EventType.DatabaseBackupRestoreCompleted,
+                Severity = EventSeverity.Warning,
+                Message = $"Database backup restore completed. File: {backupFileInfo.Name}.",
+                DetailsJson = JsonSerializer.Serialize(new
+                {
+                    request.FileId,
+                    fileName = backupFileInfo.Name,
+                    restoredFileCreatedAtUtc = backupFileInfo.LastWriteTimeUtc,
+                    preRestoreBackupFileName = preRestoreBackup.FileName,
+                    requestedBy = request.RequestedBy
+                })
+            }, cancellationToken);
+
+            return new DatabaseBackupRestoreResult
+            {
+                Succeeded = true,
+                Message = "Database restore completed successfully.",
+                RestoredFileName = backupFileInfo.Name,
+                RestoredFileCreatedAtUtc = new DateTimeOffset(backupFileInfo.LastWriteTimeUtc, TimeSpan.Zero),
+                PreRestoreBackupCreated = true,
+                PreRestoreBackupFileName = preRestoreBackup.FileName
+            };
+        }
+        catch (Exception ex) when (ex is Win32Exception || ex is InvalidOperationException || ex is IOException)
+        {
+            _logger.LogWarning(ex, "Database backup restore failed.");
+            return await CreateRestoreFailureAsync($"Database restore failed: {ex.Message}", backupFileInfo, request, true, preRestoreBackup.FileName, cancellationToken);
+        }
+    }
+
+    public async Task<DatabaseBackupDeleteResult> DeleteBackupAsync(DatabaseBackupDeleteRequest request, CancellationToken cancellationToken)
+    {
+        if (!request.ConfirmDelete)
+        {
+            return new DatabaseBackupDeleteResult
+            {
+                Succeeded = false,
+                Message = "Delete confirmation is required."
+            };
+        }
+
+        var backupPath = ResolveBackupDownloadPath(request.FileId);
+        var fileName = Path.GetFileName(backupPath);
+        File.Delete(backupPath);
+
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.System,
+            EventType = EventType.DatabaseBackupDeleted,
+            Severity = EventSeverity.Warning,
+            Message = $"Database backup deleted. File: {fileName}.",
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                request.FileId,
+                fileName,
+                requestedBy = request.RequestedBy
+            })
+        }, cancellationToken);
+
+        return new DatabaseBackupDeleteResult
+        {
+            Succeeded = true,
+            Message = "Database backup deleted.",
+            FileName = fileName
+        };
+    }
+
+    private string? ResolveExecutablePath(string? configuredPath, string fallbackExecutableName)
+    {
+        var candidateNames = new List<string>();
+        if (!string.IsNullOrWhiteSpace(configuredPath))
+        {
+            candidateNames.Add(configuredPath.Trim());
+        }
+
+        candidateNames.Add(fallbackExecutableName);
+
+        foreach (var trimmedPath in candidateNames)
+        {
+            if (string.IsNullOrWhiteSpace(trimmedPath))
+            {
+                continue;
+            }
+
+            if (Path.IsPathRooted(trimmedPath) || trimmedPath.Contains(Path.DirectorySeparatorChar) || trimmedPath.Contains(Path.AltDirectorySeparatorChar))
+            {
+                var rootedPath = Path.IsPathRooted(trimmedPath)
+                    ? trimmedPath
+                    : Path.GetFullPath(trimmedPath, _webHostEnvironment.ContentRootPath);
+                if (File.Exists(rootedPath))
+                {
+                    return rootedPath;
+                }
+            }
+
+            var pathValue = Environment.GetEnvironmentVariable("PATH");
+            if (!string.IsNullOrWhiteSpace(pathValue))
+            {
+                foreach (var pathEntry in pathValue.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                {
+                    var candidate = Path.Combine(pathEntry, trimmedPath);
+                    if (File.Exists(candidate))
                     {
-                        return candidateWithExtension;
+                        return candidate;
+                    }
+
+                    if (OperatingSystem.IsWindows())
+                    {
+                        var candidateWithExtension = candidate.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+                            ? candidate
+                            : $"{candidate}.exe";
+                        if (File.Exists(candidateWithExtension))
+                        {
+                            return candidateWithExtension;
+                        }
                     }
                 }
             }
@@ -349,7 +644,9 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
                 FileId = ComputeFileId(x.Name),
                 CreatedAtUtc = new DateTimeOffset(x.LastWriteTimeUtc, TimeSpan.Zero),
                 FileSizeBytes = x.Length,
-                FullPath = x.FullName
+                FullPath = x.FullName,
+                MetadataSummary = BuildMetadataSummary(x.Name),
+                BackupSource = x.Name.StartsWith("uploaded-db-backup-", StringComparison.OrdinalIgnoreCase) ? "Uploaded" : "Created"
             })
             .ToArray();
 
@@ -426,6 +723,41 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         };
     }
 
+    private async Task<DatabaseBackupRestoreResult> CreateRestoreFailureAsync(
+        string message,
+        FileInfo backupFileInfo,
+        DatabaseBackupRestoreRequest request,
+        bool preRestoreBackupCreated,
+        string? preRestoreBackupFileName,
+        CancellationToken cancellationToken)
+    {
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            Category = EventCategory.System,
+            EventType = EventType.DatabaseBackupRestoreFailed,
+            Severity = EventSeverity.Error,
+            Message = message,
+            DetailsJson = JsonSerializer.Serialize(new
+            {
+                request.FileId,
+                fileName = backupFileInfo.Name,
+                preRestoreBackupCreated,
+                preRestoreBackupFileName,
+                requestedBy = request.RequestedBy
+            })
+        }, cancellationToken);
+
+        return new DatabaseBackupRestoreResult
+        {
+            Succeeded = false,
+            Message = message,
+            RestoredFileName = backupFileInfo.Name,
+            RestoredFileCreatedAtUtc = new DateTimeOffset(backupFileInfo.LastWriteTimeUtc, TimeSpan.Zero),
+            PreRestoreBackupCreated = preRestoreBackupCreated,
+            PreRestoreBackupFileName = preRestoreBackupFileName
+        };
+    }
+
     private string GetBackupDirectory(string configuredPath)
     {
         var contentRoot = _webHostEnvironment.ContentRootPath;
@@ -449,5 +781,84 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 
         var trimmed = value.Trim();
         return trimmed.Length <= 300 ? trimmed : trimmed[..300];
+    }
+
+    private static string SanitizeFileName(string? originalFileName)
+    {
+        var input = string.IsNullOrWhiteSpace(originalFileName)
+            ? "uploaded.sql"
+            : Path.GetFileName(originalFileName.Trim());
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(input.Length);
+        foreach (var character in input)
+        {
+            builder.Append(invalidChars.Contains(character) ? '-' : character);
+        }
+
+        return builder.ToString().Trim();
+    }
+
+    private static string BuildStoredUploadFileName(string safeOriginalName, DateTimeOffset uploadedAtUtc)
+    {
+        var baseName = Path.GetFileNameWithoutExtension(safeOriginalName);
+        var cleanedBaseName = Regex.Replace(baseName, "[^A-Za-z0-9._-]+", "-", RegexOptions.CultureInvariant).Trim('-');
+        if (string.IsNullOrWhiteSpace(cleanedBaseName))
+        {
+            cleanedBaseName = "uploaded";
+        }
+
+        return $"uploaded-db-backup-{cleanedBaseName}-{uploadedAtUtc:yyyyMMdd-HHmmss}.sql";
+    }
+
+    private static void EnsurePathIsWithinDirectory(string baseDirectory, string targetPath)
+    {
+        var fullBase = Path.GetFullPath(baseDirectory).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var fullTarget = Path.GetFullPath(targetPath);
+        if (!fullTarget.StartsWith(fullBase + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Resolved backup path is invalid.");
+        }
+    }
+
+    private static string? ValidateSqlBackupContent(byte[] contentBytes)
+    {
+        string contentText;
+        try
+        {
+            contentText = Encoding.UTF8.GetString(contentBytes);
+        }
+        catch
+        {
+            return "Database backup file could not be read as UTF-8 SQL text.";
+        }
+
+        if (string.IsNullOrWhiteSpace(contentText))
+        {
+            return "Database backup file is empty.";
+        }
+
+        var hasSqlIndicators =
+            contentText.Contains("-- MySQL dump", StringComparison.OrdinalIgnoreCase) ||
+            contentText.Contains("CREATE TABLE", StringComparison.OrdinalIgnoreCase) ||
+            contentText.Contains("INSERT INTO", StringComparison.OrdinalIgnoreCase) ||
+            contentText.Contains("DROP TABLE", StringComparison.OrdinalIgnoreCase);
+
+        if (!hasSqlIndicators)
+        {
+            return "Database backup file is not a valid SQL backup format.";
+        }
+
+        return null;
+    }
+
+    private static string BuildMetadataSummary(string fileName)
+    {
+        var schemaMatch = Regex.Match(fileName, @"schema-v(?<version>\d+)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        if (schemaMatch.Success)
+        {
+            return $"Schema v{schemaMatch.Groups["version"].Value}";
+        }
+
+        return "MySQL logical SQL dump";
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/IDatabaseMaintenanceService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/IDatabaseMaintenanceService.cs
@@ -5,6 +5,9 @@ public interface IDatabaseMaintenanceService
     Task<DatabasePrunePreviewResult> PreviewPruneAsync(DatabasePrunePreviewRequest request, CancellationToken cancellationToken);
     Task<DatabasePruneExecuteResult> ExecutePruneAsync(DatabasePruneExecuteRequest request, CancellationToken cancellationToken);
     Task<DatabaseBackupCreateResult> CreateBackupAsync(DatabaseBackupCreateRequest request, CancellationToken cancellationToken);
+    Task<DatabaseBackupUploadResult> UploadBackupAsync(DatabaseBackupUploadRequest request, CancellationToken cancellationToken);
+    Task<DatabaseBackupRestoreResult> RestoreBackupAsync(DatabaseBackupRestoreRequest request, CancellationToken cancellationToken);
+    Task<DatabaseBackupDeleteResult> DeleteBackupAsync(DatabaseBackupDeleteRequest request, CancellationToken cancellationToken);
     Task<IReadOnlyList<DatabaseBackupFileSnapshot>> ListBackupsAsync(CancellationToken cancellationToken);
     string ResolveBackupDownloadPath(string fileId);
 }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/DatabaseStatusPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/DatabaseStatusPageViewModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
 using PingMonitor.Web.Services.DatabaseStatus;
 
 namespace PingMonitor.Web.ViewModels.Admin;
@@ -26,6 +27,9 @@ public sealed class DatabaseMaintenancePageViewModel
     public DatabasePrunePreviewViewModel? PrunePreview { get; init; }
     public string? PruneStatusMessage { get; init; }
     public DatabaseBackupForm BackupForm { get; init; } = new();
+    public DatabaseBackupUploadForm UploadForm { get; init; } = new();
+    public DatabaseBackupRestoreForm RestoreForm { get; init; } = new();
+    public DatabaseBackupDeleteForm DeleteForm { get; init; } = new();
     public string? BackupStatusMessage { get; init; }
     public IReadOnlyList<DatabaseBackupRowViewModel> Backups { get; init; } = [];
 }
@@ -124,10 +128,35 @@ public sealed class DatabaseBackupForm
     public bool ConfirmBackup { get; set; }
 }
 
+public sealed class DatabaseBackupUploadForm
+{
+    [Required(ErrorMessage = "Backup file is required.")]
+    public IFormFile? BackupFile { get; set; }
+}
+
+public sealed class DatabaseBackupRestoreForm
+{
+    [Required(ErrorMessage = "Backup file selection is required.")]
+    public string FileId { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Type RESTORE to confirm.")]
+    public string ConfirmationText { get; set; } = string.Empty;
+}
+
+public sealed class DatabaseBackupDeleteForm
+{
+    [Required(ErrorMessage = "Backup file selection is required.")]
+    public string FileId { get; set; } = string.Empty;
+
+    public bool ConfirmDelete { get; set; }
+}
+
 public sealed class DatabaseBackupRowViewModel
 {
     public string FileName { get; init; } = string.Empty;
     public string FileId { get; init; } = string.Empty;
     public DateTimeOffset CreatedAtUtc { get; init; }
     public long SizeBytes { get; init; }
+    public string MetadataSummary { get; init; } = string.Empty;
+    public string BackupSource { get; init; } = string.Empty;
 }

--- a/src/WebApp/PingMonitor.Web/Views/AdminDatabase/Maintenance.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminDatabase/Maintenance.cshtml
@@ -23,6 +23,8 @@
         input, select, button { min-height: 44px; padding: .55rem .65rem; font: inherit; }
         button { cursor: pointer; }
         .success { background: #ecfdf3; border: 1px solid #12b76a; color: #027a48; padding: .6rem; border-radius: 10px; }
+        .danger-box { background: #fef3f2; border: 1px solid #f04438; color: #912018; padding: .75rem; border-radius: 10px; }
+        .warning-box { background: #fffaeb; border: 1px solid #f79009; color: #7a2e0e; padding: .75rem; border-radius: 10px; }
         .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: .55rem .8rem; border: 1px solid var(--border); border-radius: 10px; background: #fff; color: var(--text); text-decoration: none; }
     </style>
 </head>
@@ -78,7 +80,8 @@
 
         <section class="card">
             <h2>DB backup tool (MySQL logical dump)</h2>
-            <p class="muted">This tool runs <code>mysqldump</code> to create a full logical SQL export of the current MySQL database. This is separate from configuration JSON backups.</p>
+            <p class="muted">This section manages <strong>DATABASE backups only</strong>. It does not include configuration backups. Existing create/download behaviour remains unchanged, and upload/restore/delete actions apply only to MySQL SQL dump backups.</p>
+            <p class="muted">This tool runs <code>mysqldump</code> to create a full logical SQL export of the current MySQL database.</p>
             <form method="post" action="/admin/database/backup/create" class="form-grid">
                 @Html.AntiForgeryToken()
                 <label>
@@ -87,10 +90,20 @@
                 <button type="submit">Create DB backup</button>
             </form>
 
-            <h3>Backup files</h3>
+            <h3>Upload DATABASE backup</h3>
+            <form method="post" action="/admin/database/backup/upload" enctype="multipart/form-data" class="form-grid">
+                @Html.AntiForgeryToken()
+                <label>Backup SQL file
+                    <input asp-for="UploadForm.BackupFile" type="file" accept=".sql,text/plain,application/sql" />
+                </label>
+                <p class="muted">Accepted files are validated as SQL backup content before being stored in DB backup storage.</p>
+                <button type="submit">Upload DATABASE backup</button>
+            </form>
+
+            <h3>DATABASE backup files</h3>
             <div class="table-wrap">
                 <table>
-                    <thead><tr><th>File</th><th>Created (UTC)</th><th>Size</th><th>Download</th></tr></thead>
+                    <thead><tr><th>File</th><th>Created/Exported (UTC)</th><th>Size</th><th>Source</th><th>Metadata</th><th>Actions</th></tr></thead>
                     <tbody>
                     @foreach (var backup in Model.Backups)
                     {
@@ -98,11 +111,58 @@
                             <td>@backup.FileName</td>
                             <td>@DisplayFormatting.FormatUtcDateTime(backup.CreatedAtUtc)</td>
                             <td>@DisplayFormatting.FormatBytes(backup.SizeBytes)</td>
-                            <td><a href="/admin/database/backup/download?fileId=@backup.FileId">Download</a></td>
+                            <td>@backup.BackupSource</td>
+                            <td>@backup.MetadataSummary</td>
+                            <td>
+                                <a href="/admin/database/backup/download?fileId=@backup.FileId">Download</a>
+                            </td>
                         </tr>
                     }
                     </tbody>
                 </table>
+            </div>
+
+            <div class="danger-box" style="margin-top:1rem;">
+                <h3>Restore DATABASE backup (High risk)</h3>
+                <p><strong>This will completely replace the current DATABASE.</strong></p>
+                <p class="muted">Select the backup file to restore. A pre-restore database backup will be created automatically before restore is applied.</p>
+                <form method="post" action="/admin/database/backup/restore" class="form-grid">
+                    @Html.AntiForgeryToken()
+                    <label>Backup to restore
+                        <select asp-for="RestoreForm.FileId">
+                            <option value="">-- Select DATABASE backup --</option>
+                            @foreach (var backup in Model.Backups)
+                            {
+                                <option value="@backup.FileId">@backup.FileName (@DisplayFormatting.FormatUtcDateTime(backup.CreatedAtUtc))</option>
+                            }
+                        </select>
+                    </label>
+                    <label>Type <strong>RESTORE</strong> to confirm
+                        <input asp-for="RestoreForm.ConfirmationText" autocomplete="off" />
+                    </label>
+                    <button type="submit">Restore DATABASE backup</button>
+                    <span asp-validation-for="RestoreForm.ConfirmationText"></span>
+                </form>
+            </div>
+
+            <div class="warning-box" style="margin-top:1rem;">
+                <h3>Delete DATABASE backup (Medium risk)</h3>
+                <form method="post" action="/admin/database/backup/delete" class="form-grid" onsubmit="return confirm('Delete selected DATABASE backup file? This cannot be undone.');">
+                    @Html.AntiForgeryToken()
+                    <label>Backup to delete
+                        <select asp-for="DeleteForm.FileId">
+                            <option value="">-- Select DATABASE backup --</option>
+                            @foreach (var backup in Model.Backups)
+                            {
+                                <option value="@backup.FileId">@backup.FileName (@DisplayFormatting.FormatUtcDateTime(backup.CreatedAtUtc))</option>
+                            }
+                        </select>
+                    </label>
+                    <label>
+                        <input asp-for="DeleteForm.ConfirmDelete" type="checkbox" /> I confirm I want to delete the selected DATABASE backup file.
+                    </label>
+                    <button type="submit">Delete DATABASE backup</button>
+                </form>
             </div>
         </section>
     </div>


### PR DESCRIPTION
### Motivation

- Complete the DATABASE backup workflow so operators can upload, restore, and delete MySQL logical SQL backups from the DB maintenance page while keeping configuration backups untouched. 
- Enforce strong safety and auditability for destructive actions (typed confirmation, pre-restore backup, validation, and logging).

### Description

- Added request/response models and file metadata for database backup uploads, restores, and deletes and extended the maintenance service contract with `UploadBackupAsync`, `RestoreBackupAsync`, and `DeleteBackupAsync`.
- Implemented upload validation and storage with filename sanitization, path-bound enforcement, a 100MB upload limit, and conservative SQL-content checks; uploaded files are stored in the same DB backup directory and appear in the backup list.
- Implemented safe restore flow that requires typed confirmation `RESTORE`, validates the backup before applying it, automatically creates a pre-restore database backup (and aborts the restore if that pre-backup fails), runs the restore via `mysql` client, and logs start/completion/failure events; delete requires explicit confirmation and is logged.
- UI/controller changes limited to the DB maintenance page to add an upload form, typed restore confirmation and warning, delete confirmation, and list columns for Source/Metadata; new event types added for upload/restore/delete observability.

Key changed areas (high-level): Database maintenance models/services (`Services/DatabaseStatus/*`), admin controller (`Controllers/AdminDatabaseController.cs`), page view model (`ViewModels/Admin/DatabaseStatusPageViewModel.cs`), and DB maintenance Razor view (`Views/AdminDatabase/Maintenance.cshtml`).

### Testing

- Installed .NET 10 SDK in the environment and ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully with no errors.
- Ran `dotnet test src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj --no-build`, which executed without test failures (no failing automated tests observed).
- Verified the project compiles after changes (`dotnet build` success) and validated the new controller endpoints and view compile-time wiring (no compile errors).

(Notes: UI screenshots were not captured in this environment; changes were implemented strictly within the DATABASE backup/DB maintenance surface and did not modify configuration backup controllers, services, or views.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2fc1bc0f4832a8e93b5ec64aad0f6)