### PR TITLE
Restore buffered AgentId/EndpointId to preserve accepted CheckResults during Phase 1

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedCheckResult.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedCheckResult.cs
@@ -5,8 +5,11 @@ public sealed class BufferedCheckResult
     public string CheckResultId { get; init; } = string.Empty;
 
     // AssignmentId is the authoritative identity for buffered raw results.
-    // Agent/endpoint are resolved from MonitorAssignments at flush time.
+    // AgentId/EndpointId are compatibility payload fields for Phase 1 and
+    // must be preserved with accepted raw results until Phase 2 schema slimming.
     public string AssignmentId { get; init; } = string.Empty;
+    public string AgentId { get; init; } = string.Empty;
+    public string EndpointId { get; init; } = string.Empty;
     public DateTimeOffset CheckedAtUtc { get; init; }
     public bool Success { get; init; }
     public int? RoundTripMs { get; init; }

--- a/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultFlushBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultFlushBackgroundService.cs
@@ -1,6 +1,4 @@
 using Microsoft.Extensions.Options;
-using Microsoft.EntityFrameworkCore;
-using System.Linq.Expressions;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Options;
@@ -118,7 +116,7 @@ internal sealed class BufferedResultFlushBackgroundService : BackgroundService
                 var flushResult = await PersistAndEnqueueAssignmentsAsync(batch, cancellationToken);
                 _buffer.RecordFlushOutcome(
                     batch.Count,
-                    batch.Count,
+                    flushResult.PersistedCount,
                     DateTimeOffset.UtcNow,
                     null,
                     flushResult.PersistDurationMs,
@@ -153,77 +151,22 @@ internal sealed class BufferedResultFlushBackgroundService : BackgroundService
         var dbActivityScope = scope.ServiceProvider.GetRequiredService<IDbActivityScope>();
         using var dbScope = dbActivityScope.BeginScope("RawResultFlush");
 
-        var assignmentIds = batch
-            .Select(item => item.AssignmentId)
-            .Where(x => !string.IsNullOrWhiteSpace(x))
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
-
-        if (assignmentIds.Length == 0)
+        var checkResults = batch.Select(item => new CheckResult
         {
-            return new FlushResult(
-                PersistDurationMs: 0,
-                AssignmentEnqueuedCount: 0,
-                LastAssignmentsEnqueuedAtUtc: null);
-        }
-
-        var assignmentIdPredicate = BuildAssignmentIdPredicate(assignmentIds);
-        var assignmentContextRows = await dbContext.MonitorAssignments.AsNoTracking()
-            .Where(assignmentIdPredicate)
-            .Select(x => new
-            {
-                x.AssignmentId,
-                x.AgentId,
-                x.EndpointId
-            })
-            .ToArrayAsync(cancellationToken);
-
-        var assignmentContexts = assignmentContextRows
-            .ToDictionary(x => x.AssignmentId, StringComparer.Ordinal);
-
-        var checkResults = new List<CheckResult>(batch.Count);
-        var missingAssignmentIds = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var item in batch)
-        {
-            if (!assignmentContexts.TryGetValue(item.AssignmentId, out var assignmentContext))
-            {
-                missingAssignmentIds.Add(item.AssignmentId);
-                continue;
-            }
-
-            checkResults.Add(new CheckResult
-            {
-                // AssignmentId is the source-of-truth identity for raw rows.
-                // AgentId/EndpointId are compatibility fields until Phase 2 schema slimming.
-                CheckResultId = item.CheckResultId,
-                AssignmentId = item.AssignmentId,
-                AgentId = assignmentContext.AgentId,
-                EndpointId = assignmentContext.EndpointId,
-                CheckedAtUtc = item.CheckedAtUtc,
-                Success = item.Success,
-                RoundTripMs = item.RoundTripMs,
-                ErrorCode = item.ErrorCode,
-                ErrorMessage = item.ErrorMessage,
-                ReceivedAtUtc = item.ReceivedAtUtc,
-                BatchId = item.BatchId
-            });
-        }
-
-        if (missingAssignmentIds.Count > 0)
-        {
-            _logger.LogWarning(
-                "Buffered raw result flush skipped {SkippedCount} rows due to missing assignment metadata. Missing assignment IDs: {MissingAssignmentIds}.",
-                batch.Count - checkResults.Count,
-                string.Join(", ", missingAssignmentIds.OrderBy(x => x, StringComparer.Ordinal)));
-        }
-
-        if (checkResults.Count == 0)
-        {
-            return new FlushResult(
-                PersistDurationMs: 0,
-                AssignmentEnqueuedCount: 0,
-                LastAssignmentsEnqueuedAtUtc: null);
-        }
+            // AssignmentId is the source-of-truth identity for raw rows.
+            // AgentId/EndpointId are compatibility fields until Phase 2 schema slimming.
+            CheckResultId = item.CheckResultId,
+            AssignmentId = item.AssignmentId,
+            AgentId = item.AgentId,
+            EndpointId = item.EndpointId,
+            CheckedAtUtc = item.CheckedAtUtc,
+            Success = item.Success,
+            RoundTripMs = item.RoundTripMs,
+            ErrorCode = item.ErrorCode,
+            ErrorMessage = item.ErrorMessage,
+            ReceivedAtUtc = item.ReceivedAtUtc,
+            BatchId = item.BatchId
+        }).ToArray();
 
         var persistStartedAtUtc = DateTimeOffset.UtcNow;
         dbContext.CheckResults.AddRange(checkResults);
