### PR TITLE
Handle non-git snapshots and SDK patch roll-forward in dev packaging

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.104",
-    "rollForward": "disable"
+    "rollForward": "latestPatch"
   }
 }

--- a/scripts/build-dev.ps1
+++ b/scripts/build-dev.ps1
@@ -107,14 +107,19 @@ if (-not $dotnetCommand) {
 $gitCommand = Get-Command git -ErrorAction SilentlyContinue
 $commitHash = $null
 if ($gitCommand) {
-    $gitStatus = & $gitCommand.Source status --porcelain
-    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace(($gitStatus -join ''))) {
-        Write-Warning 'Git working tree is not clean. Dev artifacts will include uncommitted changes.'
-    }
+    $isGitRepository = & $gitCommand.Source rev-parse --is-inside-work-tree 2>$null
+    if ($LASTEXITCODE -eq 0 -and $isGitRepository -eq 'true') {
+        $gitStatus = & $gitCommand.Source status --porcelain
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace(($gitStatus -join ''))) {
+            Write-Warning 'Git working tree is not clean. Dev artifacts will include uncommitted changes.'
+        }
 
-    $resolvedCommitHash = & $gitCommand.Source rev-parse --short=12 HEAD
-    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($resolvedCommitHash)) {
-        $commitHash = $resolvedCommitHash.Trim()
+        $resolvedCommitHash = & $gitCommand.Source rev-parse --short=12 HEAD
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($resolvedCommitHash)) {
+            $commitHash = $resolvedCommitHash.Trim()
+        }
+    } else {
+        Write-Warning 'Current directory is not a Git repository. Commit hash metadata will be unavailable.'
     }
 }
 


### PR DESCRIPTION
### Motivation

- Prevent developer packaging from failing or producing noisy git errors when run from a source snapshot without a `.git` folder.
- Allow the pinned .NET 10 SDK request to roll forward to newer patch releases (e.g. `10.0.106`) instead of hard-failing when the exact patch `10.0.104` is not installed.

### Description

- Update `global.json` to set `rollForward` to `latestPatch` so .NET SDK resolution can use newer patch versions within the 10.0 feature band instead of failing when the exact patch is missing. (`global.json`)
- Harden `scripts/build-dev.ps1` by checking `git rev-parse --is-inside-work-tree` before querying status/HEAD and emit a clear warning when the directory is not a git repository instead of producing fatal git noise. (`scripts/build-dev.ps1`)
- Link this PR to the repository issue tracking the regression and packaging behavior: `Fixes #415`.

### Testing

- No unit tests were changed; this is a tooling/script fix.  Packaging-related validation in the environment: `git status`, `git rev-parse --short HEAD` and the commit succeeded in this runner.  
- Attempts to run PowerShell (`pwsh`) and `dotnet` in the CI/runner environment failed because those tools are not available here, so full `pwsh ./scripts/build-dev.ps1` and `dotnet restore/publish` could not be executed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e29acdba1c832a8b0a694cb30ef088)