### PR TITLE
Harden external updater runtime log/status path handling

### DIFF
--- a/docs/manual-updater-bootstrapper-stage3a.md
+++ b/docs/manual-updater-bootstrapper-stage3a.md
@@ -38,8 +38,8 @@ Optional parameters:
 - `-SiteName` (IIS website name)
 - `-AppPoolName` (IIS application pool name)
 - `-ExpectedReleaseTag` (safety assertion)
-- `-StatusJsonPath` (defaults beside staged metadata)
-- `-LogPath` (defaults beside staged metadata)
+- `-StatusJsonPath` (optional; runtime-safe location is enforced if this path is under install root)
+- `-LogPath` (optional; runtime-safe location is enforced if this path is under install root)
 - `-PreserveRelativePaths` (defaults to `App_Data`, `appsettings.json`, `appsettings.*.json`)
 - `-DryRun` (validation + extraction + plan reporting without stop/swap/start)
 
@@ -99,9 +99,15 @@ pwsh ./scripts/run-staged-update-bootstrapper.ps1 \
 
 ## Output artifacts
 
-By default (unless overridden), outputs are written beside the staged metadata file:
+By default the bootstrapper evaluates configured output paths against `InstallRootPath`:
+- if a configured/default output path is **outside** install root, it is used directly
+- if a configured/default output path is **inside** install root (replaceable during swap), runtime writes are redirected to a per-run temp session folder under `%TEMP%`
+
+Runtime artifacts:
 - `external-updater.log`
 - `external-updater-status.json`
+
+When runtime redirection is active, final status is mirrored back to the originally requested status path after execution (best effort).
 
 `external-updater-status.json` includes:
 - start/completion timestamps

--- a/scripts/run-staged-update-bootstrapper.ps1
+++ b/scripts/run-staged-update-bootstrapper.ps1
@@ -56,6 +56,8 @@ $script:appOfflineCreated = $false
 $script:statusPathResolved = $null
 $script:logPathResolved = $null
 $script:installRootResolved = $null
