### PR TITLE
Fix dev packaging for non-git sources and .NET 10 patch updates

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.104",
-    "rollForward": "disable"
+    "rollForward": "latestPatch"
   }
 }

--- a/scripts/build-dev.ps1
+++ b/scripts/build-dev.ps1
@@ -107,14 +107,18 @@ if (-not $dotnetCommand) {
 $gitCommand = Get-Command git -ErrorAction SilentlyContinue
 $commitHash = $null
 if ($gitCommand) {
-    $gitStatus = & $gitCommand.Source status --porcelain
-    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace(($gitStatus -join ''))) {
-        Write-Warning 'Git working tree is not clean. Dev artifacts will include uncommitted changes.'
-    }
+    & $gitCommand.Source rev-parse --is-inside-work-tree *> $null
+    $isGitWorkTree = $LASTEXITCODE -eq 0
+    if ($isGitWorkTree) {
+        $gitStatus = & $gitCommand.Source status --porcelain
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace(($gitStatus -join ''))) {
+            Write-Warning 'Git working tree is not clean. Dev artifacts will include uncommitted changes.'
+        }
 
-    $resolvedCommitHash = & $gitCommand.Source rev-parse --short=12 HEAD
-    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($resolvedCommitHash)) {
-        $commitHash = $resolvedCommitHash.Trim()
+        $resolvedCommitHash = & $gitCommand.Source rev-parse --short=12 HEAD
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($resolvedCommitHash)) {
+            $commitHash = $resolvedCommitHash.Trim()
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
- The dev packaging flow failed in extracted/source-only folders with `fatal: not a git repository`, and `global.json` pinned an exact .NET 10 patch causing restore to fail when only a newer patch was installed.

### Description
- Guarded Git metadata lookups in `scripts/build-dev.ps1` with `git rev-parse --is-inside-work-tree` so status/hash commands run only inside a work tree, and changed `global.json` `rollForward` to `latestPatch` to allow patch-level SDK roll-forward while staying on the .NET 10 feature band (`10.0.x`).

### Testing
- Validated JSON and basic repo checks with `python -m json.tool global.json` and `git diff --check` which passed, and recorded that end-to-end packaging (`pwsh`/`dotnet` runs) could not be executed in this environment because the CLIs were unavailable; created issue #409 to track reproduction and rationale (Fixes #409).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27a9327c0832a81410d69e331086d)