### PR TITLE
Suppress DB-backed EventLogs during startup-gate pre-restore backup to avoid missing-table failures

### DIFF
--- a/docs/diagnostics/2026-04-06-startup-gate-restore-failure.md
+++ b/docs/diagnostics/2026-04-06-startup-gate-restore-failure.md
@@ -35,3 +35,15 @@ Startup-gate restore is a recovery path for missing schema, but the current rest
 2. `DROP DATABASE pingmonitor; CREATE DATABASE pingmonitor ...;`
 3. In `/startup-gate`, restore DATABASE backup with confirmation `RESTORE`.
 4. Observe HTTP 500 and stack trace in logs.
+
+## Regression checklist for fix validation
+Use this deterministic checklist for issue #370 validation:
+
+1. Create a DATABASE backup from `/admin/database/maintenance`.
+2. Drop and recreate the MySQL schema.
+3. Upload/select the DATABASE backup in startup-gate and run restore (`POST /startup-gate/database-backup/restore`).
+4. Confirm:
+   - response is not an unhandled HTTP 500;
+   - pre-restore backup is still created;
+   - no DB-backed `EventLogs` write is attempted before schema restore;
+   - restore success/failure is visible through runtime logs.

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceModels.cs
@@ -44,6 +44,7 @@ public sealed class DatabaseBackupCreateRequest
 {
     public DatabaseBackupMode BackupMode { get; init; } = DatabaseBackupMode.Full;
     public string? RequestedBy { get; init; }
+    public bool SuppressEventLogWrites { get; init; }
 }
 
 public sealed class DatabaseBackupUploadRequest

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
@@ -136,24 +136,28 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         var options = _options.Value;
         var backupDirectory = GetBackupDirectory(options.BackupStoragePath);
         Directory.CreateDirectory(backupDirectory);
+        var suppressEventLogWrites = request.SuppressEventLogWrites;
 
-        await _eventLogService.WriteAsync(new EventLogWriteRequest
-        {
-            Category = EventCategory.System,
-            EventType = EventType.DatabaseBackupStarted,
-            Severity = EventSeverity.Info,
-            Message = "Database backup export started.",
-            DetailsJson = JsonSerializer.Serialize(new
+        await WriteDatabaseBackupEventAsync(
+            new EventLogWriteRequest
             {
-                backupDirectory,
-                requestedBy = request.RequestedBy
-            })
-        }, cancellationToken);
+                Category = EventCategory.System,
+                EventType = EventType.DatabaseBackupStarted,
+                Severity = EventSeverity.Info,
+                Message = "Database backup export started.",
+                DetailsJson = JsonSerializer.Serialize(new
+                {
+                    backupDirectory,
+                    requestedBy = request.RequestedBy
+                })
+            },
+            suppressEventLogWrites,
+            cancellationToken);
 
         var dbConnectionString = _dbContext.Database.GetConnectionString();
         if (string.IsNullOrWhiteSpace(dbConnectionString))
         {
-            return await CreateBackupFailureAsync("Database connection string is unavailable.", request.RequestedBy, cancellationToken);
+            return await CreateBackupFailureAsync("Database connection string is unavailable.", request.RequestedBy, suppressEventLogWrites, cancellationToken);
         }
 
         var builder = new MySqlConnectionStringBuilder(dbConnectionString);
@@ -168,6 +172,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
             return await CreateBackupFailureAsync(
                 "mysqldump executable was not found. Configure DatabaseMaintenance:MySqlDumpExecutablePath with the full executable path.",
                 request.RequestedBy,
+                suppressEventLogWrites,
                 cancellationToken);
         }
 
@@ -208,7 +213,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
             using var process = Process.Start(processInfo);
             if (process is null)
             {
-                return await CreateBackupFailureAsync("Unable to start mysqldump process.", request.RequestedBy, cancellationToken);
+                return await CreateBackupFailureAsync("Unable to start mysqldump process.", request.RequestedBy, suppressEventLogWrites, cancellationToken);
             }
 
             await using (var fileStream = new FileStream(fullPath, FileMode.Create, FileAccess.Write, FileShare.None))
