### PR TITLE
Add live DATABASE backup/restore progress polling for admin and startup-gate

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/AdminDatabaseController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminDatabaseController.cs
@@ -13,13 +13,19 @@ public sealed class AdminDatabaseController : Controller
 {
     private readonly IDatabaseStatusQueryService _databaseStatusQueryService;
     private readonly IDatabaseMaintenanceService _databaseMaintenanceService;
+    private readonly IDatabaseMaintenanceProgressTracker _progressTracker;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
 
     public AdminDatabaseController(
         IDatabaseStatusQueryService databaseStatusQueryService,
-        IDatabaseMaintenanceService databaseMaintenanceService)
+        IDatabaseMaintenanceService databaseMaintenanceService,
+        IDatabaseMaintenanceProgressTracker progressTracker,
+        IServiceScopeFactory serviceScopeFactory)
     {
         _databaseStatusQueryService = databaseStatusQueryService;
         _databaseMaintenanceService = databaseMaintenanceService;
+        _progressTracker = progressTracker;
+        _serviceScopeFactory = serviceScopeFactory;
     }
 
     [HttpGet]
@@ -212,6 +218,126 @@ public sealed class AdminDatabaseController : Controller
         }
 
         return RedirectToAction(nameof(Maintenance));
+    }
+
+    [HttpPost("backup/create/start")]
+    [ValidateAntiForgeryToken]
+    public IActionResult StartCreateBackup([FromForm(Name = "BackupForm")] DatabaseBackupForm backupForm)
+    {
+        if (!backupForm.ConfirmBackup)
+        {
+            return BadRequest(new { succeeded = false, message = "Confirm backup creation before continuing." });
+        }
+
+        var start = _progressTracker.TryStartOperation(
+            DatabaseMaintenanceOperationType.BackupCreate,
+            stage: "preparing backup export",
+            fileName: null,
+            detailsMessage: null);
+        if (!start.Started || start.Operation is null)
+        {
+            return Conflict(new { succeeded = false, message = start.Message, activeOperation = start.Operation });
+        }
+
+        var operationId = start.Operation.OperationId;
+        var requestedBy = GetOperatorIdentity();
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var scope = _serviceScopeFactory.CreateScope();
+                var maintenanceService = scope.ServiceProvider.GetRequiredService<IDatabaseMaintenanceService>();
+                var result = await maintenanceService.CreateBackupAsync(
+                    new DatabaseBackupCreateRequest
+                    {
+                        OperationId = operationId,
+                        BackupMode = backupForm.BackupMode,
+                        RequestedBy = requestedBy
+                    },
+                    CancellationToken.None);
+
+                if (!result.Succeeded)
+                {
+                    _progressTracker.CompleteFailure(operationId, "failed", result.Message, result.FileName);
+                }
+            }
+            catch (Exception ex)
+            {
+                _progressTracker.CompleteFailure(operationId, "failed", ex.Message, null);
+            }
+        });
+
+        return Json(new { succeeded = true, operationId });
+    }
+
+    [HttpPost("backup/restore/start")]
+    [ValidateAntiForgeryToken]
+    public IActionResult StartRestoreBackup([FromForm(Name = "RestoreForm")] DatabaseBackupRestoreForm restoreForm)
+    {
+        if (string.IsNullOrWhiteSpace(restoreForm.FileId))
+        {
+            return BadRequest(new { succeeded = false, message = "Select a DATABASE backup file." });
+        }
+
+        if (!string.Equals(restoreForm.ConfirmationText?.Trim(), DatabaseBackupRestoreRequest.ConfirmationKeyword, StringComparison.Ordinal))
+        {
+            return BadRequest(new { succeeded = false, message = $"Type {DatabaseBackupRestoreRequest.ConfirmationKeyword} to confirm restore." });
+        }
+
+        var start = _progressTracker.TryStartOperation(
+            DatabaseMaintenanceOperationType.Restore,
+            stage: "validating backup",
+            fileName: restoreForm.FileId,
+            detailsMessage: null);
+        if (!start.Started || start.Operation is null)
+        {
+            return Conflict(new { succeeded = false, message = start.Message, activeOperation = start.Operation });
+        }
+
+        var operationId = start.Operation.OperationId;
+        var requestedBy = GetOperatorIdentity();
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var scope = _serviceScopeFactory.CreateScope();
+                var maintenanceService = scope.ServiceProvider.GetRequiredService<IDatabaseMaintenanceService>();
+                var result = await maintenanceService.RestoreBackupAsync(
+                    new DatabaseBackupRestoreRequest
+                    {
+                        OperationId = operationId,
+                        FileId = restoreForm.FileId ?? string.Empty,
+                        ConfirmationText = restoreForm.ConfirmationText ?? string.Empty,
+                        RequestedBy = requestedBy
+                    },
+                    CancellationToken.None);
+
+                if (!result.Succeeded)
+                {
+                    _progressTracker.CompleteFailure(operationId, "failed", result.Message, result.RestoredFileName);
+                }
+            }
+            catch (FileNotFoundException)
+            {
+                _progressTracker.CompleteFailure(operationId, "failed", "Selected backup file was not found.", null);
+            }
+            catch (Exception ex)
+            {
+                _progressTracker.CompleteFailure(operationId, "failed", ex.Message, null);
+            }
+        });
+
+        return Json(new { succeeded = true, operationId });
+    }
+
+    [HttpGet("backup/progress")]
+    public IActionResult GetBackupProgress([FromQuery] string? operationId = null)
+    {
+        var progress = string.IsNullOrWhiteSpace(operationId)
+            ? _progressTracker.GetCurrentOperation()
+            : _progressTracker.GetOperation(operationId);
+
+        return Json(new { operation = progress });
     }
 
     [HttpPost("backup/delete")]