+$script:runtimeStateRootResolved = $null
+$script:statusMirrorPathResolved = $null
 
 function Ensure-Directory {
     param([Parameter(Mandatory = $true)][string]$Path)
@@ -75,22 +77,98 @@ function Resolve-FullPath {
     return [System.IO.Path]::GetFullPath((Join-Path (Get-Location) $Path))
 }
 
+
+function Test-PathWithinRoot {
+    param(
+        [Parameter(Mandatory = $true)][string]$CandidatePath,
+        [Parameter(Mandatory = $true)][string]$RootPath
+    )
+
+    $candidateFull = [System.IO.Path]::GetFullPath($CandidatePath).TrimEnd('\', '/')
+    $rootFull = [System.IO.Path]::GetFullPath($RootPath).TrimEnd('\', '/')
+
+    if ([string]::Equals($candidateFull, $rootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $true
+    }
+
+    $rootWithSeparator = $rootFull + [System.IO.Path]::DirectorySeparatorChar
+    return $candidateFull.StartsWith($rootWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function New-RuntimeStateRoot {
+    $sessionName = "ping-monitor-external-updater-" + [System.Guid]::NewGuid().ToString('N')
+    return Join-Path ([System.IO.Path]::GetTempPath()) $sessionName
+}
+
+function Try-WriteTextFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Content,
+        [Parameter(Mandatory = $true)][string]$Description
+    )
+
+    try {
+        $parentDirectory = Split-Path -Path $Path -Parent
+        if (-not [string]::IsNullOrWhiteSpace($parentDirectory)) {
+            Ensure-Directory -Path $parentDirectory
+        }
+
+        Set-Content -LiteralPath $Path -Value $Content -Encoding UTF8
+        return $true
+    }
+    catch {
+        Write-Warning "Failed to write $Description at '$Path': $($_.Exception.Message)"
+        return $false
+    }
+}
+
 function Initialize-Outputs {
     $metadataResolved = Resolve-FullPath -Path $StagedMetadataPath
     $metadataDirectory = Split-Path -Path $metadataResolved -Parent
 
-    if ([string]::IsNullOrWhiteSpace($StatusJsonPath)) {
-        $script:statusPathResolved = Join-Path $metadataDirectory 'external-updater-status.json'
+    $script:installRootResolved = Resolve-FullPath -Path $InstallRootPath
+
+    $fallbackRuntimeRoot = New-RuntimeStateRoot
+    $fallbackStatusPath = Join-Path $fallbackRuntimeRoot 'external-updater-status.json'
+    $fallbackLogPath = Join-Path $fallbackRuntimeRoot 'external-updater.log'
+
+    $statusPathCandidate = if ([string]::IsNullOrWhiteSpace($StatusJsonPath)) {
+        Join-Path $metadataDirectory 'external-updater-status.json'
     }
     else {
-        $script:statusPathResolved = Resolve-FullPath -Path $StatusJsonPath
+        Resolve-FullPath -Path $StatusJsonPath
     }
 
-    if ([string]::IsNullOrWhiteSpace($LogPath)) {
-        $script:logPathResolved = Join-Path $metadataDirectory 'external-updater.log'
+    $logPathCandidate = if ([string]::IsNullOrWhiteSpace($LogPath)) {
+        Join-Path $metadataDirectory 'external-updater.log'
     }
     else {
-        $script:logPathResolved = Resolve-FullPath -Path $LogPath
+        Resolve-FullPath -Path $LogPath
+    }
+
+    $statusPathWithinInstallRoot = Test-PathWithinRoot -CandidatePath $statusPathCandidate -RootPath $script:installRootResolved
+    $logPathWithinInstallRoot = Test-PathWithinRoot -CandidatePath $logPathCandidate -RootPath $script:installRootResolved
+
+    if ($statusPathWithinInstallRoot -or $logPathWithinInstallRoot) {
+        $script:runtimeStateRootResolved = $fallbackRuntimeRoot
+        $script:statusPathResolved = $fallbackStatusPath
+        $script:logPathResolved = $fallbackLogPath
+
+        $script:statusMirrorPathResolved = $statusPathCandidate
+
+        Write-Warning "Bootstrapper runtime log/status paths are inside the replaceable install root. Using external runtime state path '$script:runtimeStateRootResolved' for live writes."
+    }
+    else {
+        $script:statusPathResolved = $statusPathCandidate
+        $script:logPathResolved = $logPathCandidate
+
+        $statusDirectory = Split-Path -Path $script:statusPathResolved -Parent
+        $script:runtimeStateRootResolved = if (-not [string]::IsNullOrWhiteSpace($statusDirectory)) {
+            $statusDirectory
+        }
+        else {
+            New-RuntimeStateRoot
+        }
     }
 
     Ensure-Directory -Path (Split-Path -Path $script:statusPathResolved -Parent)
@@ -113,14 +191,27 @@ function Write-Status {
         atUtc = (Get-Date).ToUniversalTime().ToString('o')
     }
 
-    $status | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $script:statusPathResolved -Encoding UTF8
+    $statusJson = $status | ConvertTo-Json -Depth 8
+    [void](Try-WriteTextFile -Path $script:statusPathResolved -Content $statusJson -Description 'status JSON')
 }
 
 function Write-Log {
     param([Parameter(Mandatory = $true)][string]$Message)
 
     $line = "$(Get-Date -Format o) $Message"
-    Add-Content -LiteralPath $script:logPathResolved -Value $line -Encoding UTF8
+
+    try {
+        $parentDirectory = Split-Path -Path $script:logPathResolved -Parent
+        if (-not [string]::IsNullOrWhiteSpace($parentDirectory)) {
+            Ensure-Directory -Path $parentDirectory
+        }
+
+        Add-Content -LiteralPath $script:logPathResolved -Value $line -Encoding UTF8
+    }
+    catch {
+        Write-Warning "Failed to append updater log at '$script:logPathResolved': $($_.Exception.Message)"
+    }
+
     Write-Host $line
 }
 
@@ -322,7 +413,12 @@ function Finalize-Success {
     $status.resultCode = 'success'
     $status.completedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
     $status.stage = 'completed'
-    $status | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $script:statusPathResolved -Encoding UTF8
+    $statusJson = $status | ConvertTo-Json -Depth 8
+    [void](Try-WriteTextFile -Path $script:statusPathResolved -Content $statusJson -Description 'status JSON')
+
+    if (-not [string]::IsNullOrWhiteSpace($script:statusMirrorPathResolved)) {
+        [void](Try-WriteTextFile -Path $script:statusMirrorPathResolved -Content $statusJson -Description 'mirrored status JSON')
+    }
 }
 
 function Finalize-Failure {
@@ -332,7 +428,12 @@ function Finalize-Failure {
     $status.resultCode = 'failed'
     $status.completedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
     $status.error = $ErrorMessage
-    $status | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $script:statusPathResolved -Encoding UTF8
+    $statusJson = $status | ConvertTo-Json -Depth 8
+    [void](Try-WriteTextFile -Path $script:statusPathResolved -Content $statusJson -Description 'status JSON')
+
+    if (-not [string]::IsNullOrWhiteSpace($script:statusMirrorPathResolved)) {
+        [void](Try-WriteTextFile -Path $script:statusMirrorPathResolved -Content $statusJson -Description 'mirrored status JSON')
+    }
 }
 
 try {
@@ -388,6 +489,7 @@ try {
     Write-Log "Staged release tag: $($metadata.ReleaseTag)."
     Write-Log "Staged ZIP path: $zipPathResolved."
     Write-Log "Install root path: $script:installRootResolved."
+    Write-Log "Runtime updater state path (non-replaceable): $script:runtimeStateRootResolved."
 
     $workRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("ping-monitor-updater-" + [System.Guid]::NewGuid().ToString('N'))
     $extractPath = Join-Path $workRoot 'extract'


### PR DESCRIPTION
### Motivation
- The external staged-update bootstrapper was writing its active runtime log/status beside the staged metadata inside the install tree and could fail when that tree was removed during payload replacement, producing errors like a missing `external-updater.log` path.\
- The change ensures runtime logging/state does not depend on replaceable install payload paths and makes logging resilient to transient filesystem changes during the swap.\

### Description
- Redirect live runtime writes off the replaceable install tree: the script now detects when the configured/default `StatusJsonPath`/`LogPath` is inside `InstallRootPath` and, when so, writes live artifacts to a per-run temp session folder under `%TEMP%` named `ping-monitor-external-updater-<guid>` instead of the install tree.\
- Safer write helpers and mirror semantics: added `Try-WriteTextFile`, `Test-PathWithinRoot`, and `New-RuntimeStateRoot`, ensure parent directories are created before writes, emit warnings instead of crashing on logging failures, and perform a best-effort mirror of the final status JSON back to the originally requested status path after completion.\
- Preserve semantics and boundaries: clarified which path is replaceable (`InstallRootPath`) and which is persistent (`%TEMP%` session folder), and left payload swap and IIS stop/start behavior unchanged.\
- Files changed: `scripts/run-staged-update-bootstrapper.ps1` (runtime guard, temp session root, safe writers, mirror behavior) and `docs/manual-updater-bootstrapper-stage3a.md` (documentation updates).\
- Issue linkage: Fixes #420.\

### Testing
- Static assertions: ran automated Python checks to verify presence of containment guard, temp runtime root creation, safe status/log writers, and final-status mirroring (all checks passed).\
- Commit verification: committed changes and confirmed diffs include the logging/state hardening and docs update.\
- PowerShell parse check: attempted to run a `pwsh` parse of the script but `pwsh` was not available in the test environment, so full runtime parse validation was not executed here (the change only affects logging path handling and uses conservative helpers to avoid runtime crashes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c6c0f76c832aa218231ffb273ae3)