### PR TITLE
Fix updater: require/pass IIS identity, wait for stop, and retry locked-file replacements

### DIFF
--- a/scripts/run-staged-update-bootstrapper.ps1
+++ b/scripts/run-staged-update-bootstrapper.ps1
@@ -59,6 +59,10 @@ $script:installRootResolved = $null
 $script:runtimeStateRootResolved = $null
 $script:statusMirrorPathResolved = $null
 $script:effectivePreservePatterns = @()
+$script:fileReplaceRetryCount = 5
+$script:fileReplaceRetryDelayMs = 750
+$script:iisStopWaitTimeoutSec = 45
+$script:iisStopWaitPollMs = 1000
 
 # Release/package ownership model:
 # 1) Runtime/environment-owned paths MUST survive file replacement.
@@ -229,6 +233,38 @@ function Write-Log {
     Write-Host $line
 }
 
+function Invoke-WithRetry {
+    param(
+        [Parameter(Mandatory = $true)][scriptblock]$Action,
+        [Parameter(Mandatory = $true)][string]$Description,
+        [Parameter(Mandatory = $true)][int]$MaxAttempts,
+        [Parameter(Mandatory = $true)][int]$DelayMilliseconds
+    )
+
+    if ($MaxAttempts -lt 1) {
+        throw 'MaxAttempts must be at least 1.'
+    }
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        try {
+            & $Action
+            if ($attempt -gt 1) {
+                Write-Log "$Description succeeded on retry attempt $attempt of $MaxAttempts."
+            }
+
+            return
+        }
+        catch {
+            if ($attempt -ge $MaxAttempts) {
+                throw
+            }
+
+            Write-Log "$Description failed on attempt $attempt of $MaxAttempts: $($_.Exception.Message). Retrying after ${DelayMilliseconds}ms."
+            Start-Sleep -Milliseconds $DelayMilliseconds
+        }
+    }
+}
+
 function Test-IsPreserved {
     param(
         [Parameter(Mandatory = $true)][string]$RelativePath,
@@ -390,16 +426,47 @@ function Stop-IisRuntime {
         Import-Module WebAdministration -ErrorAction Stop
     }
 
+    Write-Log "Attempting IIS stop for site='$SiteName', appPool='$AppPoolName'."
+
+    if (-not [string]::IsNullOrWhiteSpace($AppPoolName)) {
+        Write-Log "Stopping IIS app pool '$AppPoolName'."
+        Stop-WebAppPool -Name $AppPoolName -ErrorAction Stop
+        $script:appPoolStopped = $true
+    }
+
     if (-not [string]::IsNullOrWhiteSpace($SiteName)) {
         Write-Log "Stopping IIS site '$SiteName'."
         Stop-Website -Name $SiteName -ErrorAction Stop
         $script:siteStopped = $true
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($AppPoolName)) {
-        Write-Log "Stopping IIS app pool '$AppPoolName'."
-        Stop-WebAppPool -Name $AppPoolName -ErrorAction Stop
-        $script:appPoolStopped = $true
+    $waitStartedAt = Get-Date
+    while ($true) {
+        $appPoolStoppedConfirmed = $true
+        $siteStoppedConfirmed = $true
+
+        if (-not [string]::IsNullOrWhiteSpace($AppPoolName)) {
+            $appPoolState = (Get-WebAppPoolState -Name $AppPoolName -ErrorAction Stop).Value
+            $appPoolStoppedConfirmed = [string]::Equals($appPoolState, 'Stopped', [System.StringComparison]::OrdinalIgnoreCase)
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($SiteName)) {
+            $siteState = (Get-WebsiteState -Name $SiteName -ErrorAction Stop).Value
+            $siteStoppedConfirmed = [string]::Equals($siteState, 'Stopped', [System.StringComparison]::OrdinalIgnoreCase)
+        }
+
+        if ($appPoolStoppedConfirmed -and $siteStoppedConfirmed) {
+            Write-Log "Confirmed IIS runtime stop state (site='$SiteName', appPool='$AppPoolName')."
+            return
+        }
+
+        $elapsedSec = ((Get-Date) - $waitStartedAt).TotalSeconds
+        if ($elapsedSec -ge $script:iisStopWaitTimeoutSec) {
+            throw "Timed out waiting for IIS stop confirmation after $script:iisStopWaitTimeoutSec seconds (site='$SiteName', appPool='$AppPoolName')."
+        }
+
+        Write-Log "Waiting for IIS stop confirmation (site='$SiteName', appPool='$AppPoolName', elapsed=${elapsedSec:n1}s)."
+        Start-Sleep -Milliseconds $script:iisStopWaitPollMs
     }
 }
 
@@ -447,7 +514,9 @@ function Remove-IfStale {
                 Write-Log "DryRun: would remove stale path '$($_.FullName)'."
             }
             else {
-                Remove-Item -LiteralPath $_.FullName -Recurse -Force
+                Invoke-WithRetry -Description "Removing stale path '$relative'" -MaxAttempts $script:fileReplaceRetryCount -DelayMilliseconds $script:fileReplaceRetryDelayMs -Action {
+                    Remove-Item -LiteralPath $_.FullName -Recurse -Force
+                }
             }
         }
     }
