### PR TITLE
Phase 2: drop CheckResults AgentId/EndpointId compatibility columns

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -326,8 +326,6 @@ Represents a single raw check result.
 
 - `resultId` (optional, or implicit)
 - `assignmentId` (authoritative ownership identity)
-- `agentId` (compatibility duplicate; derived from `MonitorAssignment` and planned for later schema removal)
-- `endpointId` (compatibility duplicate; derived from `MonitorAssignment` and planned for later schema removal)
 
 #### Result data
 

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -166,14 +166,11 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         checkResult.HasKey(x => x.CheckResultId);
         checkResult.Property(x => x.CheckResultId).HasMaxLength(64);
         checkResult.Property(x => x.AssignmentId).HasMaxLength(64).IsRequired();
-        checkResult.Property(x => x.AgentId).HasMaxLength(64).IsRequired();
-        checkResult.Property(x => x.EndpointId).HasMaxLength(64).IsRequired();
         checkResult.Property(x => x.ErrorCode).HasMaxLength(128);
         checkResult.Property(x => x.ErrorMessage).HasMaxLength(2048);
         checkResult.Property(x => x.BatchId).HasMaxLength(128).IsRequired();
         checkResult.Property(x => x.CheckedAtUtc).IsRequired();
         checkResult.Property(x => x.ReceivedAtUtc).IsRequired();
-        checkResult.HasIndex(x => new { x.AgentId, x.BatchId });
         checkResult.HasIndex(x => new { x.AssignmentId, x.CheckedAtUtc });
 
         var resultBatch = modelBuilder.Entity<ResultBatch>();

--- a/src/WebApp/PingMonitor.Web/Models/CheckResult.cs
+++ b/src/WebApp/PingMonitor.Web/Models/CheckResult.cs
@@ -4,11 +4,7 @@ public sealed class CheckResult
 {
     public string CheckResultId { get; set; } = string.Empty;
 
-    // AssignmentId is the authoritative identity for raw result ownership.
-    // AgentId/EndpointId remain compatibility columns until Phase 2 schema slimming.
     public string AssignmentId { get; set; } = string.Empty;
-    public string AgentId { get; set; } = string.Empty;
-    public string EndpointId { get; set; } = string.Empty;
     public DateTimeOffset CheckedAtUtc { get; set; }
     public bool Success { get; set; }
     public int? RoundTripMs { get; set; }

--- a/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
@@ -5,6 +5,6 @@ public sealed class StartupGateOptions
     public const string SectionName = "StartupGate";
 
     public string StorageDirectory { get; set; } = "App_Data/StartupGate";
-    public int RequiredSchemaVersion { get; set; } = 7;
+    public int RequiredSchemaVersion { get; set; } = 8;
     public int DefaultMySqlPort { get; set; } = 3306;
 }

