### PR TITLE
Add DATABASE backup restore recovery actions to Startup Gate

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using PingMonitor.Web.Options;
+using PingMonitor.Web.Services.DatabaseStatus;
 using PingMonitor.Web.Services.StartupGate;
 using PingMonitor.Web.ViewModels.StartupGate;
 
@@ -15,6 +16,7 @@ public sealed class StartupGateController : Controller
     private readonly IStartupDatabaseConfigurationStore _configurationStore;
     private readonly IStartupSchemaService _schemaService;
     private readonly IStartupAdminBootstrapService _adminBootstrapService;
+    private readonly IDatabaseMaintenanceService _databaseMaintenanceService;
     private readonly StartupGateOptions _options;
     private readonly ILogger<StartupGateController> _logger;
 
@@ -23,6 +25,7 @@ public sealed class StartupGateController : Controller
         IStartupDatabaseConfigurationStore configurationStore,
         IStartupSchemaService schemaService,
         IStartupAdminBootstrapService adminBootstrapService,
+        IDatabaseMaintenanceService databaseMaintenanceService,
         IOptions<StartupGateOptions> options,
         ILogger<StartupGateController> logger)
     {
@@ -30,6 +33,7 @@ public sealed class StartupGateController : Controller
         _configurationStore = configurationStore;
         _schemaService = schemaService;
         _adminBootstrapService = adminBootstrapService;
+        _databaseMaintenanceService = databaseMaintenanceService;
         _options = options.Value;
         _logger = logger;
     }
@@ -38,7 +42,7 @@ public sealed class StartupGateController : Controller
     public async Task<IActionResult> Index(CancellationToken cancellationToken)
     {
         var status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
-        return View("Index", BuildViewModel(status, null, null));
+        return View("Index", await BuildViewModelAsync(status, null, null, null, null, cancellationToken: cancellationToken));
     }
 
     [HttpPost("database")]
@@ -53,7 +57,7 @@ public sealed class StartupGateController : Controller
 
         if (!ModelState.IsValid)
         {
-            return View("Index", BuildViewModel(status, form, null, errorMessage: "Database configuration could not be saved."));
+            return View("Index", await BuildViewModelAsync(status, form, null, null, null, errorMessage: "Database configuration could not be saved.", cancellationToken: cancellationToken));
         }
 
         _logger.LogInformation("Startup gate database configuration save attempt for {Host}:{Port}/{DatabaseName}.", form.Host, form.Port, form.DatabaseName);
@@ -73,11 +77,11 @@ public sealed class StartupGateController : Controller
         {
             _logger.LogWarning(exception, "Startup gate database configuration save failed.");
             status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
-            return View("Index", BuildViewModel(status, form, null, errorMessage: $"Database configuration save failed: {exception.Message}"));
+            return View("Index", await BuildViewModelAsync(status, form, null, null, null, errorMessage: $"Database configuration save failed: {exception.Message}", cancellationToken: cancellationToken));
         }
 
         status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
-        return View("Index", BuildViewModel(status, null, null, statusMessage: "Database configuration saved. Password values are not shown after saving."));
+        return View("Index", await BuildViewModelAsync(status, null, null, null, null, statusMessage: "Database configuration saved. Password values are not shown after saving.", cancellationToken: cancellationToken));
     }
 
     [HttpPost("schema/apply")]
@@ -98,11 +102,11 @@ public sealed class StartupGateController : Controller
         {
             _logger.LogWarning(exception, "Startup gate schema apply failed.");
             status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
-            return View("Index", BuildViewModel(status, null, null, errorMessage: $"Schema apply failed: {exception.Message}"));
+            return View("Index", await BuildViewModelAsync(status, null, null, null, null, errorMessage: $"Schema apply failed: {exception.Message}", cancellationToken: cancellationToken));
         }
 
         status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
-        return View("Index", BuildViewModel(status, null, null, statusMessage: "Schema apply completed."));
+        return View("Index", await BuildViewModelAsync(status, null, null, null, null, statusMessage: "Schema apply completed.", cancellationToken: cancellationToken));
     }
 
     [HttpPost("admin")]
@@ -117,7 +121,7 @@ public sealed class StartupGateController : Controller
 
         if (!ModelState.IsValid)
         {
-            return View("Index", BuildViewModel(status, null, form, errorMessage: "Initial admin could not be created."));
+            return View("Index", await BuildViewModelAsync(status, null, form, null, null, errorMessage: "Initial admin could not be created.", cancellationToken: cancellationToken));
         }
 
         var result = await _adminBootstrapService.CreateInitialAdminAsync(form, cancellationToken);
@@ -129,21 +133,125 @@ public sealed class StartupGateController : Controller
             }
 
             status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