@@ -478,7 +547,9 @@ function Copy-NewPayload {
         $destinationDirectory = Split-Path -Path $destinationPath -Parent
         if (-not $DryRun) {
             Ensure-Directory -Path $destinationDirectory
-            Copy-Item -LiteralPath $_.FullName -Destination $destinationPath -Force
+            Invoke-WithRetry -Description "Copying payload file '$relative'" -MaxAttempts $script:fileReplaceRetryCount -DelayMilliseconds $script:fileReplaceRetryDelayMs -Action {
+                Copy-Item -LiteralPath $_.FullName -Destination $destinationPath -Force
+            }
         }
         else {
             Write-Log "DryRun: would copy '$($_.FullName)' to '$destinationPath'."
@@ -591,6 +662,14 @@ try {
         throw "Install root directory does not exist: $script:installRootResolved"
     }
 
+    if ([string]::IsNullOrWhiteSpace($SiteName)) {
+        throw 'SiteName is required and cannot be empty.'
+    }
+
+    if ([string]::IsNullOrWhiteSpace($AppPoolName)) {
+        throw 'AppPoolName is required and cannot be empty.'
+    }
+
     $status.installRootPath = $script:installRootResolved
 
     $metadataRaw = Get-Content -LiteralPath $metadataPathResolved -Raw -Encoding UTF8
@@ -628,6 +707,7 @@ try {
     Write-Log "Staged release tag: $($metadata.ReleaseTag)."
     Write-Log "Staged ZIP path: $zipPathResolved."
     Write-Log "Install root path: $script:installRootResolved."
+    Write-Log "Resolved IIS identity values: site='$SiteName', appPool='$AppPoolName'."
     Write-Log "Runtime updater state path (non-replaceable): $script:runtimeStateRootResolved."
 
     $workRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("ping-monitor-updater-" + [System.Guid]::NewGuid().ToString('N'))

--- a/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateApplyServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateApplyServiceTests.cs
@@ -57,6 +57,8 @@ public sealed class ApplicationUpdateApplyServiceTests
             Assert.Equal(Path.Combine(stagingRoot, "state", "external-updater-status.json"), launcher.StatusJsonPath);
             Assert.Equal(Path.Combine(stagingRoot, "state", "external-updater.log"), launcher.LogPath);
             Assert.Equal("C:\\Program Files\\PowerShell\\7\\pwsh.exe", launcher.PowerShellExecutablePath);
+            Assert.Equal("PingMonitor", launcher.SiteName);
+            Assert.Equal("PingMonitorPool", launcher.AppPoolName);
         }
         finally
         {
@@ -161,18 +163,65 @@ public sealed class ApplicationUpdateApplyServiceTests
         }
     }
 
+    [Fact]
+    public async Task RequestApplyAsync_ThrowsWhenIisIdentityValuesAreMissing()
+    {
+        var contentRoot = CreateTempRoot();
+        try
+        {
+            var stagingRoot = Path.Combine(contentRoot, "App_Data", "Updater");
+            Directory.CreateDirectory(Path.Combine(stagingRoot, "state"));
+            Directory.CreateDirectory(Path.Combine(contentRoot, "Updater"));
+
+            var bootstrapperPath = Path.Combine(contentRoot, "Updater", "run-staged-update-bootstrapper.ps1");
+            await File.WriteAllTextAsync(bootstrapperPath, "# bootstrapper");
+
+            var zipPath = Path.Combine(stagingRoot, "staged", "current", "pkg.zip");
+            Directory.CreateDirectory(Path.GetDirectoryName(zipPath)!);
+            await File.WriteAllTextAsync(zipPath, "zip");
+
+            var metadataPath = Path.Combine(stagingRoot, "state", "staged-update.json");
+            await File.WriteAllTextAsync(metadataPath, "{}");
+
+            var store = BuildStateStore(contentRoot);
+            await store.WriteAsync(new ApplicationUpdateStagingState
+            {
+                SourceRepository = "ijyates1992/ping-monitor",
+                ReleaseTag = "V1.2.3",
+                StagedZipPath = zipPath,
+                ChecksumVerified = true,
+                Status = ApplicationUpdateStagingStatus.Ready,
+                LastUpdatedAtUtc = DateTimeOffset.UtcNow
+            }, CancellationToken.None);
+
+            var launcher = new RecordingLauncher();
+            var service = BuildService(contentRoot, store, launcher, iisSiteName: "", iisAppPoolName: "");
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.RequestApplyAsync("admin-user", CancellationToken.None));
+            Assert.Contains("ApplicationUpdater:IisSiteName", exception.Message);
+        }
+        finally
+        {
+            Directory.Delete(contentRoot, recursive: true);
+        }
+    }
+
     private static ApplicationUpdateApplyService BuildService(
         string contentRoot,
         IApplicationUpdateStagingStateStore store,
         IExternalUpdaterProcessLauncher launcher,
         string currentVersion = "V1.0.0",
-        StartupMode startupMode = StartupMode.Normal)
+        StartupMode startupMode = StartupMode.Normal,
+        string iisSiteName = "PingMonitor",
+        string iisAppPoolName = "PingMonitorPool")
     {
         var options = Microsoft.Extensions.Options.Options.Create(new ApplicationUpdaterOptions
         {
             StagingStoragePath = "App_Data/Updater",
             BootstrapperRelativePath = "Updater/run-staged-update-bootstrapper.ps1",
-            PowerShellExecutablePath = "pwsh.exe"
+            PowerShellExecutablePath = "pwsh.exe",
+            IisSiteName = iisSiteName,
+            IisAppPoolName = iisAppPoolName
         });
 
         return new ApplicationUpdateApplyService(
@@ -208,6 +257,8 @@ public sealed class ApplicationUpdateApplyServiceTests
         public string? InstallRootPath { get; private set; }
         public string? StatusJsonPath { get; private set; }
         public string? LogPath { get; private set; }
+        public string? SiteName { get; private set; }
+        public string? AppPoolName { get; private set; }
 
         public bool TryResolveExecutablePath(string configuredExecutablePath, out string? resolvedExecutablePath, out string? resolutionErrorMessage)
         {
@@ -216,12 +267,14 @@ public sealed class ApplicationUpdateApplyServiceTests
             return ResolveExecutablePathResult;
         }
 
-        public bool TryLaunch(string powerShellExecutablePath, string bootstrapperScriptPath, string stagedMetadataPath, string installRootPath, string statusJsonPath, string logPath, string? expectedReleaseTag, out string? launchErrorMessage)
+        public bool TryLaunch(string powerShellExecutablePath, string bootstrapperScriptPath, string stagedMetadataPath, string installRootPath, string siteName, string appPoolName, string statusJsonPath, string logPath, string? expectedReleaseTag, out string? launchErrorMessage)
         {
             PowerShellExecutablePath = powerShellExecutablePath;
             BootstrapperScriptPath = bootstrapperScriptPath;
             StagedMetadataPath = stagedMetadataPath;
             InstallRootPath = installRootPath;
+            SiteName = siteName;
+            AppPoolName = appPoolName;
             StatusJsonPath = statusJsonPath;
             LogPath = logPath;
             launchErrorMessage = null;

--- a/src/WebApp/PingMonitor.Web/Options/ApplicationUpdaterOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/ApplicationUpdaterOptions.cs
@@ -15,4 +15,6 @@ public sealed class ApplicationUpdaterOptions
     public string StagingStoragePath { get; set; } = "App_Data/Updater";
     public string BootstrapperRelativePath { get; set; } = "Updater/run-staged-update-bootstrapper.ps1";
     public string PowerShellExecutablePath { get; set; } = "pwsh.exe";
+    public string IisSiteName { get; set; } = string.Empty;
+    public string IisAppPoolName { get; set; } = string.Empty;
 }

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateApplyService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateApplyService.cs
@@ -22,6 +22,8 @@ public interface IExternalUpdaterProcessLauncher
         string bootstrapperScriptPath,
         string stagedMetadataPath,
         string installRootPath,
+        string siteName,
+        string appPoolName,
         string statusJsonPath,
         string logPath,
         string? expectedReleaseTag,
@@ -88,6 +90,8 @@ internal sealed class ExternalUpdaterProcessLauncher : IExternalUpdaterProcessLa
         string bootstrapperScriptPath,
         string stagedMetadataPath,
         string installRootPath,
+        string siteName,
+        string appPoolName,
         string statusJsonPath,
         string logPath,
         string? expectedReleaseTag,
@@ -114,6 +118,10 @@ internal sealed class ExternalUpdaterProcessLauncher : IExternalUpdaterProcessLa
             startInfo.ArgumentList.Add(stagedMetadataPath);
             startInfo.ArgumentList.Add("-InstallRootPath");
             startInfo.ArgumentList.Add(installRootPath);
+            startInfo.ArgumentList.Add("-SiteName");
+            startInfo.ArgumentList.Add(siteName);
+            startInfo.ArgumentList.Add("-AppPoolName");
+            startInfo.ArgumentList.Add(appPoolName);
             startInfo.ArgumentList.Add("-StatusJsonPath");
             startInfo.ArgumentList.Add(statusJsonPath);
             startInfo.ArgumentList.Add("-LogPath");
@@ -209,6 +217,14 @@ internal sealed class ApplicationUpdateApplyService : IApplicationUpdateApplySer
 
         var externalStatusPath = Path.Combine(stagingRoot, "state", "external-updater-status.json");
         var externalLogPath = Path.Combine(stagingRoot, "state", "external-updater.log");
+        var siteName = ResolveRequiredIisIdentityValue(
+            _options.IisSiteName,
+            nameof(ApplicationUpdaterOptions.IisSiteName),
+            "ApplicationUpdater:IisSiteName");
+        var appPoolName = ResolveRequiredIisIdentityValue(
+            _options.IisAppPoolName,
+            nameof(ApplicationUpdaterOptions.IisAppPoolName),
+            "ApplicationUpdater:IisAppPoolName");
 
         ValidateApplyPrerequisites(current, stagedMetadataPath, bootstrapperPath);
 
@@ -260,6 +276,8 @@ internal sealed class ApplicationUpdateApplyService : IApplicationUpdateApplySer
             bootstrapperPath,
             stagedMetadataPath,
             installRootPath,
+            siteName,
+            appPoolName,
             externalStatusPath,
             externalLogPath,
             current.ReleaseTag,
@@ -419,6 +437,17 @@ internal sealed class ApplicationUpdateApplyService : IApplicationUpdateApplySer
         return Path.IsPathRooted(configuredPath)
             ? Path.GetFullPath(configuredPath)
             : Path.GetFullPath(configuredPath, _environment.ContentRootPath);
+    }
+
+    private static string ResolveRequiredIisIdentityValue(string configuredValue, string optionName, string configurationKey)
+    {
+        if (string.IsNullOrWhiteSpace(configuredValue))
+        {
+            throw new InvalidOperationException(
+                $"Application updater cannot launch because required IIS identity value '{optionName}' is not configured. Set '{configurationKey}' to a non-empty value.");
+        }
+
+        return configuredValue.Trim();
     }
 
     private static ApplicationUpdateStagingState CloneState(

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -82,6 +82,8 @@
     "ChecksumAssetName": "SHA256.txt",
     "StagingStoragePath": "App_Data/Updater",
     "BootstrapperRelativePath": "Updater/run-staged-update-bootstrapper.ps1",
-    "PowerShellExecutablePath": "pwsh.exe"
+    "PowerShellExecutablePath": "pwsh.exe",
+    "IisSiteName": "",
+    "IisAppPoolName": ""
   }
 }


