### PR TITLE
docs: add startup-gate DB restore failure diagnostic report

### DIFF
--- a/docs/diagnostics/2026-04-06-startup-gate-restore-failure.md
+++ b/docs/diagnostics/2026-04-06-startup-gate-restore-failure.md
@@ -1,0 +1,37 @@
+# Startup-gate restore failure diagnostic (2026-04-06)
+
+Related issue: https://github.com/ijyates1992/ping-monitor/issues/370
+
+## What was validated
+- Installed prerequisites in container: MySQL 8.0, .NET SDK 10.0.104 (matching `global.json`), and PowerShell 7.6.
+- Built and ran web app (`dotnet run --no-launch-profile`).
+- Completed startup-gate flow:
+  - saved DB configuration
+  - applied schema
+  - created initial admin
+- Verified landing page (`/`) loaded to sign-in page (startup-gate no longer active).
+- Logged in and created DB backup from `/admin/database/maintenance`.
+- Dropped/recreated schema.
+- Attempted restore from startup-gate DATABASE restore form.
+
+## Result
+- Restore request `POST /startup-gate/database-backup/restore` returned HTTP 500.
+- Restore did not complete.
+
+## Root-cause diagnosis
+Observed in server logs:
+- `DatabaseMaintenanceService.RestoreBackupAsync` starts pre-restore backup.
+- Pre-restore backup path writes event logs.
+- With schema dropped, table `EventLogs` does not exist.
+- Unhandled exception bubbles and returns HTTP 500:
+  - `Microsoft.EntityFrameworkCore.DbUpdateException`
+  - inner `MySql.Data.MySqlClient.MySqlException: Table 'pingmonitor.EventLogs' doesn't exist`
+
+## Why this happens
+Startup-gate restore is a recovery path for missing schema, but the current restore flow assumes normal runtime tables already exist (specifically `EventLogs`) before restore executes.
+
+## Repro essentials
+1. Complete startup-gate setup and create full DB backup.
+2. `DROP DATABASE pingmonitor; CREATE DATABASE pingmonitor ...;`
+3. In `/startup-gate`, restore DATABASE backup with confirmation `RESTORE`.
+4. Observe HTTP 500 and stack trace in logs.


### PR DESCRIPTION
### Motivation
- Capture a deterministic reproduction and root-cause evidence for a startup-gate DATABASE restore failure observed after dropping/recreating the schema. 
- Provide a concise diagnostic that speeds follow-up fixes and satisfies the repo's regression-proof requirements by documenting exact steps and failure signatures. 

### Description
- Add a diagnostic report at `docs/diagnostics/2026-04-06-startup-gate-restore-failure.md` describing the end-to-end validation, observed failure, and suspected root cause. 
- Record that a GitHub issue was created for the problem as issue `#370` to track remediation. 
- Commit the diagnostic file to the repository to provide a reproducible starting point for the fix. 

### Testing
- Installed and verified prerequisites with `apt-get` and `dotnet-install.sh`, ensuring the SDK `10.0.104` (matching `global.json`) was available. (succeeded) 
- Built the web app with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and launched it with `dotnet run` to serve the startup-gate UI. (succeeded) 
- Executed an automated setup/validation script (Python `requests` session) that saved DB config via `POST /startup-gate/database`, applied schema via `POST /startup-gate/schema/apply`, and created the initial admin via `POST /startup-gate/admin`; the app then rendered the sign-in landing page. (succeeded) 
- Created a full database backup from the Admin → Database Maintenance UI, dropped and recreated the `pingmonitor` schema with `DROP DATABASE` / `CREATE DATABASE`, and attempted restore via the startup-gate restore workflow; the restore returned HTTP 500 and the server logs show `MySqlException: Table 'pingmonitor.EventLogs' doesn't exist`, reproducing the failure. (failure reproduced as expected) 
- Created a GitHub issue via the REST API containing reproduction steps and logs (issue `#370`) and committed the diagnostic file with `git commit`. (issue created and diagnostic committed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d40ded0290832a87e1c8609f965be4)