### PR TITLE
Stage 2 updater hardening: single-stage state, stale detection, idempotency, and staging lock

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateStagingServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateStagingServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Text.Json;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
@@ -205,9 +206,12 @@ public sealed class ApplicationUpdateStagingServiceTests
             var second = await service.StageLatestApplicableReleaseAsync(false, CancellationToken.None);
             gate.SetResult(true);
             var first = await firstTask;
+            var persisted = await ReadPersistedStateAsync(tempRoot, CancellationToken.None);
 
             Assert.Equal(ApplicationUpdateStagingStatus.StagingBlocked, second.State.Status);
             Assert.Equal(ApplicationUpdateStagingStatus.Ready, first.State.Status);
+            Assert.NotNull(persisted);
+            Assert.Equal(ApplicationUpdateStagingStatus.Ready, persisted!.Status);
         }
         finally
         {
@@ -269,6 +273,18 @@ public sealed class ApplicationUpdateStagingServiceTests
             stateStore,
             httpClientFactory,
             options);
+    }
+
+    private static async Task<ApplicationUpdateStagingState?> ReadPersistedStateAsync(string contentRoot, CancellationToken cancellationToken)
+    {
+        var statePath = Path.Combine(contentRoot, "App_Data", "Updater", "state", "staged-update.json");
+        if (!File.Exists(statePath))
+        {
+            return null;
+        }
+
+        await using var stream = File.OpenRead(statePath);
+        return await JsonSerializer.DeserializeAsync<ApplicationUpdateStagingState>(stream, cancellationToken: cancellationToken);
     }
 
     private sealed class DelayedReleaseLookupService : IGitHubReleaseLookupService

--- a/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateStagingServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateStagingServiceTests.cs
@@ -97,6 +97,124 @@ public sealed class ApplicationUpdateStagingServiceTests
         }
     }
 
+    [Fact]
+    public async Task StageLatestApplicableReleaseAsync_ReusesExistingStage_ForSameRelease()
+    {
+        var tempRoot = CreateTempRoot();
+        try
+        {
+            var zipBytes = Encoding.UTF8.GetBytes("fake-release-zip-content");
+            var checksum = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(zipBytes));
+            var release = BuildRelease("V1.2.3");
+
+            var handler = new MappingHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+            {
+                ["https://download/release.zip"] = new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(zipBytes) },
+                ["https://download/SHA256.txt"] = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent($"{checksum}  PingMonitor-V1.2.3-win-x64.zip", Encoding.UTF8, "text/plain")
+                }
+            });
+
+            var service = BuildService(tempRoot, release, handler);
+            var first = await service.StageLatestApplicableReleaseAsync(false, CancellationToken.None);
+            var second = await service.StageLatestApplicableReleaseAsync(false, CancellationToken.None);
+
+            Assert.Equal(ApplicationUpdateStagingStatus.Ready, second.State.Status);
+            Assert.True(second.State.StageOperationWasNoOp);
+            Assert.Equal(first.State.StagedZipPath, second.State.StagedZipPath);
+            Assert.True(File.Exists(second.State.StagedZipPath));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task StageLatestApplicableReleaseAsync_ReplacesPreviousStage_ForDifferentRelease()
+    {
+        var tempRoot = CreateTempRoot();
+        try
+        {
+            var releaseA = BuildRelease("V1.2.3");
+            var releaseB = BuildRelease("V1.2.4");
+            var zipA = Encoding.UTF8.GetBytes("zip-a");
+            var zipB = Encoding.UTF8.GetBytes("zip-b");
+            var checksumA = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(zipA));
+            var checksumB = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(zipB));
+
+            var handler = new MappingHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+            {
+                ["https://download/release.zip"] = new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(zipA) },
+                ["https://download/SHA256.txt"] = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent($"{checksumA}  PingMonitor-V1.2.3-win-x64.zip", Encoding.UTF8, "text/plain")
+                }
+            });
+
+            var serviceA = BuildService(tempRoot, releaseA, handler);
+            var first = await serviceA.StageLatestApplicableReleaseAsync(false, CancellationToken.None);
+
+            var handlerB = new MappingHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+            {
+                ["https://download/release.zip"] = new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(zipB) },
+                ["https://download/SHA256.txt"] = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent($"{checksumB}  PingMonitor-V1.2.4-win-x64.zip", Encoding.UTF8, "text/plain")
+                }
+            });
+
+            var serviceB = BuildService(tempRoot, releaseB, handlerB);
+            var second = await serviceB.StageLatestApplicableReleaseAsync(false, CancellationToken.None);
+
+            Assert.Equal("V1.2.4", second.State.ReleaseTag);
+            Assert.DoesNotContain("V1.2.3", second.State.StagedZipPath!);
+            Assert.False(File.Exists(first.State.StagedZipPath!));
+            Assert.True(File.Exists(second.State.StagedZipPath!));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task StageLatestApplicableReleaseAsync_BlocksConcurrentRuns()
+    {
+        var tempRoot = CreateTempRoot();
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        try
+        {
+            var zipBytes = Encoding.UTF8.GetBytes("fake-release-zip-content");
+            var checksum = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(zipBytes));
+            var release = BuildRelease("V1.2.3");
+            var delayedLookup = new DelayedReleaseLookupService(release, gate.Task);
+            var handler = new MappingHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+            {
+                ["https://download/release.zip"] = new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(zipBytes) },
+                ["https://download/SHA256.txt"] = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent($"{checksum}  PingMonitor-V1.2.3-win-x64.zip", Encoding.UTF8, "text/plain")
+                }
+            });
+
+            var service = BuildService(tempRoot, delayedLookup, handler);
+            var firstTask = service.StageLatestApplicableReleaseAsync(false, CancellationToken.None);
+            await Task.Delay(50);
+            var second = await service.StageLatestApplicableReleaseAsync(false, CancellationToken.None);
+            gate.SetResult(true);
+            var first = await firstTask;
+
+            Assert.Equal(ApplicationUpdateStagingStatus.StagingBlocked, second.State.Status);
+            Assert.Equal(ApplicationUpdateStagingStatus.Ready, first.State.Status);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
     private static string CreateTempRoot()
     {
         var path = Path.Combine(Path.GetTempPath(), "ping-monitor-stage2-tests", Guid.NewGuid().ToString("N"));
@@ -104,7 +222,29 @@ public sealed class ApplicationUpdateStagingServiceTests
         return path;
     }
 