--- a/src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs
@@ -18,6 +18,8 @@ public sealed class StartupGateController : Controller
     private readonly IStartupAdminBootstrapService _adminBootstrapService;
     private readonly IDatabaseMaintenanceService _databaseMaintenanceService;
     private readonly IStartupGateDiagnosticsLogger _startupGateDiagnosticsLogger;
+    private readonly IDatabaseMaintenanceProgressTracker _progressTracker;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly StartupGateOptions _options;
     private readonly ILogger<StartupGateController> _logger;
 
@@ -28,6 +30,8 @@ public sealed class StartupGateController : Controller
         IStartupAdminBootstrapService adminBootstrapService,
         IDatabaseMaintenanceService databaseMaintenanceService,
         IStartupGateDiagnosticsLogger startupGateDiagnosticsLogger,
+        IDatabaseMaintenanceProgressTracker progressTracker,
+        IServiceScopeFactory serviceScopeFactory,
         IOptions<StartupGateOptions> options,
         ILogger<StartupGateController> logger)
     {
@@ -37,6 +41,8 @@ public sealed class StartupGateController : Controller
         _adminBootstrapService = adminBootstrapService;
         _databaseMaintenanceService = databaseMaintenanceService;
         _startupGateDiagnosticsLogger = startupGateDiagnosticsLogger;
+        _progressTracker = progressTracker;
+        _serviceScopeFactory = serviceScopeFactory;
         _options = options.Value;
         _logger = logger;
     }
@@ -263,6 +269,80 @@ public sealed class StartupGateController : Controller
                 ? null
                 : $"DATABASE restore failed: {result.Message}",
             cancellationToken: cancellationToken));
