### PR TITLE
Fix staged updater preserve/merge behavior for startup-gate DB config and version metadata

### DIFF
--- a/docs/manual-updater-bootstrapper-stage3a.md
+++ b/docs/manual-updater-bootstrapper-stage3a.md
@@ -40,7 +40,7 @@ Optional parameters:
 - `-ExpectedReleaseTag` (safety assertion)
 - `-StatusJsonPath` (optional; runtime-safe location is enforced if this path is under install root)
 - `-LogPath` (optional; runtime-safe location is enforced if this path is under install root)
-- `-PreserveRelativePaths` (defaults to `App_Data`, `appsettings.json`, `appsettings.*.json`)
+- `-PreserveRelativePaths` (defaults to `App_Data`, `appsettings.json`, `appsettings.*.json`; runtime-critical Startup Gate/data paths are always preserved)
 - `-DryRun` (validation + extraction + plan reporting without stop/swap/start)
 
 Stage 2 metadata fields required by this script:
@@ -57,6 +57,25 @@ By default it preserves these existing paths in install root:
 - `appsettings.json`
 - `appsettings.*.json`
 
+Additionally, these runtime-owned paths are always preserved even if the caller passes a narrower custom `-PreserveRelativePaths` list:
+- `App_Data/StartupGate/**` (includes Startup Gate DB configuration files such as `dbsettings.json` and `dbpassword.bin`)
+- `App_Data/Backups/**`
+- `App_Data/DbBackups/**`
+- `App_Data/Updater/**`
+
+### Preserve / replace / merge categories
+
+The updater now treats files in explicit ownership categories:
+
+1. **Runtime/environment-owned (preserve)**  
+   Local operational state and credentials/configuration persisted by the running app.
+
+2. **Release-owned (replace)**  
+   Binaries/static payload files from the staged `app/` release folder.
+
+3. **Mixed-ownership (merge)**  
+   `appsettings.json` is preserved for environment values, then patched with release-owned `ApplicationMetadata.Version` from the staged package so About/Startup Gate version reflects the newly installed release.
+
 The replacement process:
 1. Extract ZIP to temp path.
 2. Detect payload root using one of the supported layouts:
@@ -65,6 +84,7 @@ The replacement process:
 3. Validate detected package structure (`app/` required, `manifest.json` logged if present).
 4. Remove stale files/folders from install root **excluding preserved paths**.
 5. Copy payload files into install root **excluding preserved paths**.
+6. Patch preserved `appsettings.json` with `ApplicationMetadata.Version` from staged release `appsettings.json`.
 
 ## Startup Gate compatibility
 

--- a/scripts/run-staged-update-bootstrapper.ps1
+++ b/scripts/run-staged-update-bootstrapper.ps1
@@ -58,6 +58,18 @@ $script:logPathResolved = $null
 $script:installRootResolved = $null
 $script:runtimeStateRootResolved = $null
 $script:statusMirrorPathResolved = $null
