### PR TITLE
Phase 2: remove CheckResults AgentId/EndpointId persisted columns

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -326,8 +326,8 @@ Represents a single raw check result.
 
 - `resultId` (optional, or implicit)
 - `assignmentId` (authoritative ownership identity)
-- `agentId` (compatibility duplicate; derived from `MonitorAssignment` and planned for later schema removal)
-- `endpointId` (compatibility duplicate; derived from `MonitorAssignment` and planned for later schema removal)
+
+`agentId` and `endpointId` are derived through `MonitorAssignment` when needed (`assignmentId -> MonitorAssignment.agentId/endpointId`) and are not persisted on `CheckResult`.
 
 #### Result data
 

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -166,14 +166,11 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         checkResult.HasKey(x => x.CheckResultId);
         checkResult.Property(x => x.CheckResultId).HasMaxLength(64);
         checkResult.Property(x => x.AssignmentId).HasMaxLength(64).IsRequired();
-        checkResult.Property(x => x.AgentId).HasMaxLength(64).IsRequired();
-        checkResult.Property(x => x.EndpointId).HasMaxLength(64).IsRequired();
         checkResult.Property(x => x.ErrorCode).HasMaxLength(128);
         checkResult.Property(x => x.ErrorMessage).HasMaxLength(2048);
         checkResult.Property(x => x.BatchId).HasMaxLength(128).IsRequired();
         checkResult.Property(x => x.CheckedAtUtc).IsRequired();
         checkResult.Property(x => x.ReceivedAtUtc).IsRequired();
-        checkResult.HasIndex(x => new { x.AgentId, x.BatchId });
         checkResult.HasIndex(x => new { x.AssignmentId, x.CheckedAtUtc });
 
         var resultBatch = modelBuilder.Entity<ResultBatch>();

--- a/src/WebApp/PingMonitor.Web/Models/CheckResult.cs
+++ b/src/WebApp/PingMonitor.Web/Models/CheckResult.cs
@@ -4,11 +4,7 @@ public sealed class CheckResult
 {
     public string CheckResultId { get; set; } = string.Empty;
 
-    // AssignmentId is the authoritative identity for raw result ownership.
-    // AgentId/EndpointId remain compatibility columns until Phase 2 schema slimming.
     public string AssignmentId { get; set; } = string.Empty;
-    public string AgentId { get; set; } = string.Empty;
-    public string EndpointId { get; set; } = string.Empty;
     public DateTimeOffset CheckedAtUtc { get; set; }
     public bool Success { get; set; }
     public int? RoundTripMs { get; set; }

--- a/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
@@ -5,6 +5,6 @@ public sealed class StartupGateOptions
     public const string SectionName = "StartupGate";
 
     public string StorageDirectory { get; set; } = "App_Data/StartupGate";
-    public int RequiredSchemaVersion { get; set; } = 7;
+    public int RequiredSchemaVersion { get; set; } = 8;
     public int DefaultMySqlPort { get; set; } = 3306;
 }

