### PR TITLE
Fix restore tool selection to use mysql client executable

### DIFF
--- a/src/WebApp/PingMonitor.Web/Options/DatabaseMaintenanceOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/DatabaseMaintenanceOptions.cs
@@ -6,4 +6,5 @@ public sealed class DatabaseMaintenanceOptions
 
     public string BackupStoragePath { get; set; } = "App_Data/DbBackups";
     public string MySqlDumpExecutablePath { get; set; } = "mysqldump";
+    public string MySqlExecutablePath { get; set; } = "mysql";
 }

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
@@ -449,7 +449,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         }
 
         var builder = new MySqlConnectionStringBuilder(dbConnectionString);
-        var mysqlExecutablePath = ResolveExecutablePath(null, "mysql");
+        var mysqlExecutablePath = ResolveExecutablePath(_options.Value.MySqlExecutablePath, "mysql");
         if (mysqlExecutablePath is null)
         {
             return await CreateRestoreFailureAsync("mysql executable was not found. Ensure mysql client is installed and available in PATH.", backupFileInfo, request, backupDescriptor.Mode, true, preRestoreBackup.FileName, cancellationToken);
@@ -686,7 +686,10 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
                 .OrderByDescending(x => x, StringComparer.OrdinalIgnoreCase);
             foreach (var serverDirectory in serverDirectories)
             {
-                var candidate = Path.Combine(serverDirectory, "bin", "mysqldump.exe");
+                var windowsExecutableName = fallbackExecutableName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+                    ? fallbackExecutableName
+                    : $"{fallbackExecutableName}.exe";
+                var candidate = Path.Combine(serverDirectory, "bin", windowsExecutableName);
                 if (File.Exists(candidate))
                 {
                     return candidate;

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -56,7 +56,8 @@
   },
   "DatabaseMaintenance": {
     "BackupStoragePath": "App_Data/DbBackups",
-    "MySqlDumpExecutablePath": "mysqldump"
+    "MySqlDumpExecutablePath": "mysqldump",
+    "MySqlExecutablePath": "mysql"
   },
   "ForwardedHeaders": {
     "KnownProxies": [],


### PR DESCRIPTION
### Motivation
- The Windows-program-files fallback in executable resolution was hardcoded to `mysqldump.exe`, causing restore flows that stream SQL to stdin to sometimes launch the wrong binary and hang. 
- The restore path must reliably use the MySQL client (`mysql`) while leaving backup/export using `mysqldump` unchanged.

### Description
- Added a new configuration option `DatabaseMaintenance:MySqlExecutablePath` (default `mysql`) so restore can be configured independently from the export tooling. 
- Changed the restore path to call `ResolveExecutablePath(_options.Value.MySqlExecutablePath, "mysql")` while leaving the backup/export path using `ResolveExecutablePath(options.MySqlDumpExecutablePath, "mysqldump")`. 
- Fixed the Windows fallback probing in `ResolveExecutablePath` to use the operation-specific `fallbackExecutableName` (appending `.exe` when appropriate) instead of hardcoding `mysqldump.exe`. 
- Files modified: `src/WebApp/PingMonitor.Web/Options/DatabaseMaintenanceOptions.cs`, `src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs`, and `src/WebApp/PingMonitor.Web/appsettings.json`, and this PR links and fixes issue #384.
- Confirmation: startup-gate and admin maintenance restore both use the same corrected `DatabaseMaintenanceService.RestoreBackupAsync` path and the configuration backup/restore system was not otherwise modified.

### Testing
- Built the web application with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` using the installed .NET 10.0.104 SDK and the build succeeded. 
- Performed code inspection and `rg` searches to verify that export still resolves with `MySqlDumpExecutablePath` and restore resolves with `MySqlExecutablePath`. 
- No unit tests were modified or required for this change and no automated DB integration tests were executed in this environment; the change is limited to executable selection logic and preserves the existing stdin streaming restore flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d445ee4df0832a99bf3e87d329074f)