### PR TITLE
Block Telegram polling service while Startup Gate is active

### DIFF
--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -179,6 +179,7 @@ builder.Services.AddScoped<ISecurityOperatorActionService, SecurityOperatorActio
 builder.Services.AddScoped<ISecurityEnforcementService, SecurityEnforcementService>();
 builder.Services.AddScoped<IEndpointStatusQueryService, EndpointStatusQueryService>();
 builder.Services.AddScoped<IStartupGateService, StartupGateService>();
+builder.Services.AddSingleton<IStartupGateRuntimeState, StartupGateRuntimeState>();
 builder.Services.AddSingleton<IStartupDatabaseConfigurationStore, FileStartupDatabaseConfigurationStore>();
 builder.Services.AddSingleton<ILocalRequestEvaluator, LocalRequestEvaluator>();
 builder.Services.AddScoped<IStartupSchemaService, StartupSchemaService>();
@@ -244,6 +245,9 @@ app.Use(async (context, next) =>
     var startupGateService = context.RequestServices.GetRequiredService<IStartupGateService>();
     var status = await startupGateService.EvaluateAsync(context, context.RequestAborted);
     context.Items[typeof(StartupGateStatus).FullName!] = status;
+
+    var startupGateRuntimeState = context.RequestServices.GetRequiredService<IStartupGateRuntimeState>();
+    startupGateRuntimeState.Update(status);
 
     if (status.Mode == StartupMode.Normal)
     {

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupGateRuntimeState.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupGateRuntimeState.cs
@@ -1,0 +1,63 @@
+namespace PingMonitor.Web.Services.StartupGate;
+
+public interface IStartupGateRuntimeState
+{
+    StartupMode CurrentMode { get; }
+    void Update(StartupGateStatus status);
+}
+
+internal sealed class StartupGateRuntimeState : IStartupGateRuntimeState
+{
+    private readonly ILogger<StartupGateRuntimeState> _logger;
+    private readonly object _sync = new();
+    private StartupMode _currentMode = StartupMode.Gate;
+    private StartupGateStage _failingStage = StartupGateStage.DatabaseConfiguration;
+
+    public StartupGateRuntimeState(ILogger<StartupGateRuntimeState> logger)
+    {
+        _logger = logger;
+    }
+
+    public StartupMode CurrentMode
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _currentMode;
+            }
+        }
+    }
+
+    public void Update(StartupGateStatus status)
+    {
+        ArgumentNullException.ThrowIfNull(status);
+
+        lock (_sync)
+        {
+            var modeChanged = _currentMode != status.Mode;
+            var stageChanged = _failingStage != status.FailingStage;
+            _currentMode = status.Mode;
+            _failingStage = status.FailingStage;
+
+            if (modeChanged)
+            {
+                if (status.Mode == StartupMode.Normal)
+                {
+                    _logger.LogInformation("Startup gate runtime state changed to normal mode. Background services may resume operational work.");
+                }
+                else
+                {
+                    _logger.LogInformation("Startup gate runtime state changed to gate mode at stage {Stage}. Background services requiring operational mode should remain paused.", status.FailingStage);
+                }
+
+                return;
+            }
+
+            if (status.Mode == StartupMode.Gate && stageChanged)
+            {
+                _logger.LogInformation("Startup gate runtime stage changed to {Stage}.", status.FailingStage);
+            }
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramPollingBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramPollingBackgroundService.cs
@@ -1,13 +1,22 @@
+using PingMonitor.Web.Services.StartupGate;
+
 namespace PingMonitor.Web.Services.Telegram;
 
 internal sealed class TelegramPollingBackgroundService : BackgroundService
 {
+    private static readonly TimeSpan PollLoopDelay = TimeSpan.FromSeconds(10);
+
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IStartupGateRuntimeState _startupGateRuntimeState;
     private readonly ILogger<TelegramPollingBackgroundService> _logger;
 
-    public TelegramPollingBackgroundService(IServiceScopeFactory scopeFactory, ILogger<TelegramPollingBackgroundService> logger)
+    public TelegramPollingBackgroundService(
+        IServiceScopeFactory scopeFactory,
+        IStartupGateRuntimeState startupGateRuntimeState,
+        ILogger<TelegramPollingBackgroundService> logger)
     {
         _scopeFactory = scopeFactory;
+        _startupGateRuntimeState = startupGateRuntimeState;
         _logger = logger;
     }
 
@@ -15,8 +24,36 @@ internal sealed class TelegramPollingBackgroundService : BackgroundService
     {
         _logger.LogInformation("Telegram polling background service started.");
 
+        var wasBlockedByStartupGate = false;
+
         while (!stoppingToken.IsCancellationRequested)
         {
+            if (_startupGateRuntimeState.CurrentMode != StartupMode.Normal)
+            {
+                if (!wasBlockedByStartupGate)
+                {
+                    _logger.LogInformation("Telegram polling is paused because Startup Gate is active.");
+                    wasBlockedByStartupGate = true;
+                }
+
+                try
+                {
+                    await Task.Delay(PollLoopDelay, stoppingToken);
+                }
+                catch (TaskCanceledException)
+                {
+                    break;
+                }
+
+                continue;
+            }
+
+            if (wasBlockedByStartupGate)
+            {
+                _logger.LogInformation("Startup Gate is cleared. Telegram polling is resuming normal operation.");
+                wasBlockedByStartupGate = false;
+            }
+
             try
             {
                 using var scope = _scopeFactory.CreateScope();
@@ -30,7 +67,7 @@ internal sealed class TelegramPollingBackgroundService : BackgroundService
 
             try
             {
-                await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+                await Task.Delay(PollLoopDelay, stoppingToken);
             }
             catch (TaskCanceledException)
             {


### PR DESCRIPTION
### Motivation
- The Telegram polling hosted service was executing during Startup Gate mode because the gate was only enforced in HTTP middleware and not communicated to background services. 
- While the gate is active the app must not perform Telegram polling or touch the DB until the app enters normal operational mode.

### Description
- Added a runtime guard singleton `IStartupGateRuntimeState` (`StartupGateRuntimeState`) that tracks the evaluated `StartupGateStatus` and exposes `CurrentMode` so background services can observe startup state. 
- Registered the runtime state singleton in `Program.cs` and updated the startup-gate middleware to call `startupGateRuntimeState.Update(status)` after evaluating the gate. 
- Updated `TelegramPollingBackgroundService` to check `IStartupGateRuntimeState.CurrentMode` on each loop and pause (without resolving `ITelegramPollingService`) while the gate is not `Normal`, resuming normal polling when the gate clears. 
- Files modified: `src/WebApp/PingMonitor.Web/Services/StartupGate/StartupGateRuntimeState.cs` (new), `src/WebApp/PingMonitor.Web/Program.cs`, and `src/WebApp/PingMonitor.Web/Services/Telegram/TelegramPollingBackgroundService.cs`.

### Testing
- Built the web project with `dotnet build` in `src/WebApp/PingMonitor.Web` and the build succeeded. 
- There are no dedicated test projects in the repository, so `dotnet build` is the automated verification performed and it passed. 
- Created issue `#374` to track the change and included `Fixes #374` in the PR for traceability.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d425b1b9d4832a85e82bb3fad68212)