### PR TITLE
Fix CS8601 warning in StartupGateController database restore

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs
@@ -221,7 +221,7 @@ public sealed class StartupGateController : Controller
             result = await _databaseMaintenanceService.RestoreBackupAsync(
                 new DatabaseBackupRestoreRequest
                 {
-                    FileId = form.FileId,
+                    FileId = form.FileId ?? string.Empty,
                     ConfirmationText = form.ConfirmationText ?? string.Empty,
                     RequestedBy = "startup-gate"
                 },


### PR DESCRIPTION
### Motivation
- The dev build produced a `CS8601` nullable-assignment warning in `StartupGateController` when assigning `form.FileId` into a non-nullable `DatabaseBackupRestoreRequest.FileId`, so the warning must be eliminated without changing runtime semantics.

### Description
- Make the `FileId` assignment null-safe by using `form.FileId ?? string.Empty` when constructing `DatabaseBackupRestoreRequest`, leaving behavior otherwise unchanged; Fixes #390.

### Testing
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -c Release` which completed successfully with 0 warnings, and ran `pwsh -ExecutionPolicy Bypass -File ./scripts/build-dev.ps1` which completed packaging without the `CS8601` warning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d452d32144832a94c661822bb10327)