@@ -230,26 +235,29 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
                 }
 
                 var message = $"mysqldump exited with code {process.ExitCode}. {TrimDiagnostic(stderr)}";
-                return await CreateBackupFailureAsync(message, request.RequestedBy, cancellationToken);
+                return await CreateBackupFailureAsync(message, request.RequestedBy, suppressEventLogWrites, cancellationToken);
             }
 
             var fileInfo = new FileInfo(fullPath);
-            await _eventLogService.WriteAsync(new EventLogWriteRequest
-            {
-                Category = EventCategory.System,
-                EventType = EventType.DatabaseBackupCompleted,
-                Severity = EventSeverity.Info,
-                Message = $"Database backup export completed. File: {fileName}.",
-                DetailsJson = JsonSerializer.Serialize(new
+            await WriteDatabaseBackupEventAsync(
+                new EventLogWriteRequest
                 {
-                    fileName,
-                    fullPath,
-                    backupMode = normalizedBackupMode.ToString(),
-                    fileSizeBytes = fileInfo.Length,
-                    createdAtUtc = backupTimestamp,
-                    requestedBy = request.RequestedBy
-                })
-            }, cancellationToken);
+                    Category = EventCategory.System,
+                    EventType = EventType.DatabaseBackupCompleted,
+                    Severity = EventSeverity.Info,
+                    Message = $"Database backup export completed. File: {fileName}.",
+                    DetailsJson = JsonSerializer.Serialize(new
+                    {
+                        fileName,
+                        fullPath,
+                        backupMode = normalizedBackupMode.ToString(),
+                        fileSizeBytes = fileInfo.Length,
+                        createdAtUtc = backupTimestamp,
+                        requestedBy = request.RequestedBy
+                    })
+                },
+                suppressEventLogWrites,
+                cancellationToken);
 
             return new DatabaseBackupCreateResult
             {
@@ -270,7 +278,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
             }
 
             _logger.LogWarning(ex, "Database backup export failed.");
-            return await CreateBackupFailureAsync($"Database backup export failed: {ex.Message}", request.RequestedBy, cancellationToken);
+            return await CreateBackupFailureAsync($"Database backup export failed: {ex.Message}", request.RequestedBy, suppressEventLogWrites, cancellationToken);
         }
     }
 
@@ -389,7 +397,11 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
             request.RequestedBy);
 
         var preRestoreBackup = await CreateBackupAsync(
-            new DatabaseBackupCreateRequest { RequestedBy = request.RequestedBy },
+            new DatabaseBackupCreateRequest
+            {
+                RequestedBy = request.RequestedBy,
+                SuppressEventLogWrites = IsStartupGateRestoreRequest(request)
+            },
             cancellationToken);
         if (!preRestoreBackup.Succeeded)
         {
@@ -730,19 +742,26 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         };
     }
 
