### PR TITLE
Follow-up: preserve App_Data container during staged update stale cleanup

### DIFF
--- a/docs/manual-updater-bootstrapper-stage3a.md
+++ b/docs/manual-updater-bootstrapper-stage3a.md
@@ -58,6 +58,7 @@ By default it preserves these existing paths in install root:
 - `appsettings.*.json`
 
 Additionally, these runtime-owned paths are always preserved even if the caller passes a narrower custom `-PreserveRelativePaths` list:
+- `App_Data/**` (preserves the container folder so mandatory Startup Gate/data subpaths are never removed as stale)
 - `App_Data/StartupGate/**` (includes Startup Gate DB configuration files such as `dbsettings.json` and `dbpassword.bin`)
 - `App_Data/Backups/**`
 - `App_Data/DbBackups/**`

--- a/scripts/run-staged-update-bootstrapper.ps1
+++ b/scripts/run-staged-update-bootstrapper.ps1
@@ -65,6 +65,7 @@ $script:effectivePreservePatterns = @()
 # 2) Release-owned payload files are replaced from staged package contents.
 # 3) Mixed-ownership files (for example appsettings.json) are preserved, then patched with release-owned metadata.
 $mandatoryRuntimePreservePatterns = @(
+    'App_Data',
     'App_Data/StartupGate',
     'App_Data/Backups',
     'App_Data/DbBackups',


### PR DESCRIPTION
### Motivation

- Prevent removal of the `App_Data` parent folder during staged update stale cleanup so mandatory Startup Gate runtime subpaths cannot be deleted when callers provide a narrow `-PreserveRelativePaths` list. 

### Description

- Added `'App_Data'` to the bootstrapper's `$mandatoryRuntimePreservePatterns` in `scripts/run-staged-update-bootstrapper.ps1` so the `App_Data` container is always preserved alongside `App_Data/StartupGate`, `App_Data/Backups`, `App_Data/DbBackups`, and `App_Data/Updater`. 
- Updated `docs/manual-updater-bootstrapper-stage3a.md` to explicitly document that `App_Data/**` is always preserved to protect runtime-owned data. 

### Testing

- Verified the repository diff and committed the changes (`scripts/run-staged-update-bootstrapper.ps1` and `docs/manual-updater-bootstrapper-stage3a.md`) and confirmed the mandatory preserve list now includes `App_Data`. 
- Attempted to run a PowerShell syntax parse (`pwsh -NoProfile -Command '[void][System.Management.Automation.Language.Parser]::ParseFile("scripts/run-staged-update-bootstrapper.ps1",[ref]$null,[ref]$null);'`) but the runtime is unavailable in this environment (`pwsh: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d51a8f04832aa6c4b8d4a2abca3c)