### PR TITLE
Fix bootstrapper preservation of Startup Gate DB config during staged swap

### DIFF
--- a/scripts/run-staged-update-bootstrapper.ps1
+++ b/scripts/run-staged-update-bootstrapper.ps1
@@ -65,6 +65,8 @@ $script:effectivePreservePatterns = @()
 # 2) Release-owned payload files are replaced from staged package contents.
 # 3) Mixed-ownership files (for example appsettings.json) are preserved, then patched with release-owned metadata.
 $mandatoryRuntimePreservePatterns = @(
+    # Startup Gate persists DB reconnection state in App_Data/StartupGate (dbsettings.json + dbpassword.bin).
+    # This directory is machine/runtime-owned and must survive payload replacement unchanged.
     'App_Data/StartupGate',
     'App_Data/Backups',
     'App_Data/DbBackups',
@@ -233,9 +235,11 @@ function Test-IsPreserved {
         [Parameter(Mandatory = $true)][string[]]$Patterns
     )
 
-    $normalizedRelative = $RelativePath.Replace('\\', '/').TrimStart('./').TrimStart('/')
+    $normalizedRelative = $RelativePath -replace '[\\/]+', '/'
+    $normalizedRelative = $normalizedRelative.TrimStart('./').TrimStart('/')
     foreach ($pattern in $Patterns) {
-        $normalizedPattern = $pattern.Replace('\\', '/').TrimStart('./').TrimStart('/')
+        $normalizedPattern = $pattern -replace '[\\/]+', '/'
+        $normalizedPattern = $normalizedPattern.TrimStart('./').TrimStart('/')
         if ($normalizedRelative -like $normalizedPattern) {
             return $true
         }
@@ -254,13 +258,15 @@ function Test-HasPreservedDescendant {
         [Parameter(Mandatory = $true)][string[]]$Patterns
     )
 
-    $normalizedRelative = $RelativePath.Replace('\', '/').TrimStart('./').TrimStart('/')
+    $normalizedRelative = $RelativePath -replace '[\\/]+', '/'
+    $normalizedRelative = $normalizedRelative.TrimStart('./').TrimStart('/')
     if ([string]::IsNullOrWhiteSpace($normalizedRelative)) {
         return $false
     }
 
     foreach ($pattern in $Patterns) {
-        $normalizedPattern = $pattern.Replace('\', '/').TrimStart('./').TrimStart('/')
+        $normalizedPattern = $pattern -replace '[\\/]+', '/'
+        $normalizedPattern = $normalizedPattern.TrimStart('./').TrimStart('/')
         if ($normalizedPattern.StartsWith("$normalizedRelative/", [System.StringComparison]::OrdinalIgnoreCase)) {
             return $true
         }
@@ -282,7 +288,7 @@ function Get-EffectivePreservePatterns {
             continue
         }
 
-        $normalized = $pattern.Replace('\\', '/').Trim()
+        $normalized = ($pattern -replace '[\\/]+', '/').Trim()
         if (-not $result.Contains($normalized)) {
             $result.Add($normalized)
         }


### PR DESCRIPTION
### Motivation
- The external staged-update bootstrapper could miss Windows-style paths when applying preserve rules, causing `App_Data/StartupGate` (which contains `dbsettings.json` and `dbpassword.bin`) to be replaced and the app to lose its DB connection after update.

### Description
- Normalize preserve-path handling to canonicalize both `\` and `/` separators before matching, and normalize requested preserve patterns so `Test-IsPreserved`, `Test-HasPreservedDescendant`, and `Get-EffectivePreservePatterns` reliably detect `App_Data/StartupGate` across platforms; changes live in `scripts/run-staged-update-bootstrapper.ps1`.
- Make `App_Data/StartupGate` explicitly documented as a mandatory runtime-preserved path (comment added) so the updater preserves the Startup Gate storage unit (including `dbsettings.json` and `dbpassword.bin`) rather than trying to selectively preserve files.

### Testing
- Verified PowerShell parsing with the repository script using the parser invocation (`pwsh -NoLogo -NoProfile -File /tmp/parse_updater.ps1`) which returned `PARSE_OK`.
- Ran an end-to-end local simulation (`pwsh -NoLogo -NoProfile -File /tmp/run_updater_simulation.ps1`) that built a staged ZIP and install root and asserted that `App_Data/StartupGate/dbsettings.json` and `App_Data/StartupGate/dbpassword.bin` survived the swap, stale files were removed, new payload files were copied, and `ApplicationMetadata.Version` in the preserved `appsettings.json` was merged to the staged release version, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8dc1ae29c832aadc9b0b21e6c5745)