-            return View("Index", BuildViewModel(status, null, form, errorMessage: "Initial admin could not be created."));
+            return View("Index", await BuildViewModelAsync(status, null, form, null, null, errorMessage: "Initial admin could not be created.", cancellationToken: cancellationToken));
         }
 
         status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
-        return View("Index", BuildViewModel(status, null, null, statusMessage: "Initial admin created."));
+        return View("Index", await BuildViewModelAsync(status, null, null, null, null, statusMessage: "Initial admin created.", cancellationToken: cancellationToken));
     }
 
-    private StartupGatePageViewModel BuildViewModel(
+    [HttpPost("database-backup/upload")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UploadDatabaseBackup([FromForm(Name = "DatabaseBackupUploadForm")] StartupDatabaseBackupUploadForm form, CancellationToken cancellationToken)
+    {
+        var status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
+        if (!status.CanPerformWriteActions)
+        {
+            return Forbid();
+        }
+
+        if (form.BackupFile is null || form.BackupFile.Length <= 0)
+        {
+            ModelState.AddModelError($"{nameof(StartupDatabaseBackupUploadForm)}.{nameof(StartupDatabaseBackupUploadForm.BackupFile)}", "Select a DATABASE backup file to upload.");
+            return View("Index", await BuildViewModelAsync(status, null, null, form, null, errorMessage: "DATABASE backup upload failed.", cancellationToken: cancellationToken));
+        }
+
+        await using var stream = form.BackupFile.OpenReadStream();
+        var result = await _databaseMaintenanceService.UploadBackupAsync(
+            new DatabaseBackupUploadRequest
+            {
+                OriginalFileName = form.BackupFile.FileName,
+                Content = stream,
+                RequestedBy = "startup-gate"
+            },
+            cancellationToken);
+
+        status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
+        return View("Index", await BuildViewModelAsync(
+            status,
+            null,
+            null,
+            null,
+            null,
+            statusMessage: result.Succeeded
+                ? $"DATABASE backup upload completed: {result.FileName} ({result.FileSizeBytes} bytes)."
+                : null,
+            errorMessage: result.Succeeded
+                ? null
+                : $"DATABASE backup upload failed: {result.Message}",
+            cancellationToken: cancellationToken));
+    }
+
+    [HttpPost("database-backup/restore")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RestoreDatabaseBackup([FromForm(Name = "DatabaseBackupRestoreForm")] StartupDatabaseBackupRestoreForm form, CancellationToken cancellationToken)
+    {
+        var status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
+        if (!status.CanPerformWriteActions)
+        {
+            return Forbid();
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return View("Index", await BuildViewModelAsync(status, null, null, null, form, errorMessage: "DATABASE restore could not be started.", cancellationToken: cancellationToken));
+        }
+
+        if (!string.Equals(form.ConfirmationText?.Trim(), DatabaseBackupRestoreRequest.ConfirmationKeyword, StringComparison.Ordinal))
+        {
+            ModelState.AddModelError($"{nameof(StartupDatabaseBackupRestoreForm)}.{nameof(StartupDatabaseBackupRestoreForm.ConfirmationText)}", $"Type {DatabaseBackupRestoreRequest.ConfirmationKeyword} to confirm restore.");
+            return View("Index", await BuildViewModelAsync(status, null, null, null, form, errorMessage: "DATABASE restore could not be started.", cancellationToken: cancellationToken));
+        }
+
+        DatabaseBackupRestoreResult result;
+        try
+        {
+            result = await _databaseMaintenanceService.RestoreBackupAsync(
+                new DatabaseBackupRestoreRequest
+                {
+                    FileId = form.FileId,
+                    ConfirmationText = form.ConfirmationText ?? string.Empty,
+                    RequestedBy = "startup-gate"
+                },
+                cancellationToken);
+        }
+        catch (FileNotFoundException)
+        {
+            status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
+            return View("Index", await BuildViewModelAsync(status, null, null, null, form, errorMessage: "DATABASE restore failed: selected backup file was not found.", cancellationToken: cancellationToken));
+        }
+
+        status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
+        return View("Index", await BuildViewModelAsync(
+            status,
+            null,
+            null,
+            null,
+            null,
+            statusMessage: result.Succeeded
+                ? result.BackupMode == DatabaseBackupMode.Compact
+                    ? $"Compact DATABASE backup restored from {result.RestoredFileName}. Runtime history tables excluded by compact profile were reset to empty. Pre-restore backup: {result.PreRestoreBackupFileName ?? "(none)"}."
+                    : $"Full DATABASE backup restored from {result.RestoredFileName}. Pre-restore backup: {result.PreRestoreBackupFileName ?? "(none)"}."
+                : null,
+            errorMessage: result.Succeeded
+                ? null
+                : $"DATABASE restore failed: {result.Message}",
+            cancellationToken: cancellationToken));
+    }
+
+    private async Task<StartupGatePageViewModel> BuildViewModelAsync(
         StartupGateStatus status,
         StartupDatabaseConfigurationForm? databaseForm,
         StartupAdminBootstrapForm? adminForm,
+        StartupDatabaseBackupUploadForm? databaseBackupUploadForm,
+        StartupDatabaseBackupRestoreForm? databaseBackupRestoreForm,
         string? statusMessage = null,
-        string? errorMessage = null)
+        string? errorMessage = null,
+        CancellationToken cancellationToken = default)
     {
         var existingConfig = status.DatabaseConfiguration;
+        var databaseBackups = await _databaseMaintenanceService.ListBackupsAsync(cancellationToken);
+
         return new StartupGatePageViewModel
         {
             Status = status,
@@ -156,7 +264,10 @@ public sealed class StartupGateController : Controller
                 DatabaseName = existingConfig?.DatabaseName ?? string.Empty,
                 Username = existingConfig?.Username ?? string.Empty
             },
-            AdminForm = adminForm ?? new StartupAdminBootstrapForm()
+            AdminForm = adminForm ?? new StartupAdminBootstrapForm(),
+            DatabaseBackupUploadForm = databaseBackupUploadForm ?? new StartupDatabaseBackupUploadForm(),
+            DatabaseBackupRestoreForm = databaseBackupRestoreForm ?? new StartupDatabaseBackupRestoreForm(),
+            DatabaseBackups = databaseBackups
         };
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupGateForms.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupGateForms.cs
@@ -49,3 +49,21 @@ public sealed class StartupAdminBootstrapForm
     [Display(Name = "Confirm password")]
     public string ConfirmPassword { get; set; } = string.Empty;
 }
+
+public sealed class StartupDatabaseBackupUploadForm
+{
+    [Required(ErrorMessage = "Select a DATABASE backup file to upload.")]
+    [Display(Name = "DATABASE backup SQL file")]
+    public IFormFile? BackupFile { get; set; }
+}
+
+public sealed class StartupDatabaseBackupRestoreForm
+{
+    [Required(ErrorMessage = "Select a DATABASE backup file to restore.")]
+    [Display(Name = "DATABASE backup to restore")]
+    public string FileId { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Type RESTORE to confirm.")]
+    [Display(Name = "Typed confirmation")]
+    public string ConfirmationText { get; set; } = string.Empty;
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/StartupGate/StartupGatePageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/StartupGate/StartupGatePageViewModel.cs
@@ -1,4 +1,5 @@
 using PingMonitor.Web.Services.StartupGate;
+using PingMonitor.Web.Services.DatabaseStatus;
 
 namespace PingMonitor.Web.ViewModels.StartupGate;
 
@@ -7,6 +8,9 @@ public sealed class StartupGatePageViewModel
     public required StartupGateStatus Status { get; init; }
     public required StartupDatabaseConfigurationForm DatabaseForm { get; init; }
     public required StartupAdminBootstrapForm AdminForm { get; init; }
+    public required StartupDatabaseBackupUploadForm DatabaseBackupUploadForm { get; init; }
+    public required StartupDatabaseBackupRestoreForm DatabaseBackupRestoreForm { get; init; }
+    public required IReadOnlyList<DatabaseBackupFileSnapshot> DatabaseBackups { get; init; }
     public string? StatusMessage { get; init; }
     public string? ErrorMessage { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Views/StartupGate/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/StartupGate/Index.cshtml
@@ -30,6 +30,9 @@
         .inline-list dt { font-weight: 600; }
         .hint { font-size: .95rem; }
         .validation-summary-errors { color: #b42318; }
+        .danger { border: 1px solid #fda29b; background: #fff5f4; border-radius: 10px; padding: .75rem; }
+        .warning { color: #b42318; font-weight: 700; }
+        select { width: 100%; box-sizing: border-box; padding: .85rem; border: 1px solid #cbd2d9; border-radius: 10px; font-size: 1rem; }
     </style>
 </head>
 <body>
@@ -106,6 +109,52 @@
             </div>
             <div style="grid-column: 1 / -1;">
                 <button type="submit" disabled="@(!Model.Status.CanPerformWriteActions)">Save MySQL configuration</button>
+            </div>
+        </form>
+    </section>
+
+    <section class="card">
+        <h2>DATABASE backup restore (Recovery)</h2>
+        <p class="muted">Use this only when DATABASE recovery is required before normal app use. This section is <strong>DATABASE-only</strong> and does not include configuration backup/restore.</p>
+        <div class="danger">
+            <p class="warning">Danger: restoring a DATABASE backup replaces current DATABASE contents.</p>
+            <p class="muted">Backup validation runs before restore. Restore uses the shared DATABASE maintenance restore workflow and automatically attempts a pre-restore DATABASE backup first.</p>
+        </div>
+
+        <h3>Upload DATABASE backup file</h3>
+        <form method="post" action="/startup-gate/database-backup/upload" enctype="multipart/form-data" class="grid">
+            @Html.AntiForgeryToken()
+            <div>
+                <label asp-for="DatabaseBackupUploadForm.BackupFile"></label>
+                <input asp-for="DatabaseBackupUploadForm.BackupFile" type="file" accept=".sql,text/plain,application/sql" disabled="@(!Model.Status.CanPerformWriteActions)" />
+                <span asp-validation-for="DatabaseBackupUploadForm.BackupFile"></span>
+            </div>
+            <div>
+                <button type="submit" disabled="@(!Model.Status.CanPerformWriteActions)">Upload DATABASE backup</button>
+            </div>
+        </form>
+
+        <h3>Restore DATABASE backup</h3>
+        <form method="post" action="/startup-gate/database-backup/restore" class="grid">
+            @Html.AntiForgeryToken()
+            <div>
+                <label asp-for="DatabaseBackupRestoreForm.FileId"></label>
+                <select asp-for="DatabaseBackupRestoreForm.FileId" disabled="@(!Model.Status.CanPerformWriteActions)">
+                    <option value="">-- Select DATABASE backup --</option>
+                    @foreach (var backup in Model.DatabaseBackups)
+                    {
+                        <option value="@backup.FileId">@backup.FileName (@backup.BackupModeDisplayName, @backup.CreatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss") UTC, @backup.MetadataSummary)</option>
+                    }
+                </select>
+                <span asp-validation-for="DatabaseBackupRestoreForm.FileId"></span>
+            </div>
+            <div>
+                <label asp-for="DatabaseBackupRestoreForm.ConfirmationText">Type <strong>RESTORE</strong> to confirm DATABASE replacement</label>
+                <input asp-for="DatabaseBackupRestoreForm.ConfirmationText" autocomplete="off" disabled="@(!Model.Status.CanPerformWriteActions)" />
+                <span asp-validation-for="DatabaseBackupRestoreForm.ConfirmationText"></span>
+            </div>
+            <div>
+                <button type="submit" disabled="@(!Model.Status.CanPerformWriteActions)">Restore DATABASE backup</button>
             </div>
         </form>
     </section>


### PR DESCRIPTION
### Motivation
- Operators must be able to restore a DATABASE backup from the Startup Gate when the normal admin UI is unavailable so recovery is possible before normal app use.
- The Startup Gate must reuse the existing database restore implementation and safeguards rather than introducing a separate restore engine to avoid duplicate logic and preserve audit/safety behavior.
- The restore entry must be explicitly dangerous, require typed confirmation, validate backups before applying, and re-check readiness so operators can continue only when the DB/schema are healthy.

### Description
- Added a dedicated DATABASE recovery section to the Startup Gate UI with upload and restore flows, explicit destructive warning, and typed `RESTORE` confirmation; view updated at `src/WebApp/PingMonitor.Web/Views/StartupGate/Index.cshtml`.
- Extended Startup Gate forms and view model to carry DB backup upload/restore inputs and available backup list, with new types in `src/WebApp/PingMonitor.Web/Services/StartupGate/StartupGateForms.cs` and `src/WebApp/PingMonitor.Web/ViewModels/StartupGate/StartupGatePageViewModel.cs`.
- Wired two new Startup Gate endpoints to the shared maintenance service: `POST /startup-gate/database-backup/upload` and `POST /startup-gate/database-backup/restore`, implemented in `src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs`, which call the existing `IDatabaseMaintenanceService` upload/list/restore methods so validation, logging, and pre-restore backup behavior are reused.
- Startup Gate now re-evaluates readiness after upload/restore so the operator sees updated gate status; configuration backup/restore was explicitly not changed and remains on the config admin pages.
- Files modified: `StartupGateController.cs`, `StartupGateForms.cs`, `StartupGatePageViewModel.cs`, `Views/StartupGate/Index.cshtml`.

### Testing
- Installed .NET 10 SDK matching `global.json` and built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which completed successfully.
- Ran automated tests with `dotnet test src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj --no-build` and they exited successfully (no failing tests).
- Verified the project compiles and the Startup Gate controller references the shared `IDatabaseMaintenanceService` restore path so validation, pre-restore backup creation, and event logging remain centralized and unchanged.

Fixes #361

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3382eb8e0832ab2f30de58032451b)