### PR TITLE
Label pre-restore DB backups and lift upload size caps on DB upload endpoints

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/AdminDatabaseController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminDatabaseController.cs
@@ -143,6 +143,8 @@ public sealed class AdminDatabaseController : Controller
     }
 
     [HttpPost("backup/upload")]
+    [DisableRequestSizeLimit]
+    [RequestFormLimits(MultipartBodyLengthLimit = long.MaxValue)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> UploadBackup([FromForm(Name = "UploadForm")] DatabaseBackupUploadForm uploadForm, CancellationToken cancellationToken)
     {

--- a/src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs
@@ -144,6 +144,8 @@ public sealed class StartupGateController : Controller
     }
 
     [HttpPost("database-backup/upload")]
+    [DisableRequestSizeLimit]
+    [RequestFormLimits(MultipartBodyLengthLimit = long.MaxValue)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> UploadDatabaseBackup([FromForm(Name = "DatabaseBackupUploadForm")] StartupDatabaseBackupUploadForm form, CancellationToken cancellationToken)
     {

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceModels.cs
@@ -43,6 +43,7 @@ public sealed class DatabasePruneExecuteResult
 public sealed class DatabaseBackupCreateRequest
 {
     public DatabaseBackupMode BackupMode { get; init; } = DatabaseBackupMode.Full;
+    public DatabaseBackupCreationSource BackupSource { get; init; } = DatabaseBackupCreationSource.Manual;
     public string? RequestedBy { get; init; }
     public bool SuppressEventLogWrites { get; init; }
 }
@@ -125,4 +126,10 @@ public enum DatabaseBackupMode
 {
     Full = 1,
     Compact = 2
+}
+
+public enum DatabaseBackupCreationSource
+{
+    Manual = 1,
+    PreRestore = 2
 }

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
@@ -17,7 +17,6 @@ namespace PingMonitor.Web.Services.DatabaseStatus;
 
 internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 {
-    private const int MaxUploadBytes = 100 * 1024 * 1024;
     private const string BackupModeCommentPrefix = "-- pingmonitor_backup_mode:";
     private const string BackupProfileCommentPrefix = "-- pingmonitor_backup_profile:";
     private const string CompactBackupProfileName = "compact_runtime_excluded_v1";
@@ -142,16 +141,21 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         Directory.CreateDirectory(backupDirectory);
         var suppressEventLogWrites = request.SuppressEventLogWrites;
 
+        var normalizedBackupSource = NormalizeBackupCreationSource(request.BackupSource);
+
         await WriteDatabaseBackupEventAsync(
             new EventLogWriteRequest
             {
                 Category = EventCategory.System,
                 EventType = EventType.DatabaseBackupStarted,
                 Severity = EventSeverity.Info,
-                Message = "Database backup export started.",
+                Message = normalizedBackupSource == DatabaseBackupCreationSource.PreRestore
+                    ? "Database pre-restore safety backup export started."
+                    : "Database backup export started.",
                 DetailsJson = JsonSerializer.Serialize(new
                 {
                     backupDirectory,
+                    backupSource = normalizedBackupSource.ToString(),
                     requestedBy = request.RequestedBy
                 })
             },
@@ -168,7 +172,9 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         var backupTimestamp = DateTimeOffset.UtcNow;
         var safeDatabaseName = string.IsNullOrWhiteSpace(builder.Database) ? "database" : builder.Database.Trim();
         var normalizedBackupMode = NormalizeBackupMode(request.BackupMode);
-        var fileName = $"db-backup-{safeDatabaseName}-{backupTimestamp:yyyyMMdd-HHmmss}.sql";
+        var fileName = normalizedBackupSource == DatabaseBackupCreationSource.PreRestore
+            ? $"pre-restore-db-backup-{safeDatabaseName}-{backupTimestamp:yyyyMMdd-HHmmss}.sql"
+            : $"db-backup-{safeDatabaseName}-{backupTimestamp:yyyyMMdd-HHmmss}.sql";
         var fullPath = Path.Combine(backupDirectory, fileName);
         var mysqldumpExecutablePath = ResolveExecutablePath(options.MySqlDumpExecutablePath, "mysqldump");
         if (mysqldumpExecutablePath is null)
@@ -255,6 +261,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
                         fileName,
                         fullPath,
                         backupMode = normalizedBackupMode.ToString(),
+                        backupSource = normalizedBackupSource.ToString(),
                         fileSizeBytes = fileInfo.Length,
                         createdAtUtc = backupTimestamp,
                         requestedBy = request.RequestedBy
@@ -307,19 +314,11 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
             return new DatabaseBackupUploadResult { Succeeded = false, Message = "Only .sql database backup files are accepted." };
         }
 
-        await using var uploadBuffer = new MemoryStream();
-        await request.Content.CopyToAsync(uploadBuffer, cancellationToken);
-        if (uploadBuffer.Length <= 0)
+        var contentBytes = await ReadAllBytesAsync(request.Content, cancellationToken);
+        if (contentBytes.Length <= 0)
         {
             return new DatabaseBackupUploadResult { Succeeded = false, Message = "Backup file is empty." };
         }
-
-        if (uploadBuffer.Length > MaxUploadBytes)
-        {
-            return new DatabaseBackupUploadResult { Succeeded = false, Message = $"Backup file exceeds the {MaxUploadBytes / (1024 * 1024)} MB upload limit." };
-        }
-
-        var contentBytes = uploadBuffer.ToArray();
         var validationMessage = ValidateSqlBackupContent(contentBytes);
         if (validationMessage is not null)
         {
@@ -415,6 +414,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         var preRestoreBackup = await CreateBackupAsync(
             new DatabaseBackupCreateRequest
             {
+                BackupSource = DatabaseBackupCreationSource.PreRestore,
                 RequestedBy = request.RequestedBy,
                 SuppressEventLogWrites = isStartupGateRestoreRequest
             },
@@ -743,7 +743,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
                     FileSizeBytes = x.Length,
                     FullPath = x.FullName,
                     MetadataSummary = BuildMetadataSummary(x.FullName),
-                    BackupSource = x.Name.StartsWith("uploaded-db-backup-", StringComparison.OrdinalIgnoreCase) ? "Uploaded" : "Created",
+                    BackupSource = BuildBackupSourceDisplayName(x.Name),
                     BackupMode = descriptor.Mode,
                     BackupModeDisplayName = descriptor.Mode == DatabaseBackupMode.Compact
                         ? "Compact database backup"
@@ -879,6 +879,13 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
     private static DatabaseBackupMode NormalizeBackupMode(DatabaseBackupMode mode)
     {
         return mode == DatabaseBackupMode.Compact ? DatabaseBackupMode.Compact : DatabaseBackupMode.Full;
+    }
+
+    private static DatabaseBackupCreationSource NormalizeBackupCreationSource(DatabaseBackupCreationSource source)
+    {
+        return source == DatabaseBackupCreationSource.PreRestore
+            ? DatabaseBackupCreationSource.PreRestore
+            : DatabaseBackupCreationSource.Manual;
     }
 
     private async Task ResetCompactExcludedTablesAsync(CancellationToken cancellationToken)
@@ -1055,12 +1062,38 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
     private static string BuildMetadataSummary(string fullPath)
     {
         var descriptor = ReadBackupDescriptorFromFile(fullPath);
+        var fileName = Path.GetFileName(fullPath);
+        var preRestorePrefix = fileName.StartsWith("pre-restore-db-backup-", StringComparison.OrdinalIgnoreCase)
+            ? "Pre-restore safety backup. "
+            : string.Empty;
         if (descriptor.Mode == DatabaseBackupMode.Compact)
         {
-            return "Compact profile: excludes results, metrics history, and logs";
+            return $"{preRestorePrefix}Compact profile: excludes results, metrics history, and logs";
         }
 
-        return "Full profile: includes complete MySQL logical SQL dump";
+        return $"{preRestorePrefix}Full profile: includes complete MySQL logical SQL dump";
+    }
+
+    private static string BuildBackupSourceDisplayName(string fileName)
+    {
+        if (fileName.StartsWith("pre-restore-db-backup-", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Pre-restore (Automatic)";
+        }
+
+        if (fileName.StartsWith("uploaded-db-backup-", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Uploaded";
+        }
+
+        return "Created (Manual)";
+    }
+
+    private static async Task<byte[]> ReadAllBytesAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        await using var memoryStream = new MemoryStream();
+        await stream.CopyToAsync(memoryStream, cancellationToken);
+        return memoryStream.ToArray();
     }
 
     private readonly record struct BackupDescriptor(DatabaseBackupMode Mode)

--- a/src/WebApp/PingMonitor.Web/Views/AdminDatabase/Maintenance.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminDatabase/Maintenance.cshtml
@@ -148,7 +148,7 @@
                             <option value="">-- Select DATABASE backup --</option>
                             @foreach (var backup in Model.Backups)
                             {
-                                <option value="@backup.FileId">@backup.FileName (@backup.BackupModeDisplayName, @DisplayFormatting.FormatUtcDateTime(backup.CreatedAtUtc))</option>
+                                <option value="@backup.FileId">@backup.FileName (@backup.BackupSource, @backup.BackupModeDisplayName, @DisplayFormatting.FormatUtcDateTime(backup.CreatedAtUtc))</option>
                             }
                         </select>
                     </label>

--- a/src/WebApp/PingMonitor.Web/Views/StartupGate/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/StartupGate/Index.cshtml
@@ -143,7 +143,7 @@
                     <option value="">-- Select DATABASE backup --</option>
                     @foreach (var backup in Model.DatabaseBackups)
                     {
-                        <option value="@backup.FileId">@backup.FileName (@backup.BackupModeDisplayName, @backup.CreatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss") UTC, @backup.MetadataSummary)</option>
+                        <option value="@backup.FileId">@backup.FileName (@backup.BackupSource, @backup.BackupModeDisplayName, @backup.CreatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss") UTC, @backup.MetadataSummary)</option>
                     }
                 </select>
                 <span asp-validation-for="DatabaseBackupRestoreForm.FileId"></span>


### PR DESCRIPTION
### Motivation
- Operators must be able to immediately distinguish automatic pre-restore DATABASE safety backups from normal manual DATABASE backups.  
- Large SQL database backup uploads currently fail due to app-side request size limits on the DB upload/restore paths.  
- The change must be narrowly scoped to DATABASE backup flows and must not alter CONFIGURATION backup behaviour or general file-safety checks.

### Description
- Added `DatabaseBackupCreationSource` and a `BackupSource` property on `DatabaseBackupCreateRequest` and used it to produce a distinct pre-restore filename prefix `pre-restore-db-backup-{databaseName}-{yyyyMMdd-HHmmss}.sql` while preserving manual naming `db-backup-{databaseName}-{yyyyMMdd-HHmmss}.sql`. (files modified: `DatabaseMaintenanceModels.cs`, `DatabaseMaintenanceService.cs`).
- Marked pre-restore backups clearly in metadata/UI by exposing a `BackupSource` display string (`Pre-restore (Automatic)`, `Uploaded`, `Created (Manual)`), prefixing metadata summaries for pre-restore files, and including `BackupSource` in the restore dropdowns on both the Admin DB Maintenance and Startup Gate pages. (files modified: `DatabaseMaintenanceService.cs`, `Views/AdminDatabase/Maintenance.cshtml`, `Views/StartupGate/Index.cshtml`).
- Removed the service-side hard 100 MB `MaxUploadBytes` check and switched to reading uploaded content with no small in-code cap while preserving SQL-format validation and path-traversal / filename sanitization. (file modified: `DatabaseMaintenanceService.cs`).
- Scoped request-size overrides only to the two database backup upload endpoints by adding `[DisableRequestSizeLimit]` and `[RequestFormLimits(MultipartBodyLengthLimit = long.MaxValue)]` to `AdminDatabaseController.UploadBackup` and `StartupGateController.UploadDatabaseBackup`. (files modified: `Controllers/AdminDatabaseController.cs`, `Controllers/StartupGateController.cs`).

### Testing
- Built the web project successfully with `DOTNET_ROOT=/tmp/dotnet10 /tmp/dotnet10/dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` after installing the .NET 10 SDK; build passed with a pre-existing nullable warning unrelated to these changes.  
- Verified compile-time correctness for the modified controllers and services and that the new enum/property and helper methods compile and link.  
- No new automated tests were added; this is a behaviour/UX and request-size scope change and the repository contains no existing unit tests for this exact flow to extend here.  
- Created tracking issue `#386` for this work and referenced it from the change set (see issue created during rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d44e6b412c832a9abf73332b91729a)