@@ -242,35 +185,16 @@ internal sealed class BufferedResultFlushBackgroundService : BackgroundService
 
         _logger.LogInformation(
             "Buffered result flush persisted {PersistedCount} raw check results across {AssignmentCount} assignments. Enqueued {EnqueuedAssignments} assignments for downstream processing ({CoalescedDuplicates} coalesced duplicates).",
-            checkResults.Count,
+            checkResults.Length,
             affectedAssignmentIds.Length,
             enqueueResult.EnqueuedCount,
             enqueueResult.CoalescedDuplicateCount);
 
         return new FlushResult(
+            PersistedCount: checkResults.Length,
             PersistDurationMs: persistDurationMs,
             AssignmentEnqueuedCount: enqueueResult.EnqueuedCount,
             LastAssignmentsEnqueuedAtUtc: enqueueResult.EnqueuedCount > 0 ? enqueueTimeUtc : null);
     }
-
-    private static Expression<Func<MonitorAssignment, bool>> BuildAssignmentIdPredicate(IReadOnlyList<string> assignmentIds)
-    {
-        var assignmentParameter = Expression.Parameter(typeof(MonitorAssignment), "assignment");
-        var assignmentIdProperty = Expression.Property(assignmentParameter, nameof(MonitorAssignment.AssignmentId));
-        Expression? predicateBody = null;
-
-        foreach (var assignmentId in assignmentIds)
-        {
-            var assignmentIdConstant = Expression.Constant(assignmentId, typeof(string));
-            var equalsExpression = Expression.Equal(assignmentIdProperty, assignmentIdConstant);
-            predicateBody = predicateBody is null
-                ? equalsExpression
-                : Expression.OrElse(predicateBody, equalsExpression);
-        }
-
-        predicateBody ??= Expression.Constant(false);
-        return Expression.Lambda<Func<MonitorAssignment, bool>>(predicateBody, assignmentParameter);
-    }
-
-    private sealed record FlushResult(long PersistDurationMs, int AssignmentEnqueuedCount, DateTimeOffset? LastAssignmentsEnqueuedAtUtc);
+    private sealed record FlushResult(int PersistedCount, long PersistDurationMs, int AssignmentEnqueuedCount, DateTimeOffset? LastAssignmentsEnqueuedAtUtc);
 }

--- a/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
@@ -156,6 +156,8 @@ internal sealed class ResultIngestionService : IResultIngestionService
             {
                 CheckResultId = x.CheckResultId,
                 AssignmentId = x.AssignmentId,
+                AgentId = x.AgentId,
+                EndpointId = x.EndpointId,
                 CheckedAtUtc = x.CheckedAtUtc,
                 Success = x.Success,
                 RoundTripMs = x.RoundTripMs,


### PR DESCRIPTION
### Motivation
- Fix a Phase 1 regression where `BufferedCheckResult` was slimmed to only `AssignmentId`, causing flush-time re-resolution to potentially skip/persist fewer rows than were accepted and introducing silent data-loss risk. 
- Keep the Phase 1 compatibility-first goal: do not drop schema columns or implement Phase 2, and preserve existing Startup Gate semantics. 
- Ensure flush accounting accurately reflects actual persisted rows rather than always reporting the dequeued batch size.

### Description
- Restored `AgentId` and `EndpointId` on `BufferedCheckResult` as compatibility payload fields while keeping `AssignmentId` documented as the authoritative identity. (file: `src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedCheckResult.cs`).
- Updated `ResultIngestionService` to copy `AgentId` and `EndpointId` into buffered items at accept/enqueue time so accepted rows carry the exact identity context. (file: `src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs`).
- Updated `BufferedResultFlushBackgroundService` to persist `AgentId`/`EndpointId` from buffered payload instead of re-resolving from `MonitorAssignments` at flush time, removed the skip-on-missing-assignment path, and corrected flush accounting to use the actual persisted count returned by persistence logic. (file: `src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultFlushBackgroundService.cs`).
- Preserved Startup Gate behavior and made no schema changes or Phase 2 removals; comments clearly mark `AgentId`/`EndpointId` as compatibility-only fields for Phase 1. This change also links the existing issue: Fixes #396.

### Testing
- Verified SDK/version: `dotnet --version` produced .NET 10 SDK and PowerShell was available. 
- Built the web project with an explicit runtime identifier to work around host pack resolution in this environment: `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -p:RuntimeIdentifier=linux-x64` and the build succeeded. 
- Noted that a plain `dotnet build` initially failed in this environment due to SDK/global.json host-pack resolution (environmental, not related to the code change), and using the RID resolved it; no unit/integration tests were modified or added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4c2d1eec832a8d3e02fa01b22a44)