### PR TITLE
Fix updater apply PowerShell host resolution and bootstrapper path compatibility

### DIFF
--- a/scripts/run-staged-update-bootstrapper.ps1
+++ b/scripts/run-staged-update-bootstrapper.ps1
@@ -303,7 +303,28 @@ function Get-RelativePath {
         [Parameter(Mandatory = $true)][string]$FullPath
     )
 
-    return [System.IO.Path]::GetRelativePath($BasePath, $FullPath)
+    $resolvedBasePath = [System.IO.Path]::GetFullPath($BasePath)
+    $resolvedFullPath = [System.IO.Path]::GetFullPath($FullPath)
+
+    if ($resolvedBasePath.Equals($resolvedFullPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return '.'
+    }
+
+    $baseWithSeparator = $resolvedBasePath.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+    $baseUri = [System.Uri]::new($baseWithSeparator)
+    $fullUri = [System.Uri]::new($resolvedFullPath)
+    $relativeUri = $baseUri.MakeRelativeUri($fullUri)
+
+    if ($relativeUri.IsAbsoluteUri) {
+        return $resolvedFullPath
+    }
+
+    $relativePath = [System.Uri]::UnescapeDataString($relativeUri.ToString()) -replace '/', [System.IO.Path]::DirectorySeparatorChar
+    if ([string]::IsNullOrWhiteSpace($relativePath)) {
+        return '.'
+    }
+
+    return $relativePath
 }
 
 function Update-PreservedAppSettingsVersion {

--- a/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateApplyServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateApplyServiceTests.cs
@@ -56,6 +56,7 @@ public sealed class ApplicationUpdateApplyServiceTests
             Assert.Equal(contentRoot, launcher.InstallRootPath);
             Assert.Equal(Path.Combine(stagingRoot, "state", "external-updater-status.json"), launcher.StatusJsonPath);
             Assert.Equal(Path.Combine(stagingRoot, "state", "external-updater.log"), launcher.LogPath);
+            Assert.Equal("C:\\Program Files\\PowerShell\\7\\pwsh.exe", launcher.PowerShellExecutablePath);
         }
         finally
         {
@@ -112,6 +113,54 @@ public sealed class ApplicationUpdateApplyServiceTests
         }
     }
 