### PR DESCRIPTION
### Motivation
- The external updater was launched without explicit IIS identity values which resulted in empty `siteName`/`appPoolName` in status JSON and caused file-lock failures during `replacing_payload` (for example `aspnetcorev2_inprocess.dll`).
- The goal is to ensure the updater reliably stops the IIS runtime before replacing files and to tolerate transient locked-file windows without expanding scope beyond these fixes.

### Description
- Require explicit IIS identity configuration via new options `ApplicationUpdater:IisSiteName` and `ApplicationUpdater:IisAppPoolName` and validate them at apply time; the apply flow now fails fast if these values are missing (`ApplicationUpdateApplyService`).
- Pass resolved `SiteName` and `AppPoolName` to the external bootstrapper invocation (`-SiteName` / `-AppPoolName`) so the bootstrapper can stop the correct IIS site/app-pool (`ExternalUpdaterProcessLauncher` and `ApplicationUpdateApplyService`).
- Harden the bootstrapper (`scripts/run-staged-update-bootstrapper.ps1`) to validate required IIS identity, create `app_offline.htm`, stop IIS app pool/site, and poll `Get-WebAppPoolState`/`Get-WebsiteState` until both report `Stopped` or a bounded timeout (`45s`) elapses, with clear logging and an explicit timeout failure.
- Add a conservative retry helper (`Invoke-WithRetry`) in the bootstrapper and wrap stale-path removal and payload copy operations with bounded retries (5 attempts, 750ms delay) and logging to tolerate transient locked-file conditions.

### Testing
- Added unit tests in `ApplicationUpdateApplyServiceTests` to assert that `SiteName`/`AppPoolName` are passed to the launcher and that missing IIS identity values cause a clear `InvalidOperationException` (new test `RequestApplyAsync_ThrowsWhenIisIdentityValuesAreMissing`).
- Ran unit tests: `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj --filter "FullyQualifiedName~ApplicationUpdateApplyServiceTests"` and the suite passed (4 tests passed).
- Manual script-level validation performed by exercising the bootstrapper logic in development; bootstrapper now logs resolved IIS identity values and reports stop confirmation or a bounded timeout if the stop does not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f96fc204832a84a11e3acabf416b)