### PR TITLE
Add compact mode for DATABASE backups (full + compact profiles)

### DIFF
--- a/docs/db-status-and-maintenance.md
+++ b/docs/db-status-and-maintenance.md
@@ -41,7 +41,9 @@ The DB maintenance page is action-oriented and keeps all existing maintenance to
 
 - prune preview/count
 - prune execution (typed confirmation required)
-- DB backup creation (`mysqldump` logical export)
+- DB backup creation (`mysqldump` logical export) with two explicit modes:
+  - full database backup (all tables/data)
+  - compact database backup (excludes bulky runtime/history tables such as results, metrics history, and logs)
 - backup file listing/download
 
 DB maintenance intentionally does **not** include full database overview or table-inventory status sections.

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminDatabaseController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminDatabaseController.cs
@@ -130,12 +130,13 @@ public sealed class AdminDatabaseController : Controller
         var result = await _databaseMaintenanceService.CreateBackupAsync(
             new DatabaseBackupCreateRequest
             {
+                BackupMode = backupForm.BackupMode,
                 RequestedBy = GetOperatorIdentity()
             },
             cancellationToken);
 
         TempData["DbBackupStatus"] = result.Succeeded
-            ? $"Database backup created: {result.FileName} ({result.FileSizeBytes} bytes)."
+            ? $"{result.BackupMode} database backup created: {result.FileName} ({result.FileSizeBytes} bytes)."
             : $"Database backup failed: {result.Message}";
 
         return RedirectToAction(nameof(Maintenance));
@@ -198,7 +199,9 @@ public sealed class AdminDatabaseController : Controller
                 cancellationToken);
 
             TempData["DbBackupStatus"] = result.Succeeded
-                ? $"Database backup restored from {result.RestoredFileName}. Pre-restore backup: {result.PreRestoreBackupFileName ?? "(none)"}."
+                ? result.BackupMode == DatabaseBackupMode.Compact
+                    ? $"Compact database backup restored from {result.RestoredFileName}. Historical/runtime tables excluded by compact profile were reset to empty. Pre-restore backup: {result.PreRestoreBackupFileName ?? "(none)"}."
+                    : $"Full database backup restored from {result.RestoredFileName}. Pre-restore backup: {result.PreRestoreBackupFileName ?? "(none)"}."
                 : $"Database backup restore failed: {result.Message}";
         }
         catch (FileNotFoundException)
@@ -387,6 +390,8 @@ public sealed class AdminDatabaseController : Controller
                 FileId = x.FileId,
                 CreatedAtUtc = x.CreatedAtUtc,
                 SizeBytes = x.FileSizeBytes,
+                BackupMode = x.BackupMode,
+                BackupModeDisplayName = x.BackupModeDisplayName,
                 MetadataSummary = x.MetadataSummary,
                 BackupSource = x.BackupSource
             }).ToArray()

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceModels.cs
@@ -42,6 +42,7 @@ public sealed class DatabasePruneExecuteResult
 
 public sealed class DatabaseBackupCreateRequest
 {
+    public DatabaseBackupMode BackupMode { get; init; } = DatabaseBackupMode.Full;
     public string? RequestedBy { get; init; }
 }
 
@@ -76,6 +77,7 @@ public sealed class DatabaseBackupRestoreResult
     public string Message { get; init; } = string.Empty;
     public string? RestoredFileName { get; init; }
     public DateTimeOffset? RestoredFileCreatedAtUtc { get; init; }
+    public DatabaseBackupMode BackupMode { get; init; } = DatabaseBackupMode.Full;
     public bool PreRestoreBackupCreated { get; init; }
     public string? PreRestoreBackupFileName { get; init; }
 }
@@ -100,6 +102,7 @@ public sealed class DatabaseBackupCreateResult
     public string Message { get; init; } = string.Empty;
     public string? FileName { get; init; }
     public string? FullPath { get; init; }
+    public DatabaseBackupMode BackupMode { get; init; } = DatabaseBackupMode.Full;
     public long? FileSizeBytes { get; init; }
     public DateTimeOffset? CreatedAtUtc { get; init; }
 }
@@ -113,4 +116,12 @@ public sealed class DatabaseBackupFileSnapshot
     public string FullPath { get; init; } = string.Empty;
     public string MetadataSummary { get; init; } = string.Empty;
     public string BackupSource { get; init; } = string.Empty;
