### PR TITLE
Fix dev packaging: allow .NET 10 patch roll-forward and avoid git noise

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.104",
-    "rollForward": "disable"
+    "rollForward": "latestPatch"
   }
 }

--- a/scripts/build-dev.ps1
+++ b/scripts/build-dev.ps1
@@ -107,14 +107,17 @@ if (-not $dotnetCommand) {
 $gitCommand = Get-Command git -ErrorAction SilentlyContinue
 $commitHash = $null
 if ($gitCommand) {
-    $gitStatus = & $gitCommand.Source status --porcelain
-    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace(($gitStatus -join ''))) {
-        Write-Warning 'Git working tree is not clean. Dev artifacts will include uncommitted changes.'
-    }
+    $gitRepoCheck = & $gitCommand.Source rev-parse --is-inside-work-tree 2>$null
+    if ($LASTEXITCODE -eq 0 -and $gitRepoCheck.Trim().ToLowerInvariant() -eq 'true') {
+        $gitStatus = & $gitCommand.Source status --porcelain
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace(($gitStatus -join ''))) {
+            Write-Warning 'Git working tree is not clean. Dev artifacts will include uncommitted changes.'
+        }
 
-    $resolvedCommitHash = & $gitCommand.Source rev-parse --short=12 HEAD
-    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($resolvedCommitHash)) {
-        $commitHash = $resolvedCommitHash.Trim()
+        $resolvedCommitHash = & $gitCommand.Source rev-parse --short=12 HEAD
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($resolvedCommitHash)) {
+            $commitHash = $resolvedCommitHash.Trim()
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
- Running the dev packaging script outside a Git checkout and on machines with a newer .NET 10 patch caused noisy errors and restore failures. (For example, `fatal: not a git repository` and `dotnet restore` failing when only 10.0.106 is installed but `global.json` pins 10.0.104.)
- The change aims to make local dev packaging more robust while preserving feature-band pinning for .NET 10.

### Description
- Relaxed SDK roll-forward in `global.json` from `disable` to `latestPatch` so the same feature band (10.0.x) can resolve against newer installed patch versions. (Fixes #406)
- Updated `scripts/build-dev.ps1` to guard Git metadata commands with `git rev-parse --is-inside-work-tree` so `git status` / `git rev-parse HEAD` are only run when inside a repo, preventing noisy `fatal: not a git repository` output and still capturing the commit hash when available.
- No behavioural changes to packaging logic other than improved SDK resolution and quieter Git handling.

### Testing
- Ran `git diff --check` which reported the staged changes cleanly and passed.
- Validated `global.json` formatting with `python -m json.tool global.json` which succeeded.
- Confirmed files were committed (`git commit`) and a PR description was prepared; commit succeeded locally.
- Attempted `dotnet --list-sdks` and `pwsh --version` in this environment but both commands were not available here, so an actual `dotnet restore` / publish smoke run could not be executed in this container (manual/CI validation recommended on a machine with PowerShell and .NET SDK installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e26bb60d3c832aa0bb59fcf785e5f2)