### PR TITLE
Add startup-gate plain-text diagnostics for DATABASE restore flow

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs
@@ -17,6 +17,7 @@ public sealed class StartupGateController : Controller
     private readonly IStartupSchemaService _schemaService;
     private readonly IStartupAdminBootstrapService _adminBootstrapService;
     private readonly IDatabaseMaintenanceService _databaseMaintenanceService;
+    private readonly IStartupGateDiagnosticsLogger _startupGateDiagnosticsLogger;
     private readonly StartupGateOptions _options;
     private readonly ILogger<StartupGateController> _logger;
 
@@ -26,6 +27,7 @@ public sealed class StartupGateController : Controller
         IStartupSchemaService schemaService,
         IStartupAdminBootstrapService adminBootstrapService,
         IDatabaseMaintenanceService databaseMaintenanceService,
+        IStartupGateDiagnosticsLogger startupGateDiagnosticsLogger,
         IOptions<StartupGateOptions> options,
         ILogger<StartupGateController> logger)
     {
@@ -34,6 +36,7 @@ public sealed class StartupGateController : Controller
         _schemaService = schemaService;
         _adminBootstrapService = adminBootstrapService;
         _databaseMaintenanceService = databaseMaintenanceService;
+        _startupGateDiagnosticsLogger = startupGateDiagnosticsLogger;
         _options = options.Value;
         _logger = logger;
     }
@@ -186,9 +189,16 @@ public sealed class StartupGateController : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> RestoreDatabaseBackup([FromForm(Name = "DatabaseBackupRestoreForm")] StartupDatabaseBackupRestoreForm form, CancellationToken cancellationToken)
     {
+        _startupGateDiagnosticsLogger.Write(
+            "startup-gate.database-restore.request.entry",
+            $"Restore request entered for fileId='{form.FileId ?? "(null)"}'. ConfirmationProvided={(!string.IsNullOrWhiteSpace(form.ConfirmationText)).ToString().ToLowerInvariant()}.");
+
         var status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
         if (!status.CanPerformWriteActions)
         {
+            _startupGateDiagnosticsLogger.Write(
+                "startup-gate.database-restore.request.blocked",
+                $"Restore request denied because Startup Gate write actions are disabled. mode={status.Mode}, failingStage={status.FailingStage}.");
             return Forbid();
         }
 
@@ -217,11 +227,25 @@ public sealed class StartupGateController : Controller
         }
         catch (FileNotFoundException)
         {
+            _startupGateDiagnosticsLogger.Write(
+                "startup-gate.database-restore.file-not-found",
+                $"Restore file not found for fileId='{form.FileId ?? "(null)"}'.");
             status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
             return View("Index", await BuildViewModelAsync(status, null, null, null, form, errorMessage: "DATABASE restore failed: selected backup file was not found.", cancellationToken: cancellationToken));
         }
+        catch (Exception exception)
+        {
+            _startupGateDiagnosticsLogger.WriteException(
+                "startup-gate.database-restore.exception",
+                exception,
+                $"Unhandled controller exception while invoking restore for fileId='{form.FileId ?? "(null)"}'.");
+            throw;
+        }
 
         status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