+    public DatabaseBackupMode BackupMode { get; init; } = DatabaseBackupMode.Full;
+    public string BackupModeDisplayName { get; init; } = string.Empty;
+}
+
+public enum DatabaseBackupMode
+{
+    Full = 1,
+    Compact = 2
 }

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
@@ -17,6 +17,21 @@ namespace PingMonitor.Web.Services.DatabaseStatus;
 internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 {
     private const int MaxUploadBytes = 100 * 1024 * 1024;
+    private const string BackupModeCommentPrefix = "-- pingmonitor_backup_mode:";
+    private const string BackupProfileCommentPrefix = "-- pingmonitor_backup_profile:";
+    private const string CompactBackupProfileName = "compact_runtime_excluded_v1";
+    private const int MetadataProbeBytes = 16 * 1024;
+    private static readonly string[] CompactExcludedTables =
+    [
+        "AgentHeartbeatHistory",
+        "CheckResults",
+        "ResultBatches",
+        "StateTransitions",
+        "AssignmentRttMinuteBuckets",
+        "AssignmentStateIntervals",
+        "EventLogs",
+        "SecurityAuthLogs"
+    ];
 
     private readonly PingMonitorDbContext _dbContext;
     private readonly IEventLogService _eventLogService;
@@ -144,6 +159,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         var builder = new MySqlConnectionStringBuilder(dbConnectionString);
         var backupTimestamp = DateTimeOffset.UtcNow;
         var safeDatabaseName = string.IsNullOrWhiteSpace(builder.Database) ? "database" : builder.Database.Trim();
+        var normalizedBackupMode = NormalizeBackupMode(request.BackupMode);
         var fileName = $"db-backup-{safeDatabaseName}-{backupTimestamp:yyyyMMdd-HHmmss}.sql";
         var fullPath = Path.Combine(backupDirectory, fileName);
         var mysqldumpExecutablePath = ResolveExecutablePath(options.MySqlDumpExecutablePath, "mysqldump");
@@ -177,6 +193,14 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         processInfo.ArgumentList.Add("--user");
         processInfo.ArgumentList.Add(builder.UserID);
         processInfo.ArgumentList.Add(builder.Database);
+        if (normalizedBackupMode == DatabaseBackupMode.Compact)
+        {
+            foreach (var excludedTable in CompactExcludedTables)
+            {
+                processInfo.ArgumentList.Add($"--ignore-table={builder.Database}.{excludedTable}");
+            }
+        }
+
         processInfo.Environment["MYSQL_PWD"] = builder.Password;
 
         try
@@ -189,6 +213,9 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 
             await using (var fileStream = new FileStream(fullPath, FileMode.Create, FileAccess.Write, FileShare.None))
             {
+                var headerText = BuildBackupHeader(normalizedBackupMode, backupTimestamp);
+                var headerBytes = Encoding.UTF8.GetBytes(headerText);
+                await fileStream.WriteAsync(headerBytes, cancellationToken);
                 await process.StandardOutput.BaseStream.CopyToAsync(fileStream, cancellationToken);
             }
 
@@ -217,6 +244,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
                 {
                     fileName,
                     fullPath,
+                    backupMode = normalizedBackupMode.ToString(),
                     fileSizeBytes = fileInfo.Length,
                     createdAtUtc = backupTimestamp,
                     requestedBy = request.RequestedBy
@@ -229,6 +257,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
                 Message = "Database backup export completed successfully.",
                 FileName = fileName,
                 FullPath = fullPath,
+                BackupMode = normalizedBackupMode,
                 FileSizeBytes = fileInfo.Length,
                 CreatedAtUtc = backupTimestamp
             };
@@ -329,6 +358,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         var backupPath = ResolveBackupDownloadPath(request.FileId);
         var backupFileInfo = new FileInfo(backupPath);
         var contentBytes = await File.ReadAllBytesAsync(backupPath, cancellationToken);
+        var backupDescriptor = ReadBackupDescriptorFromContent(contentBytes);
         var validationMessage = ValidateSqlBackupContent(contentBytes);
         if (validationMessage is not null)
         {
@@ -353,6 +383,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
                 Message = validationMessage,
                 RestoredFileName = backupFileInfo.Name,
                 RestoredFileCreatedAtUtc = new DateTimeOffset(backupFileInfo.LastWriteTimeUtc, TimeSpan.Zero),
+                BackupMode = backupDescriptor.Mode,
                 PreRestoreBackupCreated = false
             };
         }
