### PR TITLE
Auto-detect IIS site/app pool identity in application updater

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateApplyServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateApplyServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using PingMonitor.Web.Options;
 using PingMonitor.Web.Services.ApplicationMetadata;
@@ -164,7 +165,7 @@ public sealed class ApplicationUpdateApplyServiceTests
     }
 
     [Fact]
-    public async Task RequestApplyAsync_ThrowsWhenIisIdentityValuesAreMissing()
+    public async Task RequestApplyAsync_UsesAppPoolFallbackForSiteWhenIisLookupsDoNotResolveSite()
     {
         var contentRoot = CreateTempRoot();
         try
@@ -195,10 +196,171 @@ public sealed class ApplicationUpdateApplyServiceTests
             }, CancellationToken.None);
 
             var launcher = new RecordingLauncher();
-            var service = BuildService(contentRoot, store, launcher, iisSiteName: "", iisAppPoolName: "");
+            var iisReader = new StubIisMetadataReader
+            {
+                SiteNameFromPhysicalPath = null,
+                SiteNameFromAppPool = null
+            };
 
+            Environment.SetEnvironmentVariable("APP_POOL_ID", "DetectedPool");
+            var service = BuildService(contentRoot, store, launcher, iisSiteName: "", iisAppPoolName: "", iisMetadataReader: iisReader);
+
+            var result = await service.RequestApplyAsync("admin-user", CancellationToken.None);
+            Assert.NotNull(result);
+            Assert.Equal("DetectedPool", launcher.AppPoolName);
+            Assert.Equal("DetectedPool", launcher.SiteName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("APP_POOL_ID", null);
+            Directory.Delete(contentRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RequestApplyAsync_UsesCustomSiteMappedFromAppPool()
+    {
+        var contentRoot = CreateTempRoot();
+        try
+        {
+            var stagingRoot = Path.Combine(contentRoot, "App_Data", "Updater");
+            Directory.CreateDirectory(Path.Combine(stagingRoot, "state"));
+            Directory.CreateDirectory(Path.Combine(contentRoot, "Updater"));
+
+            var bootstrapperPath = Path.Combine(contentRoot, "Updater", "run-staged-update-bootstrapper.ps1");
+            await File.WriteAllTextAsync(bootstrapperPath, "# bootstrapper");
+
+            var zipPath = Path.Combine(stagingRoot, "staged", "current", "pkg.zip");
+            Directory.CreateDirectory(Path.GetDirectoryName(zipPath)!);
+            await File.WriteAllTextAsync(zipPath, "zip");
+
+            var metadataPath = Path.Combine(stagingRoot, "state", "staged-update.json");
+            await File.WriteAllTextAsync(metadataPath, "{}");
+
+            var store = BuildStateStore(contentRoot);
+            await store.WriteAsync(new ApplicationUpdateStagingState
+            {
+                SourceRepository = "ijyates1992/ping-monitor",
+                ReleaseTag = "V1.2.3",
+                StagedZipPath = zipPath,
+                ChecksumVerified = true,
+                Status = ApplicationUpdateStagingStatus.Ready,
+                LastUpdatedAtUtc = DateTimeOffset.UtcNow
+            }, CancellationToken.None);
+
+            var launcher = new RecordingLauncher();
+            var iisReader = new StubIisMetadataReader { SiteNameFromAppPool = "CustomSiteName" };
+
+            Environment.SetEnvironmentVariable("APP_POOL_ID", "CustomPoolName");
+            var service = BuildService(contentRoot, store, launcher, iisSiteName: "", iisAppPoolName: "", iisMetadataReader: iisReader);
+
+            var result = await service.RequestApplyAsync("admin-user", CancellationToken.None);
+            Assert.NotNull(result);
+            Assert.Equal("CustomPoolName", launcher.AppPoolName);
+            Assert.Equal("CustomSiteName", launcher.SiteName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("APP_POOL_ID", null);
+            Directory.Delete(contentRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RequestApplyAsync_ResolvesStandardIisInstallIdentityWhenConfigMissing()
+    {
+        var contentRoot = CreateTempRoot();
+        try
+        {
+            var stagingRoot = Path.Combine(contentRoot, "App_Data", "Updater");
+            Directory.CreateDirectory(Path.Combine(stagingRoot, "state"));
+            Directory.CreateDirectory(Path.Combine(contentRoot, "Updater"));
+
+            var bootstrapperPath = Path.Combine(contentRoot, "Updater", "run-staged-update-bootstrapper.ps1");
+            await File.WriteAllTextAsync(bootstrapperPath, "# bootstrapper");
+
+            var zipPath = Path.Combine(stagingRoot, "staged", "current", "pkg.zip");
+            Directory.CreateDirectory(Path.GetDirectoryName(zipPath)!);
+            await File.WriteAllTextAsync(zipPath, "zip");
+
+            var metadataPath = Path.Combine(stagingRoot, "state", "staged-update.json");
+            await File.WriteAllTextAsync(metadataPath, "{}");
+
+            var store = BuildStateStore(contentRoot);
+            await store.WriteAsync(new ApplicationUpdateStagingState
+            {
+                SourceRepository = "ijyates1992/ping-monitor",
+                ReleaseTag = "V1.2.3",
+                StagedZipPath = zipPath,
+                ChecksumVerified = true,
+                Status = ApplicationUpdateStagingStatus.Ready,
+                LastUpdatedAtUtc = DateTimeOffset.UtcNow
+            }, CancellationToken.None);
+
+            var launcher = new RecordingLauncher();
+            var iisReader = new StubIisMetadataReader { SiteNameFromPhysicalPath = "PingMonitor" };
+            Environment.SetEnvironmentVariable("APP_POOL_ID", "PingMonitor");
+
+            var service = BuildService(contentRoot, store, launcher, iisSiteName: "", iisAppPoolName: "", iisMetadataReader: iisReader);
+            var result = await service.RequestApplyAsync("admin-user", CancellationToken.None);
+            Assert.NotNull(result);
+            Assert.Equal("PingMonitor", launcher.SiteName);
+            Assert.Equal("PingMonitor", launcher.AppPoolName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("APP_POOL_ID", null);
+            Directory.Delete(contentRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RequestApplyAsync_ThrowsWhenIisIdentityCannotBeResolvedInNonIisContext()
+    {
+        var contentRoot = CreateTempRoot();
+        try
+        {
+            var stagingRoot = Path.Combine(contentRoot, "App_Data", "Updater");
+            Directory.CreateDirectory(Path.Combine(stagingRoot, "state"));
+            Directory.CreateDirectory(Path.Combine(contentRoot, "Updater"));
+
+            var bootstrapperPath = Path.Combine(contentRoot, "Updater", "run-staged-update-bootstrapper.ps1");
+            await File.WriteAllTextAsync(bootstrapperPath, "# bootstrapper");
+
+            var zipPath = Path.Combine(stagingRoot, "staged", "current", "pkg.zip");
+            Directory.CreateDirectory(Path.GetDirectoryName(zipPath)!);
+            await File.WriteAllTextAsync(zipPath, "zip");
+
+            var metadataPath = Path.Combine(stagingRoot, "state", "staged-update.json");
+            await File.WriteAllTextAsync(metadataPath, "{}");
+
+            var store = BuildStateStore(contentRoot);
+            await store.WriteAsync(new ApplicationUpdateStagingState
+            {
+                SourceRepository = "ijyates1992/ping-monitor",
+                ReleaseTag = "V1.2.3",
+                StagedZipPath = zipPath,
+                ChecksumVerified = true,
+                Status = ApplicationUpdateStagingStatus.Ready,
+                LastUpdatedAtUtc = DateTimeOffset.UtcNow
+            }, CancellationToken.None);
+
+            var launcher = new RecordingLauncher();
+            var iisReader = new StubIisMetadataReader
+            {
+                SiteNameFromPhysicalPath = null,
+                SiteNameFromAppPool = null,
+                Error = "No IIS runtime context."
+            };
+
+            Environment.SetEnvironmentVariable("APP_POOL_ID", null);
+            Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", null);
+
+            var service = BuildService(contentRoot, store, launcher, iisSiteName: "", iisAppPoolName: "", iisMetadataReader: iisReader);
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.RequestApplyAsync("admin-user", CancellationToken.None));
+            Assert.Contains("IIS identity resolution failed", exception.Message);
             Assert.Contains("ApplicationUpdater:IisSiteName", exception.Message);
+            Assert.Contains("ApplicationUpdater:IisAppPoolName", exception.Message);
         }
         finally
         {
@@ -213,7 +375,8 @@ public sealed class ApplicationUpdateApplyServiceTests
         string currentVersion = "V1.0.0",
         StartupMode startupMode = StartupMode.Normal,
         string iisSiteName = "PingMonitor",
-        string iisAppPoolName = "PingMonitorPool")
+        string iisAppPoolName = "PingMonitorPool",
+        IIisMetadataReader? iisMetadataReader = null)
     {
         var options = Microsoft.Extensions.Options.Options.Create(new ApplicationUpdaterOptions
         {
@@ -230,7 +393,30 @@ public sealed class ApplicationUpdateApplyServiceTests
             new StubStartupGateRuntimeState(startupMode),
             launcher,
             new StubWebHostEnvironment(contentRoot),
-            options);
+            options,
+            NullLogger<ApplicationUpdateApplyService>.Instance,
+            iisMetadataReader);
+    }
+
+    private sealed class StubIisMetadataReader : IIisMetadataReader
+    {
+        public string? SiteNameFromPhysicalPath { get; set; }
+        public string? SiteNameFromAppPool { get; set; }
+        public string? Error { get; set; }
+
+        public bool TryResolveSiteNameFromPhysicalPath(string normalizedInstallRootPath, out string? siteName, out string? errorMessage)
+        {
+            siteName = SiteNameFromPhysicalPath;
+            errorMessage = Error;
+            return !string.IsNullOrWhiteSpace(siteName);
+        }
+
+        public bool TryResolveSiteNameFromAppPool(string appPoolName, out string? siteName, out string? errorMessage)
+        {
+            siteName = SiteNameFromAppPool;
+            errorMessage = Error;
+            return !string.IsNullOrWhiteSpace(siteName);
+        }
     }
 
     private static ApplicationUpdateStagingStateStore BuildStateStore(string contentRoot)

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateApplyService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateApplyService.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
+using System.Reflection;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using PingMonitor.Web.Options;
 using PingMonitor.Web.Services.ApplicationMetadata;
@@ -167,6 +169,167 @@ internal sealed class ExternalUpdaterProcessLauncher : IExternalUpdaterProcessLa
     }
 }
 
+internal interface IIisMetadataReader
+{
+    bool TryResolveSiteNameFromPhysicalPath(string normalizedInstallRootPath, out string? siteName, out string? errorMessage);
+    bool TryResolveSiteNameFromAppPool(string appPoolName, out string? siteName, out string? errorMessage);
+}
+
+internal sealed class IisMetadataReader : IIisMetadataReader
+{
+    public bool TryResolveSiteNameFromPhysicalPath(string normalizedInstallRootPath, out string? siteName, out string? errorMessage)
+    {
+        return TryResolveSiteName(
+            site =>
+            {
+                var physicalPath = GetRootPhysicalPath(site);
+                if (string.IsNullOrWhiteSpace(physicalPath))
+                {
+                    return false;
+                }
+
+                return string.Equals(
+                    NormalizePath(physicalPath),
+                    normalizedInstallRootPath,
+                    StringComparison.OrdinalIgnoreCase);
+            },
+            out siteName,
+            out errorMessage);
+    }
+
+    public bool TryResolveSiteNameFromAppPool(string appPoolName, out string? siteName, out string? errorMessage)
+    {
+        return TryResolveSiteName(
+            site => string.Equals(GetRootApplicationPoolName(site), appPoolName, StringComparison.OrdinalIgnoreCase),
+            out siteName,
+            out errorMessage);
+    }
+
+    private static bool TryResolveSiteName(Func<object, bool> matcher, out string? siteName, out string? errorMessage)
+    {
+        siteName = null;
+        errorMessage = null;
+
+        if (!OperatingSystem.IsWindows())
+        {
+            errorMessage = "IIS metadata lookup is only supported on Windows hosts.";
+            return false;
+        }
+
+        try
+        {
+            var serverManagerType = Type.GetType("Microsoft.Web.Administration.ServerManager, Microsoft.Web.Administration");
+            if (serverManagerType is null)
+            {
+                errorMessage = "Microsoft.Web.Administration assembly is not available.";
+                return false;
+            }
+
+            using var serverManager = Activator.CreateInstance(serverManagerType) as IDisposable;
+            if (serverManager is null)
+            {
+                errorMessage = "Failed to construct Microsoft.Web.Administration.ServerManager.";
+                return false;
+            }
+
+            var sitesProperty = serverManagerType.GetProperty("Sites", BindingFlags.Public | BindingFlags.Instance);
+            var sites = sitesProperty?.GetValue(serverManager);
+            if (sites is not System.Collections.IEnumerable enumerableSites)
+            {
+                errorMessage = "Could not enumerate IIS sites from ServerManager.";
+                return false;
+            }
+
+            foreach (var site in enumerableSites)
+            {
+                if (site is null || !matcher(site))
+                {
+                    continue;
+                }
+
+                var name = site.GetType().GetProperty("Name", BindingFlags.Public | BindingFlags.Instance)?.GetValue(site) as string;
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    siteName = name;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        catch (Exception ex)
+        {
+            errorMessage = ex.Message;
+            return false;
+        }
+    }
+
+    private static object? GetRootApplication(object site)
+    {
+        var applications = site.GetType().GetProperty("Applications", BindingFlags.Public | BindingFlags.Instance)?.GetValue(site);
+        if (applications is null)
+        {
+            return null;
+        }
+
+        var indexer = applications.GetType()
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(property =>
+            {
+                var indexes = property.GetIndexParameters();
+                return indexes.Length == 1 && indexes[0].ParameterType == typeof(string);
+            });
+
+        return indexer?.GetValue(applications, ["/"]);
+    }
+
+    private static string? GetRootApplicationPoolName(object site)
+    {
+        var rootApplication = GetRootApplication(site);
+        return rootApplication?.GetType().GetProperty("ApplicationPoolName", BindingFlags.Public | BindingFlags.Instance)
+            ?.GetValue(rootApplication) as string;
+    }
+
+    private static string? GetRootPhysicalPath(object site)
+    {
+        var rootApplication = GetRootApplication(site);
+        if (rootApplication is null)
+        {
+            return null;
+        }
+
+        var virtualDirectories = rootApplication.GetType().GetProperty("VirtualDirectories", BindingFlags.Public | BindingFlags.Instance)
+            ?.GetValue(rootApplication);
+        if (virtualDirectories is null)
+        {
+            return null;
+        }
+
+        var indexer = virtualDirectories.GetType()
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(property =>
+            {
+                var indexes = property.GetIndexParameters();
+                return indexes.Length == 1 && indexes[0].ParameterType == typeof(string);
+            });
+
+        var rootVirtualDirectory = indexer?.GetValue(virtualDirectories, ["/"]);
+        return rootVirtualDirectory?.GetType().GetProperty("PhysicalPath", BindingFlags.Public | BindingFlags.Instance)
+            ?.GetValue(rootVirtualDirectory) as string;
+    }
+
+    private static string NormalizePath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return string.Empty;
+        }
+
+        var fullPath = Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return fullPath.Length == 0 ? Path.DirectorySeparatorChar.ToString() : fullPath;
+    }
+}
+
 internal sealed class ApplicationUpdateApplyService : IApplicationUpdateApplyService
 {
     private static readonly JsonSerializerOptions ExternalStatusSerializerOptions = new()
@@ -178,8 +341,10 @@ internal sealed class ApplicationUpdateApplyService : IApplicationUpdateApplySer
     private readonly IApplicationMetadataProvider _applicationMetadataProvider;
     private readonly IStartupGateRuntimeState _startupGateRuntimeState;
     private readonly IExternalUpdaterProcessLauncher _launcher;
+    private readonly IIisMetadataReader _iisMetadataReader;
     private readonly IWebHostEnvironment _environment;
     private readonly ApplicationUpdaterOptions _options;
+    private readonly ILogger<ApplicationUpdateApplyService> _logger;
 
     public ApplicationUpdateApplyService(
         IApplicationUpdateStagingStateStore stagingStateStore,
@@ -187,7 +352,9 @@ internal sealed class ApplicationUpdateApplyService : IApplicationUpdateApplySer
         IStartupGateRuntimeState startupGateRuntimeState,
         IExternalUpdaterProcessLauncher launcher,
         IWebHostEnvironment environment,
-        IOptions<ApplicationUpdaterOptions> options)
+        IOptions<ApplicationUpdaterOptions> options,
+        ILogger<ApplicationUpdateApplyService> logger,
+        IIisMetadataReader? iisMetadataReader = null)
     {
         _stagingStateStore = stagingStateStore;
         _applicationMetadataProvider = applicationMetadataProvider;
@@ -195,6 +362,8 @@ internal sealed class ApplicationUpdateApplyService : IApplicationUpdateApplySer
         _launcher = launcher;
         _environment = environment;
         _options = options.Value;
+        _logger = logger;
+        _iisMetadataReader = iisMetadataReader ?? new IisMetadataReader();
     }
 
     public async Task<ApplicationUpdateStagingState?> RequestApplyAsync(string requestedByUserId, CancellationToken cancellationToken)
@@ -217,14 +386,16 @@ internal sealed class ApplicationUpdateApplyService : IApplicationUpdateApplySer
 
         var externalStatusPath = Path.Combine(stagingRoot, "state", "external-updater-status.json");
         var externalLogPath = Path.Combine(stagingRoot, "state", "external-updater.log");
-        var siteName = ResolveRequiredIisIdentityValue(
-            _options.IisSiteName,
-            nameof(ApplicationUpdaterOptions.IisSiteName),
-            "ApplicationUpdater:IisSiteName");
-        var appPoolName = ResolveRequiredIisIdentityValue(
-            _options.IisAppPoolName,
-            nameof(ApplicationUpdaterOptions.IisAppPoolName),
-            "ApplicationUpdater:IisAppPoolName");
+        _logger.LogInformation("Attempting IIS identity resolution for application updater launch.");
+        var appPoolName = ResolveAppPoolName();
+        var siteName = ResolveSiteName(installRootPath, appPoolName);
+        if (string.IsNullOrWhiteSpace(siteName) && string.IsNullOrWhiteSpace(appPoolName))
+        {
+            throw new InvalidOperationException(
+                "Application updater cannot launch because IIS identity resolution failed. " +
+                "Attempted strategies: APP_POOL_ID, ApplicationUpdater:IisSiteName, WEBSITE_SITE_NAME, IIS site lookup by physical path, IIS site lookup by app pool. " +
+                "Configure ApplicationUpdater:IisSiteName and ApplicationUpdater:IisAppPoolName manually in appsettings when automatic detection is unavailable.");
+        }
 
         ValidateApplyPrerequisites(current, stagedMetadataPath, bootstrapperPath);
 
@@ -276,8 +447,8 @@ internal sealed class ApplicationUpdateApplyService : IApplicationUpdateApplySer
             bootstrapperPath,
             stagedMetadataPath,
             installRootPath,
-            siteName,
-            appPoolName,
+            siteName!,
+            appPoolName!,
             externalStatusPath,
             externalLogPath,
             current.ReleaseTag,
@@ -439,15 +610,122 @@ internal sealed class ApplicationUpdateApplyService : IApplicationUpdateApplySer
             : Path.GetFullPath(configuredPath, _environment.ContentRootPath);
     }
 
-    private static string ResolveRequiredIisIdentityValue(string configuredValue, string optionName, string configurationKey)
+    private string ResolveAppPoolName()
     {
-        if (string.IsNullOrWhiteSpace(configuredValue))
+        if (!string.IsNullOrWhiteSpace(_options.IisAppPoolName))
         {
-            throw new InvalidOperationException(
-                $"Application updater cannot launch because required IIS identity value '{optionName}' is not configured. Set '{configurationKey}' to a non-empty value.");
+            var configured = _options.IisAppPoolName.Trim();
+            _logger.LogInformation("Using configured IIS app pool name '{AppPoolName}' from ApplicationUpdater:IisAppPoolName.", configured);
+            return configured;
         }
 
-        return configuredValue.Trim();
+        var appPoolId = Environment.GetEnvironmentVariable("APP_POOL_ID");
+        if (string.IsNullOrWhiteSpace(appPoolId))
+        {
+            _logger.LogWarning("APP_POOL_ID environment variable is not available; app pool identity remains unresolved.");
+            return string.Empty;
+        }
+
+        var resolved = appPoolId.Trim();
+        _logger.LogInformation("Found APP_POOL_ID = '{AppPoolName}'.", resolved);
+        return resolved;
+    }
+
+    private string ResolveSiteName(string installRootPath, string appPoolName)
+    {
+        if (!string.IsNullOrWhiteSpace(_options.IisSiteName))
+        {
+            var configured = _options.IisSiteName.Trim();
+            _logger.LogInformation("Using configured IIS site name '{SiteName}' from ApplicationUpdater:IisSiteName.", configured);
+            return configured;
+        }
+
+        var websiteSiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+        if (!string.IsNullOrWhiteSpace(websiteSiteName))
+        {
+            var resolvedFromEnvironment = websiteSiteName.Trim();
+            _logger.LogInformation("Resolved IIS site name from WEBSITE_SITE_NAME = '{SiteName}'.", resolvedFromEnvironment);
+            return resolvedFromEnvironment;
+        }
+
+        _logger.LogInformation("Attempting site resolution via physical path lookup.");
+        var resolvedFromPath = ResolveSiteFromPhysicalPath(installRootPath);
+        if (!string.IsNullOrWhiteSpace(resolvedFromPath))
+        {
+            return resolvedFromPath;
+        }
+
+        if (!string.IsNullOrWhiteSpace(appPoolName))
+        {
+            _logger.LogInformation("Attempting site resolution via IIS app-pool mapping.");
+            var resolvedFromAppPool = ResolveSiteFromAppPool(appPoolName);
+            if (!string.IsNullOrWhiteSpace(resolvedFromAppPool))
+            {
+                return resolvedFromAppPool;
+            }
+
+            _logger.LogWarning(
+                "IIS site name could not be determined; using app pool name '{AppPoolName}' as fallback.",
+                appPoolName);
+            return appPoolName;
+        }
+
+        _logger.LogWarning("Could not resolve IIS site name from configuration, environment, or IIS metadata.");
+        return string.Empty;
+    }
+
+    private string ResolveSiteFromPhysicalPath(string installRootPath)
+    {
+        var normalizedInstallRootPath = NormalizePath(installRootPath);
+        if (_iisMetadataReader.TryResolveSiteNameFromPhysicalPath(normalizedInstallRootPath, out var siteName, out var errorMessage) &&
+            !string.IsNullOrWhiteSpace(siteName))
+        {
+            _logger.LogInformation("Matched IIS site '{SiteName}' via physical path.", siteName);
+            return siteName.Trim();
+        }
+
+        if (string.IsNullOrWhiteSpace(errorMessage))
+        {
+            _logger.LogWarning("Could not resolve site via IIS physical-path lookup.");
+        }
+        else
+        {
+            _logger.LogWarning("Could not resolve site via IIS physical-path lookup: {ErrorMessage}", errorMessage);
+        }
+
+        return string.Empty;
+    }
+
+    private string ResolveSiteFromAppPool(string appPoolName)
+    {
+        if (_iisMetadataReader.TryResolveSiteNameFromAppPool(appPoolName, out var siteName, out var errorMessage) &&
+            !string.IsNullOrWhiteSpace(siteName))
+        {
+            _logger.LogInformation("Matched IIS site '{SiteName}' via app pool '{AppPoolName}'.", siteName, appPoolName);
+            return siteName.Trim();
+        }
+
+        if (string.IsNullOrWhiteSpace(errorMessage))
+        {
+            _logger.LogWarning("Could not resolve site via IIS app-pool lookup for '{AppPoolName}'.", appPoolName);
+        }
+        else
+        {
+            _logger.LogWarning("Could not resolve site via IIS app-pool lookup for '{AppPoolName}': {ErrorMessage}", appPoolName, errorMessage);
+        }
+
+        return string.Empty;
+    }
+
+    private static string NormalizePath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return string.Empty;
+        }
+
+        var fullPath = Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return fullPath.Length == 0 ? Path.DirectorySeparatorChar.ToString() : fullPath;
     }
 
     private static ApplicationUpdateStagingState CloneState(


### PR DESCRIPTION
### Motivation

- The updater currently requires fragile, manual IIS identity values in configuration which often fail in IIS deployments. 
- The change aims to reduce reliance on appsettings values by deterministically discovering the IIS `Site` and `AppPool` at runtime while preserving manual overrides. 
- The behavior must be safe for non-IIS contexts and provide clear diagnostics and fallback semantics. 

### Description

- Added an `IIisMetadataReader` abstraction and a default `IisMetadataReader` that loads `Microsoft.Web.Administration.ServerManager` at runtime and enumerates sites and apps to support physical-path and app-pool lookups. 
- Refactored identity resolution into helpers: `ResolveAppPoolName()`, `ResolveSiteName()`, `ResolveSiteFromPhysicalPath()`, `ResolveSiteFromAppPool()`, and `NormalizePath()` and integrated them into `ApplicationUpdateApplyService` apply flow. 
- Resolution strategy implemented (in order): config override `ApplicationUpdater:IisSiteName`, environment `WEBSITE_SITE_NAME`, IIS physical-path match, IIS app-pool→site mapping, and final fallback of using the app pool name as the site name when appropriate; `APP_POOL_ID` is used as authoritative app-pool source when config is empty. 
- Added structured logging for each step and warnings for fallback or unresolved states, and ensured manual configuration still overrides auto-detection. 
- Tests were added/updated to validate auto-detection, app-pool fallback, app-pool→site mapping, standard IIS install behavior, and graceful failure in non-IIS contexts. 
- Fixes #431

### Testing

- Ran the unit test suite with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj`, and the run completed successfully with all tests passing (`Passed: 24, Failed: 0`). 
- New/updated tests in `ApplicationUpdateApplyServiceTests` cover the auto-detection paths: `RequestApplyAsync_UsesAppPoolFallbackForSiteWhenIisLookupsDoNotResolveSite`, `RequestApplyAsync_UsesCustomSiteMappedFromAppPool`, `RequestApplyAsync_ResolvesStandardIisInstallIdentityWhenConfigMissing`, and `RequestApplyAsync_ThrowsWhenIisIdentityCannotBeResolvedInNonIisContext`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e901d4ac08832aba10ad6de99e0c4c)