+$script:effectivePreservePatterns = @()
+
+# Release/package ownership model:
+# 1) Runtime/environment-owned paths MUST survive file replacement.
+# 2) Release-owned payload files are replaced from staged package contents.
+# 3) Mixed-ownership files (for example appsettings.json) are preserved, then patched with release-owned metadata.
+$mandatoryRuntimePreservePatterns = @(
+    'App_Data/StartupGate',
+    'App_Data/Backups',
+    'App_Data/DbBackups',
+    'App_Data/Updater'
+)
 
 function Ensure-Directory {
     param([Parameter(Mandatory = $true)][string]$Path)
@@ -236,6 +248,28 @@ function Test-IsPreserved {
     return $false
 }
 
+function Get-EffectivePreservePatterns {
+    param([Parameter(Mandatory = $true)][string[]]$RequestedPatterns)
+
+    $allPatterns = @()
+    $allPatterns += $mandatoryRuntimePreservePatterns
+    $allPatterns += $RequestedPatterns
+
+    $result = New-Object System.Collections.Generic.List[string]
+    foreach ($pattern in $allPatterns) {
+        if ([string]::IsNullOrWhiteSpace($pattern)) {
+            continue
+        }
+
+        $normalized = $pattern.Replace('\\', '/').Trim()
+        if (-not $result.Contains($normalized)) {
+            $result.Add($normalized)
+        }
+    }
+
+    return $result.ToArray()
+}
+
 function Get-RelativePath {
     param(
         [Parameter(Mandatory = $true)][string]$BasePath,
@@ -243,6 +277,59 @@ function Get-RelativePath {
     )
 
     return [System.IO.Path]::GetRelativePath($BasePath, $FullPath)
+}
+
+function Update-PreservedAppSettingsVersion {
+    param(
+        [Parameter(Mandatory = $true)][string]$SourceRoot,
+        [Parameter(Mandatory = $true)][string]$DestinationRoot
+    )
+
+    $sourceAppSettingsPath = Join-Path $SourceRoot 'appsettings.json'
+    $destinationAppSettingsPath = Join-Path $DestinationRoot 'appsettings.json'
+
+    if (-not (Test-Path -LiteralPath $sourceAppSettingsPath -PathType Leaf)) {
+        Write-Log "Mixed-ownership merge skipped: staged payload appsettings.json not found at '$sourceAppSettingsPath'."
+        return
+    }
+
+    if (-not (Test-Path -LiteralPath $destinationAppSettingsPath -PathType Leaf)) {
+        Write-Log "Mixed-ownership merge skipped: existing appsettings.json not found at '$destinationAppSettingsPath'."
+        return
+    }
+
+    $sourceSettings = Get-Content -LiteralPath $sourceAppSettingsPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $destinationSettings = Get-Content -LiteralPath $destinationAppSettingsPath -Raw -Encoding UTF8 | ConvertFrom-Json
+
+    if (-not $sourceSettings -or -not $destinationSettings) {
+        throw 'Unable to parse appsettings.json for mixed-ownership merge.'
+    }
+
+    $sourceVersion = $sourceSettings.ApplicationMetadata.Version
+    if ([string]::IsNullOrWhiteSpace($sourceVersion)) {
+        Write-Log 'Mixed-ownership merge skipped: staged appsettings.json does not define ApplicationMetadata.Version.'
+        return
+    }
+
+    if (-not $destinationSettings.ApplicationMetadata) {
+        $destinationSettings | Add-Member -NotePropertyName 'ApplicationMetadata' -NotePropertyValue ([PSCustomObject]@{})
+    }
+
+    if (-not ($destinationSettings.ApplicationMetadata.PSObject.Properties.Name -contains 'Version')) {
+        $destinationSettings.ApplicationMetadata | Add-Member -NotePropertyName 'Version' -NotePropertyValue $sourceVersion
+    }
+    else {
+        $destinationSettings.ApplicationMetadata.Version = $sourceVersion
+    }
+
+    if ($DryRun) {
+        Write-Log "DryRun: would merge staged ApplicationMetadata.Version '$sourceVersion' into preserved appsettings.json."
+        return
+    }
+
+    $mergedJson = $destinationSettings | ConvertTo-Json -Depth 32
+    Set-Content -LiteralPath $destinationAppSettingsPath -Value $mergedJson -Encoding UTF8
+    Write-Log "Merged staged ApplicationMetadata.Version '$sourceVersion' into preserved appsettings.json."
 }
 
 function Stop-IisRuntime {
@@ -505,6 +592,8 @@ try {
         Test-PackageStructure -PackageRoot $packageRoot
 
         $status.appOfflinePath = Join-Path $script:installRootResolved 'app_offline.htm'
+        $script:effectivePreservePatterns = Get-EffectivePreservePatterns -RequestedPatterns $PreserveRelativePaths
+        Write-Log "Effective preserve patterns: $($script:effectivePreservePatterns -join ', ')."
 
         Write-Status -Stage 'entering_maintenance' -Message 'Creating app_offline marker and stopping IIS runtime.'
         if ($DryRun) {
@@ -525,8 +614,11 @@ try {
         Stop-IisRuntime
 
         Write-Status -Stage 'replacing_payload' -Message 'Replacing IIS payload while preserving configured local paths.'
-        Remove-IfStale -DestinationRoot $script:installRootResolved -SourceRoot $payloadRoot -PreservePatterns $PreserveRelativePaths
-        Copy-NewPayload -SourceRoot $payloadRoot -DestinationRoot $script:installRootResolved -PreservePatterns $PreserveRelativePaths
+        Remove-IfStale -DestinationRoot $script:installRootResolved -SourceRoot $payloadRoot -PreservePatterns $script:effectivePreservePatterns
+        Copy-NewPayload -SourceRoot $payloadRoot -DestinationRoot $script:installRootResolved -PreservePatterns $script:effectivePreservePatterns
+
+        Write-Status -Stage 'merging_mixed_ownership_configuration' -Message 'Merging release-owned version metadata into preserved runtime configuration.'
+        Update-PreservedAppSettingsVersion -SourceRoot $payloadRoot -DestinationRoot $script:installRootResolved
 
         Write-Status -Stage 'starting_iis_runtime' -Message 'Starting IIS runtime after payload replacement.'
         Start-IisRuntime

--- a/scripts/run-staged-update-bootstrapper.ps1
+++ b/scripts/run-staged-update-bootstrapper.ps1
@@ -248,6 +248,27 @@ function Test-IsPreserved {
     return $false
 }
 
+function Test-HasPreservedDescendant {
+    param(
+        [Parameter(Mandatory = $true)][string]$RelativePath,
+        [Parameter(Mandatory = $true)][string[]]$Patterns
+    )
+
+    $normalizedRelative = $RelativePath.Replace('\', '/').TrimStart('./').TrimStart('/')
+    if ([string]::IsNullOrWhiteSpace($normalizedRelative)) {
+        return $false
+    }
+
+    foreach ($pattern in $Patterns) {
+        $normalizedPattern = $pattern.Replace('\', '/').TrimStart('./').TrimStart('/')
+        if ($normalizedPattern.StartsWith("$normalizedRelative/", [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
 function Get-EffectivePreservePatterns {
     param([Parameter(Mandatory = $true)][string[]]$RequestedPatterns)
 
@@ -386,6 +407,10 @@ function Remove-IfStale {
     Get-ChildItem -LiteralPath $DestinationRoot -Recurse -Force | Sort-Object -Property FullName -Descending | ForEach-Object {
         $relative = Get-RelativePath -BasePath $DestinationRoot -FullPath $_.FullName
         if (Test-IsPreserved -RelativePath $relative -Patterns $PreservePatterns) {
+            return
+        }
+
+        if ($_.PSIsContainer -and (Test-HasPreservedDescendant -RelativePath $relative -Patterns $PreservePatterns)) {
             return
         }
 


### PR DESCRIPTION
### Motivation

- The external updater could overwrite the persisted Startup Gate DB configuration and leave `appsettings.json` intact so the UI continued to show the old release version after an update.
- The goal is to explicitly preserve runtime/environment state (DB config, backups, updater sessions) while allowing release-owned metadata (the displayed application version) to be updated during cutover.
- Changes must be narrowly scoped to preservation/merge behavior and must not alter Startup Gate semantics, schema handling, rollback, or packaging.

### Description

- Enforce mandatory runtime-preserve paths inside the bootstrapper by always preserving `App_Data/StartupGate`, `App_Data/Backups`, `App_Data/DbBackups`, and `App_Data/Updater` regardless of caller-supplied `-PreserveRelativePaths` to protect `dbsettings.json` and `dbpassword.bin` used by Startup Gate (change in `scripts/run-staged-update-bootstrapper.ps1`).
- Introduced an explicit ownership model in the bootstrapper (runtime/environment-owned = preserve, release-owned = replace, mixed-ownership = merge) and computed `effectivePreservePatterns` that combine mandatory runtime paths with requested preserve patterns (`scripts/run-staged-update-bootstrapper.ps1`).
- Implemented a mixed-ownership merge step `Update-PreservedAppSettingsVersion` that, after payload copy, reads the staged `appsettings.json` and patches the preserved `appsettings.json` `ApplicationMetadata.Version` field with the staged release value so the updated app shows the new release version (`scripts/run-staged-update-bootstrapper.ps1`).
- Documented the changes and the preserve/replace/merge categories in `docs/manual-updater-bootstrapper-stage3a.md` so operator guidance and future reviewers understand the preservation policy and the version-patch behavior.

Files changed:
- `scripts/run-staged-update-bootstrapper.ps1` (added mandatory preserve patterns, `Get-EffectivePreservePatterns`, `Update-PreservedAppSettingsVersion`, and merge stage logging)
- `docs/manual-updater-bootstrapper-stage3a.md` (documented preservation categories and version merge)

### Testing

- Performed static validations and repository inspections by running repository searches and file reads (`rg`, `sed`, `cat`) to verify the script and related startup-gate storage code paths; these checks succeeded.
- Verified the bootstrapper script logic paths by reading the updated `scripts/run-staged-update-bootstrapper.ps1` and confirming the new `merging_mixed_ownership_configuration` stage is emitted in status updates; the code changes are syntactically consistent in the repository copy.
- Could not execute runtime/integration tests that require PowerShell or the .NET SDK in this environment because `pwsh` and `dotnet` were not available, so live `-DryRun` or full end-to-end validation on Windows/IIS was not performed here (the script preserves a `-DryRun` mode to allow deterministic host validation by operators).
- Included a deterministic reproduction/validation checklist in the change rationale so operators can reproduce the regression and confirm the fix on a host with PowerShell/.NET (steps: stage a release, run bootstrapper with defaults and with a narrow custom `-PreserveRelativePaths`, confirm `App_Data/StartupGate/*` survives and `appsettings.json` `ApplicationMetadata.Version` is updated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8cca69da4832aa3a04f1be5678764)