--- a/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedCheckResult.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedCheckResult.cs
@@ -4,12 +4,7 @@ public sealed class BufferedCheckResult
 {
     public string CheckResultId { get; init; } = string.Empty;
 
-    // AssignmentId is the authoritative identity for buffered raw results.
-    // AgentId/EndpointId are compatibility payload fields for Phase 1 and
-    // must be preserved with accepted raw results until Phase 2 schema slimming.
     public string AssignmentId { get; init; } = string.Empty;
-    public string AgentId { get; init; } = string.Empty;
-    public string EndpointId { get; init; } = string.Empty;
     public DateTimeOffset CheckedAtUtc { get; init; }
     public bool Success { get; init; }
     public int? RoundTripMs { get; init; }

--- a/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultFlushBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultFlushBackgroundService.cs
@@ -153,12 +153,8 @@ internal sealed class BufferedResultFlushBackgroundService : BackgroundService
 
         var checkResults = batch.Select(item => new CheckResult
         {
-            // AssignmentId is the source-of-truth identity for raw rows.
-            // AgentId/EndpointId are compatibility fields until Phase 2 schema slimming.
             CheckResultId = item.CheckResultId,
             AssignmentId = item.AssignmentId,
-            AgentId = item.AgentId,
-            EndpointId = item.EndpointId,
             CheckedAtUtc = item.CheckedAtUtc,
             Success = item.Success,
             RoundTripMs = item.RoundTripMs,

--- a/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
@@ -122,8 +122,6 @@ internal sealed class ResultIngestionService : IResultIngestionService
                 {
                     CheckResultId = Guid.NewGuid().ToString(),
                     AssignmentId = assignment.AssignmentId,
-                    AgentId = agent.AgentId,
-                    EndpointId = assignment.EndpointId,
                     CheckedAtUtc = result.CheckedAtUtc,
                     Success = result.Success,
                     RoundTripMs = result.RoundTripMs,
@@ -156,8 +154,6 @@ internal sealed class ResultIngestionService : IResultIngestionService
             {
                 CheckResultId = x.CheckResultId,
                 AssignmentId = x.AssignmentId,
-                AgentId = x.AgentId,
-                EndpointId = x.EndpointId,
                 CheckedAtUtc = x.CheckedAtUtc,
                 Success = x.Success,
                 RoundTripMs = x.RoundTripMs,

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -163,6 +163,18 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "LastSuccessfulCheckUtc",
         "UpdatedAtUtc"
     ];
+    private static readonly string[] RequiredCheckResultsColumns =
+    [
+        "CheckResultId",
+        "AssignmentId",
+        "CheckedAtUtc",
+        "Success",
+        "RoundTripMs",
+        "ErrorCode",
+        "ErrorMessage",
+        "ReceivedAtUtc",
+        "BatchId"
+    ];
 
     private readonly IDbContextFactory<PingMonitorDbContext> _dbContextFactory;
     private readonly IStartupDatabaseConfigurationStore _configurationStore;
@@ -264,6 +276,23 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         {
             var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
             status.Diagnostics.Add($"AssignmentMetrics24h table is missing required columns: {string.Join(", ", missingAssignmentMetrics24hColumns)}.");
+            return status;
+        }
+
+        var missingCheckResultsColumns = await GetMissingCheckResultsColumnsAsync(connection, cancellationToken);
+        if (missingCheckResultsColumns.Length > 0)
+        {
+            var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
+            status.Diagnostics.Add($"CheckResults table is missing required columns: {string.Join(", ", missingCheckResultsColumns)}.");
+            return status;
+        }
+
+        var hasLegacyCheckResultsAgentId = await HasCheckResultsColumnAsync(connection, "AgentId", cancellationToken);
+        var hasLegacyCheckResultsEndpointId = await HasCheckResultsColumnAsync(connection, "EndpointId", cancellationToken);
+        if (hasLegacyCheckResultsAgentId || hasLegacyCheckResultsEndpointId)
+        {
+            var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
+            status.Diagnostics.Add("CheckResults table still contains legacy compatibility columns (AgentId and/or EndpointId). Apply schema upgrade to complete Phase 2 normalization.");
             return status;
         }
 
@@ -698,6 +727,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await EnsureUserNotificationSettingsColumnsAsync(dbContext, cancellationToken);
         await EnsureAssignmentMetrics24hColumnsAsync(dbContext, cancellationToken);
         await EnsureAgentColumnsAsync(dbContext, cancellationToken);
+        await EnsureCheckResultsNormalizedSchemaAsync(dbContext, cancellationToken);
         await EnsureMetricsIndexesAsync(dbContext, cancellationToken);
         await MigrateLegacyEndpointDependenciesAsync(dbContext, cancellationToken);
     }
@@ -717,6 +747,45 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             "IX_StateTransitions_AssignmentId_TransitionAtUtc",
             "CREATE INDEX `IX_StateTransitions_AssignmentId_TransitionAtUtc` ON `StateTransitions` (`AssignmentId`, `TransitionAtUtc`);",
             cancellationToken);
+    }
+
+    private static async Task EnsureCheckResultsNormalizedSchemaAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
+    {
+        var connection = dbContext.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        if (await HasCheckResultsIndexAsync(connection, "IX_CheckResults_AgentId_BatchId", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `CheckResults`
+                DROP INDEX `IX_CheckResults_AgentId_BatchId`;
+                """,
+                cancellationToken);
+        }
+
+        if (await HasCheckResultsColumnAsync(connection, "AgentId", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `CheckResults`
+                DROP COLUMN `AgentId`;
+                """,
+                cancellationToken);
+        }
+
+        if (await HasCheckResultsColumnAsync(connection, "EndpointId", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `CheckResults`
+                DROP COLUMN `EndpointId`;
+                """,
+                cancellationToken);
+        }
     }
 
     private static async Task EnsureIndexExistsAsync(
@@ -872,6 +941,28 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         }
 
         return RequiredAssignmentMetrics24hColumns
+            .Where(column => !existingColumns.Contains(column))
+            .ToArray();
+    }
+
+    private static async Task<string[]> GetMissingCheckResultsColumnsAsync(MySqlConnection connection, CancellationToken cancellationToken)
+    {
+        var existingColumns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COLUMN_NAME
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'CheckResults';
+            """;
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            existingColumns.Add(reader.GetString(0));
+        }
+
+        return RequiredCheckResultsColumns
             .Where(column => !existingColumns.Contains(column))
             .ToArray();
     }
@@ -1548,6 +1639,46 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         command.Parameters.Add(parameter);
 
         return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
+    }
+
+    private static async Task<bool> HasCheckResultsColumnAsync(System.Data.Common.DbConnection connection, string columnName, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'CheckResults'
+              AND column_name = @columnName;
+            """;
+
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "@columnName";
+        parameter.Value = columnName;
+        command.Parameters.Add(parameter);
+
+        var count = Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken), System.Globalization.CultureInfo.InvariantCulture);
+        return count > 0;
+    }
+
+    private static async Task<bool> HasCheckResultsIndexAsync(System.Data.Common.DbConnection connection, string indexName, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM information_schema.statistics
+            WHERE table_schema = DATABASE()
+              AND table_name = 'CheckResults'
+              AND index_name = @indexName;
+            """;
+
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "@indexName";
+        parameter.Value = indexName;
+        command.Parameters.Add(parameter);
+
+        var count = Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken), System.Globalization.CultureInfo.InvariantCulture);
+        return count > 0;
     }
 
     private static async Task<bool> HasEndpointDependencyColumnAsync(System.Data.Common.DbConnection connection, string columnName, CancellationToken cancellationToken)

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 7,
+    "RequiredSchemaVersion": 8,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 7,
+    "RequiredSchemaVersion": 8,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
### Motivation