+    }
+
+    [HttpPost("database-backup/restore/start")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> StartRestoreDatabaseBackup([FromForm(Name = "DatabaseBackupRestoreForm")] StartupDatabaseBackupRestoreForm form, CancellationToken cancellationToken)
+    {
+        var status = await _startupGateService.EvaluateAsync(HttpContext, cancellationToken);
+        if (!status.CanPerformWriteActions)
+        {
+            return Forbid();
+        }
+
+        if (string.IsNullOrWhiteSpace(form.FileId))
+        {
+            return BadRequest(new { succeeded = false, message = "Select a DATABASE backup file to restore." });
+        }
+
+        if (!string.Equals(form.ConfirmationText?.Trim(), DatabaseBackupRestoreRequest.ConfirmationKeyword, StringComparison.Ordinal))
+        {
+            return BadRequest(new { succeeded = false, message = $"Type {DatabaseBackupRestoreRequest.ConfirmationKeyword} to confirm restore." });
+        }
+
+        var start = _progressTracker.TryStartOperation(
+            DatabaseMaintenanceOperationType.Restore,
+            stage: "validating backup",
+            fileName: form.FileId,
+            detailsMessage: "startup-gate");
+        if (!start.Started || start.Operation is null)
+        {
+            return Conflict(new { succeeded = false, message = start.Message, activeOperation = start.Operation });
+        }
+
+        var operationId = start.Operation.OperationId;
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var scope = _serviceScopeFactory.CreateScope();
+                var maintenanceService = scope.ServiceProvider.GetRequiredService<IDatabaseMaintenanceService>();
+                var result = await maintenanceService.RestoreBackupAsync(
+                    new DatabaseBackupRestoreRequest
+                    {
+                        OperationId = operationId,
+                        FileId = form.FileId ?? string.Empty,
+                        ConfirmationText = form.ConfirmationText ?? string.Empty,
+                        RequestedBy = "startup-gate"
+                    },
+                    CancellationToken.None);
+
+                if (!result.Succeeded)
+                {
+                    _progressTracker.CompleteFailure(operationId, "failed", result.Message, result.RestoredFileName);
+                }
+            }
+            catch (FileNotFoundException)
+            {
+                _progressTracker.CompleteFailure(operationId, "failed", "Selected backup file was not found.", form.FileId);
+            }
+            catch (Exception ex)
+            {
+                _progressTracker.CompleteFailure(operationId, "failed", ex.Message, form.FileId);
+            }
+        });
+
+        return Json(new { succeeded = true, operationId });
+    }
+
+    [HttpGet("database-backup/progress")]
+    public IActionResult GetDatabaseBackupProgress([FromQuery] string? operationId = null)
+    {
+        var operation = string.IsNullOrWhiteSpace(operationId)
+            ? _progressTracker.GetCurrentOperation()
+            : _progressTracker.GetOperation(operationId);
+        return Json(new { operation });
     }
 
     private async Task<StartupGatePageViewModel> BuildViewModelAsync(

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -192,6 +192,7 @@ builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsServi
 builder.Services.AddSingleton<IApplicationMetadataProvider, ApplicationMetadataProvider>();
 builder.Services.AddScoped<IDatabaseStatusQueryService, DatabaseStatusQueryService>();
 builder.Services.AddScoped<IDatabaseMaintenanceService, DatabaseMaintenanceService>();
+builder.Services.AddSingleton<IDatabaseMaintenanceProgressTracker, DatabaseMaintenanceProgressTracker>();
 builder.Services.AddScoped<INotificationSettingsService, NotificationSettingsService>();
 builder.Services.AddScoped<IUserNotificationSettingsService, UserNotificationSettingsService>();
 builder.Services.AddScoped<INotificationSuppressionService, NotificationSuppressionService>();

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceModels.cs
@@ -42,6 +42,7 @@ public sealed class DatabasePruneExecuteResult
 
 public sealed class DatabaseBackupCreateRequest
 {
+    public string? OperationId { get; init; }
     public DatabaseBackupMode BackupMode { get; init; } = DatabaseBackupMode.Full;
     public DatabaseBackupCreationSource BackupSource { get; init; } = DatabaseBackupCreationSource.Manual;
     public string? RequestedBy { get; init; }
@@ -68,6 +69,7 @@ public sealed class DatabaseBackupRestoreRequest
 {
     public const string ConfirmationKeyword = "RESTORE";
 
+    public string? OperationId { get; init; }
     public string FileId { get; init; } = string.Empty;
     public string ConfirmationText { get; init; } = string.Empty;
     public string? RequestedBy { get; init; }

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceProgressModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceProgressModels.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace PingMonitor.Web.Services.DatabaseStatus;
+
+public enum DatabaseMaintenanceOperationType
+{
+    BackupCreate = 1,
+    Restore = 2
+}
+
+public sealed record DatabaseMaintenanceOperationProgress
+{
+    public string OperationId { get; init; } = string.Empty;
+    public DatabaseMaintenanceOperationType OperationType { get; init; }
+    public DateTimeOffset StartedAtUtc { get; init; }
+    public DateTimeOffset? CompletedAtUtc { get; init; }
+    public DateTimeOffset LastUpdatedAtUtc { get; init; }
+    public bool IsRunning { get; init; }
+    public bool Succeeded { get; init; }
+    public bool Failed { get; init; }
+    public string Stage { get; init; } = string.Empty;
+    public int ApproximatePercentComplete { get; init; }
+    public long? BytesProcessed { get; init; }
+    public long? TotalBytes { get; init; }
+    public string? FileName { get; init; }
+    public string? BackupName { get; init; }
+    public string? StatusMessage { get; init; }
+    public string? DetailsMessage { get; init; }
+    public string? ErrorMessage { get; init; }
+
+    [JsonIgnore]
+    public TimeSpan Elapsed => (CompletedAtUtc ?? DateTimeOffset.UtcNow) - StartedAtUtc;
+}
+
+public sealed class DatabaseMaintenanceOperationStartResult
+{
+    public bool Started { get; init; }
+    public string Message { get; init; } = string.Empty;
+    public DatabaseMaintenanceOperationProgress? Operation { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceProgressTracker.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceProgressTracker.cs
@@ -1,0 +1,221 @@
+using System.Text.Json;
+
+namespace PingMonitor.Web.Services.DatabaseStatus;
+
+internal sealed class DatabaseMaintenanceProgressTracker : IDatabaseMaintenanceProgressTracker
+{
+    private static readonly object Sync = new();
+
+    private readonly IWebHostEnvironment _environment;
+    private readonly ILogger<DatabaseMaintenanceProgressTracker> _logger;
+    private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+
+    private DatabaseMaintenanceOperationProgress? _currentOperation;
+
+    public DatabaseMaintenanceProgressTracker(
+        IWebHostEnvironment environment,
+        ILogger<DatabaseMaintenanceProgressTracker> logger)
+    {
+        _environment = environment;
+        _logger = logger;
+    }
+
+    public DatabaseMaintenanceOperationStartResult TryStartOperation(
+        DatabaseMaintenanceOperationType operationType,
+        string stage,
+        string? fileName,
+        string? detailsMessage)
+    {
+        lock (Sync)
+        {
+            if (_currentOperation is { IsRunning: true })
+            {
+                return new DatabaseMaintenanceOperationStartResult
+                {
+                    Started = false,
+                    Message = "A DATABASE maintenance operation is already running.",
+                    Operation = _currentOperation
+                };
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            _currentOperation = new DatabaseMaintenanceOperationProgress
+            {
+                OperationId = Guid.NewGuid().ToString("N"),
+                OperationType = operationType,
+                StartedAtUtc = now,
+                LastUpdatedAtUtc = now,
+                IsRunning = true,
+                Succeeded = false,
+                Failed = false,
+                Stage = stage,
+                ApproximatePercentComplete = 0,
+                FileName = fileName,
+                BackupName = fileName,
+                DetailsMessage = detailsMessage
+            };
+
+            PersistSnapshot(_currentOperation);
+
+            return new DatabaseMaintenanceOperationStartResult
+            {
+                Started = true,
+                Message = "DATABASE maintenance operation started.",
+                Operation = _currentOperation
+            };
+        }
+    }
+
+    public DatabaseMaintenanceOperationProgress? GetCurrentOperation()
+    {
+        lock (Sync)
+        {
+            return _currentOperation;
+        }
+    }
+
+    public DatabaseMaintenanceOperationProgress? GetOperation(string operationId)
+    {
+        if (string.IsNullOrWhiteSpace(operationId))
+        {
+            return null;
+        }
+
+        lock (Sync)
+        {
+            if (_currentOperation is not null && string.Equals(_currentOperation.OperationId, operationId, StringComparison.Ordinal))
+            {
+                return _currentOperation;
+            }
+        }
+
+        var historyPath = GetHistoryFilePath(operationId);
+        if (!File.Exists(historyPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var json = File.ReadAllText(historyPath);
+            return JsonSerializer.Deserialize<DatabaseMaintenanceOperationProgress>(json, _jsonOptions);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogWarning(exception, "Failed to read DATABASE maintenance progress snapshot {Path}.", historyPath);
+            return null;
+        }
+    }
+
+    public void UpdateProgress(
+        string operationId,
+        string stage,
+        int approximatePercentComplete,
+        long? bytesProcessed,
+        long? totalBytes,
+        string? statusMessage,
+        string? detailsMessage)
+    {
+        lock (Sync)
+        {
+            if (_currentOperation is null ||
+                !_currentOperation.IsRunning ||
+                !string.Equals(_currentOperation.OperationId, operationId, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            var normalizedPercent = Math.Clamp(approximatePercentComplete, 0, 100);
+            _currentOperation = _currentOperation with
+            {
+                LastUpdatedAtUtc = now,
+                Stage = stage,
+                ApproximatePercentComplete = normalizedPercent,
+                BytesProcessed = bytesProcessed,
+                TotalBytes = totalBytes,
+                StatusMessage = statusMessage,
+                DetailsMessage = detailsMessage
+            };
+
+            PersistSnapshot(_currentOperation);
+        }
+    }
+
+    public void CompleteSuccess(string operationId, string stage, string? statusMessage, string? detailsMessage)
+    {
+        CompleteCore(operationId, stage, succeeded: true, failed: false, statusMessage, detailsMessage, errorMessage: null);
+    }
+
+    public void CompleteFailure(string operationId, string stage, string errorMessage, string? detailsMessage)
+    {
+        CompleteCore(operationId, stage, succeeded: false, failed: true, statusMessage: null, detailsMessage, errorMessage);
+    }
+
+    private void CompleteCore(
+        string operationId,
+        string stage,
+        bool succeeded,
+        bool failed,
+        string? statusMessage,
+        string? detailsMessage,
+        string? errorMessage)
+    {
+        lock (Sync)
+        {
+            if (_currentOperation is null || !string.Equals(_currentOperation.OperationId, operationId, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            _currentOperation = _currentOperation with
+            {
+                LastUpdatedAtUtc = now,
+                CompletedAtUtc = now,
+                IsRunning = false,
+                Succeeded = succeeded,
+                Failed = failed,
+                Stage = stage,
+                ApproximatePercentComplete = succeeded ? 100 : Math.Max(_currentOperation.ApproximatePercentComplete, 1),
+                StatusMessage = statusMessage,
+                DetailsMessage = detailsMessage,
+                ErrorMessage = errorMessage
+            };
+
+            PersistSnapshot(_currentOperation);
+        }
+    }
+
+    private void PersistSnapshot(DatabaseMaintenanceOperationProgress operation)
+    {
+        try
+        {
+            var directory = GetProgressDirectoryPath();
+            Directory.CreateDirectory(directory);
+            var json = JsonSerializer.Serialize(operation, _jsonOptions);
+
+            File.WriteAllText(GetCurrentFilePath(), json);
+            File.WriteAllText(GetHistoryFilePath(operation.OperationId), json);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogWarning(exception, "Failed to persist DATABASE maintenance progress snapshot.");
+        }
+    }
+
+    private string GetProgressDirectoryPath()
+    {
+        return Path.Combine(_environment.ContentRootPath, "App_Data", "DbMaintenanceProgress");
+    }
+
+    private string GetCurrentFilePath()
+    {
+        return Path.Combine(GetProgressDirectoryPath(), "current-operation.json");
+    }
+
+    private string GetHistoryFilePath(string operationId)
+    {
+        return Path.Combine(GetProgressDirectoryPath(), $"{operationId}.json");
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
@@ -38,6 +38,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
     private readonly IOptions<DatabaseMaintenanceOptions> _options;
     private readonly IWebHostEnvironment _webHostEnvironment;
     private readonly IStartupGateDiagnosticsLogger _startupGateDiagnosticsLogger;
+    private readonly IDatabaseMaintenanceProgressTracker _progressTracker;
     private readonly ILogger<DatabaseMaintenanceService> _logger;
 
     public DatabaseMaintenanceService(
@@ -46,6 +47,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         IOptions<DatabaseMaintenanceOptions> options,
         IWebHostEnvironment webHostEnvironment,
         IStartupGateDiagnosticsLogger startupGateDiagnosticsLogger,
+        IDatabaseMaintenanceProgressTracker progressTracker,
         ILogger<DatabaseMaintenanceService> logger)
     {
         _dbContext = dbContext;
@@ -53,6 +55,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         _options = options;
         _webHostEnvironment = webHostEnvironment;
         _startupGateDiagnosticsLogger = startupGateDiagnosticsLogger;
+        _progressTracker = progressTracker;
         _logger = logger;
     }
 
@@ -136,6 +139,15 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 
     public async Task<DatabaseBackupCreateResult> CreateBackupAsync(DatabaseBackupCreateRequest request, CancellationToken cancellationToken)
     {
+        ReportProgress(
+            request.OperationId,
+            stage: "preparing backup export",
+            approximatePercentComplete: 3,
+            bytesProcessed: null,
+            totalBytes: null,
+            statusMessage: "Preparing DATABASE backup export.",
+            detailsMessage: null);
+
         var options = _options.Value;
         var backupDirectory = GetBackupDirectory(options.BackupStoragePath);
         Directory.CreateDirectory(backupDirectory);
@@ -165,7 +177,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         var dbConnectionString = _dbContext.Database.GetConnectionString();
         if (string.IsNullOrWhiteSpace(dbConnectionString))
         {
-            return await CreateBackupFailureAsync("Database connection string is unavailable.", request.RequestedBy, suppressEventLogWrites, cancellationToken);
+            return await CreateBackupFailureAsync("Database connection string is unavailable.", request.OperationId, request.RequestedBy, suppressEventLogWrites, cancellationToken);
         }
 
         var builder = new MySqlConnectionStringBuilder(dbConnectionString);
@@ -181,6 +193,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         {
             return await CreateBackupFailureAsync(
                 "mysqldump executable was not found. Configure DatabaseMaintenance:MySqlDumpExecutablePath with the full executable path.",
+                request.OperationId,
                 request.RequestedBy,
                 suppressEventLogWrites,
                 cancellationToken);
@@ -223,16 +236,52 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
             using var process = Process.Start(processInfo);
             if (process is null)
             {
-                return await CreateBackupFailureAsync("Unable to start mysqldump process.", request.RequestedBy, suppressEventLogWrites, cancellationToken);
+                return await CreateBackupFailureAsync("Unable to start mysqldump process.", request.OperationId, request.RequestedBy, suppressEventLogWrites, cancellationToken);
             }
+
+            ReportProgress(
+                request.OperationId,
+                stage: "streaming SQL dump to file",
+                approximatePercentComplete: 12,
+                bytesProcessed: 0,
+                totalBytes: null,
+                statusMessage: "Streaming mysqldump output to backup file.",
+                detailsMessage: null);
 
             await using (var fileStream = new FileStream(fullPath, FileMode.Create, FileAccess.Write, FileShare.None))
             {
                 var headerText = BuildBackupHeader(normalizedBackupMode, backupTimestamp);
                 var headerBytes = Encoding.UTF8.GetBytes(headerText);
                 await fileStream.WriteAsync(headerBytes, cancellationToken);
-                await process.StandardOutput.BaseStream.CopyToAsync(fileStream, cancellationToken);
+                var bytesWritten = headerBytes.Length;
+                ReportProgress(request.OperationId, "streaming SQL dump to file", 13, bytesWritten, null, "Backup stream started.", null);
+
+                var buffer = new byte[128 * 1024];
+                int read;
+                while ((read = await process.StandardOutput.BaseStream.ReadAsync(buffer, cancellationToken)) > 0)
+                {
+                    await fileStream.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+                    bytesWritten += read;
+                    var progressPercent = Math.Min(90, 12 + (int)Math.Min(78d, Math.Log10(Math.Max(10, bytesWritten)) * 14d));
+                    ReportProgress(
+                        request.OperationId,
+                        stage: "streaming SQL dump to file",
+                        approximatePercentComplete: progressPercent,
+                        bytesProcessed: bytesWritten,
+                        totalBytes: null,
+                        statusMessage: "Backup stream is actively writing.",
+                        detailsMessage: null);
+                }
             }
+
+            ReportProgress(
+                request.OperationId,
+                stage: "waiting for mysqldump exit",
+                approximatePercentComplete: 94,
+                bytesProcessed: new FileInfo(fullPath).Length,
+                totalBytes: null,
+                statusMessage: "Finalizing backup export.",
+                detailsMessage: null);
 
             var stderr = await process.StandardError.ReadToEndAsync(cancellationToken);
             await process.WaitForExitAsync(cancellationToken);
@@ -245,7 +294,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
                 }
 
                 var message = $"mysqldump exited with code {process.ExitCode}. {TrimDiagnostic(stderr)}";
-                return await CreateBackupFailureAsync(message, request.RequestedBy, suppressEventLogWrites, cancellationToken);
+                return await CreateBackupFailureAsync(message, request.OperationId, request.RequestedBy, suppressEventLogWrites, cancellationToken);
             }
 
             var fileInfo = new FileInfo(fullPath);
@@ -270,6 +319,12 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
                 suppressEventLogWrites,
                 cancellationToken);
 
+            _progressTracker.CompleteSuccess(
+                request.OperationId ?? string.Empty,
+                stage: "completed",
+                statusMessage: "DATABASE backup export completed successfully.",
+                detailsMessage: fileName);
+
             return new DatabaseBackupCreateResult
             {
                 Succeeded = true,
@@ -289,7 +344,12 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
             }
 
             _logger.LogWarning(ex, "Database backup export failed.");
-            return await CreateBackupFailureAsync($"Database backup export failed: {ex.Message}", request.RequestedBy, suppressEventLogWrites, cancellationToken);
+            _progressTracker.CompleteFailure(
+                request.OperationId ?? string.Empty,
+                stage: "failed",
+                errorMessage: $"Database backup export failed: {ex.Message}",
+                detailsMessage: null);
+            return await CreateBackupFailureAsync($"Database backup export failed: {ex.Message}", request.OperationId, request.RequestedBy, suppressEventLogWrites, cancellationToken);
         }
     }
 
@@ -361,6 +421,15 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 
     public async Task<DatabaseBackupRestoreResult> RestoreBackupAsync(DatabaseBackupRestoreRequest request, CancellationToken cancellationToken)
     {
+        ReportProgress(
+            request.OperationId,
+            stage: "validating backup",
+            approximatePercentComplete: 3,
+            bytesProcessed: null,
+            totalBytes: null,
+            statusMessage: "Validating backup before restore.",
+            detailsMessage: null);
+
         var restoreStopwatch = Stopwatch.StartNew();
         var isStartupGateRestoreRequest = IsStartupGateRestoreRequest(request);
         _startupGateDiagnosticsLogger.Write(
@@ -411,6 +480,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         _startupGateDiagnosticsLogger.Write(
             "database-restore.pre-restore-backup.start",
             $"Starting pre-restore backup. fileName='{backupFileInfo.Name}', backupMode={backupDescriptor.Mode}, elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
+        ReportProgress(request.OperationId, "creating pre-restore backup", 10, null, null, "Creating pre-restore safety backup.", backupFileInfo.Name);
         var preRestoreBackup = await CreateBackupAsync(
             new DatabaseBackupCreateRequest
             {
@@ -431,6 +501,11 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
                 preRestoreBackup.Message,
                 request.RequestedBy);
 
+            _progressTracker.CompleteFailure(
+                request.OperationId ?? string.Empty,
+                stage: "failed",
+                errorMessage: $"Restore aborted: pre-restore backup failed: {preRestoreBackup.Message}",
+                detailsMessage: backupFileInfo.Name);
             return new DatabaseBackupRestoreResult
             {
                 Succeeded = false,
@@ -477,6 +552,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 
         try
         {
+            ReportProgress(request.OperationId, "starting mysql restore", 28, 0, contentBytes.Length, "Starting mysql restore process.", backupFileInfo.Name);
             _startupGateDiagnosticsLogger.Write(
                 "database-restore.process.launch",
                 $"Launching mysql restore process. executable='{processInfo.FileName}', arguments=\"{argumentSummary}\", elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
@@ -492,7 +568,21 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
             _startupGateDiagnosticsLogger.Write(
                 "database-restore.stdin-copy.start",
                 $"Starting stdin copy of restore payload. bytes={contentBytes.Length}, processId={process.Id}, elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
-            await process.StandardInput.BaseStream.WriteAsync(contentBytes, cancellationToken);
+            ReportProgress(request.OperationId, "streaming restore payload", 35, 0, contentBytes.Length, "Streaming restore payload to mysql stdin.", backupFileInfo.Name);
+            var buffer = new byte[128 * 1024];
+            var totalBytes = contentBytes.Length;
+            var totalWritten = 0;
+            var offset = 0;
+            while (offset < contentBytes.Length)
+            {
+                var chunkLength = Math.Min(buffer.Length, contentBytes.Length - offset);
+                Buffer.BlockCopy(contentBytes, offset, buffer, 0, chunkLength);
+                await process.StandardInput.BaseStream.WriteAsync(buffer.AsMemory(0, chunkLength), cancellationToken);
+                offset += chunkLength;
+                totalWritten += chunkLength;
+                var percent = Math.Min(88, 35 + (int)Math.Round((totalWritten / (double)Math.Max(1, totalBytes)) * 53d));
+                ReportProgress(request.OperationId, "streaming restore payload", percent, totalWritten, totalBytes, "Restore payload stream is active.", backupFileInfo.Name);
+            }
             await process.StandardInput.BaseStream.FlushAsync(cancellationToken);
             _startupGateDiagnosticsLogger.Write(
                 "database-restore.stdin-copy.complete",
@@ -506,6 +596,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
             _startupGateDiagnosticsLogger.Write(
                 "database-restore.process.waiting-for-exit",
                 $"Waiting for mysql restore process exit. processId={process.Id}, elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
+            ReportProgress(request.OperationId, "waiting for mysql exit", 92, contentBytes.Length, contentBytes.Length, "Waiting for mysql process to finish restore.", backupFileInfo.Name);
             await process.WaitForExitAsync(cancellationToken);
             var stderr = await stderrReadTask;
             var stdout = await stdoutReadTask;
@@ -523,6 +614,7 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 
             if (backupDescriptor.Mode == DatabaseBackupMode.Compact)
             {
+                ReportProgress(request.OperationId, "resetting compact tables", 96, contentBytes.Length, contentBytes.Length, "Resetting compact-excluded runtime tables.", backupFileInfo.Name);
                 await ResetCompactExcludedTablesAsync(cancellationToken);
             }
 
@@ -543,6 +635,12 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
                 })
             }, cancellationToken);
 
+            _progressTracker.CompleteSuccess(
+                request.OperationId ?? string.Empty,
+                stage: "completed",
+                statusMessage: "DATABASE restore completed successfully.",
+                detailsMessage: backupFileInfo.Name);
+
             return new DatabaseBackupRestoreResult
             {
                 Succeeded = true,
@@ -561,6 +659,11 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
                 "database-restore.exception",
                 ex,
                 $"Restore failed with handled exception category. elapsedMs={restoreStopwatch.ElapsedMilliseconds}.");
+            _progressTracker.CompleteFailure(
+                request.OperationId ?? string.Empty,
+                stage: "failed",
+                errorMessage: $"Database restore failed: {ex.Message}",
+                detailsMessage: backupFileInfo.Name);
             return await CreateRestoreFailureAsync($"Database restore failed: {ex.Message}", backupFileInfo, request, backupDescriptor.Mode, true, preRestoreBackup.FileName, cancellationToken);
         }
         catch (Exception ex)
@@ -806,10 +909,17 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 
     private async Task<DatabaseBackupCreateResult> CreateBackupFailureAsync(
         string message,
+        string? operationId,
         string? requestedBy,
         bool suppressEventLogWrites,
         CancellationToken cancellationToken)
     {
+        _progressTracker.CompleteFailure(
+            operationId ?? string.Empty,
+            stage: "failed",
+            errorMessage: message,
+            detailsMessage: null);
+
         await WriteDatabaseBackupEventAsync(
             new EventLogWriteRequest
             {
@@ -842,6 +952,11 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         CancellationToken cancellationToken)
     {
         _ = cancellationToken;
+        _progressTracker.CompleteFailure(
+            request.OperationId ?? string.Empty,
+            stage: "failed",
+            errorMessage: message,
+            detailsMessage: backupFileInfo.Name);
 
         _logger.LogWarning(
             "Database backup restore failed before completion. FileId: {FileId}, FileName: {FileName}, BackupMode: {BackupMode}, PreRestoreBackupCreated: {PreRestoreBackupCreated}, PreRestoreBackupFileName: {PreRestoreBackupFileName}, RequestedBy: {RequestedBy}, Message: {Message}",
@@ -863,6 +978,30 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
             PreRestoreBackupCreated = preRestoreBackupCreated,
             PreRestoreBackupFileName = preRestoreBackupFileName
         });
+    }
+
+    private void ReportProgress(
+        string? operationId,
+        string stage,
+        int approximatePercentComplete,
+        long? bytesProcessed,
+        long? totalBytes,
+        string? statusMessage,
+        string? detailsMessage)
+    {
+        if (string.IsNullOrWhiteSpace(operationId))
+        {
+            return;
+        }
+
+        _progressTracker.UpdateProgress(
+            operationId,
+            stage,
+            approximatePercentComplete,
+            bytesProcessed,
+            totalBytes,
+            statusMessage,
+            detailsMessage);
     }
 
     private static string BuildBackupHeader(DatabaseBackupMode mode, DateTimeOffset createdAtUtc)

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/IDatabaseMaintenanceProgressTracker.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/IDatabaseMaintenanceProgressTracker.cs
@@ -1,0 +1,25 @@
+namespace PingMonitor.Web.Services.DatabaseStatus;
+
+public interface IDatabaseMaintenanceProgressTracker
+{
+    DatabaseMaintenanceOperationStartResult TryStartOperation(
+        DatabaseMaintenanceOperationType operationType,
+        string stage,
+        string? fileName,
+        string? detailsMessage);
+
+    DatabaseMaintenanceOperationProgress? GetCurrentOperation();
+    DatabaseMaintenanceOperationProgress? GetOperation(string operationId);
+
+    void UpdateProgress(
+        string operationId,
+        string stage,
+        int approximatePercentComplete,
+        long? bytesProcessed,
+        long? totalBytes,
+        string? statusMessage,
+        string? detailsMessage);
+
+    void CompleteSuccess(string operationId, string stage, string? statusMessage, string? detailsMessage);
+    void CompleteFailure(string operationId, string stage, string errorMessage, string? detailsMessage);
+}

--- a/src/WebApp/PingMonitor.Web/Views/AdminDatabase/Maintenance.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminDatabase/Maintenance.cshtml
@@ -30,6 +30,9 @@
         .risk-emphasis { color: #912018; }
         .warning-emphasis { color: #7a2e0e; }
         .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: .55rem .8rem; border: 1px solid var(--border); border-radius: 10px; background: #fff; color: var(--text); text-decoration: none; }
+        .progress-wrap { border: 1px solid var(--border); border-radius: 10px; padding: .75rem; }
+        .progress-bar { height: 14px; background: var(--border); border-radius: 999px; overflow: hidden; }
+        .progress-fill { height: 100%; width: 0; background: #0f62fe; transition: width .2s linear; }
         html[data-theme='dark'] .risk-emphasis { color: #ffb4ae; }
         html[data-theme='dark'] .warning-emphasis { color: #ffd29d; }
     </style>
@@ -103,6 +106,13 @@
                 <button type="submit">Create DB backup</button>
             </form>
 
+            <div id="db-maintenance-progress" class="progress-wrap" style="margin-top:.75rem; display:none;">
+                <p><strong>Live operation progress</strong></p>
+                <p id="progress-stage" class="muted">Waiting…</p>
+                <div class="progress-bar"><div id="progress-fill" class="progress-fill"></div></div>
+                <p id="progress-meta" class="muted" style="margin-bottom:0;"></p>
+            </div>
+
             <h3>Upload DATABASE backup</h3>
             <form method="post" action="/admin/database/backup/upload" enctype="multipart/form-data" class="form-grid">
                 @Html.AntiForgeryToken()
@@ -141,7 +151,7 @@
                 <p><strong class="risk-emphasis">This will completely replace the current DATABASE.</strong></p>
                 <p class="muted">Select the backup file to restore. A pre-restore database backup will be created automatically before restore is applied.</p>
                 <p class="muted"><strong>Compact restore note:</strong> compact backups exclude runtime history (results, metrics, logs). Those excluded runtime tables are reset to empty during restore.</p>
-                <form method="post" action="/admin/database/backup/restore" class="form-grid">
+                <form id="admin-restore-form" method="post" action="/admin/database/backup/restore" class="form-grid">
                     @Html.AntiForgeryToken()
                     <label>Backup to restore
                         <select asp-for="RestoreForm.FileId">
@@ -183,5 +193,63 @@
         </section>
     </div>
 </main>
+<script>
+(() => {
+    const createForm = document.querySelector('form[action="/admin/database/backup/create"]');
+    const restoreForm = document.getElementById('admin-restore-form');
+    const panel = document.getElementById('db-maintenance-progress');
+    const stageEl = document.getElementById('progress-stage');
+    const fillEl = document.getElementById('progress-fill');
+    const metaEl = document.getElementById('progress-meta');
+    let pollTimer = null;
+
+    function setProgress(op) {
+        if (!op) return;
+        panel.style.display = 'block';
+        stageEl.textContent = `${op.stage || 'Working'}${op.failed ? ' (failed)' : op.succeeded ? ' (completed)' : ''}`;
+        fillEl.style.width = `${Math.max(0, Math.min(100, op.approximatePercentComplete || 0))}%`;
+        const bytes = op.bytesProcessed != null ? `Bytes: ${op.bytesProcessed}${op.totalBytes != null ? ' / ' + op.totalBytes : ''}` : '';
+        const msg = op.errorMessage || op.statusMessage || op.detailsMessage || '';
+        metaEl.textContent = [bytes, msg].filter(Boolean).join(' • ');
+    }
+
+    async function poll(operationId) {
+        const res = await fetch(`/admin/database/backup/progress?operationId=${encodeURIComponent(operationId)}`);
+        const payload = await res.json();
+        setProgress(payload.operation);
+        if (payload.operation && payload.operation.isRunning) {
+            pollTimer = setTimeout(() => poll(operationId), 1000);
+            return;
+        }
+        setTimeout(() => window.location.reload(), 1200);
+    }
+
+    async function start(form, endpoint) {
+        if (pollTimer) clearTimeout(pollTimer);
+        const submit = form.querySelector('button[type="submit"]');
+        submit.disabled = true;
+        const body = new FormData(form);
+        const res = await fetch(endpoint, { method: 'POST', body });
+        const payload = await res.json();
+        if (!res.ok || !payload.succeeded) {
+            alert(payload.message || 'Failed to start DATABASE maintenance operation.');
+            submit.disabled = false;
+            return;
+        }
+        panel.style.display = 'block';
+        await poll(payload.operationId);
+        submit.disabled = false;
+    }
+
+    createForm?.addEventListener('submit', (event) => {
+        event.preventDefault();
+        start(createForm, '/admin/database/backup/create/start');
+    });
+    restoreForm?.addEventListener('submit', (event) => {
+        event.preventDefault();
+        start(restoreForm, '/admin/database/backup/restore/start');
+    });
+})();
+</script>
 </body>
 </html>

--- a/src/WebApp/PingMonitor.Web/Views/StartupGate/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/StartupGate/Index.cshtml
@@ -33,6 +33,9 @@
         .danger { border: 1px solid #fda29b; background: #fff5f4; border-radius: 10px; padding: .75rem; }
         .warning { color: #b42318; font-weight: 700; }
         select { width: 100%; box-sizing: border-box; padding: .85rem; border: 1px solid #cbd2d9; border-radius: 10px; font-size: 1rem; }
+        .progress-wrap { border: 1px solid #cbd2d9; border-radius: 10px; padding: .75rem; }
+        .progress-bar { height: 12px; background: #d9e2ec; border-radius: 999px; overflow: hidden; }
+        .progress-fill { height: 100%; width: 0; background: #0f62fe; transition: width .2s linear; }
     </style>
 </head>
 <body>
@@ -135,7 +138,7 @@
         </form>
 
         <h3>Restore DATABASE backup</h3>
-        <form method="post" action="/startup-gate/database-backup/restore" class="grid">
+        <form id="startup-gate-restore-form" method="post" action="/startup-gate/database-backup/restore" class="grid">
             @Html.AntiForgeryToken()
             <div>
                 <label asp-for="DatabaseBackupRestoreForm.FileId"></label>
@@ -157,6 +160,12 @@
                 <button type="submit" disabled="@(!Model.Status.CanPerformWriteActions)">Restore DATABASE backup</button>
             </div>
         </form>
+        <div id="startup-gate-progress" class="progress-wrap" style="display:none; margin-top:.75rem;">
+            <p><strong>Live restore progress</strong></p>
+            <p id="startup-progress-stage" class="muted">Waiting…</p>
+            <div class="progress-bar"><div id="startup-progress-fill" class="progress-fill"></div></div>
+            <p id="startup-progress-meta" class="muted" style="margin-bottom:0;"></p>
+        </div>
     </section>
 
     <section class="card">
@@ -196,5 +205,52 @@
         </form>
     </section>
 </main>
+<script>
+(() => {
+    const form = document.getElementById('startup-gate-restore-form');
+    const panel = document.getElementById('startup-gate-progress');
+    const stageEl = document.getElementById('startup-progress-stage');
+    const fillEl = document.getElementById('startup-progress-fill');
+    const metaEl = document.getElementById('startup-progress-meta');
+    let pollTimer = null;
+
+    function setProgress(op) {
+        if (!op) return;
+        panel.style.display = 'block';
+        stageEl.textContent = `${op.stage || 'Working'}${op.failed ? ' (failed)' : op.succeeded ? ' (completed)' : ''}`;
+        fillEl.style.width = `${Math.max(0, Math.min(100, op.approximatePercentComplete || 0))}%`;
+        const bytes = op.bytesProcessed != null ? `Bytes: ${op.bytesProcessed}${op.totalBytes != null ? ' / ' + op.totalBytes : ''}` : '';
+        const msg = op.errorMessage || op.statusMessage || op.detailsMessage || '';
+        metaEl.textContent = [bytes, msg].filter(Boolean).join(' • ');
+    }
+
+    async function poll(operationId) {
+        const res = await fetch(`/startup-gate/database-backup/progress?operationId=${encodeURIComponent(operationId)}`);
+        const payload = await res.json();
+        setProgress(payload.operation);
+        if (payload.operation && payload.operation.isRunning) {
+            pollTimer = setTimeout(() => poll(operationId), 1000);
+            return;
+        }
+        setTimeout(() => window.location.reload(), 1500);
+    }
+
+    form?.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (pollTimer) clearTimeout(pollTimer);
+        const submit = form.querySelector('button[type="submit"]');
+        submit.disabled = true;
+        const res = await fetch('/startup-gate/database-backup/restore/start', { method: 'POST', body: new FormData(form) });
+        const payload = await res.json();
+        if (!res.ok || !payload.succeeded) {
+            alert(payload.message || 'DATABASE restore could not be started.');
+            submit.disabled = false;
+            return;
+        }
+        await poll(payload.operationId);
+        submit.disabled = false;
+    });
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Long-running DATABASE backup and restore operations can appear to hang for operators; a lightweight progress indicator reassures operators without adding DB/event-log dependencies.
- Progress must remain readable during Startup Gate and while the database may be unavailable, and only one maintenance operation should run at a time.

### Description
- Add a small progress model and singleton tracker `IDatabaseMaintenanceProgressTracker` that keeps a single active operation in memory and persists JSON snapshots to `App_Data/DbMaintenanceProgress` so Startup Gate can read progress without DB access. 
- Instrument `DatabaseMaintenanceService` to report staged progress during backup and restore, including chunked streaming loops for `mysqldump` stdout-to-file and chunked writes of restore payload to `mysql` stdin, and write final success/failure snapshots. 
- Add async start + polling endpoints and controllers: `POST /admin/database/backup/create/start`, `POST /admin/database/backup/restore/start`, `GET /admin/database/backup/progress`, `POST /startup-gate/database-backup/restore/start`, and `GET /startup-gate/database-backup/progress`, with single-operation concurrency gating. 
- Update admin `/admin/database/maintenance` and startup-gate `/startup-gate` views to start operations via `fetch`, show a live progress panel (stage, approximate percent, bytes, messages) and poll until completion, then reload; preserve existing validation, pre-restore backup, compact/full semantics and startup-gate write-safety checks. 

### Testing
- `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` succeeded (build output produced without errors). 
- `dotnet test` was not applicable in this repository layout and returned an error because there is no root test project; no unit tests were added. 
- Manual local verification steps performed in code: compilation and smoke inspection of modified controllers, services, and views; no runtime integration tests were run against a live MySQL instance in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5c3b31ae0832ab561abbd0d1e0c62)