--- a/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedCheckResult.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedCheckResult.cs
@@ -4,12 +4,7 @@ public sealed class BufferedCheckResult
 {
     public string CheckResultId { get; init; } = string.Empty;
 
-    // AssignmentId is the authoritative identity for buffered raw results.
-    // AgentId/EndpointId are compatibility payload fields for Phase 1 and
-    // must be preserved with accepted raw results until Phase 2 schema slimming.
     public string AssignmentId { get; init; } = string.Empty;
-    public string AgentId { get; init; } = string.Empty;
-    public string EndpointId { get; init; } = string.Empty;
     public DateTimeOffset CheckedAtUtc { get; init; }
     public bool Success { get; init; }
     public int? RoundTripMs { get; init; }

--- a/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultFlushBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultFlushBackgroundService.cs
@@ -153,12 +153,8 @@ internal sealed class BufferedResultFlushBackgroundService : BackgroundService
 
         var checkResults = batch.Select(item => new CheckResult
         {
-            // AssignmentId is the source-of-truth identity for raw rows.
-            // AgentId/EndpointId are compatibility fields until Phase 2 schema slimming.
             CheckResultId = item.CheckResultId,
             AssignmentId = item.AssignmentId,
-            AgentId = item.AgentId,
-            EndpointId = item.EndpointId,
             CheckedAtUtc = item.CheckedAtUtc,
             Success = item.Success,
             RoundTripMs = item.RoundTripMs,

--- a/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
@@ -122,8 +122,6 @@ internal sealed class ResultIngestionService : IResultIngestionService
                 {
                     CheckResultId = Guid.NewGuid().ToString(),
                     AssignmentId = assignment.AssignmentId,
-                    AgentId = agent.AgentId,
-                    EndpointId = assignment.EndpointId,
                     CheckedAtUtc = result.CheckedAtUtc,
                     Success = result.Success,
                     RoundTripMs = result.RoundTripMs,
@@ -156,8 +154,6 @@ internal sealed class ResultIngestionService : IResultIngestionService
             {
                 CheckResultId = x.CheckResultId,
                 AssignmentId = x.AssignmentId,
-                AgentId = x.AgentId,
-                EndpointId = x.EndpointId,
                 CheckedAtUtc = x.CheckedAtUtc,
                 Success = x.Success,
                 RoundTripMs = x.RoundTripMs,

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -698,8 +698,47 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await EnsureUserNotificationSettingsColumnsAsync(dbContext, cancellationToken);
         await EnsureAssignmentMetrics24hColumnsAsync(dbContext, cancellationToken);
         await EnsureAgentColumnsAsync(dbContext, cancellationToken);
+        await EnsureCheckResultsNormalizedAsync(dbContext, cancellationToken);
         await EnsureMetricsIndexesAsync(dbContext, cancellationToken);
         await MigrateLegacyEndpointDependenciesAsync(dbContext, cancellationToken);
+    }
+
+    private static async Task EnsureCheckResultsNormalizedAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
+    {
+        await using var connection = dbContext.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        if (await HasTableIndexAsync(connection, "CheckResults", "IX_CheckResults_AgentId_BatchId", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                DROP INDEX `IX_CheckResults_AgentId_BatchId` ON `CheckResults`;
+                """,
+                cancellationToken);
+        }
+
+        if (await HasTableColumnAsync(connection, "CheckResults", "AgentId", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `CheckResults`
+                DROP COLUMN `AgentId`;
+                """,
+                cancellationToken);
+        }
+
+        if (await HasTableColumnAsync(connection, "CheckResults", "EndpointId", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `CheckResults`
+                DROP COLUMN `EndpointId`;
+                """,
+                cancellationToken);
+        }
     }
 
     private static async Task EnsureMetricsIndexesAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
@@ -1516,104 +1555,52 @@ internal sealed class StartupSchemaService : IStartupSchemaService
 
     private static async Task<bool> HasEndpointColumnAsync(System.Data.Common.DbConnection connection, string columnName, CancellationToken cancellationToken)
     {
-        await using var command = connection.CreateCommand();
-        command.CommandText = """
-            SELECT COUNT(*)
-            FROM information_schema.columns
-            WHERE table_schema = DATABASE()
-              AND table_name = 'Endpoints'
-              AND column_name = @columnName;
-            """;
-        var parameter = command.CreateParameter();
-        parameter.ParameterName = "@columnName";
-        parameter.Value = columnName;
-        command.Parameters.Add(parameter);
-
-        return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
+        return await HasTableColumnAsync(connection, "Endpoints", columnName, cancellationToken);
     }
 
     private static async Task<bool> HasAssignmentMetrics24hColumnAsync(System.Data.Common.DbConnection connection, string columnName, CancellationToken cancellationToken)
     {
-        await using var command = connection.CreateCommand();
-        command.CommandText = """
-            SELECT COUNT(*)
-            FROM information_schema.columns
-            WHERE table_schema = DATABASE()
-              AND table_name = 'AssignmentMetrics24h'
-              AND column_name = @columnName;
-            """;
-        var parameter = command.CreateParameter();
-        parameter.ParameterName = "@columnName";
-        parameter.Value = columnName;
-        command.Parameters.Add(parameter);
-
-        return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
+        return await HasTableColumnAsync(connection, "AssignmentMetrics24h", columnName, cancellationToken);
     }
 
     private static async Task<bool> HasEndpointDependencyColumnAsync(System.Data.Common.DbConnection connection, string columnName, CancellationToken cancellationToken)
     {
-        await using var command = connection.CreateCommand();
-        command.CommandText = """
-            SELECT COUNT(*)
-            FROM information_schema.columns
-            WHERE table_schema = DATABASE()
-              AND table_name = 'EndpointDependencies'
-              AND column_name = @columnName;
-            """;
-        var parameter = command.CreateParameter();
-        parameter.ParameterName = "@columnName";
-        parameter.Value = columnName;
-        command.Parameters.Add(parameter);
-
-        return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
+        return await HasTableColumnAsync(connection, "EndpointDependencies", columnName, cancellationToken);
     }
 
     private static async Task<bool> HasSecuritySettingsColumnAsync(System.Data.Common.DbConnection connection, string columnName, CancellationToken cancellationToken)
     {
-        await using var command = connection.CreateCommand();
-        command.CommandText = """
-            SELECT COUNT(*)
-            FROM information_schema.columns
-            WHERE table_schema = DATABASE()
-              AND table_name = 'SecuritySettings'
-              AND column_name = @columnName;
-            """;
-        var parameter = command.CreateParameter();
-        parameter.ParameterName = "@columnName";
-        parameter.Value = columnName;
-        command.Parameters.Add(parameter);
-
-        return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
+        return await HasTableColumnAsync(connection, "SecuritySettings", columnName, cancellationToken);
     }
 
     private static async Task<bool> HasNotificationSettingsColumnAsync(System.Data.Common.DbConnection connection, string columnName, CancellationToken cancellationToken)
     {
-        await using var command = connection.CreateCommand();
-        command.CommandText = """
-            SELECT COUNT(*)
-            FROM information_schema.columns
-            WHERE table_schema = DATABASE()
-              AND table_name = 'NotificationSettings'
-              AND column_name = @columnName;
-            """;
-        var parameter = command.CreateParameter();
-        parameter.ParameterName = "@columnName";
-        parameter.Value = columnName;
-        command.Parameters.Add(parameter);
-
-        return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
+        return await HasTableColumnAsync(connection, "NotificationSettings", columnName, cancellationToken);
     }
 
     private static async Task<bool> HasUserNotificationSettingsColumnAsync(System.Data.Common.DbConnection connection, string columnName, CancellationToken cancellationToken)
+    {
+        return await HasTableColumnAsync(connection, "UserNotificationSettings", columnName, cancellationToken);
+    }
+
+    private static async Task<bool> HasTableColumnAsync(
+        System.Data.Common.DbConnection connection,
+        string tableName,
+        string columnName,
+        CancellationToken cancellationToken)
     {
         await using var command = connection.CreateCommand();
         command.CommandText = """
             SELECT COUNT(*)
             FROM information_schema.columns
             WHERE table_schema = DATABASE()
-              AND table_name = 'UserNotificationSettings'
+              AND table_name = @tableName
               AND column_name = @columnName;
             """;
+        var tableParameter = command.CreateParameter();
+        tableParameter.ParameterName = "@tableName";
+        tableParameter.Value = tableName;
+        command.Parameters.Add(tableParameter);
         var parameter = command.CreateParameter();
         parameter.ParameterName = "@columnName";
         parameter.Value = columnName;
@@ -1642,14 +1629,27 @@ internal sealed class StartupSchemaService : IStartupSchemaService
 
     private static async Task<bool> HasEndpointDependencyIndexAsync(System.Data.Common.DbConnection connection, string indexName, CancellationToken cancellationToken)
     {
+        return await HasTableIndexAsync(connection, "EndpointDependencies", indexName, cancellationToken);
+    }
+
+    private static async Task<bool> HasTableIndexAsync(
+        System.Data.Common.DbConnection connection,
+        string tableName,
+        string indexName,
+        CancellationToken cancellationToken)
+    {
         await using var command = connection.CreateCommand();
         command.CommandText = """
             SELECT COUNT(*)
             FROM information_schema.statistics
             WHERE table_schema = DATABASE()
-              AND table_name = 'EndpointDependencies'
+              AND table_name = @tableName
               AND index_name = @indexName;
             """;
+        var tableParameter = command.CreateParameter();
+        tableParameter.ParameterName = "@tableName";
+        tableParameter.Value = tableName;
+        command.Parameters.Add(tableParameter);
         var parameter = command.CreateParameter();
         parameter.ParameterName = "@indexName";
         parameter.Value = indexName;

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 7,
+    "RequiredSchemaVersion": 8,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 7,
+    "RequiredSchemaVersion": 8,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
### Motivation
- Finalize Phase 2 of the CheckResults normalization by removing the redundant persisted `AgentId` and `EndpointId` now that `AssignmentId` is authoritative, while preserving existing runtime behavior and safety.
- Ensure the schema change is applied explicitly and safely via the Startup Gate so mixed-version deployments are gated and operator-controlled.

### Description
- Remove `AgentId` and `EndpointId` from the `CheckResult` model and EF mapping and drop the obsolete `IX_CheckResults_AgentId_BatchId` index from the model, while preserving the critical `IX_CheckResults_AssignmentId_CheckedAtUtc` index and assignment-centric hot paths. (files: `Models/CheckResult.cs`, `Data/PingMonitorDbContext.cs`)
- Stop writing compatibility-only fields in both direct ingestion and buffered paths by updating `ResultIngestionService`, `BufferedCheckResult`, and `BufferedResultFlushBackgroundService` so persisted rows are assignment-centric only. (files: `Services/ResultIngestionService.cs`, `Services/BufferedResults/BufferedCheckResult.cs`, `Services/BufferedResults/BufferedResultFlushBackgroundService.cs`)
- Add a guarded schema-normalization step `EnsureCheckResultsNormalizedAsync` to the startup-gate schema apply flow that conditionally drops the legacy index and then drops `CheckResults.AgentId`/`CheckResults.EndpointId` if present, and introduce reusable helpers for table/index/column existence checks. (file: `Services/StartupGate/StartupSchemaService.cs`)
- Bump required schema version from `7` to `8` and update settings so the startup-gate flags old schemas until an explicit local apply is run, and update `docs/data-model.md` to document that agent/endpoint identity is derived from `MonitorAssignment`. (files: `Options/StartupGateOptions.cs`, `appsettings.json`, `appsettings.Development.json`, `docs/data-model.md`) 
- Create issue #401 for traceability of this Phase 2 work.

### Testing
- Built the web project successfully with .NET 10 (`$HOME/.dotnet/dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`).
- No in-repo unit test suite was present to run automatically, and the migration DDL was not executed against a live MySQL instance in this session, so the DDL is implemented but requires validation against a staging MySQL instance before production apply. 
- Verified compilation and that assignment-centric hot-path LINQ queries still compile after the model changes (assignment/time index retained).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da55f3c004832a88e31327a560d064)