-    private async Task<DatabaseBackupCreateResult> CreateBackupFailureAsync(string message, string? requestedBy, CancellationToken cancellationToken)
+    private async Task<DatabaseBackupCreateResult> CreateBackupFailureAsync(
+        string message,
+        string? requestedBy,
+        bool suppressEventLogWrites,
+        CancellationToken cancellationToken)
     {
-        await _eventLogService.WriteAsync(new EventLogWriteRequest
-        {
-            Category = EventCategory.System,
-            EventType = EventType.DatabaseBackupFailed,
-            Severity = EventSeverity.Error,
-            Message = message,
-            DetailsJson = JsonSerializer.Serialize(new
+        await WriteDatabaseBackupEventAsync(
+            new EventLogWriteRequest
             {
-                requestedBy
-            })
-        }, cancellationToken);
+                Category = EventCategory.System,
+                EventType = EventType.DatabaseBackupFailed,
+                Severity = EventSeverity.Error,
+                Message = message,
+                DetailsJson = JsonSerializer.Serialize(new
+                {
+                    requestedBy
+                })
+            },
+            suppressEventLogWrites,
+            cancellationToken);
 
         return new DatabaseBackupCreateResult
         {
@@ -975,5 +994,27 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
     private readonly record struct BackupDescriptor(DatabaseBackupMode Mode)
     {
         public static BackupDescriptor FullByDefault => new(DatabaseBackupMode.Full);
+    }
+
+    private static bool IsStartupGateRestoreRequest(DatabaseBackupRestoreRequest request)
+    {
+        return string.Equals(request.RequestedBy?.Trim(), "startup-gate", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task WriteDatabaseBackupEventAsync(
+        EventLogWriteRequest eventRequest,
+        bool suppressEventLogWrites,
+        CancellationToken cancellationToken)
+    {
+        if (suppressEventLogWrites)
+        {
+            _logger.LogInformation(
+                "Database backup event log suppressed because event-log tables may be unavailable. EventType: {EventType}, Message: {Message}",
+                eventRequest.EventType,
+                eventRequest.Message);
+            return;
+        }
+
+        await _eventLogService.WriteAsync(eventRequest, cancellationToken);
     }
 }


### PR DESCRIPTION
### Motivation

- Fix startup-gate DATABASE restore HTTP 500 when schema has been dropped and pre-restore backup path attempted to write to `EventLogs`, as reported in issue #370 and docs/diagnostics/2026-04-06-startup-gate-restore-failure.md. (Root cause: pre-restore `CreateBackupAsync` used normal DB-backed event logging while schema may be absent.)

### Description

- Add a `SuppressEventLogWrites` flag to `DatabaseBackupCreateRequest` and thread it through `CreateBackupAsync` to allow callers to suppress DB-backed event writes when the schema may be missing.
- Introduce `WriteDatabaseBackupEventAsync` helper in `DatabaseMaintenanceService` that either calls `IEventLogService.WriteAsync` or emits a runtime `ILogger` message when suppression is requested, and add `IsStartupGateRestoreRequest` helper to enable suppression for startup-gate restores.
- Make `CreateBackupFailureAsync` accept the suppression flag so failure reporting follows the same runtime-only vs DB-backed semantics.
- Update `RestoreBackupAsync` to call `CreateBackupAsync` with `SuppressEventLogWrites = true` when the restore request `RequestedBy` equals `startup-gate`, retaining the pre-restore backup behavior but avoiding DB table assumptions during the pre-schema phase.
- Update diagnostics doc `docs/diagnostics/2026-04-06-startup-gate-restore-failure.md` to include a deterministic regression checklist for validating the fix.

Files modified:
- src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceModels.cs
- src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
- docs/diagnostics/2026-04-06-startup-gate-restore-failure.md

Behavior notes:
- Pre-restore backup is retained; the backup step still runs and the restore still aborts if that backup fails, but DB-backed `EventLogs` writes are suppressed for the pre-restore backup when invoked from the startup-gate path.
- Normal admin DB maintenance backup/export behavior is unchanged (no suppression by default), so DB-backed event logging still occurs in regular runtime flows.
- Configuration backup/restore (separate system) was not modified.

### Testing

- Installed and validated SDK/tools: installed .NET SDK 10.0.104 and PowerShell 7.6 in the environment successfully.
- Built the web project: ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the build completed successfully with SDK `10.0.104` (succeeded).
- No automated integration test run for a live MySQL restore was executed in this container; instead a deterministic regression checklist was added to the diagnostics document to validate end-to-end behavior in an environment with MySQL available.
- No unit tests were modified; existing project build and compilation were verified (succeeded).

Fixes #370

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d419ad8e4c832a9dd37f3a72bd21ff)