### PR TITLE
Fix bootstrapper parser error and enforce pwsh -ExecutionPolicy Bypass -File launch

### DIFF
--- a/scripts/run-staged-update-bootstrapper.ps1
+++ b/scripts/run-staged-update-bootstrapper.ps1
@@ -259,7 +259,7 @@ function Invoke-WithRetry {
                 throw
             }
 
-            Write-Log "$Description failed on attempt $attempt of $MaxAttempts: $($_.Exception.Message). Retrying after ${DelayMilliseconds}ms."
+            Write-Log (("{0} failed on attempt {1} of {2}: {3}. Retrying after {4}ms." -f $Description, $attempt, $MaxAttempts, $_.Exception.Message, $DelayMilliseconds))
             Start-Sleep -Milliseconds $DelayMilliseconds
         }
     }

--- a/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateApplyServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateApplyServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Diagnostics;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -13,6 +14,107 @@ namespace PingMonitor.Web.Tests;
 
 public sealed class ApplicationUpdateApplyServiceTests
 {
+    [Fact]
+    public void ExternalUpdaterProcessLauncher_TryLaunch_UsesExecutionPolicyBypassAndFile_WithArgumentList()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var tempRoot = CreateTempRoot();
+        try
+        {
+            var argsCapturePath = Path.Combine(tempRoot, "captured-args.json");
+            var executablePath = Path.Combine(tempRoot, "record-args");
+            var bootstrapperPath = Path.Combine(tempRoot, "Updater", "run-staged-update-bootstrapper.ps1");
+            var installRootPath = Path.Combine(tempRoot, "install root");
+            Directory.CreateDirectory(installRootPath);
+            Directory.CreateDirectory(Path.GetDirectoryName(bootstrapperPath)!);
+            File.WriteAllText(bootstrapperPath, "# bootstrapper");
+
+            var recorderScript = """
+                #!/usr/bin/env python3
+                import json
+                import pathlib
+                import sys
+                output = pathlib.Path(r'__ARGS_CAPTURE_PATH__')
+                output.write_text(json.dumps(sys.argv[1:]))
+                """;
+            File.WriteAllText(executablePath, recorderScript.Replace("__ARGS_CAPTURE_PATH__", argsCapturePath.Replace("\\", "\\\\")));
+            File.SetUnixFileMode(
+                executablePath,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+
+            var launcher = new ExternalUpdaterProcessLauncher();
+            var launched = launcher.TryLaunch(
+                powerShellExecutablePath: executablePath,
+                bootstrapperScriptPath: bootstrapperPath,
+                stagedMetadataPath: Path.Combine(tempRoot, "state folder", "staged update.json"),
+                installRootPath: installRootPath,
+                siteName: "Ping Monitor Site",
+                appPoolName: "Ping Monitor Pool",
+                statusJsonPath: argsCapturePath,
+                logPath: Path.Combine(tempRoot, "logs", "external updater.log"),
+                expectedReleaseTag: "V1.2.3",
+                out var processId,
+                out var launchErrorMessage);
+
+            Assert.True(launched);
+            Assert.Null(launchErrorMessage);
+            Assert.NotNull(processId);
+
+            var timeoutUtc = DateTimeOffset.UtcNow.AddSeconds(5);
+            while (!File.Exists(argsCapturePath) && DateTimeOffset.UtcNow < timeoutUtc)
+            {
+                Thread.Sleep(50);
+            }
+
+            Assert.True(File.Exists(argsCapturePath), "Argument capture file was not written by recorder process.");
+
+            var capturedArgs = JsonSerializer.Deserialize<string[]>(File.ReadAllText(argsCapturePath));
+            Assert.NotNull(capturedArgs);
+            Assert.Equal("-NoProfile", capturedArgs![0]);
+            Assert.Equal("-ExecutionPolicy", capturedArgs[1]);
+            Assert.Equal("Bypass", capturedArgs[2]);
+            Assert.Equal("-File", capturedArgs[3]);
+            Assert.Equal(bootstrapperPath, capturedArgs[4]);
+            Assert.Equal("-StagedMetadataPath", capturedArgs[5]);
+            Assert.Equal(Path.Combine(tempRoot, "state folder", "staged update.json"), capturedArgs[6]);
+            Assert.Equal("-InstallRootPath", capturedArgs[7]);
+            Assert.Equal(installRootPath, capturedArgs[8]);
+            Assert.Equal("-SiteName", capturedArgs[9]);
+            Assert.Equal("Ping Monitor Site", capturedArgs[10]);
+            Assert.Equal("-AppPoolName", capturedArgs[11]);
+            Assert.Equal("Ping Monitor Pool", capturedArgs[12]);
+            Assert.Equal("-StatusJsonPath", capturedArgs[13]);
+            Assert.Equal(argsCapturePath, capturedArgs[14]);
+            Assert.Equal("-LogPath", capturedArgs[15]);
+            Assert.Equal(Path.Combine(tempRoot, "logs", "external updater.log"), capturedArgs[16]);
+            Assert.Equal("-ExpectedReleaseTag", capturedArgs[17]);
+            Assert.Equal("V1.2.3", capturedArgs[18]);
+
+            if (processId is int launchedProcessId)
+            {
+                try
+                {
+                    using var process = Process.GetProcessById(launchedProcessId);
+                    process.WaitForExit(5000);
+                }
+                catch (ArgumentException)
+                {
+                    // Process may already have exited between capture and lookup.
+                }
+            }
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
     [Fact]
     public async Task RequestApplyAsync_UsesExplicitResolvedPaths_AndWritesHandoffState()
     {


### PR DESCRIPTION
### Motivation

- The bootstrapper failed immediately under PowerShell 7 with a parser error caused by a fragile interpolated string where a variable was immediately followed by `:`.  
- The launcher must explicitly invoke PowerShell with `-ExecutionPolicy Bypass -File` to avoid execution-policy and parsing quirks when launching the bootstrapper.  
- Fixes #427.

### Description

- Replace the fragile interpolated retry log string in `scripts/run-staged-update-bootstrapper.ps1` with a safe format expression using `-f` to avoid PowerShell variable parsing ambiguity.  
- Add a focused regression test `ExternalUpdaterProcessLauncher_TryLaunch_UsesExecutionPolicyBypassAndFile_WithArgumentList` in `src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateApplyServiceTests.cs` that runs on non-Windows hosts and verifies the launcher composes `-NoProfile`, `-ExecutionPolicy`, `Bypass`, `-File`, the script path, and subsequent named script arguments via `ProcessStartInfo.ArgumentList`.  
- Keep launcher semantics unchanged aside from verifying explicit argument composition and safe token-by-token argument passing so paths with spaces remain safe.

### Testing

- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the build succeeded.  
- Ran the new focused test with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj --filter "FullyQualifiedName~ApplicationUpdateApplyServiceTests.ExternalUpdaterProcessLauncher_TryLaunch_UsesExecutionPolicyBypassAndFile_WithArgumentList"` and it passed.  
- Manually validated the bootstrapper now parses under `pwsh -ExecutionPolicy Bypass -File scripts/run-staged-update-bootstrapper.ps1 -StagedMetadataPath /tmp/nope.json -InstallRootPath /tmp -DryRun`, which advanced to the expected runtime validation error about the missing staged metadata file rather than failing with a parser error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92e75e294832ab1a2e3673a091f4f)