@@ -367,6 +398,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
             {
                 request.FileId,
                 fileName = backupFileInfo.Name,
+                backupMode = backupDescriptor.Mode.ToString(),
                 fileSizeBytes = backupFileInfo.Length,
                 requestedBy = request.RequestedBy
             })
@@ -398,6 +430,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
                 Message = $"Restore was aborted because pre-restore backup failed: {preRestoreBackup.Message}",
                 RestoredFileName = backupFileInfo.Name,
                 RestoredFileCreatedAtUtc = new DateTimeOffset(backupFileInfo.LastWriteTimeUtc, TimeSpan.Zero),
+                BackupMode = backupDescriptor.Mode,
                 PreRestoreBackupCreated = false
             };
         }
@@ -405,14 +438,14 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         var dbConnectionString = _dbContext.Database.GetConnectionString();
         if (string.IsNullOrWhiteSpace(dbConnectionString))
         {
-            return await CreateRestoreFailureAsync("Database connection string is unavailable.", backupFileInfo, request, true, preRestoreBackup.FileName, cancellationToken);
+            return await CreateRestoreFailureAsync("Database connection string is unavailable.", backupFileInfo, request, backupDescriptor.Mode, true, preRestoreBackup.FileName, cancellationToken);
         }
 
         var builder = new MySqlConnectionStringBuilder(dbConnectionString);
         var mysqlExecutablePath = ResolveExecutablePath(null, "mysql");
         if (mysqlExecutablePath is null)
         {
-            return await CreateRestoreFailureAsync("mysql executable was not found. Ensure mysql client is installed and available in PATH.", backupFileInfo, request, true, preRestoreBackup.FileName, cancellationToken);
+            return await CreateRestoreFailureAsync("mysql executable was not found. Ensure mysql client is installed and available in PATH.", backupFileInfo, request, backupDescriptor.Mode, true, preRestoreBackup.FileName, cancellationToken);
         }
 
         var processInfo = new ProcessStartInfo
@@ -439,7 +472,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
             using var process = Process.Start(processInfo);
             if (process is null)
             {
-                return await CreateRestoreFailureAsync("Unable to start mysql restore process.", backupFileInfo, request, true, preRestoreBackup.FileName, cancellationToken);
+                return await CreateRestoreFailureAsync("Unable to start mysql restore process.", backupFileInfo, request, backupDescriptor.Mode, true, preRestoreBackup.FileName, cancellationToken);
             }
 
             await process.StandardInput.BaseStream.WriteAsync(contentBytes, cancellationToken);
@@ -450,7 +483,12 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 
             if (process.ExitCode != 0)
             {
-                return await CreateRestoreFailureAsync($"mysql restore exited with code {process.ExitCode}. {TrimDiagnostic(stderr)}", backupFileInfo, request, true, preRestoreBackup.FileName, cancellationToken);
+                return await CreateRestoreFailureAsync($"mysql restore exited with code {process.ExitCode}. {TrimDiagnostic(stderr)}", backupFileInfo, request, backupDescriptor.Mode, true, preRestoreBackup.FileName, cancellationToken);
+            }
+
+            if (backupDescriptor.Mode == DatabaseBackupMode.Compact)
+            {
+                await ResetCompactExcludedTablesAsync(cancellationToken);
             }
 
             await _eventLogService.WriteAsync(new EventLogWriteRequest
@@ -463,6 +501,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
                 {
                     request.FileId,
                     fileName = backupFileInfo.Name,
+                    backupMode = backupDescriptor.Mode.ToString(),
                     restoredFileCreatedAtUtc = backupFileInfo.LastWriteTimeUtc,
                     preRestoreBackupFileName = preRestoreBackup.FileName,
                     requestedBy = request.RequestedBy
@@ -475,6 +514,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
                 Message = "Database restore completed successfully.",
                 RestoredFileName = backupFileInfo.Name,
                 RestoredFileCreatedAtUtc = new DateTimeOffset(backupFileInfo.LastWriteTimeUtc, TimeSpan.Zero),
+                BackupMode = backupDescriptor.Mode,
                 PreRestoreBackupCreated = true,
                 PreRestoreBackupFileName = preRestoreBackup.FileName
             };
@@ -482,7 +522,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         catch (Exception ex) when (ex is Win32Exception || ex is InvalidOperationException || ex is IOException)
         {
             _logger.LogWarning(ex, "Database backup restore failed.");
-            return await CreateRestoreFailureAsync($"Database restore failed: {ex.Message}", backupFileInfo, request, true, preRestoreBackup.FileName, cancellationToken);
+            return await CreateRestoreFailureAsync($"Database restore failed: {ex.Message}", backupFileInfo, request, backupDescriptor.Mode, true, preRestoreBackup.FileName, cancellationToken);
         }
     }
 