+    [Fact]
+    public async Task RequestApplyAsync_ThrowsWhenPowerShellHostCannotBeResolved()
+    {
+        var contentRoot = CreateTempRoot();
+        try
+        {
+            var stagingRoot = Path.Combine(contentRoot, "App_Data", "Updater");
+            Directory.CreateDirectory(Path.Combine(stagingRoot, "state"));
+            Directory.CreateDirectory(Path.Combine(contentRoot, "Updater"));
+
+            var bootstrapperPath = Path.Combine(contentRoot, "Updater", "run-staged-update-bootstrapper.ps1");
+            await File.WriteAllTextAsync(bootstrapperPath, "# bootstrapper");
+
+            var zipPath = Path.Combine(stagingRoot, "staged", "current", "pkg.zip");
+            Directory.CreateDirectory(Path.GetDirectoryName(zipPath)!);
+            await File.WriteAllTextAsync(zipPath, "zip");
+
+            var metadataPath = Path.Combine(stagingRoot, "state", "staged-update.json");
+            await File.WriteAllTextAsync(metadataPath, "{}");
+
+            var store = BuildStateStore(contentRoot);
+            await store.WriteAsync(new ApplicationUpdateStagingState
+            {
+                SourceRepository = "ijyates1992/ping-monitor",
+                ReleaseTag = "V1.2.3",
+                StagedZipPath = zipPath,
+                ChecksumVerified = true,
+                Status = ApplicationUpdateStagingStatus.Ready,
+                LastUpdatedAtUtc = DateTimeOffset.UtcNow
+            }, CancellationToken.None);
+
+            var launcher = new RecordingLauncher
+            {
+                ResolveExecutablePathResult = false,
+                ResolutionErrorMessage = "Configured PowerShell executable 'pwsh.exe' was not found on PATH."
+            };
+
+            var service = BuildService(contentRoot, store, launcher);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.RequestApplyAsync("admin-user", CancellationToken.None));
+            Assert.Contains("Unable to resolve the configured PowerShell host", exception.Message);
+        }
+        finally
+        {
+            Directory.Delete(contentRoot, recursive: true);
+        }
+    }
+
     private static ApplicationUpdateApplyService BuildService(
         string contentRoot,
         IApplicationUpdateStagingStateStore store,
@@ -123,7 +172,7 @@ public sealed class ApplicationUpdateApplyServiceTests
         {
             StagingStoragePath = "App_Data/Updater",
             BootstrapperRelativePath = "Updater/run-staged-update-bootstrapper.ps1",
-            PowerShellExecutablePath = "powershell.exe"
+            PowerShellExecutablePath = "pwsh.exe"
         });
 
         return new ApplicationUpdateApplyService(
@@ -151,14 +200,25 @@ public sealed class ApplicationUpdateApplyServiceTests
 
     private sealed class RecordingLauncher : IExternalUpdaterProcessLauncher
     {
+        public bool ResolveExecutablePathResult { get; set; } = true;
+        public string? ResolutionErrorMessage { get; set; }
+        public string? PowerShellExecutablePath { get; private set; }
         public string? BootstrapperScriptPath { get; private set; }
         public string? StagedMetadataPath { get; private set; }
         public string? InstallRootPath { get; private set; }
         public string? StatusJsonPath { get; private set; }
         public string? LogPath { get; private set; }
 
+        public bool TryResolveExecutablePath(string configuredExecutablePath, out string? resolvedExecutablePath, out string? resolutionErrorMessage)
+        {
+            resolvedExecutablePath = ResolveExecutablePathResult ? "C:\\Program Files\\PowerShell\\7\\pwsh.exe" : null;
+            resolutionErrorMessage = ResolutionErrorMessage;
+            return ResolveExecutablePathResult;
+        }
+
         public bool TryLaunch(string powerShellExecutablePath, string bootstrapperScriptPath, string stagedMetadataPath, string installRootPath, string statusJsonPath, string logPath, string? expectedReleaseTag, out string? launchErrorMessage)
         {
+            PowerShellExecutablePath = powerShellExecutablePath;
             BootstrapperScriptPath = bootstrapperScriptPath;
             StagedMetadataPath = stagedMetadataPath;
             InstallRootPath = installRootPath;

--- a/src/WebApp/PingMonitor.Web/Options/ApplicationUpdaterOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/ApplicationUpdaterOptions.cs
@@ -14,5 +14,5 @@ public sealed class ApplicationUpdaterOptions
     public string ChecksumAssetName { get; set; } = "SHA256.txt";
     public string StagingStoragePath { get; set; } = "App_Data/Updater";
     public string BootstrapperRelativePath { get; set; } = "Updater/run-staged-update-bootstrapper.ps1";
-    public string PowerShellExecutablePath { get; set; } = "powershell.exe";
+    public string PowerShellExecutablePath { get; set; } = "pwsh.exe";
 }

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateApplyService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateApplyService.cs
@@ -15,6 +15,8 @@ public interface IApplicationUpdateApplyService
 
 public interface IExternalUpdaterProcessLauncher
 {
+    bool TryResolveExecutablePath(string configuredExecutablePath, out string? resolvedExecutablePath, out string? resolutionErrorMessage);
+
     bool TryLaunch(
         string powerShellExecutablePath,
         string bootstrapperScriptPath,
@@ -28,6 +30,59 @@ public interface IExternalUpdaterProcessLauncher
 
 internal sealed class ExternalUpdaterProcessLauncher : IExternalUpdaterProcessLauncher
 {
+    public bool TryResolveExecutablePath(string configuredExecutablePath, out string? resolvedExecutablePath, out string? resolutionErrorMessage)
+    {
+        resolvedExecutablePath = null;
+        resolutionErrorMessage = null;
+
+        if (string.IsNullOrWhiteSpace(configuredExecutablePath))
+        {
+            resolutionErrorMessage = "PowerShell executable path is not configured.";
+            return false;
+        }
+
+        var configured = configuredExecutablePath.Trim();
+        if (Path.IsPathRooted(configured))
+        {
+            var absolutePath = Path.GetFullPath(configured);
+            if (!File.Exists(absolutePath))
+            {
+                resolutionErrorMessage = $"Configured PowerShell executable was not found at '{absolutePath}'.";
+                return false;
+            }
+
+            resolvedExecutablePath = absolutePath;
+            return true;
+        }
+
+        var candidateNames = BuildExecutableCandidates(configured);
+        var pathValue = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        var directories = pathValue.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        foreach (var directory in directories)
+        {
+            if (string.IsNullOrWhiteSpace(directory))
+            {
+                continue;
+            }
+
+            foreach (var candidateName in candidateNames)
+            {
+                var candidatePath = Path.Combine(directory, candidateName);
+                if (!File.Exists(candidatePath))
+                {
+                    continue;
+                }
+
+                resolvedExecutablePath = Path.GetFullPath(candidatePath);
+                return true;
+            }
+        }
+
+        resolutionErrorMessage = $"Configured PowerShell executable '{configuredExecutablePath}' was not found on PATH.";
+        return false;
+    }
+
     public bool TryLaunch(
         string powerShellExecutablePath,
         string bootstrapperScriptPath,
@@ -85,6 +140,23 @@ internal sealed class ExternalUpdaterProcessLauncher : IExternalUpdaterProcessLa
             return false;
         }
     }
+
+    private static string[] BuildExecutableCandidates(string configuredExecutablePath)
+    {
+        var names = new List<string>();
+        var configured = configuredExecutablePath.Trim();
+        names.Add(configured);
+
+        if (Path.GetExtension(configured).Length == 0 &&
+            OperatingSystem.IsWindows())
+        {
+            names.Add($"{configured}.exe");
+            names.Add($"{configured}.cmd");
+            names.Add($"{configured}.bat");
+        }
+
+        return names.ToArray();
+    }
 }
 
 internal sealed class ApplicationUpdateApplyService : IApplicationUpdateApplyService
@@ -129,6 +201,12 @@ internal sealed class ApplicationUpdateApplyService : IApplicationUpdateApplySer
         var stagedMetadataPath = Path.Combine(stagingRoot, "state", "staged-update.json");
         var bootstrapperPath = ResolveBootstrapperPath();
         var installRootPath = Path.GetFullPath(_environment.ContentRootPath);
+        if (!_launcher.TryResolveExecutablePath(_options.PowerShellExecutablePath, out var powerShellExecutablePath, out var powerShellResolutionError))
+        {
+            throw new InvalidOperationException(
+                $"Unable to resolve the configured PowerShell host '{_options.PowerShellExecutablePath}'. {powerShellResolutionError}");
+        }
+
         var externalStatusPath = Path.Combine(stagingRoot, "state", "external-updater-status.json");
         var externalLogPath = Path.Combine(stagingRoot, "state", "external-updater.log");
 
@@ -178,7 +256,7 @@ internal sealed class ApplicationUpdateApplyService : IApplicationUpdateApplySer
         await _stagingStateStore.WriteAsync(requestedState, cancellationToken);
 
         var launched = _launcher.TryLaunch(
-            _options.PowerShellExecutablePath,
+            powerShellExecutablePath!,
             bootstrapperPath,
             stagedMetadataPath,
             installRootPath,

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -82,6 +82,6 @@
     "ChecksumAssetName": "SHA256.txt",
     "StagingStoragePath": "App_Data/Updater",
     "BootstrapperRelativePath": "Updater/run-staged-update-bootstrapper.ps1",
-    "PowerShellExecutablePath": "powershell.exe"
+    "PowerShellExecutablePath": "pwsh.exe"
   }
 }


### PR DESCRIPTION
### Motivation

- Prevent external updater bootstrapper failures caused by running under a PowerShell/.NET runtime where `System.IO.Path.GetRelativePath()` is not available. 
- Ensure the app explicitly launches the intended PowerShell host instead of relying on ambient shell defaults which can cause the updater to run under the wrong runtime.

### Description

- Resolve the configured PowerShell host to a concrete executable path before launching and fail with a clear error if it cannot be found, via `IExternalUpdaterProcessLauncher.TryResolveExecutablePath` and the launcher now passing the resolved path to `ProcessStartInfo.FileName`.
- Change updater defaults to target `pwsh.exe` (updated `ApplicationUpdaterOptions` default and `appsettings.json`) so PowerShell 7 is the explicit default host for the external bootstrapper.
- Replace unsafe use of `[System.IO.Path]::GetRelativePath` in `scripts/run-staged-update-bootstrapper.ps1` with a URI-based compatible `Get-RelativePath` helper that normalizes full paths, returns `.` for same-path, and falls back to the absolute full path for absolute-URI cases.
- Add and update unit tests in `ApplicationUpdateApplyServiceTests` to assert the resolved host is handed off and to verify that `RequestApplyAsync` throws early when the configured PowerShell host cannot be resolved.

Files changed: `src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateApplyService.cs`, `src/WebApp/PingMonitor.Web/Options/ApplicationUpdaterOptions.cs`, `src/WebApp/PingMonitor.Web/appsettings.json`, `scripts/run-staged-update-bootstrapper.ps1`, and `src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateApplyServiceTests.cs`.

### Testing

- Ran unit tests for the apply service with `dotnet test ... --filter ApplicationUpdateApplyServiceTests` and all tests passed (`Passed: 3` in the filtered run).
- Performed a deterministic dry-run of the bootstrapper under `pwsh` against a staged payload fixture and verified the bootstrapper reached the `completed` stage and included the `replacing_payload` step.
- Added a unit test verifying that `RequestApplyAsync` throws a clear `InvalidOperationException` when the configured PowerShell host cannot be resolved, providing a regression barrier for this class of failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ef2284c4832aaa5d4af1cdd4e7f9)