+    private static GitHubReleaseSummary BuildRelease(string tag)
+    {
+        return new GitHubReleaseSummary
+        {
+            TagName = tag,
+            Name = "Release",
+            IsPrerelease = false,
+            HtmlUrl = "https://example/release",
+            PublishedAtUtc = DateTimeOffset.UtcNow,
+            Assets =
+            [
+                new GitHubReleaseAssetSummary { Name = $"PingMonitor-{tag}-win-x64.zip", BrowserDownloadUrl = "https://download/release.zip" },
+                new GitHubReleaseAssetSummary { Name = "SHA256.txt", BrowserDownloadUrl = "https://download/SHA256.txt" }
+            ]
+        };
+    }
+
     private static ApplicationUpdateStagingService BuildService(string contentRoot, GitHubReleaseSummary release, HttpMessageHandler handler)
+    {
+        return BuildService(contentRoot, new FakeReleaseLookupService(release), handler);
+    }
+
+    private static ApplicationUpdateStagingService BuildService(string contentRoot, IGitHubReleaseLookupService releaseLookupService, HttpMessageHandler handler)
     {
         var options = Microsoft.Extensions.Options.Options.Create(new ApplicationUpdaterOptions
         {
@@ -125,10 +265,28 @@ public sealed class ApplicationUpdateStagingServiceTests
         var httpClientFactory = new StubHttpClientFactory(new HttpClient(handler));
 
         return new ApplicationUpdateStagingService(
-            new FakeReleaseLookupService(release),
+            releaseLookupService,
             stateStore,
             httpClientFactory,
             options);
+    }
+
+    private sealed class DelayedReleaseLookupService : IGitHubReleaseLookupService
+    {
+        private readonly GitHubReleaseSummary _release;
+        private readonly Task _delayTask;
+
+        public DelayedReleaseLookupService(GitHubReleaseSummary release, Task delayTask)
+        {
+            _release = release;
+            _delayTask = delayTask;
+        }
+
+        public async Task<GitHubReleaseSummary?> GetLatestApplicableReleaseAsync(bool allowPreviewReleases, CancellationToken cancellationToken)
+        {
+            await _delayTask.WaitAsync(cancellationToken);
+            return _release;
+        }
     }
 
     private sealed class FakeReleaseLookupService : IGitHubReleaseLookupService

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminApplicationUpdaterController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminApplicationUpdaterController.cs
@@ -66,6 +66,8 @@ public sealed class AdminApplicationUpdaterController : Controller
 
     private ApplicationUpdaterPageViewModel ToViewModel(ApplicationUpdateCheckResult result, ApplicationUpdateStagingState? staged)
     {
+        var decoratedStaged = ApplyLatestComparison(staged, result.LatestApplicableRelease?.TagName);
+
         return new ApplicationUpdaterPageViewModel
         {
             CurrentVersion = result.CurrentVersion,
@@ -80,7 +82,50 @@ public sealed class AdminApplicationUpdaterController : Controller
             LatestIsPrerelease = result.LatestApplicableRelease?.IsPrerelease,
             LatestReleaseUrl = result.LatestApplicableRelease?.HtmlUrl,
             LatestPublishedAtUtc = result.LatestApplicableRelease?.PublishedAtUtc,
-            StagedUpdate = staged
+            StagedUpdate = decoratedStaged
+        };
+    }
+
+    private static ApplicationUpdateStagingState? ApplyLatestComparison(ApplicationUpdateStagingState? staged, string? latestTag)
+    {
+        if (staged is null)
+        {
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(latestTag) || string.IsNullOrWhiteSpace(staged.ReleaseTag))
+        {
+            return staged;
+        }
+
+        var isCurrentLatest = string.Equals(staged.ReleaseTag, latestTag, StringComparison.OrdinalIgnoreCase);
+        return new ApplicationUpdateStagingState
+        {
+            SourceRepository = staged.SourceRepository,
+            AllowPreviewReleases = staged.AllowPreviewReleases,
+            ReleaseTag = staged.ReleaseTag,
+            ReleaseTitle = staged.ReleaseTitle,
+            ReleaseIsPrerelease = staged.ReleaseIsPrerelease,
+            ReleasePublishedAtUtc = staged.ReleasePublishedAtUtc,
+            ReleaseUrl = staged.ReleaseUrl,
+            SelectedAssetName = staged.SelectedAssetName,
+            SelectedChecksumAssetName = staged.SelectedChecksumAssetName,
+            StagedZipPath = staged.StagedZipPath,
+            StagedChecksumPath = staged.StagedChecksumPath,
+            ExpectedSha256 = staged.ExpectedSha256,
+            ActualSha256 = staged.ActualSha256,
+            ChecksumVerified = staged.ChecksumVerified,
+            StagedAtUtc = staged.StagedAtUtc,
+            StagingInProgress = staged.StagingInProgress,
+            StageOperationWasNoOp = staged.StageOperationWasNoOp,
+            StageOperationMessage = staged.StageOperationMessage,
+            LastStageAttemptAtUtc = staged.LastStageAttemptAtUtc,
+            LatestApplicableReleaseTag = latestTag,
+            IsCurrentLatest = isCurrentLatest,
+            IsOutdated = !isCurrentLatest,
+            Status = staged.Status,
+            FailureMessage = staged.FailureMessage,
+            LastUpdatedAtUtc = staged.LastUpdatedAtUtc
         };
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateStagingModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateStagingModels.cs
@@ -10,7 +10,9 @@ public enum ApplicationUpdateStagingStatus
     ChecksumVerificationFailed = 3,
     AssetResolutionFailed = 4,
     NoApplicableRelease = 5,
-    StagingFailed = 6
+    StagingFailed = 6,
+    StagingInProgress = 7,
+    StagingBlocked = 8
 }
 
 public sealed class ApplicationUpdateStagingState
@@ -30,6 +32,13 @@ public sealed class ApplicationUpdateStagingState
     public string? ActualSha256 { get; init; }
     public bool ChecksumVerified { get; init; }
     public DateTimeOffset? StagedAtUtc { get; init; }
+    public bool StagingInProgress { get; init; }
+    public bool StageOperationWasNoOp { get; init; }
+    public string? StageOperationMessage { get; init; }
+    public DateTimeOffset? LastStageAttemptAtUtc { get; init; }
+    public string? LatestApplicableReleaseTag { get; init; }
+    public bool? IsCurrentLatest { get; init; }
+    public bool? IsOutdated { get; init; }
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public ApplicationUpdateStagingStatus Status { get; init; }
     public string? FailureMessage { get; init; }

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateStagingService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateStagingService.cs
@@ -13,6 +13,9 @@ public interface IApplicationUpdateStagingService
 
 internal sealed partial class ApplicationUpdateStagingService : IApplicationUpdateStagingService
 {
+    private const string StagedCurrentFolderName = "current";
+    private const string StageLockFileName = "stage.lock";
+
     private readonly IGitHubReleaseLookupService _gitHubReleaseLookupService;
     private readonly IApplicationUpdateStagingStateStore _stagingStateStore;
     private readonly IHttpClientFactory _httpClientFactory;
@@ -33,17 +36,42 @@ internal sealed partial class ApplicationUpdateStagingService : IApplicationUpda
     public async Task<ApplicationUpdateStagingResult> StageLatestApplicableReleaseAsync(bool allowPreviewReleases, CancellationToken cancellationToken)
     {
         var repository = $"{_options.GitHubOwner}/{_options.GitHubRepository}";
+        var now = DateTimeOffset.UtcNow;
+        var currentState = await _stagingStateStore.ReadAsync(cancellationToken);
+        var stagingRoot = _stagingStateStore.GetStagingRootPath();
+
+        var lockPath = Path.Combine(stagingRoot, StageLockFileName);
+        var lockHandle = TryAcquireStageLock(lockPath);
+        if (lockHandle is null)
+        {
+            return await WriteAndReturnAsync(BuildState(
+                repository,
+                allowPreviewReleases,
+                ApplicationUpdateStagingStatus.StagingBlocked,
+                "A staging operation is already running. Please wait for it to complete and try again.",
+                now,
+                currentState), cancellationToken);
+        }
+
+        await using var _ = lockHandle;
+        await WriteAndReturnAsync(BuildState(
+            repository,
+            allowPreviewReleases,
+            ApplicationUpdateStagingStatus.StagingInProgress,
+            "Staging operation started. Download and checksum verification are in progress.",
+            now,
+            currentState,
+            stagingInProgress: true), cancellationToken);
 
         if (!_options.UpdateChecksEnabled)
         {
-            return await WriteAndReturnAsync(new ApplicationUpdateStagingState
-            {
-                SourceRepository = repository,
-                AllowPreviewReleases = allowPreviewReleases,
-                Status = ApplicationUpdateStagingStatus.StagingFailed,
-                FailureMessage = "Update checks are disabled by configuration.",
-                LastUpdatedAtUtc = DateTimeOffset.UtcNow
-            }, cancellationToken);
+            return await WriteAndReturnAsync(BuildState(
+                repository,
+                allowPreviewReleases,
+                ApplicationUpdateStagingStatus.StagingFailed,
+                "Update checks are disabled by configuration.",
+                DateTimeOffset.UtcNow,
+                currentState), cancellationToken);
         }
 
         GitHubReleaseSummary? release;
@@ -53,71 +81,83 @@ internal sealed partial class ApplicationUpdateStagingService : IApplicationUpda
         }
         catch (Exception ex)
         {
-            return await WriteAndReturnAsync(new ApplicationUpdateStagingState
-            {
-                SourceRepository = repository,
-                AllowPreviewReleases = allowPreviewReleases,
-                Status = ApplicationUpdateStagingStatus.StagingFailed,
-                FailureMessage = $"Unable to resolve latest applicable release: {ex.Message}",
-                LastUpdatedAtUtc = DateTimeOffset.UtcNow
-            }, cancellationToken);
+            return await WriteAndReturnAsync(BuildState(
+                repository,
+                allowPreviewReleases,
+                ApplicationUpdateStagingStatus.StagingFailed,
+                $"Unable to resolve latest applicable release: {ex.Message}",
+                DateTimeOffset.UtcNow,
+                currentState), cancellationToken);
         }
 
         if (release is null)
         {
-            return await WriteAndReturnAsync(new ApplicationUpdateStagingState
-            {
-                SourceRepository = repository,
-                AllowPreviewReleases = allowPreviewReleases,
-                Status = ApplicationUpdateStagingStatus.NoApplicableRelease,
-                FailureMessage = "No applicable GitHub release was found using the current preview-release filter.",
-                LastUpdatedAtUtc = DateTimeOffset.UtcNow
-            }, cancellationToken);
+            return await WriteAndReturnAsync(BuildState(
+                repository,
+                allowPreviewReleases,
+                ApplicationUpdateStagingStatus.NoApplicableRelease,
+                "No applicable GitHub release was found using the current preview-release filter.",
+                DateTimeOffset.UtcNow,
+                currentState), cancellationToken);
+        }
+
+        if (CanReuseCurrentStage(currentState, release.TagName) &&
+            await ValidateExistingStagedArtifactsAsync(currentState!, cancellationToken))
+        {
+            return await WriteAndReturnAsync(BuildState(
+                repository,
+                allowPreviewReleases,
+                ApplicationUpdateStagingStatus.Ready,
+                $"Release {release.TagName} is already staged and verified. No staging changes were required.",
+                DateTimeOffset.UtcNow,
+                currentState,
+                latestApplicableReleaseTag: release.TagName,
+                stageOperationWasNoOp: true), cancellationToken);
         }
 
         var zipName = BuildExpectedZipAssetName(release.TagName);
         var zipAsset = release.Assets.FirstOrDefault(asset => string.Equals(asset.Name, zipName, StringComparison.OrdinalIgnoreCase));
         if (zipAsset is null || string.IsNullOrWhiteSpace(zipAsset.BrowserDownloadUrl))
         {
-            return await WriteAndReturnAsync(BuildAssetFailureState(repository, allowPreviewReleases, release, $"Release zip asset '{zipName}' was not found."), cancellationToken);
+            return await WriteAndReturnAsync(BuildAssetFailureState(repository, allowPreviewReleases, release, $"Release zip asset '{zipName}' was not found.", currentState), cancellationToken);
         }
 
         var checksumAsset = release.Assets.FirstOrDefault(asset => string.Equals(asset.Name, _options.ChecksumAssetName, StringComparison.OrdinalIgnoreCase));
         if (checksumAsset is null || string.IsNullOrWhiteSpace(checksumAsset.BrowserDownloadUrl))
         {
-            return await WriteAndReturnAsync(BuildAssetFailureState(repository, allowPreviewReleases, release, $"Checksum asset '{_options.ChecksumAssetName}' was not found."), cancellationToken);
+            return await WriteAndReturnAsync(BuildAssetFailureState(repository, allowPreviewReleases, release, $"Checksum asset '{_options.ChecksumAssetName}' was not found.", currentState), cancellationToken);
         }
 
-        var stagingRoot = _stagingStateStore.GetStagingRootPath();
-        var downloadsPath = Path.Combine(stagingRoot, "staged", release.TagName);
+        var downloadsPath = Path.Combine(stagingRoot, "staged", StagedCurrentFolderName);
         var zipPath = Path.Combine(downloadsPath, zipAsset.Name);
         var checksumPath = Path.Combine(downloadsPath, checksumAsset.Name);
 
         try
         {
+            if (Directory.Exists(downloadsPath))
+            {
+                Directory.Delete(downloadsPath, recursive: true);
+            }
+
             Directory.CreateDirectory(downloadsPath);
             await DownloadToFileAsync(zipAsset.BrowserDownloadUrl!, zipPath, cancellationToken);
             await DownloadToFileAsync(checksumAsset.BrowserDownloadUrl!, checksumPath, cancellationToken);
         }
         catch (Exception ex)
         {
-            return await WriteAndReturnAsync(new ApplicationUpdateStagingState
-            {
-                SourceRepository = repository,
-                AllowPreviewReleases = allowPreviewReleases,
-                ReleaseTag = release.TagName,
-                ReleaseTitle = release.Name,
-                ReleaseIsPrerelease = release.IsPrerelease,
-                ReleasePublishedAtUtc = release.PublishedAtUtc,
-                ReleaseUrl = release.HtmlUrl,
-                SelectedAssetName = zipAsset.Name,
-                SelectedChecksumAssetName = checksumAsset.Name,
-                StagedZipPath = zipPath,
-                StagedChecksumPath = checksumPath,
-                Status = ApplicationUpdateStagingStatus.DownloadFailed,
-                FailureMessage = $"Failed to download release assets: {ex.Message}",
-                LastUpdatedAtUtc = DateTimeOffset.UtcNow
-            }, cancellationToken);
+            return await WriteAndReturnAsync(BuildState(
+                repository,
+                allowPreviewReleases,
+                ApplicationUpdateStagingStatus.DownloadFailed,
+                $"Failed to download release assets: {ex.Message}",
+                DateTimeOffset.UtcNow,
+                currentState,
+                release,
+                zipAsset.Name,
+                checksumAsset.Name,
+                zipPath,
+                checksumPath,
+                latestApplicableReleaseTag: release.TagName), cancellationToken);
         }
 
         string expectedHash;
@@ -129,69 +169,96 @@ internal sealed partial class ApplicationUpdateStagingService : IApplicationUpda
         }
         catch (Exception ex)
         {
-            return await WriteAndReturnAsync(new ApplicationUpdateStagingState
-            {
-                SourceRepository = repository,
-                AllowPreviewReleases = allowPreviewReleases,
-                ReleaseTag = release.TagName,
-                ReleaseTitle = release.Name,
-                ReleaseIsPrerelease = release.IsPrerelease,
-                ReleasePublishedAtUtc = release.PublishedAtUtc,
-                ReleaseUrl = release.HtmlUrl,
-                SelectedAssetName = zipAsset.Name,
-                SelectedChecksumAssetName = checksumAsset.Name,
-                StagedZipPath = zipPath,
-                StagedChecksumPath = checksumPath,
-                Status = ApplicationUpdateStagingStatus.ChecksumVerificationFailed,
-                FailureMessage = $"Unable to verify checksum: {ex.Message}",
-                LastUpdatedAtUtc = DateTimeOffset.UtcNow
-            }, cancellationToken);
+            return await WriteAndReturnAsync(BuildState(
+                repository,
+                allowPreviewReleases,
+                ApplicationUpdateStagingStatus.ChecksumVerificationFailed,
+                $"Unable to verify checksum: {ex.Message}",
+                DateTimeOffset.UtcNow,
+                currentState,
+                release,
+                zipAsset.Name,
+                checksumAsset.Name,
+                zipPath,
+                checksumPath,
+                latestApplicableReleaseTag: release.TagName), cancellationToken);
         }
 
         if (!string.Equals(expectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
         {
-            return await WriteAndReturnAsync(new ApplicationUpdateStagingState
-            {
-                SourceRepository = repository,
-                AllowPreviewReleases = allowPreviewReleases,
-                ReleaseTag = release.TagName,
-                ReleaseTitle = release.Name,
-                ReleaseIsPrerelease = release.IsPrerelease,
-                ReleasePublishedAtUtc = release.PublishedAtUtc,
-                ReleaseUrl = release.HtmlUrl,
-                SelectedAssetName = zipAsset.Name,
-                SelectedChecksumAssetName = checksumAsset.Name,
-                StagedZipPath = zipPath,
-                StagedChecksumPath = checksumPath,
-                ExpectedSha256 = expectedHash,
-                ActualSha256 = actualHash,
-                ChecksumVerified = false,
-                Status = ApplicationUpdateStagingStatus.ChecksumVerificationFailed,
-                FailureMessage = "Checksum verification failed. The staged package hash does not match SHA256.txt.",
-                LastUpdatedAtUtc = DateTimeOffset.UtcNow
-            }, cancellationToken);
+            return await WriteAndReturnAsync(BuildState(
+                repository,
+                allowPreviewReleases,
+                ApplicationUpdateStagingStatus.ChecksumVerificationFailed,
+                "Checksum verification failed. The staged package hash does not match SHA256.txt.",
+                DateTimeOffset.UtcNow,
+                currentState,
+                release,
+                zipAsset.Name,
+                checksumAsset.Name,
+                zipPath,
+                checksumPath,
+                expectedHash,
+                actualHash,
+                false,
+                latestApplicableReleaseTag: release.TagName), cancellationToken);
         }
 
-        return await WriteAndReturnAsync(new ApplicationUpdateStagingState
+        return await WriteAndReturnAsync(BuildState(
+            repository,
+            allowPreviewReleases,
+            ApplicationUpdateStagingStatus.Ready,
+            $"Release {release.TagName} was downloaded, checksum-verified, and staged.",
+            DateTimeOffset.UtcNow,
+            currentState,
+            release,
+            zipAsset.Name,
+            checksumAsset.Name,
+            zipPath,
+            checksumPath,
+            expectedHash,
+            actualHash,
+            true,
+            DateTimeOffset.UtcNow,
+            latestApplicableReleaseTag: release.TagName), cancellationToken);
+    }
+
+    private static FileStream? TryAcquireStageLock(string lockPath)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
+        try
         {
-            SourceRepository = repository,
-            AllowPreviewReleases = allowPreviewReleases,
-            ReleaseTag = release.TagName,
-            ReleaseTitle = release.Name,
-            ReleaseIsPrerelease = release.IsPrerelease,
-            ReleasePublishedAtUtc = release.PublishedAtUtc,
-            ReleaseUrl = release.HtmlUrl,
-            SelectedAssetName = zipAsset.Name,
-            SelectedChecksumAssetName = checksumAsset.Name,
-            StagedZipPath = zipPath,
-            StagedChecksumPath = checksumPath,
-            ExpectedSha256 = expectedHash,
-            ActualSha256 = actualHash,
-            ChecksumVerified = true,
-            StagedAtUtc = DateTimeOffset.UtcNow,
-            Status = ApplicationUpdateStagingStatus.Ready,
-            LastUpdatedAtUtc = DateTimeOffset.UtcNow
-        }, cancellationToken);
+            return new FileStream(lockPath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 1, FileOptions.DeleteOnClose);
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+    }
+
+    private static bool CanReuseCurrentStage(ApplicationUpdateStagingState? currentState, string releaseTag)
+    {
+        return currentState?.Status == ApplicationUpdateStagingStatus.Ready
+               && string.Equals(currentState.ReleaseTag, releaseTag, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task<bool> ValidateExistingStagedArtifactsAsync(ApplicationUpdateStagingState currentState, CancellationToken cancellationToken)
+    {
+        if (!currentState.ChecksumVerified
+            || string.IsNullOrWhiteSpace(currentState.StagedZipPath)
+            || string.IsNullOrWhiteSpace(currentState.StagedChecksumPath)
+            || string.IsNullOrWhiteSpace(currentState.ExpectedSha256))
+        {
+            return false;
+        }
+
+        if (!File.Exists(currentState.StagedZipPath) || !File.Exists(currentState.StagedChecksumPath))
+        {
+            return false;
+        }
+
+        var actual = await ComputeSha256Async(currentState.StagedZipPath, cancellationToken);
+        return string.Equals(actual, currentState.ExpectedSha256, StringComparison.OrdinalIgnoreCase);
     }
 
     private static async Task<string> ComputeSha256Async(string filePath, CancellationToken cancellationToken)
@@ -240,20 +307,72 @@ internal sealed partial class ApplicationUpdateStagingService : IApplicationUpda
         return new ApplicationUpdateStagingResult { State = state };
     }
 
-    private ApplicationUpdateStagingState BuildAssetFailureState(string repository, bool allowPreviewReleases, GitHubReleaseSummary release, string message)
+    private ApplicationUpdateStagingState BuildAssetFailureState(string repository, bool allowPreviewReleases, GitHubReleaseSummary release, string message, ApplicationUpdateStagingState? currentState)
     {
+        return BuildState(
+            repository,
+            allowPreviewReleases,
+            ApplicationUpdateStagingStatus.AssetResolutionFailed,
+            message,
+            DateTimeOffset.UtcNow,
+            currentState,
+            release,
+            latestApplicableReleaseTag: release.TagName);
+    }
+
+    private ApplicationUpdateStagingState BuildState(
+        string repository,
+        bool allowPreviewReleases,
+        ApplicationUpdateStagingStatus status,
+        string? operationMessage,
+        DateTimeOffset now,
+        ApplicationUpdateStagingState? previous,
+        GitHubReleaseSummary? release = null,
+        string? selectedAssetName = null,
+        string? selectedChecksumAssetName = null,
+        string? stagedZipPath = null,
+        string? stagedChecksumPath = null,
+        string? expectedSha256 = null,
+        string? actualSha256 = null,
+        bool? checksumVerified = null,
+        DateTimeOffset? stagedAtUtc = null,
+        string? latestApplicableReleaseTag = null,
+        bool stagingInProgress = false,
+        bool stageOperationWasNoOp = false)
+    {
+        var resolvedReleaseTag = release?.TagName ?? previous?.ReleaseTag;
+        var resolvedLatestTag = latestApplicableReleaseTag ?? previous?.LatestApplicableReleaseTag ?? resolvedReleaseTag;
         return new ApplicationUpdateStagingState
         {
             SourceRepository = repository,
             AllowPreviewReleases = allowPreviewReleases,
-            ReleaseTag = release.TagName,
-            ReleaseTitle = release.Name,
-            ReleaseIsPrerelease = release.IsPrerelease,
-            ReleasePublishedAtUtc = release.PublishedAtUtc,
-            ReleaseUrl = release.HtmlUrl,
-            Status = ApplicationUpdateStagingStatus.AssetResolutionFailed,
-            FailureMessage = message,
-            LastUpdatedAtUtc = DateTimeOffset.UtcNow
+            ReleaseTag = resolvedReleaseTag,
+            ReleaseTitle = release?.Name ?? previous?.ReleaseTitle,
+            ReleaseIsPrerelease = release?.IsPrerelease ?? previous?.ReleaseIsPrerelease,
+            ReleasePublishedAtUtc = release?.PublishedAtUtc ?? previous?.ReleasePublishedAtUtc,
+            ReleaseUrl = release?.HtmlUrl ?? previous?.ReleaseUrl,
+            SelectedAssetName = selectedAssetName ?? previous?.SelectedAssetName,
+            SelectedChecksumAssetName = selectedChecksumAssetName ?? previous?.SelectedChecksumAssetName,
+            StagedZipPath = stagedZipPath ?? previous?.StagedZipPath,
+            StagedChecksumPath = stagedChecksumPath ?? previous?.StagedChecksumPath,
+            ExpectedSha256 = expectedSha256 ?? previous?.ExpectedSha256,
+            ActualSha256 = actualSha256 ?? previous?.ActualSha256,
+            ChecksumVerified = checksumVerified ?? previous?.ChecksumVerified ?? false,
+            StagedAtUtc = stagedAtUtc ?? previous?.StagedAtUtc,
+            StagingInProgress = stagingInProgress,
+            StageOperationWasNoOp = stageOperationWasNoOp,
+            StageOperationMessage = operationMessage,
+            LastStageAttemptAtUtc = now,
+            LatestApplicableReleaseTag = resolvedLatestTag,
+            IsCurrentLatest = resolvedReleaseTag is not null && resolvedLatestTag is not null
+                ? string.Equals(resolvedReleaseTag, resolvedLatestTag, StringComparison.OrdinalIgnoreCase)
+                : null,
+            IsOutdated = resolvedReleaseTag is not null && resolvedLatestTag is not null
+                ? !string.Equals(resolvedReleaseTag, resolvedLatestTag, StringComparison.OrdinalIgnoreCase)
+                : null,
+            Status = status,
+            FailureMessage = status == ApplicationUpdateStagingStatus.Ready ? null : operationMessage,
+            LastUpdatedAtUtc = now
         };
     }
 

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateStagingService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateStagingService.cs
@@ -44,13 +44,13 @@ internal sealed partial class ApplicationUpdateStagingService : IApplicationUpda
         var lockHandle = TryAcquireStageLock(lockPath);
         if (lockHandle is null)
         {
-            return await WriteAndReturnAsync(BuildState(
+            return ReturnWithoutWrite(BuildState(
                 repository,
                 allowPreviewReleases,
                 ApplicationUpdateStagingStatus.StagingBlocked,
                 "A staging operation is already running. Please wait for it to complete and try again.",
                 now,
-                currentState), cancellationToken);
+                currentState));
         }
 
         await using var _ = lockHandle;
@@ -304,6 +304,11 @@ internal sealed partial class ApplicationUpdateStagingService : IApplicationUpda
     private async Task<ApplicationUpdateStagingResult> WriteAndReturnAsync(ApplicationUpdateStagingState state, CancellationToken cancellationToken)
     {
         await _stagingStateStore.WriteAsync(state, cancellationToken);
+        return new ApplicationUpdateStagingResult { State = state };
+    }
+
+    private static ApplicationUpdateStagingResult ReturnWithoutWrite(ApplicationUpdateStagingState state)
+    {
         return new ApplicationUpdateStagingResult { State = state };
     }
 

--- a/src/WebApp/PingMonitor.Web/Views/AdminApplicationUpdater/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminApplicationUpdater/Index.cshtml
@@ -118,8 +118,12 @@
                 <h2>Stage latest applicable release</h2>
                 <p class="muted">Downloads the selected zip and checksum, verifies SHA256, and stores artifacts under app-controlled updater storage.</p>
                 <div class="button-row">
-                    <button class="button" type="submit" @(Model.UpdateChecksEnabled ? null : "disabled")>Download, verify, and stage</button>
+                    <button class="button" type="submit" @((Model.UpdateChecksEnabled && Model.StagedUpdate?.StagingInProgress != true) ? null : "disabled")>Download, verify, and stage</button>
                 </div>
+                @if (Model.StagedUpdate?.StagingInProgress == true)
+                {
+                    <p class="muted">A staging operation is currently active. Additional requests are blocked until it completes.</p>
+                }
             </section>
         </form>
 
@@ -133,7 +137,10 @@
             {
                 var stagedStatusClass = Model.StagedUpdate.Status == PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.Ready
                     ? "status-ok"
-                    : "status-error";
+                    : Model.StagedUpdate.Status is PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.StagingInProgress
+                        or PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.StagingBlocked
+                        ? "status-warn"
+                        : "status-error";
 
                 <div class="status @stagedStatusClass" role="status">
                     Status: @Model.StagedUpdate.Status
@@ -145,7 +152,21 @@
 
                 <dl style="margin-top:1rem;">
                     <div><dt>Last updated</dt><dd>@Model.StagedUpdate.LastUpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</dd></div>
+                    <div><dt>Last stage attempt</dt><dd>@(Model.StagedUpdate.LastStageAttemptAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "(none)")</dd></div>
                     <div><dt>Release tag</dt><dd>@(Model.StagedUpdate.ReleaseTag ?? "(none)")</dd></div>
+                    <div><dt>Latest applicable release tag</dt><dd>@(Model.StagedUpdate.LatestApplicableReleaseTag ?? "(unknown)")</dd></div>
+                    <div><dt>Staged release freshness</dt>
+                        <dd>
+                            @(Model.StagedUpdate.IsOutdated == true
+                                ? "Outdated — a newer applicable release is available."
+                                : Model.StagedUpdate.IsCurrentLatest == true
+                                    ? "Current — staged release matches latest applicable release."
+                                    : "Unknown")
+                        </dd>
+                    </div>
+                    <div><dt>Staging in progress</dt><dd>@(Model.StagedUpdate.StagingInProgress ? "Yes" : "No")</dd></div>
+                    <div><dt>No-op restage</dt><dd>@(Model.StagedUpdate.StageOperationWasNoOp ? "Yes" : "No")</dd></div>
+                    <div><dt>Stage message</dt><dd>@(Model.StagedUpdate.StageOperationMessage ?? "(none)")</dd></div>
                     <div><dt>Release title</dt><dd>@(Model.StagedUpdate.ReleaseTitle ?? "(none)")</dd></div>
                     <div><dt>Selected archive</dt><dd>@(Model.StagedUpdate.SelectedAssetName ?? "(none)")</dd></div>
                     <div><dt>Staged zip path</dt><dd>@(Model.StagedUpdate.StagedZipPath ?? "(none)")</dd></div>


### PR DESCRIPTION
### Motivation
- Tighten Stage 2 staging safety so only validated artifacts are kept and operator intent is explicit. 
- Prevent confusion and accidental duplicate/stale staged artifacts by enforcing a single staged release and surfacing when a staged release is no longer the latest applicable release. 
- Avoid concurrent or overlapping staging runs that could leave partial state by adding a simple in-progress guard.

### Description
- Added new staging statuses and state fields in `ApplicationUpdateStagingState` to track `StagingInProgress`, `StageOperationWasNoOp`, `StageOperationMessage`, `LastStageAttemptAtUtc`, `LatestApplicableReleaseTag`, `IsCurrentLatest`, and `IsOutdated` (file: `ApplicationUpdateStagingModels.cs`).
- Enforced a single staged-release location by switching staging to `staged/current` and deleting prior staged content before creating a new staged package so only one staged artifact set exists for v1 (file: `ApplicationUpdateStagingService.cs`).
- Implemented idempotent restage behavior that reuses an already-verified staged artifact (no-op with clear message) and deterministic replacement when the requested release differs (file: `ApplicationUpdateStagingService.cs`).
- Added a simple lock-file guard (`stage.lock`) to block overlapping staging attempts and return a clear `StagingBlocked` state when another staging run is active (file: `ApplicationUpdateStagingService.cs`).
- Decorated controller-side staged state with latest-release comparison so the admin UI can show whether the staged release is current or outdated, and updated the admin UI to present staging-in-progress, blocked messages, freshness, no-op outcomes and last-attempt time (files: `AdminApplicationUpdaterController.cs`, `Index.cshtml`).
- Added deterministic unit tests covering idempotent restage, replacement of previous staged release, and concurrent staging blocking (file: `ApplicationUpdateStagingServiceTests.cs`).
- Scope: Stage 2 only; no Stage 3/apply behavior, no IIS stop/start, and no live installation files are modified by these changes.
- Closes #417

### Testing
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -v minimal`, which succeeded.
- Ran unit tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj -v minimal`; all tests passed (Passed: 17, Failed: 0).
- Unit tests added/specified validate these scenarios and passed: staging A when nothing is staged; staging A again (idempotent no-op); staging B after A (previous staged content replaced); overlapping/manual concurrent stage attempts are blocked safely.
- Confirmed no Stage 3 behavior or live-file modifications were introduced by the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7539c81f4832aba4db87c3463e039)