### PR TITLE
Fix Stage 3a updater payload root detection for nested release package layout

### DIFF
--- a/docs/manual-updater-bootstrapper-stage3a.md
+++ b/docs/manual-updater-bootstrapper-stage3a.md
@@ -59,9 +59,12 @@ By default it preserves these existing paths in install root:
 
 The replacement process:
 1. Extract ZIP to temp path.
-2. Validate extracted `app/` payload root.
-3. Remove stale files/folders from install root **excluding preserved paths**.
-4. Copy payload files into install root **excluding preserved paths**.
+2. Detect payload root using one of the supported layouts:
+   - `<extract-root>/app`
+   - `<extract-root>/<single-package-folder>/app`
+3. Validate detected package structure (`app/` required, `manifest.json` logged if present).
+4. Remove stale files/folders from install root **excluding preserved paths**.
+5. Copy payload files into install root **excluding preserved paths**.
 
 ## Startup Gate compatibility
 

--- a/scripts/run-staged-update-bootstrapper.ps1
+++ b/scripts/run-staged-update-bootstrapper.ps1
@@ -256,6 +256,67 @@ function Copy-NewPayload {
     }
 }
 
+function Resolve-PayloadRoot {
+    param(
+        [Parameter(Mandatory = $true)][string]$ExtractRoot
+    )
+
+    $directPayloadRoot = Join-Path $ExtractRoot 'app'
+    if (Test-Path -LiteralPath $directPayloadRoot -PathType Container) {
+        Write-Log "Detected payload layout A at '$directPayloadRoot'."
+        return [ordered]@{
+            payloadRoot = $directPayloadRoot
+            packageRoot = $ExtractRoot
+            layout = 'extract-root/app'
+        }
+    }
+
+    $topLevelDirectories = @(Get-ChildItem -LiteralPath $ExtractRoot -Directory -Force)
+    if ($topLevelDirectories.Count -eq 1) {
+        $nestedPackageRoot = $topLevelDirectories[0].FullName
+        $nestedPayloadRoot = Join-Path $nestedPackageRoot 'app'
+        if (Test-Path -LiteralPath $nestedPayloadRoot -PathType Container) {
+            Write-Log "Detected payload layout B at '$nestedPayloadRoot'."
+            return [ordered]@{
+                payloadRoot = $nestedPayloadRoot
+                packageRoot = $nestedPackageRoot
+                layout = 'extract-root/<single-package-folder>/app'
+            }
+        }
+    }
+
+    $topLevelEntries = @(Get-ChildItem -LiteralPath $ExtractRoot -Force | ForEach-Object {
+            if ($_.PSIsContainer) { "[D] $($_.Name)" } else { "[F] $($_.Name)" }
+        })
+    $topLevelSummary = if ($topLevelEntries.Count -gt 0) { $topLevelEntries -join ', ' } else { '(none)' }
+
+    $attemptedLayouts = @(
+        "A: '$directPayloadRoot'",
+        "B: '<extract-root>/<single-top-level-dir>/app'"
+    ) -join '; '
+
+    throw "Unable to detect staged ZIP payload root. Extract root: '$ExtractRoot'. Top-level entries: $topLevelSummary. Attempted layouts: $attemptedLayouts."
+}
+
+function Test-PackageStructure {
+    param(
+        [Parameter(Mandatory = $true)][string]$PackageRoot
+    )
+
+    $payloadRoot = Join-Path $PackageRoot 'app'
+    if (-not (Test-Path -LiteralPath $payloadRoot -PathType Container)) {
+        throw "Detected package root '$PackageRoot' is missing required 'app' folder."
+    }
+
+    $manifestPath = Join-Path $PackageRoot 'manifest.json'
+    if (Test-Path -LiteralPath $manifestPath -PathType Leaf) {
+        Write-Log "Package structure validation: found manifest at '$manifestPath'."
+    }
+    else {
+        Write-Log "Package structure validation: manifest.json not found at '$manifestPath' (continuing)."
+    }
+}
+
 function Finalize-Success {
     $status.succeeded = $true
     $status.resultCode = 'success'
@@ -335,10 +396,11 @@ try {
     try {
         Expand-Archive -LiteralPath $zipPathResolved -DestinationPath $extractPath -Force
 
-        $payloadRoot = Join-Path $extractPath 'app'
-        if (-not (Test-Path -LiteralPath $payloadRoot -PathType Container)) {
-            throw "Staged ZIP did not contain expected 'app' payload folder at '$payloadRoot'."
-        }
+        $resolvedPayload = Resolve-PayloadRoot -ExtractRoot $extractPath
+        $payloadRoot = $resolvedPayload.payloadRoot
+        $packageRoot = $resolvedPayload.packageRoot
+        Write-Log "Using payload root '$payloadRoot' (layout: $($resolvedPayload.layout))."
+        Test-PackageStructure -PackageRoot $packageRoot
 
         $status.appOfflinePath = Join-Path $script:installRootResolved 'app_offline.htm'
 


### PR DESCRIPTION
### Motivation
- The Stage 3a external updater bootstrapper failed when release ZIPs were packaged with a versioned top-level folder (e.g. `PingMonitor-V0.0.2-win-x64/app`) instead of `app` at the ZIP root, causing payload detection errors; this change addresses that mismatch.  
- Support both packaging layouts to avoid requiring changes to `scripts/build.ps1`.  
- Fixes #420.

### Description
- Added `Resolve-PayloadRoot` to detect payload layout A (`<extract-root>/app`) or layout B (`<extract-root>/<single-package-folder>/app`) and return the resolved `payloadRoot`, `packageRoot`, and `layout`.  
- Added `Test-PackageStructure` to validate that the detected package root contains the required `app/` folder and to log presence of `manifest.json`.  
- Replaced the previous hardcoded `extract/app` presence check with the new detection + validation flow and improved diagnostic logging when detection fails (extract root, top-level entries, attempted layouts).  
- Updated documentation to describe the supported extraction layouts and the new validation sequence.  
- Files changed: `scripts/run-staged-update-bootstrapper.ps1`, `docs/manual-updater-bootstrapper-stage3a.md`.

### Testing
- Verified the script parses with `pwsh -NoLogo -NoProfile -File /tmp/parse_check.ps1` (parse succeeded).  
- Ran deterministic layout tests using a synthetic ZIP in three scenarios with the updater in `-DryRun`: layout A (direct-root `app/`) passed, layout B (nested single package folder + `app/`) passed, and an invalid layout without `app/` failed with a clear diagnostics message (behaviour as expected).  
- Environment helper installs used during validation (`powershell` and `dotnet-sdk-10.0`) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c3aaf51c832aa217eb00899ebc95)