### PR TITLE
Extend configuration backup/export/import scope for groups, dependencies, and settings

### DIFF
--- a/docs/config-backup-and-restore.md
+++ b/docs/config-backup-and-restore.md
@@ -22,9 +22,13 @@ The following entities are included in configuration backups:
 
 - Agents
 - Endpoints
-- Endpoint metadata (tags, attributes if applicable)
+- Groups (including endpoint group memberships)
+- Endpoint dependencies
 - Agent ↔ Endpoint assignments
-- Other structural monitoring configuration (if added in future)
+- Security settings
+- Notification infrastructure settings (SMTP/Telegram/global notification config)
+- User notification settings
+- Endpoint metadata (tags, attributes if applicable)
 
 ---
 
@@ -71,7 +75,7 @@ Example:
 
 ```json
 {
-  "formatVersion": 1,
+  "formatVersion": 2,
   "appVersion": "1.0.3",
   "backupName": "prod-before-vlan-work",
   "notes": "Taken before changing core switch and endpoint dependency layout. Known-good production config.",
@@ -81,7 +85,15 @@ Example:
   "sections": {
     "agents": [...],
     "endpoints": [...],
+    "groups": {
+      "groups": [...],
+      "endpointMemberships": [...]
+    },
+    "dependencies": [...],
     "assignments": [...],
+    "security_settings": {...},
+    "notification_settings": {...},
+    "user_notification_settings": [...],
     "identity": [...]
   }
 }
@@ -99,7 +111,12 @@ Example:
 - Restore supports these sections:
   - `agents`
   - `endpoints`
+  - `groups`
+  - `dependencies`
   - `assignments`
+  - `security_settings`
+  - `notification_settings`
+  - `user_notification_settings`
   - `identity` (optional and explicit, sensitive)
 - Restore supports two modes:
   - `merge`

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminBackupsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminBackupsController.cs
@@ -128,7 +128,12 @@ public sealed class AdminBackupsController : Controller
                 SelectedFileId = preview.FileId,
                 IncludeAgents = preview.IncludedSections.Contains(ConfigurationBackupSections.Agents, StringComparer.Ordinal),
                 IncludeEndpoints = preview.IncludedSections.Contains(ConfigurationBackupSections.Endpoints, StringComparer.Ordinal),
+                IncludeGroups = preview.IncludedSections.Contains(ConfigurationBackupSections.Groups, StringComparer.Ordinal),
+                IncludeDependencies = preview.IncludedSections.Contains(ConfigurationBackupSections.Dependencies, StringComparer.Ordinal),
                 IncludeAssignments = preview.IncludedSections.Contains(ConfigurationBackupSections.Assignments, StringComparer.Ordinal),
+                IncludeSecuritySettings = preview.IncludedSections.Contains(ConfigurationBackupSections.SecuritySettings, StringComparer.Ordinal),
+                IncludeNotificationSettings = preview.IncludedSections.Contains(ConfigurationBackupSections.NotificationSettings, StringComparer.Ordinal),
+                IncludeUserNotificationSettings = preview.IncludedSections.Contains(ConfigurationBackupSections.UserNotificationSettings, StringComparer.Ordinal),
                 IncludeIdentity = false,
                 RestoreMode = ConfigurationRestoreModes.Merge
             };
@@ -347,6 +352,31 @@ public sealed class AdminBackupsController : Controller
             sections.Add(ConfigurationBackupSections.Assignments);
         }
 
+        if (form.IncludeGroups)
+        {
+            sections.Add(ConfigurationBackupSections.Groups);
+        }
+
+        if (form.IncludeDependencies)
+        {
+            sections.Add(ConfigurationBackupSections.Dependencies);
+        }
+
+        if (form.IncludeSecuritySettings)
+        {
+            sections.Add(ConfigurationBackupSections.SecuritySettings);
+        }
+
+        if (form.IncludeNotificationSettings)
+        {
+            sections.Add(ConfigurationBackupSections.NotificationSettings);
+        }
+
+        if (form.IncludeUserNotificationSettings)
+        {
+            sections.Add(ConfigurationBackupSections.UserNotificationSettings);
+        }
+
         if (form.IncludeIdentity)
         {
             sections.Add(ConfigurationBackupSections.Identity);
@@ -373,6 +403,31 @@ public sealed class AdminBackupsController : Controller
             sections.Add(ConfigurationBackupSections.Assignments);
         }
 
+        if (form.IncludeGroups)
+        {
+            sections.Add(ConfigurationBackupSections.Groups);
+        }
+
+        if (form.IncludeDependencies)
+        {
+            sections.Add(ConfigurationBackupSections.Dependencies);
+        }
+
+        if (form.IncludeSecuritySettings)
+        {
+            sections.Add(ConfigurationBackupSections.SecuritySettings);
+        }
+
+        if (form.IncludeNotificationSettings)
+        {
+            sections.Add(ConfigurationBackupSections.NotificationSettings);
+        }
+
+        if (form.IncludeUserNotificationSettings)
+        {
+            sections.Add(ConfigurationBackupSections.UserNotificationSettings);
+        }
+
         if (form.IncludeIdentity)
         {
             sections.Add(ConfigurationBackupSections.Identity);
@@ -396,7 +451,13 @@ public sealed class AdminBackupsController : Controller
             {
                 Agents = preview.Counts.Agents,
                 Endpoints = preview.Counts.Endpoints,
+                Groups = preview.Counts.Groups,
+                GroupEndpointMemberships = preview.Counts.GroupEndpointMemberships,
+                Dependencies = preview.Counts.Dependencies,
                 Assignments = preview.Counts.Assignments,
+                SecuritySettings = preview.Counts.SecuritySettings,
+                NotificationSettings = preview.Counts.NotificationSettings,
+                UserNotificationSettings = preview.Counts.UserNotificationSettings,
                 IdentityUsers = preview.Counts.IdentityUsers,
                 IdentityRoles = preview.Counts.IdentityRoles,
                 IdentityUserRoles = preview.Counts.IdentityUserRoles
@@ -431,7 +492,12 @@ public sealed class AdminBackupsController : Controller
         {
             ConfigurationBackupSections.Agents => "Agents",
             ConfigurationBackupSections.Endpoints => "Endpoints",
+            ConfigurationBackupSections.Groups => "Groups",
+            ConfigurationBackupSections.Dependencies => "Dependencies",
             ConfigurationBackupSections.Assignments => "Assignments",
+            ConfigurationBackupSections.SecuritySettings => "Security settings",
+            ConfigurationBackupSections.NotificationSettings => "Notification infrastructure settings",
+            ConfigurationBackupSections.UserNotificationSettings => "User notification settings",
             ConfigurationBackupSections.Identity => "Identity",
             _ => section
         };

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationAutoBackupBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationAutoBackupBackgroundService.cs
@@ -118,7 +118,12 @@ public sealed class ConfigurationAutoBackupBackgroundService : BackgroundService
         {
             ConfigurationBackupSections.Agents,
             ConfigurationBackupSections.Endpoints,
-            ConfigurationBackupSections.Assignments
+            ConfigurationBackupSections.Groups,
+            ConfigurationBackupSections.Dependencies,
+            ConfigurationBackupSections.Assignments,
+            ConfigurationBackupSections.SecuritySettings,
+            ConfigurationBackupSections.NotificationSettings,
+            ConfigurationBackupSections.UserNotificationSettings
         };
 
         if (_options.AutoBackup.IncludeIdentityByDefault)

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentLoader.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentLoader.cs
@@ -165,6 +165,27 @@ public sealed class ConfigurationBackupDocumentLoader : IConfigurationBackupDocu
                         includedSections.Add(section);
                     }
                 }
+
+                if (!includedSections.Contains(ConfigurationBackupSections.Dependencies, StringComparer.Ordinal)
+                    && sectionsElement.TryGetProperty("endpoints", out var endpointsElement)
+                    && endpointsElement.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var endpointElement in endpointsElement.EnumerateArray())
+                    {
+                        if (endpointElement.ValueKind != JsonValueKind.Object)
+                        {
+                            continue;
+                        }
+
+                        if (endpointElement.TryGetProperty("dependsOnEndpointIds", out var dependsOnElement)
+                            && dependsOnElement.ValueKind == JsonValueKind.Array
+                            && dependsOnElement.GetArrayLength() > 0)
+                        {
+                            includedSections.Add(ConfigurationBackupSections.Dependencies);
+                            break;
+                        }
+                    }
+                }
             }
 
             string? notes = null;

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentValidator.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentValidator.cs
@@ -11,7 +11,7 @@ public sealed class ConfigurationBackupDocumentValidator : IConfigurationBackupD
     {
         _ = fileIdForErrors;
 
-        if (document.FormatVersion != ConfigurationBackupMetadata.CurrentFormatVersion)
+        if (document.FormatVersion <= 0 || document.FormatVersion > ConfigurationBackupMetadata.CurrentFormatVersion)
         {
             throw new InvalidOperationException($"Backup formatVersion {document.FormatVersion} is not supported.");
         }
@@ -37,7 +37,12 @@ public sealed class ConfigurationBackupDocumentValidator : IConfigurationBackupD
         var hasAtLeastOneSection =
             document.Sections.Agents is not null
             || document.Sections.Endpoints is not null
+            || document.Sections.Groups is not null
+            || document.Sections.Dependencies is not null
             || document.Sections.Assignments is not null
+            || document.Sections.SecuritySettings is not null
+            || document.Sections.NotificationSettings is not null
+            || document.Sections.UserNotificationSettings is not null
             || document.Sections.Identity is not null;
 
         if (!hasAtLeastOneSection)
@@ -67,6 +72,29 @@ public sealed class ConfigurationBackupDocumentValidator : IConfigurationBackupD
             }
         }
 
+        if (document.Sections.Groups is not null)
+        {
+            foreach (var group in document.Sections.Groups.Groups)
+            {
+                if (string.IsNullOrWhiteSpace(group.Name))
+                {
+                    throw new InvalidOperationException("Groups section contains an invalid record (name missing).");
+                }
+            }
+        }
+
+        if (document.Sections.Dependencies is not null)
+        {
+            foreach (var dependency in document.Sections.Dependencies)
+            {
+                if (string.IsNullOrWhiteSpace(dependency.EndpointId)
+                    || string.IsNullOrWhiteSpace(dependency.DependsOnEndpointId))
+                {
+                    throw new InvalidOperationException("Dependencies section contains an invalid record.");
+                }
+            }
+        }
+
         if (document.Sections.Assignments is not null)
         {
             foreach (var assignment in document.Sections.Assignments)
@@ -87,6 +115,17 @@ public sealed class ConfigurationBackupDocumentValidator : IConfigurationBackupD
                 if (string.IsNullOrWhiteSpace(user.NormalizedUserName) && string.IsNullOrWhiteSpace(user.NormalizedEmail))
                 {
                     throw new InvalidOperationException("Identity section contains a user without normalized username/email.");
+                }
+            }
+        }
+
+        if (document.Sections.UserNotificationSettings is not null)
+        {
+            foreach (var userSettings in document.Sections.UserNotificationSettings)
+            {
+                if (string.IsNullOrWhiteSpace(userSettings.UserId))
+                {
+                    throw new InvalidOperationException("User notification settings section contains an invalid record (userId missing).");
                 }
             }
         }

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs
@@ -8,10 +8,26 @@ public static class ConfigurationBackupSections
 {
     public const string Agents = "agents";
     public const string Endpoints = "endpoints";
+    public const string Groups = "groups";
+    public const string Dependencies = "dependencies";
     public const string Assignments = "assignments";
+    public const string SecuritySettings = "security_settings";
+    public const string NotificationSettings = "notification_settings";
+    public const string UserNotificationSettings = "user_notification_settings";
     public const string Identity = "identity";
 
-    public static readonly string[] All = [Agents, Endpoints, Assignments, Identity];
+    public static readonly string[] All =
+    [
+        Agents,
+        Endpoints,
+        Groups,
+        Dependencies,
+        Assignments,
+        SecuritySettings,
+        NotificationSettings,
+        UserNotificationSettings,
+        Identity
+    ];
 }
 
 public static class ConfigurationRestoreModes
@@ -49,7 +65,7 @@ public static class BackupDeleteModes
 
 public sealed class ConfigurationBackupMetadata
 {
-    public const int CurrentFormatVersion = 1;
+    public const int CurrentFormatVersion = 2;
 
     public int FormatVersion { get; init; } = CurrentFormatVersion;
     public string AppVersion { get; init; } = string.Empty;
@@ -124,8 +140,23 @@ public sealed class ConfigurationBackupSectionData
     [JsonPropertyName("endpoints")]
     public IReadOnlyList<BackupEndpointRecord>? Endpoints { get; init; }
 
+    [JsonPropertyName("groups")]
+    public BackupGroupSection? Groups { get; init; }
+
+    [JsonPropertyName("dependencies")]
+    public IReadOnlyList<BackupEndpointDependencyRecord>? Dependencies { get; init; }
+
     [JsonPropertyName("assignments")]
     public IReadOnlyList<BackupAssignmentRecord>? Assignments { get; init; }
+
+    [JsonPropertyName("security_settings")]
+    public BackupSecuritySettingsRecord? SecuritySettings { get; init; }
+
+    [JsonPropertyName("notification_settings")]
+    public BackupNotificationSettingsRecord? NotificationSettings { get; init; }
+
+    [JsonPropertyName("user_notification_settings")]
+    public IReadOnlyList<BackupUserNotificationSettingsRecord>? UserNotificationSettings { get; init; }
 
     [JsonPropertyName("identity")]
     public BackupIdentitySection? Identity { get; init; }
@@ -152,8 +183,37 @@ public sealed class BackupEndpointRecord
     public string IconKey { get; init; } = string.Empty;
     public bool Enabled { get; init; }
     public IReadOnlyList<string> Tags { get; init; } = [];
-    public IReadOnlyList<string> DependsOnEndpointIds { get; init; } = [];
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? DependsOnEndpointIds { get; init; }
     public string? Notes { get; init; }
+    public DateTimeOffset CreatedAtUtc { get; init; }
+}
+
+public sealed class BackupGroupSection
+{
+    public IReadOnlyList<BackupGroupRecord> Groups { get; init; } = [];
+    public IReadOnlyList<BackupEndpointGroupMembershipRecord> EndpointMemberships { get; init; } = [];
+}
+
+public sealed class BackupGroupRecord
+{
+    public string GroupId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public DateTimeOffset CreatedAtUtc { get; init; }
+}
+
+public sealed class BackupEndpointGroupMembershipRecord
+{
+    public string EndpointId { get; init; } = string.Empty;
+    public string GroupId { get; init; } = string.Empty;
+    public DateTimeOffset CreatedAtUtc { get; init; }
+}
+
+public sealed class BackupEndpointDependencyRecord
+{
+    public string EndpointId { get; init; } = string.Empty;
+    public string DependsOnEndpointId { get; init; } = string.Empty;
     public DateTimeOffset CreatedAtUtc { get; init; }
 }
 
@@ -170,6 +230,89 @@ public sealed class BackupAssignmentRecord
     public int FailureThreshold { get; init; }
     public int RecoveryThreshold { get; init; }
     public DateTimeOffset CreatedAtUtc { get; init; }
+    public DateTimeOffset UpdatedAtUtc { get; init; }
+}
+
+public sealed class BackupSecuritySettingsRecord
+{
+    public int AgentFailedAttemptsBeforeTemporaryIpBlock { get; init; }
+    public int AgentTemporaryIpBlockDurationMinutes { get; init; }
+    public int AgentFailedAttemptsBeforePermanentIpBlock { get; init; }
+    public int UserFailedAttemptsBeforeTemporaryIpBlock { get; init; }
+    public int UserTemporaryIpBlockDurationMinutes { get; init; }
+    public int UserFailedAttemptsBeforePermanentIpBlock { get; init; }
+    public int UserFailedAttemptsBeforeTemporaryAccountLockout { get; init; }
+    public int UserTemporaryAccountLockoutDurationMinutes { get; init; }
+    public bool SecurityLogRetentionEnabled { get; init; }
+    public int SecurityLogRetentionDays { get; init; }
+    public bool SecurityLogAutoPruneEnabled { get; init; }
+    public DateTimeOffset UpdatedAtUtc { get; init; }
+}
+
+public sealed class BackupNotificationSettingsRecord
+{
+    public bool BrowserNotificationsEnabled { get; init; }
+    public bool BrowserNotifyEndpointDown { get; init; }
+    public bool BrowserNotifyEndpointRecovered { get; init; }
+    public bool BrowserNotifyAgentOffline { get; init; }
+    public bool BrowserNotifyAgentOnline { get; init; }
+    public string? BrowserNotificationsPermissionState { get; init; }
+    public bool TelegramEnabled { get; init; }
+    public string? TelegramBotTokenProtected { get; init; }
+    public string TelegramInboundMode { get; init; } = "polling";
+    public int TelegramPollIntervalSeconds { get; init; }
+    public long TelegramLastProcessedUpdateId { get; init; }
+    public string? TelegramWebhookUrl { get; init; }
+    public string? TelegramWebhookSecretToken { get; init; }
+    public bool QuietHoursEnabled { get; init; }
+    public string QuietHoursStartLocalTime { get; init; } = "22:00";
+    public string QuietHoursEndLocalTime { get; init; } = "07:00";
+    public string QuietHoursTimeZoneId { get; init; } = "UTC";
+    public bool QuietHoursSuppressBrowserNotifications { get; init; }
+    public bool QuietHoursSuppressSmtpNotifications { get; init; }
+    public bool SmtpNotificationsEnabled { get; init; }
+    public string? SmtpHost { get; init; }
+    public int SmtpPort { get; init; }
+    public bool SmtpUseTls { get; init; }
+    public string? SmtpUsername { get; init; }
+    public string? SmtpPasswordProtected { get; init; }
+    public string? SmtpFromAddress { get; init; }
+    public string? SmtpFromDisplayName { get; init; }
+    public string? SmtpRecipientAddresses { get; init; }
+    public bool SmtpNotifyEndpointDown { get; init; }
+    public bool SmtpNotifyEndpointRecovered { get; init; }
+    public bool SmtpNotifyAgentOffline { get; init; }
+    public bool SmtpNotifyAgentOnline { get; init; }
+    public DateTimeOffset UpdatedAtUtc { get; init; }
+    public string? UpdatedByUserId { get; init; }
+}
+
+public sealed class BackupUserNotificationSettingsRecord
+{
+    public string UserId { get; init; } = string.Empty;
+    public bool BrowserNotificationsEnabled { get; init; }
+    public bool BrowserNotifyEndpointDown { get; init; }
+    public bool BrowserNotifyEndpointRecovered { get; init; }
+    public bool BrowserNotifyAgentOffline { get; init; }
+    public bool BrowserNotifyAgentOnline { get; init; }
+    public string? BrowserNotificationsPermissionState { get; init; }
+    public bool SmtpNotificationsEnabled { get; init; }
+    public bool SmtpNotifyEndpointDown { get; init; }
+    public bool SmtpNotifyEndpointRecovered { get; init; }
+    public bool SmtpNotifyAgentOffline { get; init; }
+    public bool SmtpNotifyAgentOnline { get; init; }
+    public bool TelegramNotificationsEnabled { get; init; }
+    public bool TelegramNotifyEndpointDown { get; init; }
+    public bool TelegramNotifyEndpointRecovered { get; init; }
+    public bool TelegramNotifyAgentOffline { get; init; }
+    public bool TelegramNotifyAgentOnline { get; init; }
+    public bool QuietHoursSuppressTelegramNotifications { get; init; }
+    public bool QuietHoursEnabled { get; init; }
+    public string QuietHoursStartLocalTime { get; init; } = "22:00";
+    public string QuietHoursEndLocalTime { get; init; } = "07:00";
+    public string QuietHoursTimeZoneId { get; init; } = "UTC";
+    public bool QuietHoursSuppressBrowserNotifications { get; init; }
+    public bool QuietHoursSuppressSmtpNotifications { get; init; }
     public DateTimeOffset UpdatedAtUtc { get; init; }
 }
 
@@ -303,7 +446,13 @@ public sealed class ConfigurationBackupSectionCounts
 {
     public int Agents { get; init; }
     public int Endpoints { get; init; }
+    public int Groups { get; init; }
+    public int GroupEndpointMemberships { get; init; }
+    public int Dependencies { get; init; }
     public int Assignments { get; init; }
+    public int SecuritySettings { get; init; }
+    public int NotificationSettings { get; init; }
+    public int UserNotificationSettings { get; init; }
     public int IdentityUsers { get; init; }
     public int IdentityRoles { get; init; }
     public int IdentityUserRoles { get; init; }

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupService.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
 using PingMonitor.Web.Options;
 
 namespace PingMonitor.Web.Services.Backups;
@@ -84,8 +85,23 @@ public sealed class ConfigurationBackupService : IConfigurationBackupService
             Endpoints = selectedSections.Contains(ConfigurationBackupSections.Endpoints, StringComparer.Ordinal)
                 ? await LoadEndpointsAsync(cancellationToken)
                 : null,
+            Groups = selectedSections.Contains(ConfigurationBackupSections.Groups, StringComparer.Ordinal)
+                ? await LoadGroupsAsync(cancellationToken)
+                : null,
+            Dependencies = selectedSections.Contains(ConfigurationBackupSections.Dependencies, StringComparer.Ordinal)
+                ? await LoadDependenciesAsync(cancellationToken)
+                : null,
             Assignments = selectedSections.Contains(ConfigurationBackupSections.Assignments, StringComparer.Ordinal)
                 ? await LoadAssignmentsAsync(cancellationToken)
+                : null,
+            SecuritySettings = selectedSections.Contains(ConfigurationBackupSections.SecuritySettings, StringComparer.Ordinal)
+                ? await LoadSecuritySettingsAsync(cancellationToken)
+                : null,
+            NotificationSettings = selectedSections.Contains(ConfigurationBackupSections.NotificationSettings, StringComparer.Ordinal)
+                ? await LoadNotificationSettingsAsync(cancellationToken)
+                : null,
+            UserNotificationSettings = selectedSections.Contains(ConfigurationBackupSections.UserNotificationSettings, StringComparer.Ordinal)
+                ? await LoadUserNotificationSettingsAsync(cancellationToken)
                 : null,
             Identity = selectedSections.Contains(ConfigurationBackupSections.Identity, StringComparer.Ordinal)
                 ? await LoadIdentityAsync(cancellationToken)
@@ -156,19 +172,6 @@ public sealed class ConfigurationBackupService : IConfigurationBackupService
 
     private async Task<IReadOnlyList<BackupEndpointRecord>> LoadEndpointsAsync(CancellationToken cancellationToken)
     {
-        var dependencies = await _dbContext.EndpointDependencies
-            .AsNoTracking()
-            .OrderBy(x => x.EndpointId)
-            .ThenBy(x => x.DependsOnEndpointId)
-            .ToListAsync(cancellationToken);
-
-        var dependencyLookup = dependencies
-            .GroupBy(x => x.EndpointId, StringComparer.Ordinal)
-            .ToDictionary(
-                group => group.Key,
-                group => (IReadOnlyList<string>)group.Select(x => x.DependsOnEndpointId).ToArray(),
-                StringComparer.Ordinal);
-
         var endpoints = await _dbContext.Endpoints
             .AsNoTracking()
             .OrderBy(x => x.Name)
@@ -183,13 +186,58 @@ public sealed class ConfigurationBackupService : IConfigurationBackupService
                 IconKey = x.IconKey,
                 Enabled = x.Enabled,
                 Tags = x.Tags,
-                DependsOnEndpointIds = dependencyLookup.TryGetValue(x.EndpointId, out var dependsOnIds)
-                    ? dependsOnIds
-                    : [],
                 Notes = x.Notes,
                 CreatedAtUtc = x.CreatedAtUtc
             })
             .ToArray();
+    }
+
+    private async Task<BackupGroupSection> LoadGroupsAsync(CancellationToken cancellationToken)
+    {
+        var groups = await _dbContext.Groups
+            .AsNoTracking()
+            .OrderBy(x => x.Name)
+            .Select(x => new BackupGroupRecord
+            {
+                GroupId = x.GroupId,
+                Name = x.Name,
+                Description = x.Description,
+                CreatedAtUtc = x.CreatedAtUtc
+            })
+            .ToListAsync(cancellationToken);
+
+        var memberships = await _dbContext.EndpointGroupMemberships
+            .AsNoTracking()
+            .OrderBy(x => x.GroupId)
+            .ThenBy(x => x.EndpointId)
+            .Select(x => new BackupEndpointGroupMembershipRecord
+            {
+                EndpointId = x.EndpointId,
+                GroupId = x.GroupId,
+                CreatedAtUtc = x.CreatedAtUtc
+            })
+            .ToListAsync(cancellationToken);
+
+        return new BackupGroupSection
+        {
+            Groups = groups,
+            EndpointMemberships = memberships
+        };
+    }
+
+    private async Task<IReadOnlyList<BackupEndpointDependencyRecord>> LoadDependenciesAsync(CancellationToken cancellationToken)
+    {
+        return await _dbContext.EndpointDependencies
+            .AsNoTracking()
+            .OrderBy(x => x.EndpointId)
+            .ThenBy(x => x.DependsOnEndpointId)
+            .Select(x => new BackupEndpointDependencyRecord
+            {
+                EndpointId = x.EndpointId,
+                DependsOnEndpointId = x.DependsOnEndpointId,
+                CreatedAtUtc = x.CreatedAtUtc
+            })
+            .ToListAsync(cancellationToken);
     }
 
     private async Task<IReadOnlyList<BackupAssignmentRecord>> LoadAssignmentsAsync(CancellationToken cancellationToken)
@@ -263,5 +311,117 @@ public sealed class ConfigurationBackupService : IConfigurationBackupService
             Roles = roles,
             UserRoles = userRoles
         };
+    }
+
+    private async Task<BackupSecuritySettingsRecord?> LoadSecuritySettingsAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _dbContext.SecuritySettings
+            .AsNoTracking()
+            .SingleOrDefaultAsync(x => x.SecuritySettingsId == SecuritySettings.SingletonId, cancellationToken);
+        if (settings is null)
+        {
+            return null;
+        }
+
+        return new BackupSecuritySettingsRecord
+        {
+            AgentFailedAttemptsBeforeTemporaryIpBlock = settings.AgentFailedAttemptsBeforeTemporaryIpBlock,
+            AgentTemporaryIpBlockDurationMinutes = settings.AgentTemporaryIpBlockDurationMinutes,
+            AgentFailedAttemptsBeforePermanentIpBlock = settings.AgentFailedAttemptsBeforePermanentIpBlock,
+            UserFailedAttemptsBeforeTemporaryIpBlock = settings.UserFailedAttemptsBeforeTemporaryIpBlock,
+            UserTemporaryIpBlockDurationMinutes = settings.UserTemporaryIpBlockDurationMinutes,
+            UserFailedAttemptsBeforePermanentIpBlock = settings.UserFailedAttemptsBeforePermanentIpBlock,
+            UserFailedAttemptsBeforeTemporaryAccountLockout = settings.UserFailedAttemptsBeforeTemporaryAccountLockout,
+            UserTemporaryAccountLockoutDurationMinutes = settings.UserTemporaryAccountLockoutDurationMinutes,
+            SecurityLogRetentionEnabled = settings.SecurityLogRetentionEnabled,
+            SecurityLogRetentionDays = settings.SecurityLogRetentionDays,
+            SecurityLogAutoPruneEnabled = settings.SecurityLogAutoPruneEnabled,
+            UpdatedAtUtc = settings.UpdatedAtUtc
+        };
+    }
+
+    private async Task<BackupNotificationSettingsRecord?> LoadNotificationSettingsAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _dbContext.NotificationSettings
+            .AsNoTracking()
+            .SingleOrDefaultAsync(x => x.NotificationSettingsId == NotificationSettings.SingletonId, cancellationToken);
+        if (settings is null)
+        {
+            return null;
+        }
+
+        return new BackupNotificationSettingsRecord
+        {
+            BrowserNotificationsEnabled = settings.BrowserNotificationsEnabled,
+            BrowserNotifyEndpointDown = settings.BrowserNotifyEndpointDown,
+            BrowserNotifyEndpointRecovered = settings.BrowserNotifyEndpointRecovered,
+            BrowserNotifyAgentOffline = settings.BrowserNotifyAgentOffline,
+            BrowserNotifyAgentOnline = settings.BrowserNotifyAgentOnline,
+            BrowserNotificationsPermissionState = settings.BrowserNotificationsPermissionState,
+            TelegramEnabled = settings.TelegramEnabled,
+            TelegramBotTokenProtected = settings.TelegramBotTokenProtected,
+            TelegramInboundMode = settings.TelegramInboundMode.ToString().ToLowerInvariant(),
+            TelegramPollIntervalSeconds = settings.TelegramPollIntervalSeconds,
+            TelegramLastProcessedUpdateId = settings.TelegramLastProcessedUpdateId,
+            TelegramWebhookUrl = settings.TelegramWebhookUrl,
+            TelegramWebhookSecretToken = settings.TelegramWebhookSecretToken,
+            QuietHoursEnabled = settings.QuietHoursEnabled,
+            QuietHoursStartLocalTime = settings.QuietHoursStartLocalTime,
+            QuietHoursEndLocalTime = settings.QuietHoursEndLocalTime,
+            QuietHoursTimeZoneId = settings.QuietHoursTimeZoneId,
+            QuietHoursSuppressBrowserNotifications = settings.QuietHoursSuppressBrowserNotifications,
+            QuietHoursSuppressSmtpNotifications = settings.QuietHoursSuppressSmtpNotifications,
+            SmtpNotificationsEnabled = settings.SmtpNotificationsEnabled,
+            SmtpHost = settings.SmtpHost,
+            SmtpPort = settings.SmtpPort,
+            SmtpUseTls = settings.SmtpUseTls,
+            SmtpUsername = settings.SmtpUsername,
+            SmtpPasswordProtected = settings.SmtpPasswordProtected,
+            SmtpFromAddress = settings.SmtpFromAddress,
+            SmtpFromDisplayName = settings.SmtpFromDisplayName,
+            SmtpRecipientAddresses = settings.SmtpRecipientAddresses,
+            SmtpNotifyEndpointDown = settings.SmtpNotifyEndpointDown,
+            SmtpNotifyEndpointRecovered = settings.SmtpNotifyEndpointRecovered,
+            SmtpNotifyAgentOffline = settings.SmtpNotifyAgentOffline,
+            SmtpNotifyAgentOnline = settings.SmtpNotifyAgentOnline,
+            UpdatedAtUtc = settings.UpdatedAtUtc,
+            UpdatedByUserId = settings.UpdatedByUserId
+        };
+    }
+
+    private async Task<IReadOnlyList<BackupUserNotificationSettingsRecord>> LoadUserNotificationSettingsAsync(CancellationToken cancellationToken)
+    {
+        return await _dbContext.UserNotificationSettings
+            .AsNoTracking()
+            .OrderBy(x => x.UserId)
+            .Select(x => new BackupUserNotificationSettingsRecord
+            {
+                UserId = x.UserId,
+                BrowserNotificationsEnabled = x.BrowserNotificationsEnabled,
+                BrowserNotifyEndpointDown = x.BrowserNotifyEndpointDown,
+                BrowserNotifyEndpointRecovered = x.BrowserNotifyEndpointRecovered,
+                BrowserNotifyAgentOffline = x.BrowserNotifyAgentOffline,
+                BrowserNotifyAgentOnline = x.BrowserNotifyAgentOnline,
+                BrowserNotificationsPermissionState = x.BrowserNotificationsPermissionState,
+                SmtpNotificationsEnabled = x.SmtpNotificationsEnabled,
+                SmtpNotifyEndpointDown = x.SmtpNotifyEndpointDown,
+                SmtpNotifyEndpointRecovered = x.SmtpNotifyEndpointRecovered,
+                SmtpNotifyAgentOffline = x.SmtpNotifyAgentOffline,
+                SmtpNotifyAgentOnline = x.SmtpNotifyAgentOnline,
+                TelegramNotificationsEnabled = x.TelegramNotificationsEnabled,
+                TelegramNotifyEndpointDown = x.TelegramNotifyEndpointDown,
+                TelegramNotifyEndpointRecovered = x.TelegramNotifyEndpointRecovered,
+                TelegramNotifyAgentOffline = x.TelegramNotifyAgentOffline,
+                TelegramNotifyAgentOnline = x.TelegramNotifyAgentOnline,
+                QuietHoursSuppressTelegramNotifications = x.QuietHoursSuppressTelegramNotifications,
+                QuietHoursEnabled = x.QuietHoursEnabled,
+                QuietHoursStartLocalTime = x.QuietHoursStartLocalTime,
+                QuietHoursEndLocalTime = x.QuietHoursEndLocalTime,
+                QuietHoursTimeZoneId = x.QuietHoursTimeZoneId,
+                QuietHoursSuppressBrowserNotifications = x.QuietHoursSuppressBrowserNotifications,
+                QuietHoursSuppressSmtpNotifications = x.QuietHoursSuppressSmtpNotifications,
+                UpdatedAtUtc = x.UpdatedAtUtc
+            })
+            .ToListAsync(cancellationToken);
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestorePreviewService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestorePreviewService.cs
@@ -40,7 +40,13 @@ public sealed class ConfigurationRestorePreviewService : IConfigurationRestorePr
             {
                 Agents = document.Sections.Agents?.Count ?? 0,
                 Endpoints = document.Sections.Endpoints?.Count ?? 0,
+                Groups = document.Sections.Groups?.Groups.Count ?? 0,
+                GroupEndpointMemberships = document.Sections.Groups?.EndpointMemberships.Count ?? 0,
+                Dependencies = document.Sections.Dependencies?.Count ?? document.Sections.Endpoints?.Sum(x => x.DependsOnEndpointIds?.Count ?? 0) ?? 0,
                 Assignments = document.Sections.Assignments?.Count ?? 0,
+                SecuritySettings = document.Sections.SecuritySettings is null ? 0 : 1,
+                NotificationSettings = document.Sections.NotificationSettings is null ? 0 : 1,
+                UserNotificationSettings = document.Sections.UserNotificationSettings?.Count ?? 0,
                 IdentityUsers = document.Sections.Identity?.Users.Count ?? 0,
                 IdentityRoles = document.Sections.Identity?.Roles.Count ?? 0,
                 IdentityUserRoles = document.Sections.Identity?.UserRoles.Count ?? 0
@@ -67,9 +73,35 @@ public sealed class ConfigurationRestorePreviewService : IConfigurationRestorePr
             yield return ConfigurationBackupSections.Endpoints;
         }
 
+        if (document.Sections.Groups is not null)
+        {
+            yield return ConfigurationBackupSections.Groups;
+        }
+
+        if (document.Sections.Dependencies is not null
+            || document.Sections.Endpoints?.Any(x => x.DependsOnEndpointIds is { Count: > 0 }) == true)
+        {
+            yield return ConfigurationBackupSections.Dependencies;
+        }
+
         if (document.Sections.Assignments is not null)
         {
             yield return ConfigurationBackupSections.Assignments;
+        }
+
+        if (document.Sections.SecuritySettings is not null)
+        {
+            yield return ConfigurationBackupSections.SecuritySettings;
+        }
+
+        if (document.Sections.NotificationSettings is not null)
+        {
+            yield return ConfigurationBackupSections.NotificationSettings;
+        }
+
+        if (document.Sections.UserNotificationSettings is not null)
+        {
+            yield return ConfigurationBackupSections.UserNotificationSettings;
         }
 
         if (document.Sections.Identity is not null)

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs
@@ -88,9 +88,44 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
             sectionResults.Add(section);
         }
 
+        if (selectedSections.Contains(ConfigurationBackupSections.Groups, StringComparer.Ordinal))
+        {
+            var section = await RestoreGroupsAsync(backup, endpointIdMapping, cancellationToken);
+            section.DeletedCount = GetDeletedCount(deletedCounts, section.Section);
+            sectionResults.Add(section);
+        }
+
+        if (selectedSections.Contains(ConfigurationBackupSections.Dependencies, StringComparer.Ordinal))
+        {
+            var section = await RestoreDependenciesAsync(backup, endpointIdMapping, cancellationToken);
+            section.DeletedCount = GetDeletedCount(deletedCounts, section.Section);
+            sectionResults.Add(section);
+        }
+
         if (selectedSections.Contains(ConfigurationBackupSections.Assignments, StringComparer.Ordinal))
         {
             var section = await RestoreAssignmentsAsync(backup, endpointIdMapping, agentIdMapping, cancellationToken);
+            section.DeletedCount = GetDeletedCount(deletedCounts, section.Section);
+            sectionResults.Add(section);
+        }
+
+        if (selectedSections.Contains(ConfigurationBackupSections.SecuritySettings, StringComparer.Ordinal))
+        {
+            var section = await RestoreSecuritySettingsAsync(backup, cancellationToken);
+            section.DeletedCount = GetDeletedCount(deletedCounts, section.Section);
+            sectionResults.Add(section);
+        }
+
+        if (selectedSections.Contains(ConfigurationBackupSections.NotificationSettings, StringComparer.Ordinal))
+        {
+            var section = await RestoreNotificationSettingsAsync(backup, cancellationToken);
+            section.DeletedCount = GetDeletedCount(deletedCounts, section.Section);
+            sectionResults.Add(section);
+        }
+
+        if (selectedSections.Contains(ConfigurationBackupSections.UserNotificationSettings, StringComparer.Ordinal))
+        {
+            var section = await RestoreUserNotificationSettingsAsync(backup, cancellationToken);
             section.DeletedCount = GetDeletedCount(deletedCounts, section.Section);
             sectionResults.Add(section);
         }
@@ -160,11 +195,12 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
 
         var includesAgents = selectedSections.Contains(ConfigurationBackupSections.Agents, StringComparer.Ordinal);
         var includesEndpoints = selectedSections.Contains(ConfigurationBackupSections.Endpoints, StringComparer.Ordinal);
+        var includesDependencies = selectedSections.Contains(ConfigurationBackupSections.Dependencies, StringComparer.Ordinal);
         var includesAssignments = selectedSections.Contains(ConfigurationBackupSections.Assignments, StringComparer.Ordinal);
 
-        if ((includesAgents || includesEndpoints) && !includesAssignments)
+        if ((includesAgents || includesEndpoints || includesDependencies) && !includesAssignments)
         {
-            throw new InvalidOperationException("Replace mode for agents/endpoints requires selecting assignments so relationship rows are replaced deterministically.");
+            throw new InvalidOperationException("Replace mode for agents/endpoints/dependencies requires selecting assignments so relationship rows are replaced deterministically.");
         }
     }
 
@@ -191,19 +227,43 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
 
         if (selectedSections.Contains(ConfigurationBackupSections.Endpoints, StringComparer.Ordinal))
         {
-            var deletedDependencies = await _dbContext.EndpointDependencies.ExecuteDeleteAsync(cancellationToken);
             var deletedEndpointMemberships = await _dbContext.EndpointGroupMemberships.ExecuteDeleteAsync(cancellationToken);
             var deletedEndpointAccess = await _dbContext.UserEndpointAccesses.ExecuteDeleteAsync(cancellationToken);
             var deletedEndpoints = await _dbContext.Endpoints.ExecuteDeleteAsync(cancellationToken);
 
-            deletedCounts[ConfigurationBackupSections.Endpoints] = deletedEndpoints + deletedDependencies + deletedEndpointMemberships + deletedEndpointAccess;
+            deletedCounts[ConfigurationBackupSections.Endpoints] = deletedEndpoints + deletedEndpointMemberships + deletedEndpointAccess;
             _logger.LogInformation(
-                "Replace delete completed for section {Section}. Deleted endpoints {EndpointCount}, dependencies {DependencyCount}, memberships {MembershipCount}, endpoint access {AccessCount}.",
+                "Replace delete completed for section {Section}. Deleted endpoints {EndpointCount}, memberships {MembershipCount}, endpoint access {AccessCount}.",
                 ConfigurationBackupSections.Endpoints,
                 deletedEndpoints,
-                deletedDependencies,
                 deletedEndpointMemberships,
                 deletedEndpointAccess);
+        }
+
+        if (selectedSections.Contains(ConfigurationBackupSections.Dependencies, StringComparer.Ordinal))
+        {
+            var deletedDependencies = await _dbContext.EndpointDependencies.ExecuteDeleteAsync(cancellationToken);
+            deletedCounts[ConfigurationBackupSections.Dependencies] = deletedDependencies;
+            _logger.LogInformation("Replace delete completed for section {Section}. Deleted {DeletedCount} records.", ConfigurationBackupSections.Dependencies, deletedDependencies);
+        }
+
+        if (selectedSections.Contains(ConfigurationBackupSections.Groups, StringComparer.Ordinal))
+        {
+            var deletedMemberships = await _dbContext.EndpointGroupMemberships.ExecuteDeleteAsync(cancellationToken);
+            var deletedGroups = await _dbContext.Groups.ExecuteDeleteAsync(cancellationToken);
+            deletedCounts[ConfigurationBackupSections.Groups] = deletedMemberships + deletedGroups;
+            _logger.LogInformation(
+                "Replace delete completed for section {Section}. Deleted groups {GroupCount}, memberships {MembershipCount}.",
+                ConfigurationBackupSections.Groups,
+                deletedGroups,
+                deletedMemberships);
+        }
+
+        if (selectedSections.Contains(ConfigurationBackupSections.UserNotificationSettings, StringComparer.Ordinal))
+        {
+            var deleted = await _dbContext.UserNotificationSettings.ExecuteDeleteAsync(cancellationToken);
+            deletedCounts[ConfigurationBackupSections.UserNotificationSettings] = deleted;
+            _logger.LogInformation("Replace delete completed for section {Section}. Deleted {DeletedCount} records.", ConfigurationBackupSections.UserNotificationSettings, deleted);
         }
 
         if (selectedSections.Contains(ConfigurationBackupSections.Agents, StringComparer.Ordinal))
@@ -227,7 +287,13 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
             {
                 ConfigurationBackupSections.Agents => backup.Sections.Agents is not null,
                 ConfigurationBackupSections.Endpoints => backup.Sections.Endpoints is not null,
+                ConfigurationBackupSections.Groups => backup.Sections.Groups is not null,
+                ConfigurationBackupSections.Dependencies => backup.Sections.Dependencies is not null
+                    || backup.Sections.Endpoints?.Any(x => x.DependsOnEndpointIds is { Count: > 0 }) == true,
                 ConfigurationBackupSections.Assignments => backup.Sections.Assignments is not null,
+                ConfigurationBackupSections.SecuritySettings => backup.Sections.SecuritySettings is not null,
+                ConfigurationBackupSections.NotificationSettings => backup.Sections.NotificationSettings is not null,
+                ConfigurationBackupSections.UserNotificationSettings => backup.Sections.UserNotificationSettings is not null,
                 ConfigurationBackupSections.Identity => backup.Sections.Identity is not null,
                 _ => false
             };
@@ -311,7 +377,6 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
         var sourceEndpoints = backup.Sections.Endpoints ?? [];
 
         var existingEndpoints = await _dbContext.Endpoints.ToListAsync(cancellationToken);
-        var existingDependencies = await _dbContext.EndpointDependencies.ToListAsync(cancellationToken);
 
         foreach (var source in sourceEndpoints)
         {
@@ -350,48 +415,166 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
             }
         }
 
-        foreach (var source in sourceEndpoints)
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Restored section {Section}. Inserted {InsertedCount}, updated {UpdatedCount}, skipped {SkippedCount}, errors {ErrorCount}.",
+            result.Section,
+            result.InsertedCount,
+            result.UpdatedCount,
+            result.SkippedCount,
+            result.ErrorCount);
+
+        return result;
+    }
+
+    private async Task<RestoreSectionResult> RestoreGroupsAsync(
+        ConfigurationBackupDocument backup,
+        IDictionary<string, string> endpointIdMapping,
+        CancellationToken cancellationToken)
+    {
+        var result = new RestoreSectionResult { Section = ConfigurationBackupSections.Groups };
+        var sourceGroups = backup.Sections.Groups;
+        if (sourceGroups is null)
         {
-            if (!endpointIdMapping.TryGetValue(source.EndpointId, out var endpointId))
+            throw new InvalidOperationException("Groups section is missing in selected backup.");
+        }
+
+        var existingGroups = await _dbContext.Groups.ToListAsync(cancellationToken);
+        var existingMemberships = await _dbContext.EndpointGroupMemberships.ToListAsync(cancellationToken);
+        var existingEndpointIds = await _dbContext.Endpoints.AsNoTracking().Select(x => x.EndpointId).ToListAsync(cancellationToken);
+        var existingEndpointIdSet = existingEndpointIds.ToHashSet(StringComparer.Ordinal);
+
+        var groupIdMapping = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var source in sourceGroups.Groups)
+        {
+            var target = existingGroups.FirstOrDefault(x => string.Equals(x.Name, source.Name, StringComparison.OrdinalIgnoreCase));
+            if (target is null)
+            {
+                target = new Group
+                {
+                    GroupId = string.IsNullOrWhiteSpace(source.GroupId) ? Guid.NewGuid().ToString() : source.GroupId,
+                    Name = source.Name,
+                    Description = source.Description,
+                    CreatedAtUtc = source.CreatedAtUtc == default ? DateTimeOffset.UtcNow : source.CreatedAtUtc
+                };
+
+                _dbContext.Groups.Add(target);
+                existingGroups.Add(target);
+                result.InsertedCount++;
+            }
+            else
+            {
+                target.Description = source.Description;
+                result.UpdatedCount++;
+            }
+
+            groupIdMapping[source.GroupId] = target.GroupId;
+        }
+
+        foreach (var sourceMembership in sourceGroups.EndpointMemberships)
+        {
+            if (!groupIdMapping.TryGetValue(sourceMembership.GroupId, out var resolvedGroupId))
+            {
+                result.SkippedCount++;
+                result.Warnings.Add($"Skipped group membership for group id '{sourceMembership.GroupId}' because the group was not restored.");
+                continue;
+            }
+
+            var resolvedEndpointId = ResolveMappedOrExistingId(sourceMembership.EndpointId, endpointIdMapping, existingEndpointIdSet);
+            if (resolvedEndpointId is null)
+            {
+                result.SkippedCount++;
+                result.Warnings.Add($"Skipped group membership for endpoint id '{sourceMembership.EndpointId}' because the endpoint was not available.");
+                continue;
+            }
+
+            var exists = existingMemberships.Any(x => string.Equals(x.GroupId, resolvedGroupId, StringComparison.Ordinal)
+                && string.Equals(x.EndpointId, resolvedEndpointId, StringComparison.Ordinal));
+            if (exists)
             {
                 continue;
             }
 
-            foreach (var sourceDependencyId in source.DependsOnEndpointIds)
+            var membership = new EndpointGroupMembership
             {
-                if (!endpointIdMapping.TryGetValue(sourceDependencyId, out var dependsOnEndpointId))
-                {
-                    result.SkippedCount++;
-                    result.Warnings.Add($"Skipped dependency mapping for endpoint '{source.Name}' because dependency endpoint id '{sourceDependencyId}' was not available in restore scope.");
-                    continue;
-                }
+                EndpointGroupMembershipId = Guid.NewGuid().ToString(),
+                GroupId = resolvedGroupId,
+                EndpointId = resolvedEndpointId,
+                CreatedAtUtc = sourceMembership.CreatedAtUtc == default ? DateTimeOffset.UtcNow : sourceMembership.CreatedAtUtc
+            };
 
-                if (string.Equals(endpointId, dependsOnEndpointId, StringComparison.Ordinal))
-                {
-                    result.SkippedCount++;
-                    result.Warnings.Add($"Skipped self-dependency for endpoint '{source.Name}'.");
-                    continue;
-                }
+            _dbContext.EndpointGroupMemberships.Add(membership);
+            existingMemberships.Add(membership);
+            result.InsertedCount++;
+        }
 
-                var exists = existingDependencies.Any(x => string.Equals(x.EndpointId, endpointId, StringComparison.Ordinal)
-                    && string.Equals(x.DependsOnEndpointId, dependsOnEndpointId, StringComparison.Ordinal));
-                if (exists)
-                {
-                    continue;
-                }
+        await _dbContext.SaveChangesAsync(cancellationToken);
 
-                var dependency = new EndpointDependency
-                {
-                    EndpointDependencyId = Guid.NewGuid().ToString(),
-                    EndpointId = endpointId,
-                    DependsOnEndpointId = dependsOnEndpointId,
-                    CreatedAtUtc = DateTimeOffset.UtcNow
-                };
+        _logger.LogInformation(
+            "Restored section {Section}. Inserted {InsertedCount}, updated {UpdatedCount}, skipped {SkippedCount}, errors {ErrorCount}.",
+            result.Section,
+            result.InsertedCount,
+            result.UpdatedCount,
+            result.SkippedCount,
+            result.ErrorCount);
 
-                _dbContext.EndpointDependencies.Add(dependency);
-                existingDependencies.Add(dependency);
-                result.InsertedCount++;
+        return result;
+    }
+
+    private async Task<RestoreSectionResult> RestoreDependenciesAsync(
+        ConfigurationBackupDocument backup,
+        IDictionary<string, string> endpointIdMapping,
+        CancellationToken cancellationToken)
+    {
+        var result = new RestoreSectionResult { Section = ConfigurationBackupSections.Dependencies };
+        var sourceDependencies = backup.Sections.Dependencies?.ToList()
+            ?? BuildLegacyDependencyRecords(backup.Sections.Endpoints);
+        if (sourceDependencies.Count == 0)
+        {
+            return result;
+        }
+
+        var existingDependencies = await _dbContext.EndpointDependencies.ToListAsync(cancellationToken);
+        var existingEndpointIds = await _dbContext.Endpoints.AsNoTracking().Select(x => x.EndpointId).ToListAsync(cancellationToken);
+        var existingEndpointIdSet = existingEndpointIds.ToHashSet(StringComparer.Ordinal);
+
+        foreach (var source in sourceDependencies)
+        {
+            var resolvedEndpointId = ResolveMappedOrExistingId(source.EndpointId, endpointIdMapping, existingEndpointIdSet);
+            var resolvedDependsOnId = ResolveMappedOrExistingId(source.DependsOnEndpointId, endpointIdMapping, existingEndpointIdSet);
+            if (resolvedEndpointId is null || resolvedDependsOnId is null)
+            {
+                result.SkippedCount++;
+                result.Warnings.Add($"Skipped dependency '{source.EndpointId}' -> '{source.DependsOnEndpointId}' because one or both endpoints were not available.");
+                continue;
             }
+
+            if (string.Equals(resolvedEndpointId, resolvedDependsOnId, StringComparison.Ordinal))
+            {
+                result.SkippedCount++;
+                result.Warnings.Add($"Skipped self-dependency '{resolvedEndpointId}'.");
+                continue;
+            }
+
+            var exists = existingDependencies.Any(x => string.Equals(x.EndpointId, resolvedEndpointId, StringComparison.Ordinal)
+                && string.Equals(x.DependsOnEndpointId, resolvedDependsOnId, StringComparison.Ordinal));
+            if (exists)
+            {
+                continue;
+            }
+
+            var dependency = new EndpointDependency
+            {
+                EndpointDependencyId = Guid.NewGuid().ToString(),
+                EndpointId = resolvedEndpointId,
+                DependsOnEndpointId = resolvedDependsOnId,
+                CreatedAtUtc = source.CreatedAtUtc == default ? DateTimeOffset.UtcNow : source.CreatedAtUtc
+            };
+
+            _dbContext.EndpointDependencies.Add(dependency);
+            existingDependencies.Add(dependency);
+            result.InsertedCount++;
         }
 
         await _dbContext.SaveChangesAsync(cancellationToken);
@@ -490,6 +673,189 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
             result.SkippedCount,
             result.ErrorCount);
 
+        return result;
+    }
+
+    private async Task<RestoreSectionResult> RestoreSecuritySettingsAsync(ConfigurationBackupDocument backup, CancellationToken cancellationToken)
+    {
+        var result = new RestoreSectionResult { Section = ConfigurationBackupSections.SecuritySettings };
+        var source = backup.Sections.SecuritySettings;
+        if (source is null)
+        {
+            throw new InvalidOperationException("Security settings section is missing in selected backup.");
+        }
+
+        var target = await _dbContext.SecuritySettings
+            .SingleOrDefaultAsync(x => x.SecuritySettingsId == SecuritySettings.SingletonId, cancellationToken);
+        if (target is null)
+        {
+            target = new SecuritySettings { SecuritySettingsId = SecuritySettings.SingletonId };
+            _dbContext.SecuritySettings.Add(target);
+            result.InsertedCount++;
+        }
+        else
+        {
+            result.UpdatedCount++;
+        }
+
+        target.AgentFailedAttemptsBeforeTemporaryIpBlock = source.AgentFailedAttemptsBeforeTemporaryIpBlock;
+        target.AgentTemporaryIpBlockDurationMinutes = source.AgentTemporaryIpBlockDurationMinutes;
+        target.AgentFailedAttemptsBeforePermanentIpBlock = source.AgentFailedAttemptsBeforePermanentIpBlock;
+        target.UserFailedAttemptsBeforeTemporaryIpBlock = source.UserFailedAttemptsBeforeTemporaryIpBlock;
+        target.UserTemporaryIpBlockDurationMinutes = source.UserTemporaryIpBlockDurationMinutes;
+        target.UserFailedAttemptsBeforePermanentIpBlock = source.UserFailedAttemptsBeforePermanentIpBlock;
+        target.UserFailedAttemptsBeforeTemporaryAccountLockout = source.UserFailedAttemptsBeforeTemporaryAccountLockout;
+        target.UserTemporaryAccountLockoutDurationMinutes = source.UserTemporaryAccountLockoutDurationMinutes;
+        target.SecurityLogRetentionEnabled = source.SecurityLogRetentionEnabled;
+        target.SecurityLogRetentionDays = source.SecurityLogRetentionDays;
+        target.SecurityLogAutoPruneEnabled = source.SecurityLogAutoPruneEnabled;
+        target.UpdatedAtUtc = source.UpdatedAtUtc == default ? DateTimeOffset.UtcNow : source.UpdatedAtUtc;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation(
+            "Restored section {Section}. Inserted {InsertedCount}, updated {UpdatedCount}, skipped {SkippedCount}, errors {ErrorCount}.",
+            result.Section,
+            result.InsertedCount,
+            result.UpdatedCount,
+            result.SkippedCount,
+            result.ErrorCount);
+        return result;
+    }
+
+    private async Task<RestoreSectionResult> RestoreNotificationSettingsAsync(ConfigurationBackupDocument backup, CancellationToken cancellationToken)
+    {
+        var result = new RestoreSectionResult { Section = ConfigurationBackupSections.NotificationSettings };
+        var source = backup.Sections.NotificationSettings;
+        if (source is null)
+        {
+            throw new InvalidOperationException("Notification settings section is missing in selected backup.");
+        }
+
+        var target = await _dbContext.NotificationSettings
+            .SingleOrDefaultAsync(x => x.NotificationSettingsId == NotificationSettings.SingletonId, cancellationToken);
+        if (target is null)
+        {
+            target = new NotificationSettings { NotificationSettingsId = NotificationSettings.SingletonId };
+            _dbContext.NotificationSettings.Add(target);
+            result.InsertedCount++;
+        }
+        else
+        {
+            result.UpdatedCount++;
+        }
+
+        if (!TryParseTelegramInboundMode(source.TelegramInboundMode, out var telegramInboundMode))
+        {
+            result.SkippedCount++;
+            result.Warnings.Add($"Notification settings contained unsupported telegram inbound mode '{source.TelegramInboundMode}'. Defaulted to polling.");
+            telegramInboundMode = TelegramInboundMode.Polling;
+        }
+
+        target.BrowserNotificationsEnabled = source.BrowserNotificationsEnabled;
+        target.BrowserNotifyEndpointDown = source.BrowserNotifyEndpointDown;
+        target.BrowserNotifyEndpointRecovered = source.BrowserNotifyEndpointRecovered;
+        target.BrowserNotifyAgentOffline = source.BrowserNotifyAgentOffline;
+        target.BrowserNotifyAgentOnline = source.BrowserNotifyAgentOnline;
+        target.BrowserNotificationsPermissionState = source.BrowserNotificationsPermissionState;
+        target.TelegramEnabled = source.TelegramEnabled;
+        target.TelegramBotTokenProtected = source.TelegramBotTokenProtected;
+        target.TelegramInboundMode = telegramInboundMode;
+        target.TelegramPollIntervalSeconds = source.TelegramPollIntervalSeconds;
+        target.TelegramLastProcessedUpdateId = source.TelegramLastProcessedUpdateId;
+        target.TelegramWebhookUrl = source.TelegramWebhookUrl;
+        target.TelegramWebhookSecretToken = source.TelegramWebhookSecretToken;
+        target.QuietHoursEnabled = source.QuietHoursEnabled;
+        target.QuietHoursStartLocalTime = source.QuietHoursStartLocalTime;
+        target.QuietHoursEndLocalTime = source.QuietHoursEndLocalTime;
+        target.QuietHoursTimeZoneId = source.QuietHoursTimeZoneId;
+        target.QuietHoursSuppressBrowserNotifications = source.QuietHoursSuppressBrowserNotifications;
+        target.QuietHoursSuppressSmtpNotifications = source.QuietHoursSuppressSmtpNotifications;
+        target.SmtpNotificationsEnabled = source.SmtpNotificationsEnabled;
+        target.SmtpHost = source.SmtpHost;
+        target.SmtpPort = source.SmtpPort;
+        target.SmtpUseTls = source.SmtpUseTls;
+        target.SmtpUsername = source.SmtpUsername;
+        target.SmtpPasswordProtected = source.SmtpPasswordProtected;
+        target.SmtpFromAddress = source.SmtpFromAddress;
+        target.SmtpFromDisplayName = source.SmtpFromDisplayName;
+        target.SmtpRecipientAddresses = source.SmtpRecipientAddresses;
+        target.SmtpNotifyEndpointDown = source.SmtpNotifyEndpointDown;
+        target.SmtpNotifyEndpointRecovered = source.SmtpNotifyEndpointRecovered;
+        target.SmtpNotifyAgentOffline = source.SmtpNotifyAgentOffline;
+        target.SmtpNotifyAgentOnline = source.SmtpNotifyAgentOnline;
+        target.UpdatedAtUtc = source.UpdatedAtUtc == default ? DateTimeOffset.UtcNow : source.UpdatedAtUtc;
+        target.UpdatedByUserId = source.UpdatedByUserId;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation(
+            "Restored section {Section}. Inserted {InsertedCount}, updated {UpdatedCount}, skipped {SkippedCount}, errors {ErrorCount}.",
+            result.Section,
+            result.InsertedCount,
+            result.UpdatedCount,
+            result.SkippedCount,
+            result.ErrorCount);
+        return result;
+    }
+
+    private async Task<RestoreSectionResult> RestoreUserNotificationSettingsAsync(ConfigurationBackupDocument backup, CancellationToken cancellationToken)
+    {
+        var result = new RestoreSectionResult { Section = ConfigurationBackupSections.UserNotificationSettings };
+        var sourceRows = backup.Sections.UserNotificationSettings ?? [];
+        var existingRows = await _dbContext.UserNotificationSettings.ToListAsync(cancellationToken);
+
+        foreach (var source in sourceRows)
+        {
+            var target = existingRows.FirstOrDefault(x => string.Equals(x.UserId, source.UserId, StringComparison.Ordinal));
+            if (target is null)
+            {
+                target = new UserNotificationSettings
+                {
+                    UserId = source.UserId
+                };
+
+                _dbContext.UserNotificationSettings.Add(target);
+                existingRows.Add(target);
+                result.InsertedCount++;
+            }
+            else
+            {
+                result.UpdatedCount++;
+            }
+
+            target.BrowserNotificationsEnabled = source.BrowserNotificationsEnabled;
+            target.BrowserNotifyEndpointDown = source.BrowserNotifyEndpointDown;
+            target.BrowserNotifyEndpointRecovered = source.BrowserNotifyEndpointRecovered;
+            target.BrowserNotifyAgentOffline = source.BrowserNotifyAgentOffline;
+            target.BrowserNotifyAgentOnline = source.BrowserNotifyAgentOnline;
+            target.BrowserNotificationsPermissionState = source.BrowserNotificationsPermissionState;
+            target.SmtpNotificationsEnabled = source.SmtpNotificationsEnabled;
+            target.SmtpNotifyEndpointDown = source.SmtpNotifyEndpointDown;
+            target.SmtpNotifyEndpointRecovered = source.SmtpNotifyEndpointRecovered;
+            target.SmtpNotifyAgentOffline = source.SmtpNotifyAgentOffline;
+            target.SmtpNotifyAgentOnline = source.SmtpNotifyAgentOnline;
+            target.TelegramNotificationsEnabled = source.TelegramNotificationsEnabled;
+            target.TelegramNotifyEndpointDown = source.TelegramNotifyEndpointDown;
+            target.TelegramNotifyEndpointRecovered = source.TelegramNotifyEndpointRecovered;
+            target.TelegramNotifyAgentOffline = source.TelegramNotifyAgentOffline;
+            target.TelegramNotifyAgentOnline = source.TelegramNotifyAgentOnline;
+            target.QuietHoursSuppressTelegramNotifications = source.QuietHoursSuppressTelegramNotifications;
+            target.QuietHoursEnabled = source.QuietHoursEnabled;
+            target.QuietHoursStartLocalTime = source.QuietHoursStartLocalTime;
+            target.QuietHoursEndLocalTime = source.QuietHoursEndLocalTime;
+            target.QuietHoursTimeZoneId = source.QuietHoursTimeZoneId;
+            target.QuietHoursSuppressBrowserNotifications = source.QuietHoursSuppressBrowserNotifications;
+            target.QuietHoursSuppressSmtpNotifications = source.QuietHoursSuppressSmtpNotifications;
+            target.UpdatedAtUtc = source.UpdatedAtUtc == default ? DateTimeOffset.UtcNow : source.UpdatedAtUtc;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation(
+            "Restored section {Section}. Inserted {InsertedCount}, updated {UpdatedCount}, skipped {SkippedCount}, errors {ErrorCount}.",
+            result.Section,
+            result.InsertedCount,
+            result.UpdatedCount,
+            result.SkippedCount,
+            result.ErrorCount);
         return result;
     }
 
@@ -634,5 +1000,52 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
 
         checkType = default;
         return false;
+    }
+
+    private static bool TryParseTelegramInboundMode(string? rawValue, out TelegramInboundMode mode)
+    {
+        if (string.Equals(rawValue, "polling", StringComparison.OrdinalIgnoreCase))
+        {
+            mode = TelegramInboundMode.Polling;
+            return true;
+        }
+
+        if (string.Equals(rawValue, "webhook", StringComparison.OrdinalIgnoreCase))
+        {
+            mode = TelegramInboundMode.Webhook;
+            return true;
+        }
+
+        mode = default;
+        return false;
+    }
+
+    private static List<BackupEndpointDependencyRecord> BuildLegacyDependencyRecords(IReadOnlyList<BackupEndpointRecord>? endpoints)
+    {
+        if (endpoints is null)
+        {
+            return [];
+        }
+
+        var records = new List<BackupEndpointDependencyRecord>();
+        foreach (var endpoint in endpoints)
+        {
+            if (endpoint.DependsOnEndpointIds is null || endpoint.DependsOnEndpointIds.Count == 0)
+            {
+                continue;
+            }
+
+            foreach (var dependsOnEndpointId in endpoint.DependsOnEndpointIds)
+            {
+                records.Add(new BackupEndpointDependencyRecord
+                {
+                    EndpointId = endpoint.EndpointId,
+                    DependsOnEndpointId = dependsOnEndpointId,
+                    CreatedAtUtc = DateTimeOffset.UtcNow
+                });
+            }
+        }
+
+        return records;
     }
 }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Backups/BackupsPageViewModels.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Backups/BackupsPageViewModels.cs
@@ -19,8 +19,23 @@ public sealed class CreateBackupPageForm
     [Display(Name = "Include endpoints")]
     public bool IncludeEndpoints { get; set; } = true;
 
+    [Display(Name = "Include groups")]
+    public bool IncludeGroups { get; set; } = true;
+
+    [Display(Name = "Include dependencies")]
+    public bool IncludeDependencies { get; set; } = true;
+
     [Display(Name = "Include assignments")]
     public bool IncludeAssignments { get; set; } = true;
+
+    [Display(Name = "Include security settings")]
+    public bool IncludeSecuritySettings { get; set; } = true;
+
+    [Display(Name = "Include notification infrastructure settings")]
+    public bool IncludeNotificationSettings { get; set; } = true;
+
+    [Display(Name = "Include user notification settings")]
+    public bool IncludeUserNotificationSettings { get; set; } = true;
 
     [Display(Name = "Include identity")]
     public bool IncludeIdentity { get; set; }
@@ -96,8 +111,23 @@ public sealed class RestoreApplyForm
     [Display(Name = "Restore endpoints")]
     public bool IncludeEndpoints { get; set; } = true;
 
+    [Display(Name = "Restore groups")]
+    public bool IncludeGroups { get; set; } = true;
+
+    [Display(Name = "Restore dependencies")]
+    public bool IncludeDependencies { get; set; } = true;
+
     [Display(Name = "Restore assignments")]
     public bool IncludeAssignments { get; set; } = true;
+
+    [Display(Name = "Restore security settings")]
+    public bool IncludeSecuritySettings { get; set; } = true;
+
+    [Display(Name = "Restore notification infrastructure settings")]
+    public bool IncludeNotificationSettings { get; set; } = true;
+
+    [Display(Name = "Restore user notification settings")]
+    public bool IncludeUserNotificationSettings { get; set; } = true;
 
     [Display(Name = "Restore identity")]
     public bool IncludeIdentity { get; set; }
@@ -125,7 +155,13 @@ public sealed class ConfigurationBackupSectionCountViewModel
 {
     public int Agents { get; init; }
     public int Endpoints { get; init; }
+    public int Groups { get; init; }
+    public int GroupEndpointMemberships { get; init; }
+    public int Dependencies { get; init; }
     public int Assignments { get; init; }
+    public int SecuritySettings { get; init; }
+    public int NotificationSettings { get; init; }
+    public int UserNotificationSettings { get; init; }
     public int IdentityUsers { get; init; }
     public int IdentityRoles { get; init; }
     public int IdentityUserRoles { get; init; }

--- a/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
@@ -60,7 +60,7 @@
     <div class="stack">
         <section class="card">
             <h1>Configuration backups</h1>
-            <p class="muted">Create/download configuration-only JSON backups and restore from server-side files with explicit preview. Restore supports <strong>MERGE</strong> (safe default) and <strong>REPLACE</strong> (destructive for selected sections only).</p>
+            <p class="muted">Create/download <strong>CONFIGURATION-only</strong> JSON backups and restore from server-side files with explicit preview. This page does not manage DATABASE backups. Restore supports <strong>MERGE</strong> (safe default) and <strong>REPLACE</strong> (destructive for selected sections only).</p>
             <div class="button-row">
                 <a class="button-secondary" href="/admin">Back to admin settings</a>
                 <a class="button-secondary" href="/status">Back to status</a>
@@ -96,7 +96,12 @@
                         <div class="check-list">
                             <label class="check-item"><input asp-for="Form.IncludeAgents" /> Agents</label>
                             <label class="check-item"><input asp-for="Form.IncludeEndpoints" /> Endpoints</label>
+                            <label class="check-item"><input asp-for="Form.IncludeGroups" /> Groups (with endpoint memberships)</label>
+                            <label class="check-item"><input asp-for="Form.IncludeDependencies" /> Endpoint dependencies</label>
                             <label class="check-item"><input asp-for="Form.IncludeAssignments" /> Assignments</label>
+                            <label class="check-item"><input asp-for="Form.IncludeSecuritySettings" /> Security settings</label>
+                            <label class="check-item"><input asp-for="Form.IncludeNotificationSettings" /> Notification infrastructure settings</label>
+                            <label class="check-item"><input asp-for="Form.IncludeUserNotificationSettings" /> User notification settings</label>
                             <label class="check-item"><input asp-for="Form.IncludeIdentity" /> Identity (optional; disabled by default)</label>
                         </div>
                     </div>
@@ -174,7 +179,13 @@
                                 <tbody>
                                     <tr><td>Agents</td><td>@Model.Preview.Counts.Agents</td></tr>
                                     <tr><td>Endpoints</td><td>@Model.Preview.Counts.Endpoints</td></tr>
+                                    <tr><td>Groups</td><td>@Model.Preview.Counts.Groups</td></tr>
+                                    <tr><td>Group memberships</td><td>@Model.Preview.Counts.GroupEndpointMemberships</td></tr>
+                                    <tr><td>Dependencies</td><td>@Model.Preview.Counts.Dependencies</td></tr>
                                     <tr><td>Assignments</td><td>@Model.Preview.Counts.Assignments</td></tr>
+                                    <tr><td>Security settings records</td><td>@Model.Preview.Counts.SecuritySettings</td></tr>
+                                    <tr><td>Notification settings records</td><td>@Model.Preview.Counts.NotificationSettings</td></tr>
+                                    <tr><td>User notification settings</td><td>@Model.Preview.Counts.UserNotificationSettings</td></tr>
                                     <tr><td>Identity users</td><td>@Model.Preview.Counts.IdentityUsers</td></tr>
                                     <tr><td>Identity roles</td><td>@Model.Preview.Counts.IdentityRoles</td></tr>
                                     <tr><td>Identity user-role links</td><td>@Model.Preview.Counts.IdentityUserRoles</td></tr>
@@ -190,8 +201,13 @@
                         <p class="muted">Select one or more sections. Only selected sections are restored. Non-selected sections remain untouched.</p>
                         <div class="check-list">
                             <label class="check-item"><input asp-for="RestoreApplyForm.IncludeAgents" /> Agents</label>
-                            <label class="check-item"><input asp-for="RestoreApplyForm.IncludeEndpoints" /> Endpoints (includes endpoint dependency links)</label>
+                            <label class="check-item"><input asp-for="RestoreApplyForm.IncludeEndpoints" /> Endpoints</label>
+                            <label class="check-item"><input asp-for="RestoreApplyForm.IncludeGroups" /> Groups (with endpoint memberships)</label>
+                            <label class="check-item"><input asp-for="RestoreApplyForm.IncludeDependencies" /> Endpoint dependencies</label>
                             <label class="check-item"><input asp-for="RestoreApplyForm.IncludeAssignments" /> Assignments</label>
+                            <label class="check-item"><input asp-for="RestoreApplyForm.IncludeSecuritySettings" /> Security settings</label>
+                            <label class="check-item"><input asp-for="RestoreApplyForm.IncludeNotificationSettings" /> Notification infrastructure settings</label>
+                            <label class="check-item"><input asp-for="RestoreApplyForm.IncludeUserNotificationSettings" /> User notification settings</label>
                             <label class="check-item"><input asp-for="RestoreApplyForm.IncludeIdentity" /> Identity (sensitive and optional)</label>
                         </div>
                         <div>


### PR DESCRIPTION
### Motivation
- Expand the CONFIGURATION backup to cover the full structural setup (groups, endpoint dependency relationships, security settings, notification infrastructure, and per-user notification settings) so an operator can recreate app configuration without relying on full database dumps. 
- Keep the feature strictly configuration-only and preserve the existing optional identity behaviour (identity import remains explicit and merge-only). 
- Preserve safety and backward compatibility by supporting legacy dependency representation embedded in endpoints and by validating incoming backup structure before applying a restore. 

### Description
- Added new backup sections/constants/models for `groups`, `dependencies`, `security_settings`, `notification_settings`, and `user_notification_settings` and incremented configuration backup `formatVersion` from `1` to `2`. 
- Export was extended to serialize groups (and memberships), canonical dependencies, the security singleton, the notification infrastructure singleton, and per-user notification rows, while import/restore was extended to restore those sections deterministically in `merge` and `replace` modes and to fall back to legacy `dependsOnEndpointIds` embedded in endpoints when needed. 
- Updated preview, loader and validator to detect and validate the new sections (and to accept older backups that contain endpoint-embedded dependencies), and updated the admin UI and documentation to show the new configurable sections and to clarify this is CONFIGURATION-only (not DATABASE) backup. 
- Files modified: `docs/config-backup-and-restore.md`, `src/WebApp/PingMonitor.Web/Controllers/AdminBackupsController.cs`, `src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationAutoBackupBackgroundService.cs`, `src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentLoader.cs`, `src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentValidator.cs`, `src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs`, `src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupService.cs`, `src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestorePreviewService.cs`, `src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs`, `src/WebApp/PingMonitor.Web/ViewModels/Backups/BackupsPageViewModels.cs`, `src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml`, and this change is linked to issue `#357` (Fixes #357). 

### Testing
- Ran `git diff --check` which passed. 
- Attempted `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` in this environment, which failed during package restore with `NU1101` reporting a missing host package (`Microsoft.NETCore.App.Host.ubuntu.24.04-x64`); this is an environment/package resolution issue and not caused by the code changes. 
- No new automated unit tests were added in this change; validation/regression guards include format-version checks, schema validation in `ConfigurationBackupDocumentValidator`, and a legacy-dependency fallback in restore preview/restore to ensure older backups import gracefully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d324da481c832a8e27242c4035eeb2)