@@ -638,15 +678,27 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
             .GetFiles(backupDirectory, "*.sql", SearchOption.TopDirectoryOnly)
             .Select(path => new FileInfo(path))
             .OrderByDescending(x => x.LastWriteTimeUtc)
-            .Select(x => new DatabaseBackupFileSnapshot
+            .Select(x =>
             {
-                FileName = x.Name,
-                FileId = ComputeFileId(x.Name),
-                CreatedAtUtc = new DateTimeOffset(x.LastWriteTimeUtc, TimeSpan.Zero),
-                FileSizeBytes = x.Length,
-                FullPath = x.FullName,
-                MetadataSummary = BuildMetadataSummary(x.Name),
-                BackupSource = x.Name.StartsWith("uploaded-db-backup-", StringComparison.OrdinalIgnoreCase) ? "Uploaded" : "Created"
+                // Probe lightweight backup metadata from the SQL comment header when available.
+                // This allows operator-visible mode (Full vs Compact) and restore warnings.
+                // Uploaded files without PingMonitor metadata default to Full mode semantics.
+                // The restore path also independently re-parses metadata from content bytes.
+                var descriptor = ReadBackupDescriptorFromFile(x.FullName);
+                return new DatabaseBackupFileSnapshot
+                {
+                    FileName = x.Name,
+                    FileId = ComputeFileId(x.Name),
+                    CreatedAtUtc = new DateTimeOffset(x.LastWriteTimeUtc, TimeSpan.Zero),
+                    FileSizeBytes = x.Length,
+                    FullPath = x.FullName,
+                    MetadataSummary = BuildMetadataSummary(x.FullName),
+                    BackupSource = x.Name.StartsWith("uploaded-db-backup-", StringComparison.OrdinalIgnoreCase) ? "Uploaded" : "Created",
+                    BackupMode = descriptor.Mode,
+                    BackupModeDisplayName = descriptor.Mode == DatabaseBackupMode.Compact
+                        ? "Compact database backup"
+                        : "Full database backup"
+                };
             })
             .ToArray();
 
@@ -727,6 +779,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         string message,
         FileInfo backupFileInfo,
         DatabaseBackupRestoreRequest request,
+        DatabaseBackupMode backupMode,
         bool preRestoreBackupCreated,
         string? preRestoreBackupFileName,
         CancellationToken cancellationToken)
@@ -741,6 +794,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
             {
                 request.FileId,
                 fileName = backupFileInfo.Name,
+                backupMode = backupMode.ToString(),
                 preRestoreBackupCreated,
                 preRestoreBackupFileName,
                 requestedBy = request.RequestedBy
@@ -753,9 +807,94 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
             Message = message,
             RestoredFileName = backupFileInfo.Name,
             RestoredFileCreatedAtUtc = new DateTimeOffset(backupFileInfo.LastWriteTimeUtc, TimeSpan.Zero),
+            BackupMode = backupMode,
             PreRestoreBackupCreated = preRestoreBackupCreated,
             PreRestoreBackupFileName = preRestoreBackupFileName
         };