+        _startupGateDiagnosticsLogger.Write(
+            "startup-gate.database-restore.readiness-recheck",
+            $"Post-restore Startup Gate re-check completed. mode={status.Mode}, failingStage={status.FailingStage}, canPerformWriteActions={status.CanPerformWriteActions.ToString().ToLowerInvariant()}.");
         return View("Index", await BuildViewModelAsync(
             status,
             null,

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -180,6 +180,7 @@ builder.Services.AddScoped<ISecurityEnforcementService, SecurityEnforcementServi
 builder.Services.AddScoped<IEndpointStatusQueryService, EndpointStatusQueryService>();
 builder.Services.AddScoped<IStartupGateService, StartupGateService>();
 builder.Services.AddSingleton<IStartupGateRuntimeState, StartupGateRuntimeState>();
+builder.Services.AddSingleton<IStartupGateDiagnosticsLogger, StartupGateDiagnosticsLogger>();
 builder.Services.AddSingleton<IStartupDatabaseConfigurationStore, FileStartupDatabaseConfigurationStore>();
 builder.Services.AddSingleton<ILocalRequestEvaluator, LocalRequestEvaluator>();
 builder.Services.AddScoped<IStartupSchemaService, StartupSchemaService>();

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
@@ -11,6 +11,7 @@ using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Options;
 using PingMonitor.Web.Services.EventLogs;
+using PingMonitor.Web.Services.StartupGate;
 
 namespace PingMonitor.Web.Services.DatabaseStatus;
 
@@ -37,6 +38,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
     private readonly IEventLogService _eventLogService;
     private readonly IOptions<DatabaseMaintenanceOptions> _options;
     private readonly IWebHostEnvironment _webHostEnvironment;
+    private readonly IStartupGateDiagnosticsLogger _startupGateDiagnosticsLogger;
     private readonly ILogger<DatabaseMaintenanceService> _logger;
 
     public DatabaseMaintenanceService(
@@ -44,12 +46,14 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         IEventLogService eventLogService,
         IOptions<DatabaseMaintenanceOptions> options,
         IWebHostEnvironment webHostEnvironment,
+        IStartupGateDiagnosticsLogger startupGateDiagnosticsLogger,
         ILogger<DatabaseMaintenanceService> logger)
     {
         _dbContext = dbContext;
         _eventLogService = eventLogService;
         _options = options;
         _webHostEnvironment = webHostEnvironment;
+        _startupGateDiagnosticsLogger = startupGateDiagnosticsLogger;
         _logger = logger;
     }
 
@@ -358,6 +362,12 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 
     public async Task<DatabaseBackupRestoreResult> RestoreBackupAsync(DatabaseBackupRestoreRequest request, CancellationToken cancellationToken)
     {
+        var restoreStopwatch = Stopwatch.StartNew();
+        var isStartupGateRestoreRequest = IsStartupGateRestoreRequest(request);
+        _startupGateDiagnosticsLogger.Write(
+            "database-restore.entry",
+            $"Restore requested. requestedBy='{request.RequestedBy ?? "(null)"}', startupGateModeRequest={isStartupGateRestoreRequest.ToString().ToLowerInvariant()}, fileId='{request.FileId}'.");
+
         if (!string.Equals(request.ConfirmationText?.Trim(), DatabaseBackupRestoreRequest.ConfirmationKeyword, StringComparison.Ordinal))
         {
             throw new InvalidOperationException($"Type {DatabaseBackupRestoreRequest.ConfirmationKeyword} to confirm restore.");
@@ -365,6 +375,9 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 
         var backupPath = ResolveBackupDownloadPath(request.FileId);
         var backupFileInfo = new FileInfo(backupPath);
+        _startupGateDiagnosticsLogger.Write(
+            "database-restore.backup-selected",
+            $"Selected backup file. fileId='{request.FileId}', fileName='{backupFileInfo.Name}', fullPath='{backupPath}', fileSizeBytes={backupFileInfo.Length}.");
         var contentBytes = await File.ReadAllBytesAsync(backupPath, cancellationToken);
         var backupDescriptor = ReadBackupDescriptorFromContent(contentBytes);
         var validationMessage = ValidateSqlBackupContent(contentBytes);
@@ -396,13 +409,19 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
             backupFileInfo.Length,
             request.RequestedBy);
 
+        _startupGateDiagnosticsLogger.Write(
+            "database-restore.pre-restore-backup.start",
+            $"Starting pre-restore backup. fileName='{backupFileInfo.Name}', backupMode={backupDescriptor.Mode}, elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
         var preRestoreBackup = await CreateBackupAsync(
             new DatabaseBackupCreateRequest
             {
                 RequestedBy = request.RequestedBy,
-                SuppressEventLogWrites = IsStartupGateRestoreRequest(request)
+                SuppressEventLogWrites = isStartupGateRestoreRequest
             },
             cancellationToken);
+        _startupGateDiagnosticsLogger.Write(
+            "database-restore.pre-restore-backup.complete",
+            $"Pre-restore backup completed. succeeded={preRestoreBackup.Succeeded.ToString().ToLowerInvariant()}, fileName='{preRestoreBackup.FileName ?? "(none)"}', message='{preRestoreBackup.Message}', elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
         if (!preRestoreBackup.Succeeded)
         {
             _logger.LogWarning(
@@ -454,20 +473,48 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         processInfo.ArgumentList.Add(builder.UserID);
         processInfo.ArgumentList.Add(builder.Database);
         processInfo.Environment["MYSQL_PWD"] = builder.Password;
+        var argumentSummary = string.Join(' ', processInfo.ArgumentList.Select(QuoteProcessArgument));
 
         try
         {
+            _startupGateDiagnosticsLogger.Write(
+                "database-restore.process.launch",
+                $"Launching mysql restore process. executable='{processInfo.FileName}', arguments=\"{argumentSummary}\", elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
             using var process = Process.Start(processInfo);
             if (process is null)
             {
                 return await CreateRestoreFailureAsync("Unable to start mysql restore process.", backupFileInfo, request, backupDescriptor.Mode, true, preRestoreBackup.FileName, cancellationToken);
             }
 
+            _startupGateDiagnosticsLogger.Write(
+                "database-restore.process.started",
+                $"mysql restore process started. processId={process.Id}, elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
+            _startupGateDiagnosticsLogger.Write(
+                "database-restore.stdin-copy.start",
+                $"Starting stdin copy of restore payload. bytes={contentBytes.Length}, processId={process.Id}, elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
             await process.StandardInput.BaseStream.WriteAsync(contentBytes, cancellationToken);
             await process.StandardInput.BaseStream.FlushAsync(cancellationToken);
+            _startupGateDiagnosticsLogger.Write(
+                "database-restore.stdin-copy.complete",
+                $"Completed stdin copy of restore payload. bytes={contentBytes.Length}, processId={process.Id}, elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
             process.StandardInput.Close();
-            var stderr = await process.StandardError.ReadToEndAsync(cancellationToken);
+            _startupGateDiagnosticsLogger.Write(
+                "database-restore.stdin.close",
+                $"Closed mysql restore process stdin. processId={process.Id}, elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
+            var stderrReadTask = process.StandardError.ReadToEndAsync(cancellationToken);
+            var stdoutReadTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            _startupGateDiagnosticsLogger.Write(
+                "database-restore.process.waiting-for-exit",
+                $"Waiting for mysql restore process exit. processId={process.Id}, elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
             await process.WaitForExitAsync(cancellationToken);
+            var stderr = await stderrReadTask;
+            var stdout = await stdoutReadTask;
+            _startupGateDiagnosticsLogger.Write(
+                "database-restore.process.exit",
+                $"mysql restore process exited. processId={process.Id}, exitCode={process.ExitCode}, elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
+            _startupGateDiagnosticsLogger.Write(
+                "database-restore.process.output-summary",
+                $"stdout='{TrimDiagnostic(stdout)}', stderr='{TrimDiagnostic(stderr)}', elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
 
             if (process.ExitCode != 0)
             {
@@ -510,7 +557,19 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         catch (Exception ex) when (ex is Win32Exception || ex is InvalidOperationException || ex is IOException)
         {
             _logger.LogWarning(ex, "Database backup restore failed.");
+            _startupGateDiagnosticsLogger.WriteException(
+                "database-restore.exception",
+                ex,
+                $"Restore failed with handled exception category. elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
             return await CreateRestoreFailureAsync($"Database restore failed: {ex.Message}", backupFileInfo, request, backupDescriptor.Mode, true, preRestoreBackup.FileName, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _startupGateDiagnosticsLogger.WriteException(
+                "database-restore.exception-unhandled",
+                ex,
+                $"Restore failed with unhandled exception category. elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
+            throw;
         }
     }
 
@@ -910,6 +969,16 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 
         var trimmed = value.Trim();
         return trimmed.Length <= 300 ? trimmed : trimmed[..300];
+    }
+
+    private static string QuoteProcessArgument(string argument)
+    {
+        if (argument.Contains(' ', StringComparison.Ordinal))
+        {
+            return $"\"{argument}\"";
+        }
+
+        return argument;
     }
 
     private static string SanitizeFileName(string? originalFileName)

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/IStartupGateDiagnosticsLogger.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/IStartupGateDiagnosticsLogger.cs
@@ -1,0 +1,10 @@
+namespace PingMonitor.Web.Services.StartupGate;
+
+public interface IStartupGateDiagnosticsLogger
+{
+    string LogFilePath { get; }
+
+    void Write(string milestone, string message);
+
+    void WriteException(string milestone, Exception exception, string? message = null);
+}

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupGateDiagnosticsLogger.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupGateDiagnosticsLogger.cs
@@ -1,0 +1,70 @@
+using Microsoft.Extensions.Options;
+using PingMonitor.Web.Options;
+using System.Text;
+
+namespace PingMonitor.Web.Services.StartupGate;
+
+internal sealed class StartupGateDiagnosticsLogger : IStartupGateDiagnosticsLogger
+{
+    private const string FileName = "startup-gate-debug.log";
+    private static readonly object Sync = new();
+
+    private readonly ILogger<StartupGateDiagnosticsLogger> _logger;
+    private readonly string _logFilePath;
+
+    public StartupGateDiagnosticsLogger(
+        IOptions<StartupGateOptions> options,
+        IWebHostEnvironment environment,
+        ILogger<StartupGateDiagnosticsLogger> logger)
+    {
+        _logger = logger;
+        var startupGateOptions = options.Value;
+        var storageDirectory = Path.IsPathRooted(startupGateOptions.StorageDirectory)
+            ? startupGateOptions.StorageDirectory
+            : Path.Combine(environment.ContentRootPath, startupGateOptions.StorageDirectory);
+        _logFilePath = Path.Combine(storageDirectory, FileName);
+    }
+
+    public string LogFilePath => _logFilePath;
+
+    public void Write(string milestone, string message)
+    {
+        AppendCore(milestone, message);
+    }
+
+    public void WriteException(string milestone, Exception exception, string? message = null)
+    {
+        var detail = new StringBuilder();
+        if (!string.IsNullOrWhiteSpace(message))
+        {
+            detail.Append(message.Trim());
+            detail.Append(" | ");
+        }
+
+        detail.Append("Exception: ");
+        detail.Append(exception.ToString());
+        AppendCore(milestone, detail.ToString());
+    }
+
+    private void AppendCore(string milestone, string message)
+    {
+        try
+        {
+            var directory = Path.GetDirectoryName(_logFilePath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var line = $"{DateTimeOffset.UtcNow:O} | pid={Environment.ProcessId} | {milestone} | {message}{Environment.NewLine}";
+            lock (Sync)
+            {
+                File.AppendAllText(_logFilePath, line, Encoding.UTF8);
+            }
+        }
+        catch (Exception exception)
+        {
+            _logger.LogWarning(exception, "Startup gate diagnostics write failed for milestone {Milestone}.", milestone);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple, file-based diagnostic trace that runs during Startup Gate to diagnose environment-specific DATABASE restore hangs when DB-backed logging or schema tables are unavailable.
- The change must be safe, lightweight, not alter existing logging semantics, and produce timestamped, append-only troubleshooting output that survives missing DB/schema conditions.

### Description
- Add a dedicated diagnostics interface and file logger (`IStartupGateDiagnosticsLogger`, `StartupGateDiagnosticsLogger`) that writes timestamped, PID-tagged plain-text lines to `<StartupGateOptions.StorageDirectory>/startup-gate-debug.log` (default `App_Data/StartupGate/startup-gate-debug.log`).
- Register the diagnostics logger in DI and keep existing structured/event logging unchanged.
- Instrument Startup Gate restore paths in the controller and `DatabaseMaintenanceService.RestoreBackupAsync` to log the requested milestones (backup selection, pre-restore backup start/complete, process launch, executable/arguments summary, stdin copy start/complete/close, waiting for exit, exit code, stdout/stderr summary, post-restore readiness re-check, and exceptions including full stack traces), and include elapsed timings and process IDs where available.
- Files changed: `Program.cs`, `Controllers/StartupGateController.cs`, `Services/DatabaseStatus/DatabaseMaintenanceService.cs`, and new files `Services/StartupGate/IStartupGateDiagnosticsLogger.cs` and `Services/StartupGate/StartupGateDiagnosticsLogger.cs`; this PR also links the work to the created issue (Fixes #382).

### Testing
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully with no errors and one nullable warning in the existing startup-gate controller path.
- The change is unit- and side-effect free at compile time and added safe try/catch around file writes so failed diagnostic writes fall back to normal logging without interrupting restore flows.
- No automated runtime integration tests were executed in this PR; validation checklist for merge includes exercising the startup-gate restore flow and confirming `startup-gate-debug.log` is created and populated with the listed milestones.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4418dbf14832a9710919c0144b90c)