### PR TITLE
Show dependency children on Endpoints manage cards

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs
@@ -93,6 +93,13 @@ internal sealed class EndpointManagementQueryService : IEndpointManagementQueryS
                 group => group.Key,
                 group => (IReadOnlyList<string>)group.Select(x => x.DependsOnEndpointId).ToArray(),
                 StringComparer.Ordinal);
+        var dependencyChildLookup = dependencies
+            .Where(x => endpointIdSet.Contains(x.DependsOnEndpointId))
+            .GroupBy(x => x.DependsOnEndpointId, StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<string>)group.Select(x => x.EndpointId).ToArray(),
+                StringComparer.Ordinal);
 
         var assignmentIds = rows.Select(x => x.AssignmentId).ToArray();
         var metricsByAssignmentId = await _assignmentMetrics24hService.GetSummariesAsync(
@@ -131,6 +138,10 @@ internal sealed class EndpointManagementQueryService : IEndpointManagementQueryS
                 Target = row.Target,
                 AgentDisplay = row.AgentDisplay,
                 DependencyEndpointNames = dependencyLookup.GetValueOrDefault(row.EndpointId, Array.Empty<string>())
+                    .Select(endpointId => endpointNames.GetValueOrDefault(endpointId, endpointId))
+                    .OrderBy(x => x)
+                    .ToArray(),
+                DependencyChildEndpointNames = dependencyChildLookup.GetValueOrDefault(row.EndpointId, Array.Empty<string>())
                     .Select(endpointId => endpointNames.GetValueOrDefault(endpointId, endpointId))
                     .OrderBy(x => x)
                     .ToArray(),

--- a/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/ManageEndpointsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Endpoints/ManageEndpointsPageViewModel.cs
@@ -21,6 +21,7 @@ public sealed class ManageEndpointRowViewModel
     public string Target { get; init; } = string.Empty;
     public string AgentDisplay { get; init; } = string.Empty;
     public IReadOnlyList<string> DependencyEndpointNames { get; init; } = [];
+    public IReadOnlyList<string> DependencyChildEndpointNames { get; init; } = [];
     public IReadOnlyList<string> GroupNames { get; init; } = [];
     public bool EndpointEnabled { get; init; }
     public bool AssignmentEnabled { get; init; }

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/_AssignmentsSection.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/_AssignmentsSection.cshtml
@@ -46,6 +46,7 @@
                         <div class="meta-item"><span>Agent / instance</span><div>@row.AgentDisplay</div></div>
                         <div class="meta-item"><span>Groups</span><div>@(row.GroupNames.Count == 0 ? "None" : string.Join(", ", row.GroupNames))</div></div>
                         <div class="meta-item"><span>Dependency parents</span><div>@(row.DependencyEndpointNames.Count == 0 ? "None" : string.Join(", ", row.DependencyEndpointNames))</div></div>
+                        <div class="meta-item"><span>Dependency children</span><div>@(row.DependencyChildEndpointNames.Count == 0 ? "None" : string.Join(", ", row.DependencyChildEndpointNames))</div></div>
                         <div class="meta-item"><span>Endpoint enabled</span><div>@(row.EndpointEnabled ? "Enabled" : "Disabled")</div></div>
                         <div class="meta-item"><span>Assignment enabled</span><div>@(row.AssignmentEnabled ? "Enabled" : "Disabled")</div></div>
                         <div class="meta-item"><span>Ping interval</span><div>@row.PingIntervalSeconds s</div></div>


### PR DESCRIPTION
### Motivation
- Operators need downstream visibility on the Endpoints page so they can see which endpoints depend on the currently inspected endpoint in addition to the existing parents view. 
- This change is a display/query-only enhancement and must not alter dependency storage or suppression logic. 
- Keep the existing parents display and layout intact while adding a matching `Dependency children` field.

### Description
- Add a new view-model field `ManageEndpointRowViewModel.DependencyChildEndpointNames` to carry downstream dependency names for each assignment row. (file: `src/WebApp/PingMonitor.Web/ViewModels/Endpoints/ManageEndpointsPageViewModel.cs`).
- Populate children in `EndpointManagementQueryService.GetManagePageAsync` by building a reverse lookup grouped by `DependsOnEndpointId` from `EndpointDependencies` and projecting child endpoint IDs to names using the existing `endpointNames` dictionary. (file: `src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs`).
- Render a new `Dependency children` meta-item in the expanded assignment card and display `None` when empty, matching the existing `Dependency parents` style. (file: `src/WebApp/PingMonitor.Web/Views/Endpoints/_AssignmentsSection.cshtml`).
- No dependency rules, suppression logic, storage schemas, or agent behaviour were changed; this is purely a UI/query projection change and children are resolved by name using the existing endpoint-name mapping.

### Testing
- Automated build: installed and used .NET SDK `10.0.104` and ran `dotnet build` for the web project, which succeeded with zero errors. 
- No automated unit tests were added or changed for this display-only enhancement. 
- Regression barrier: explicit view-model field + query projection + UI binding were added to make the presence of children deterministic and prevent silent regressions in future UI changes.

Fixes #355

Files modified:
- `src/WebApp/PingMonitor.Web/ViewModels/Endpoints/ManageEndpointsPageViewModel.cs`
- `src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointManagementQueryService.cs`
- `src/WebApp/PingMonitor.Web/Views/Endpoints/_AssignmentsSection.cshtml`

Where dependency children are populated: `EndpointManagementQueryService.GetManagePageAsync` constructs `dependencyChildLookup` from `EndpointDependencies` (grouped by `DependsOnEndpointId`) and projects resolved endpoint names into `ManageEndpointRowViewModel.DependencyChildEndpointNames` for display.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d320ec4848832aae3034a97937bd18)