+    }
+
+    private static string BuildBackupHeader(DatabaseBackupMode mode, DateTimeOffset createdAtUtc)
+    {
+        var profile = mode == DatabaseBackupMode.Compact ? CompactBackupProfileName : "full_database";
+        var modeToken = mode == DatabaseBackupMode.Compact ? "compact" : "full";
+        return
+            $"-- PingMonitor database backup metadata{Environment.NewLine}" +
+            $"{BackupModeCommentPrefix}{modeToken}{Environment.NewLine}" +
+            $"{BackupProfileCommentPrefix}{profile}{Environment.NewLine}" +
+            $"-- pingmonitor_backup_created_at_utc:{createdAtUtc:O}{Environment.NewLine}";
+    }
+
+    private static DatabaseBackupMode NormalizeBackupMode(DatabaseBackupMode mode)
+    {
+        return mode == DatabaseBackupMode.Compact ? DatabaseBackupMode.Compact : DatabaseBackupMode.Full;
+    }
+
+    private async Task ResetCompactExcludedTablesAsync(CancellationToken cancellationToken)
+    {
+        foreach (var tableName in CompactExcludedTables)
+        {
+            var sql = $"DELETE FROM `{tableName}`;";
+            await _dbContext.Database.ExecuteSqlRawAsync(sql, cancellationToken);
+        }
+    }
+
+    private static BackupDescriptor ReadBackupDescriptorFromFile(string fullPath)
+    {
+        try
+        {
+            using var stream = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            var probeLength = (int)Math.Min(MetadataProbeBytes, stream.Length);
+            if (probeLength <= 0)
+            {
+                return BackupDescriptor.FullByDefault;
+            }
+
+            var buffer = new byte[probeLength];
+            _ = stream.Read(buffer, 0, probeLength);
+            return ReadBackupDescriptorFromContent(buffer);
+        }
+        catch
+        {
+            return BackupDescriptor.FullByDefault;
+        }
+    }
+
+    private static BackupDescriptor ReadBackupDescriptorFromContent(byte[] contentBytes)
+    {
+        try
+        {
+            var prefixLength = Math.Min(contentBytes.Length, MetadataProbeBytes);
+            if (prefixLength <= 0)
+            {
+                return BackupDescriptor.FullByDefault;
+            }
+
+            var text = Encoding.UTF8.GetString(contentBytes, 0, prefixLength);
+            foreach (var line in text.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (!line.StartsWith(BackupModeCommentPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var rawMode = line[BackupModeCommentPrefix.Length..].Trim();
+                if (rawMode.Equals("compact", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new BackupDescriptor(DatabaseBackupMode.Compact);
+                }
+
+                if (rawMode.Equals("full", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new BackupDescriptor(DatabaseBackupMode.Full);
+                }
+            }
+        }
+        catch
+        {
+            // Fall back to full mode semantics for unknown or non-UTF8 files.
+        }
+
+        return BackupDescriptor.FullByDefault;
     }
 
     private string GetBackupDirectory(string configuredPath)
@@ -851,14 +990,19 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         return null;
     }
 
-    private static string BuildMetadataSummary(string fileName)
+    private static string BuildMetadataSummary(string fullPath)
     {
-        var schemaMatch = Regex.Match(fileName, @"schema-v(?<version>\d+)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-        if (schemaMatch.Success)
+        var descriptor = ReadBackupDescriptorFromFile(fullPath);
+        if (descriptor.Mode == DatabaseBackupMode.Compact)
         {
-            return $"Schema v{schemaMatch.Groups["version"].Value}";
+            return "Compact profile: excludes results, metrics history, and logs";
         }
 
-        return "MySQL logical SQL dump";
+        return "Full profile: includes complete MySQL logical SQL dump";
+    }
+
+    private readonly record struct BackupDescriptor(DatabaseBackupMode Mode)
+    {
+        public static BackupDescriptor FullByDefault => new(DatabaseBackupMode.Full);
     }
 }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/DatabaseStatusPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/DatabaseStatusPageViewModel.cs
@@ -125,6 +125,9 @@ public sealed class DatabasePrunePreviewViewModel
 
 public sealed class DatabaseBackupForm
 {
+    [Required]
+    public DatabaseBackupMode BackupMode { get; set; } = DatabaseBackupMode.Full;
+
     public bool ConfirmBackup { get; set; }
 }
 
@@ -157,6 +160,8 @@ public sealed class DatabaseBackupRowViewModel
     public string FileId { get; init; } = string.Empty;
     public DateTimeOffset CreatedAtUtc { get; init; }
     public long SizeBytes { get; init; }
+    public DatabaseBackupMode BackupMode { get; init; } = DatabaseBackupMode.Full;
+    public string BackupModeDisplayName { get; init; } = string.Empty;
     public string MetadataSummary { get; init; } = string.Empty;
     public string BackupSource { get; init; } = string.Empty;
 }

--- a/src/WebApp/PingMonitor.Web/Views/AdminDatabase/Maintenance.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminDatabase/Maintenance.cshtml
@@ -81,9 +81,16 @@
         <section class="card">
             <h2>DB backup tool (MySQL logical dump)</h2>
             <p class="muted">This section manages <strong>DATABASE backups only</strong>. It does not include configuration backups. Existing create/download behaviour remains unchanged, and upload/restore/delete actions apply only to MySQL SQL dump backups.</p>
-            <p class="muted">This tool runs <code>mysqldump</code> to create a full logical SQL export of the current MySQL database.</p>
+            <p class="muted">This tool runs <code>mysqldump</code> to create either a full or compact logical SQL export of the current MySQL database.</p>
             <form method="post" action="/admin/database/backup/create" class="form-grid">
                 @Html.AntiForgeryToken()
+                <label>Backup mode
+                    <select asp-for="BackupForm.BackupMode">
+                        <option value="@DatabaseBackupMode.Full">Full database backup</option>
+                        <option value="@DatabaseBackupMode.Compact">Compact database backup (excludes results, metrics, and logs)</option>
+                    </select>
+                </label>
+                <p class="muted">Compact backup preserves configuration and core state, while excluding bulky runtime history (results, metrics history, and logs) to reduce file size.</p>
                 <label>
                     <input asp-for="BackupForm.ConfirmBackup" type="checkbox" /> I confirm I want to create a database backup export now.
                 </label>
@@ -103,7 +110,7 @@
             <h3>DATABASE backup files</h3>
             <div class="table-wrap">
                 <table>
-                    <thead><tr><th>File</th><th>Created/Exported (UTC)</th><th>Size</th><th>Source</th><th>Metadata</th><th>Actions</th></tr></thead>
+                    <thead><tr><th>File</th><th>Created/Exported (UTC)</th><th>Size</th><th>Type</th><th>Source</th><th>Metadata</th><th>Actions</th></tr></thead>
                     <tbody>
                     @foreach (var backup in Model.Backups)
                     {
@@ -111,6 +118,7 @@
                             <td>@backup.FileName</td>
                             <td>@DisplayFormatting.FormatUtcDateTime(backup.CreatedAtUtc)</td>
                             <td>@DisplayFormatting.FormatBytes(backup.SizeBytes)</td>
+                            <td>@backup.BackupModeDisplayName</td>
                             <td>@backup.BackupSource</td>
                             <td>@backup.MetadataSummary</td>
                             <td>
@@ -126,6 +134,7 @@
                 <h3>Restore DATABASE backup (High risk)</h3>
                 <p><strong>This will completely replace the current DATABASE.</strong></p>
                 <p class="muted">Select the backup file to restore. A pre-restore database backup will be created automatically before restore is applied.</p>
+                <p class="muted"><strong>Compact restore note:</strong> compact backups exclude runtime history (results, metrics, logs). Those excluded runtime tables are reset to empty during restore.</p>
                 <form method="post" action="/admin/database/backup/restore" class="form-grid">
                     @Html.AntiForgeryToken()
                     <label>Backup to restore
@@ -133,7 +142,7 @@
                             <option value="">-- Select DATABASE backup --</option>
                             @foreach (var backup in Model.Backups)
                             {
-                                <option value="@backup.FileId">@backup.FileName (@DisplayFormatting.FormatUtcDateTime(backup.CreatedAtUtc))</option>
+                                <option value="@backup.FileId">@backup.FileName (@backup.BackupModeDisplayName, @DisplayFormatting.FormatUtcDateTime(backup.CreatedAtUtc))</option>
                             }
                         </select>
                     </label>


### PR DESCRIPTION
### Motivation
- Provide operators a compact DATABASE backup option that preserves system configuration and core state while excluding bulky runtime/history data to reduce backup size.  
- Keep full backup behavior unchanged and limit the scope of changes to the DATABASE backup subsystem (do not touch configuration backups).  
- Track backup type in metadata so operators can see whether a backup contains historical/runtime data (addresses issue #359). 

### Description
- Add explicit backup mode model (`DatabaseBackupMode` with `Full` and `Compact`) and propagate it through create/list/restore models and viewmodels.  
- Implement compact export by adding `mysqldump --ignore-table=` arguments for a curated set of large runtime/history tables and emit lightweight SQL comment metadata at the top of created backups.  
- Parse the SQL header metadata when listing and restoring backups so the UI shows the backup type and the restore flow can detect compact backups, and when restoring a compact backup run deterministic cleanup to reset the excluded runtime/history tables to empty.  
- UI and docs updates: add a backup mode selector and explanatory copy, show a Type column in the DB backups list, and show a compact-restore note in the restore UI.  
- Files modified: `DatabaseMaintenanceModels.cs`, `DatabaseMaintenanceService.cs`, `AdminDatabaseController.cs`, `DatabaseStatusPageViewModel.cs`, `Maintenance.cshtml`, and `docs/db-status-and-maintenance.md` (all under `src/WebApp/PingMonitor.Web` except docs). 

### Testing
- Built the web application with .NET 10 SDK (`dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`) and the build succeeded with no compilation errors.  
- No automated unit tests were added in this change; compilation is the automated validation performed in this environment and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d32935c880832a9e7d197e62f9ee3d)