- Fixes #401.
- Remove redundant denormalized `CheckResults.AgentId` and `CheckResults.EndpointId` now that `MonitorAssignments.AssignmentId` is authoritative, to reduce storage and index overhead on the high-volume `CheckResults` table.
- Perform the real schema-slimming step safely under the Startup Gate so live systems remain protected and hot-path assignment-centric queries are preserved.

### Description

- Removed `AgentId` and `EndpointId` from the `CheckResult` model and from the buffered DTO, and removed the obsolete `IX_CheckResults_AgentId_BatchId` index from the EF model mapping.
- Updated write paths so persisted `CheckResults` rows no longer include compatibility fields by changing `ResultIngestionService` and the buffered flush path to stop populating `AgentId`/`EndpointId`.
- Added explicit Startup Gate schema normalization logic to validate normalized `CheckResults` columns, detect legacy `AgentId`/`EndpointId` presence, and drop the legacy index and columns during `ApplySchemaAsync`, and bumped required schema version from `7` to `8` in options and appsettings.
- Updated documentation to reflect assignment-centric `CheckResult` identity and touched files include `src/WebApp/PingMonitor.Web/Models/CheckResult.cs`, `src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs`, `src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs`, `src/WebApp/PingMonitor.Web/Services/BufferedResults/*`, `src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs`, `src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs`, `src/WebApp/PingMonitor.Web/appsettings*.json`, and `docs/data-model.md`.

### Testing

- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which completed successfully.
- Ran tests with `dotnet test src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj --no-build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da58eceaa0832a993befa55be2619f)