### PR TITLE
Persist updater operational settings and expose them on Admin Updater page

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/AdminApplicationUpdaterController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminApplicationUpdaterController.cs
@@ -19,6 +19,7 @@ public sealed class AdminApplicationUpdaterController : Controller
     private readonly IApplicationUpdateStagingService _applicationUpdateStagingService;
     private readonly IApplicationUpdateApplyService _applicationUpdateApplyService;
     private readonly IApplicationUpdaterRuntimeStateStore _runtimeStateStore;
+    private readonly IApplicationUpdaterOperationalSettingsService _operationalSettingsService;
     private readonly IPowerShellPrerequisiteDetector _powerShellPrerequisiteDetector;
     private readonly ApplicationUpdaterOptions _updaterOptions;
 
@@ -28,6 +29,7 @@ public sealed class AdminApplicationUpdaterController : Controller
         IApplicationUpdateStagingService applicationUpdateStagingService,
         IApplicationUpdateApplyService applicationUpdateApplyService,
         IApplicationUpdaterRuntimeStateStore runtimeStateStore,
+        IApplicationUpdaterOperationalSettingsService operationalSettingsService,
         IPowerShellPrerequisiteDetector powerShellPrerequisiteDetector,
         IOptions<ApplicationUpdaterOptions> updaterOptions)
     {
@@ -36,6 +38,7 @@ public sealed class AdminApplicationUpdaterController : Controller
         _applicationUpdateStagingService = applicationUpdateStagingService;
         _applicationUpdateApplyService = applicationUpdateApplyService;
         _runtimeStateStore = runtimeStateStore;
+        _operationalSettingsService = operationalSettingsService;
         _powerShellPrerequisiteDetector = powerShellPrerequisiteDetector;
         _updaterOptions = updaterOptions.Value;
     }
@@ -43,14 +46,15 @@ public sealed class AdminApplicationUpdaterController : Controller
     [HttpGet]
     public async Task<IActionResult> Index(CancellationToken cancellationToken)
     {
+        var operationalSettings = await _operationalSettingsService.GetCurrentAsync(cancellationToken);
         var currentVersion = _applicationMetadataProvider.GetSnapshot().Version;
         var result = _updaterOptions.UpdateChecksEnabled
-            ? ApplicationUpdateCheckResult.NotPerformed(currentVersion, _updaterOptions.AllowPreviewReleases)
-            : ApplicationUpdateCheckResult.Disabled(currentVersion, _updaterOptions.AllowPreviewReleases);
+            ? ApplicationUpdateCheckResult.NotPerformed(currentVersion, operationalSettings.AllowPreviewReleases)
+            : ApplicationUpdateCheckResult.Disabled(currentVersion, operationalSettings.AllowPreviewReleases);
 
         var staged = await _applicationUpdateApplyService.RefreshApplyStateAsync(cancellationToken);
         var runtimeState = await _runtimeStateStore.ReadAsync(cancellationToken);
-        return View("Index", ToViewModel(result, staged, runtimeState));
+        return View("Index", ToViewModel(result, staged, runtimeState, operationalSettings, saved: false));
     }
 
     [HttpPost("check")]
@@ -58,9 +62,10 @@ public sealed class AdminApplicationUpdaterController : Controller
     public async Task<IActionResult> Check([FromForm] bool allowPreviewReleases, CancellationToken cancellationToken)
     {
         var result = await _applicationUpdateDetectionService.CheckForUpdatesAsync(allowPreviewReleases, cancellationToken);
+        var operationalSettings = await _operationalSettingsService.GetCurrentAsync(cancellationToken);
         var staged = await _applicationUpdateApplyService.RefreshApplyStateAsync(cancellationToken);
         var runtimeState = await _runtimeStateStore.ReadAsync(cancellationToken);
-        return View("Index", ToViewModel(result, staged, runtimeState));
+        return View("Index", ToViewModel(result, staged, runtimeState, operationalSettings, saved: false));
     }
 
     [HttpPost("stage")]
@@ -69,9 +74,10 @@ public sealed class AdminApplicationUpdaterController : Controller
     {
         await _applicationUpdateStagingService.StageLatestApplicableReleaseAsync(allowPreviewReleases, cancellationToken);
         var result = await _applicationUpdateDetectionService.CheckForUpdatesAsync(allowPreviewReleases, cancellationToken);
+        var operationalSettings = await _operationalSettingsService.GetCurrentAsync(cancellationToken);
         var staged = await _applicationUpdateApplyService.RefreshApplyStateAsync(cancellationToken);
         var runtimeState = await _runtimeStateStore.ReadAsync(cancellationToken);
-        return View("Index", ToViewModel(result, staged, runtimeState));
+        return View("Index", ToViewModel(result, staged, runtimeState, operationalSettings, saved: false));
     }
 
     [HttpPost("apply")]
@@ -81,12 +87,53 @@ public sealed class AdminApplicationUpdaterController : Controller
         var requestedByUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? User.Identity?.Name ?? "unknown";
         await _applicationUpdateApplyService.RequestApplyAsync(requestedByUserId, cancellationToken);
         var result = await _applicationUpdateDetectionService.CheckForUpdatesAsync(allowPreviewReleases, cancellationToken);
+        var operationalSettings = await _operationalSettingsService.GetCurrentAsync(cancellationToken);
         var staged = await _applicationUpdateApplyService.RefreshApplyStateAsync(cancellationToken);
         var runtimeState = await _runtimeStateStore.ReadAsync(cancellationToken);
-        return View("Index", ToViewModel(result, staged, runtimeState));
+        return View("Index", ToViewModel(result, staged, runtimeState, operationalSettings, saved: false));
     }
 
-    private ApplicationUpdaterPageViewModel ToViewModel(ApplicationUpdateCheckResult result, ApplicationUpdateStagingState? staged, ApplicationUpdaterRuntimeState? runtimeState)
+    [HttpPost("settings")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Settings([FromForm] ApplicationUpdaterPageViewModel model, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            var currentVersion = _applicationMetadataProvider.GetSnapshot().Version;
+            var result = _updaterOptions.UpdateChecksEnabled
+                ? ApplicationUpdateCheckResult.NotPerformed(currentVersion, model.AllowPreviewReleases)
+                : ApplicationUpdateCheckResult.Disabled(currentVersion, model.AllowPreviewReleases);
+            var stagedState = await _applicationUpdateApplyService.RefreshApplyStateAsync(cancellationToken);
+            var runtimeState = await _runtimeStateStore.ReadAsync(cancellationToken);
+            var currentSettings = await _operationalSettingsService.GetCurrentAsync(cancellationToken);
+            return View("Index", ToViewModel(result, stagedState, runtimeState, currentSettings, saved: false));
+        }
+
+        var updatedSettings = await _operationalSettingsService.UpdateAsync(
+            new UpdateApplicationUpdaterOperationalSettingsCommand
+            {
+                EnableAutomaticUpdateChecks = model.EnableAutomaticUpdateChecks,
+                AutomaticUpdateCheckIntervalMinutes = model.AutomaticUpdateCheckIntervalMinutes,
+                AutomaticallyDownloadAndStageUpdates = model.AutomaticallyDownloadAndStageUpdates,
+                AllowPreviewReleases = model.AllowPreviewReleases
+            },
+            cancellationToken);
+
+        var checkResult = _updaterOptions.UpdateChecksEnabled
+            ? ApplicationUpdateCheckResult.NotPerformed(_applicationMetadataProvider.GetSnapshot().Version, updatedSettings.AllowPreviewReleases)
+            : ApplicationUpdateCheckResult.Disabled(_applicationMetadataProvider.GetSnapshot().Version, updatedSettings.AllowPreviewReleases);
+
+        var staged = await _applicationUpdateApplyService.RefreshApplyStateAsync(cancellationToken);
+        var runtime = await _runtimeStateStore.ReadAsync(cancellationToken);
+        return View("Index", ToViewModel(checkResult, staged, runtime, updatedSettings, saved: true));
+    }
+
+    private ApplicationUpdaterPageViewModel ToViewModel(
+        ApplicationUpdateCheckResult result,
+        ApplicationUpdateStagingState? staged,
+        ApplicationUpdaterRuntimeState? runtimeState,
+        ApplicationUpdaterOperationalSettingsDto operationalSettings,
+        bool saved)
     {
         var decoratedStaged = ApplyLatestComparison(staged, result.LatestApplicableRelease?.TagName);
         var powerShellStatus = _powerShellPrerequisiteDetector.GetStatus();
@@ -96,11 +143,12 @@ public sealed class AdminApplicationUpdaterController : Controller
             CurrentVersion = result.CurrentVersion,
             AllowPreviewReleases = result.AllowPreviewReleases,
             UpdateChecksEnabled = _updaterOptions.UpdateChecksEnabled,
-            EnableAutomaticUpdateChecks = _updaterOptions.EnableAutomaticUpdateChecks,
-            AutomaticallyDownloadAndStageUpdates = _updaterOptions.AutomaticallyDownloadAndStageUpdates,
-            AutomaticUpdateCheckIntervalMinutes = _updaterOptions.AutomaticUpdateCheckIntervalMinutes,
+            EnableAutomaticUpdateChecks = operationalSettings.EnableAutomaticUpdateChecks,
+            AutomaticallyDownloadAndStageUpdates = operationalSettings.AutomaticallyDownloadAndStageUpdates,
+            AutomaticUpdateCheckIntervalMinutes = operationalSettings.AutomaticUpdateCheckIntervalMinutes,
             RepositoryOwner = _updaterOptions.GitHubOwner,
             RepositoryName = _updaterOptions.GitHubRepository,
+            SettingsSaved = saved,
             PowerShellPrerequisiteAvailable = powerShellStatus.IsAvailable,
             PowerShellPrerequisiteMessage = powerShellStatus.Message,
             PowerShellResolvedPath = powerShellStatus.ResolvedExecutablePath,

--- a/src/WebApp/PingMonitor.Web/Models/ApplicationSettings.cs
+++ b/src/WebApp/PingMonitor.Web/Models/ApplicationSettings.cs
@@ -18,5 +18,15 @@ public sealed class ApplicationSettings
 
     public int DefaultRecoveryThreshold { get; set; } = 2;
 
+    public bool EnableAutomaticUpdateChecks { get; set; } = true;
+
+    public int AutomaticUpdateCheckIntervalMinutes { get; set; } = 15;
+
+    public bool AutomaticallyDownloadAndStageUpdates { get; set; }
+
+    public bool AllowPreviewReleases { get; set; }
+
+    public DateTimeOffset? UpdaterOperationalSettingsInitializedAtUtc { get; set; }
+
     public DateTimeOffset UpdatedAtUtc { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -196,6 +196,7 @@ builder.Services.AddHttpClient(nameof(GitHubReleaseLookupService));
 builder.Services.AddHttpClient(nameof(ApplicationUpdateStagingService));
 builder.Services.AddScoped<IGitHubReleaseLookupService, GitHubReleaseLookupService>();
 builder.Services.AddScoped<IApplicationUpdateDetectionService, ApplicationUpdateDetectionService>();
+builder.Services.AddScoped<IApplicationUpdaterOperationalSettingsService, ApplicationUpdaterOperationalSettingsService>();
 builder.Services.AddSingleton<IApplicationUpdateStagingStateStore, ApplicationUpdateStagingStateStore>();
 builder.Services.AddSingleton<IApplicationUpdaterRuntimeStateStore, ApplicationUpdaterRuntimeStateStore>();
 builder.Services.AddScoped<IApplicationUpdateStagingService, ApplicationUpdateStagingService>();

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationSettingsService.cs
@@ -10,11 +10,16 @@ internal sealed class ApplicationSettingsService : IApplicationSettingsService
 {
     private readonly PingMonitorDbContext _dbContext;
     private readonly AgentProvisioningOptions _provisioningOptions;
+    private readonly ApplicationUpdaterOptions _updaterOptions;
 
-    public ApplicationSettingsService(PingMonitorDbContext dbContext, IOptions<AgentProvisioningOptions> provisioningOptions)
+    public ApplicationSettingsService(
+        PingMonitorDbContext dbContext,
+        IOptions<AgentProvisioningOptions> provisioningOptions,
+        IOptions<ApplicationUpdaterOptions> updaterOptions)
     {
         _dbContext = dbContext;
         _provisioningOptions = provisioningOptions.Value;
+        _updaterOptions = updaterOptions.Value;
     }
 
     public async Task<ApplicationSettingsDto> GetCurrentAsync(CancellationToken cancellationToken)
@@ -58,6 +63,11 @@ internal sealed class ApplicationSettingsService : IApplicationSettingsService
             DefaultTimeoutMs = 1000,
             DefaultFailureThreshold = 3,
             DefaultRecoveryThreshold = 2,
+            EnableAutomaticUpdateChecks = _updaterOptions.EnableAutomaticUpdateChecks,
+            AutomaticUpdateCheckIntervalMinutes = ResolveAutomaticCheckInterval(_updaterOptions.AutomaticUpdateCheckIntervalMinutes),
+            AutomaticallyDownloadAndStageUpdates = _updaterOptions.AutomaticallyDownloadAndStageUpdates,
+            AllowPreviewReleases = _updaterOptions.AllowPreviewReleases,
+            UpdaterOperationalSettingsInitializedAtUtc = DateTimeOffset.UtcNow,
             UpdatedAtUtc = DateTimeOffset.UtcNow
         };
 
@@ -91,5 +101,10 @@ internal sealed class ApplicationSettingsService : IApplicationSettingsService
             DefaultRecoveryThreshold = settings.DefaultRecoveryThreshold,
             UpdatedAtUtc = settings.UpdatedAtUtc
         };
+    }
+
+    private static int ResolveAutomaticCheckInterval(int configuredIntervalMinutes)
+    {
+        return configuredIntervalMinutes < 1 ? 1 : configuredIntervalMinutes;
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateBackgroundService.cs
@@ -35,8 +35,9 @@ internal sealed class ApplicationUpdateBackgroundService : BackgroundService
 
         while (!stoppingToken.IsCancellationRequested)
         {
-            var interval = ResolveInterval();
-            if (!_options.UpdateChecksEnabled || !_options.EnableAutomaticUpdateChecks)
+            var operationalSettings = await ReadOperationalSettingsAsync(stoppingToken);
+            var interval = ResolveInterval(operationalSettings.AutomaticUpdateCheckIntervalMinutes);
+            if (!_options.UpdateChecksEnabled || !operationalSettings.EnableAutomaticUpdateChecks)
             {
                 await Task.Delay(interval, stoppingToken);
                 continue;
@@ -62,7 +63,7 @@ internal sealed class ApplicationUpdateBackgroundService : BackgroundService
 
             try
             {
-                await RunAutomaticCheckAsync(stoppingToken);
+                await RunAutomaticCheckAsync(operationalSettings, stoppingToken);
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
@@ -77,7 +78,9 @@ internal sealed class ApplicationUpdateBackgroundService : BackgroundService
         }
     }
 
-    private async Task RunAutomaticCheckAsync(CancellationToken cancellationToken)
+    private async Task RunAutomaticCheckAsync(
+        ApplicationUpdaterOperationalSettingsDto operationalSettings,
+        CancellationToken cancellationToken)
     {
         using var scope = _scopeFactory.CreateScope();
         var detectionService = scope.ServiceProvider.GetRequiredService<IApplicationUpdateDetectionService>();
@@ -89,7 +92,7 @@ internal sealed class ApplicationUpdateBackgroundService : BackgroundService
         var previousState = await runtimeStateStore.ReadAsync(cancellationToken);
         var nextState = Clone(previousState, lastAutomaticCheckAtUtc: now);
 
-        var result = await detectionService.CheckForUpdatesAsync(_options.AllowPreviewReleases, cancellationToken);
+        var result = await detectionService.CheckForUpdatesAsync(operationalSettings.AllowPreviewReleases, cancellationToken);
         if (result.State == ApplicationUpdateCheckState.CheckFailed)
         {
             var shouldLogFailureTransition = previousState?.LastAutomaticCheckSucceededAtUtc is not null;
@@ -140,12 +143,19 @@ internal sealed class ApplicationUpdateBackgroundService : BackgroundService
                 }, DetailsJsonOptions)
             }, cancellationToken);
 
-            if (_options.AutomaticallyDownloadAndStageUpdates)
+            if (operationalSettings.AutomaticallyDownloadAndStageUpdates)
             {
                 var alreadyAttempted = string.Equals(previousState?.LastAutoStageAttemptedReleaseTag, latestTag, StringComparison.OrdinalIgnoreCase);
                 if (!alreadyAttempted)
                 {
-                    nextState = await RunAutoStageAsync(stagingService, eventLogService, nextState, latestTag, now, cancellationToken);
+                    nextState = await RunAutoStageAsync(
+                        stagingService,
+                        eventLogService,
+                        nextState,
+                        latestTag,
+                        operationalSettings.AllowPreviewReleases,
+                        now,
+                        cancellationToken);
                 }
             }
         }
@@ -158,6 +168,7 @@ internal sealed class ApplicationUpdateBackgroundService : BackgroundService
         IEventLogService eventLogService,
         ApplicationUpdaterRuntimeState currentState,
         string latestTag,
+        bool allowPreviewReleases,
         DateTimeOffset now,
         CancellationToken cancellationToken)
     {
@@ -175,7 +186,7 @@ internal sealed class ApplicationUpdateBackgroundService : BackgroundService
             DetailsJson = JsonSerializer.Serialize(new { latestTag }, DetailsJsonOptions)
         }, cancellationToken);
 
-        var stageResult = await stagingService.StageLatestApplicableReleaseAsync(_options.AllowPreviewReleases, cancellationToken);
+        var stageResult = await stagingService.StageLatestApplicableReleaseAsync(allowPreviewReleases, cancellationToken);
         if (stageResult.State.Status == ApplicationUpdateStagingStatus.Ready)
         {
             await eventLogService.WriteAsync(new EventLogWriteRequest
@@ -217,9 +228,16 @@ internal sealed class ApplicationUpdateBackgroundService : BackgroundService
             lastAutoStageFailureMessage: stageResult.State.StageOperationMessage ?? stageResult.State.FailureMessage ?? "Automatic staging failed.");
     }
 
-    private TimeSpan ResolveInterval()
+    private async Task<ApplicationUpdaterOperationalSettingsDto> ReadOperationalSettingsAsync(CancellationToken cancellationToken)
     {
-        var configured = _options.AutomaticUpdateCheckIntervalMinutes;
+        using var scope = _scopeFactory.CreateScope();
+        var settingsService = scope.ServiceProvider.GetRequiredService<IApplicationUpdaterOperationalSettingsService>();
+        return await settingsService.GetCurrentAsync(cancellationToken);
+    }
+
+    private static TimeSpan ResolveInterval(int configuredIntervalMinutes)
+    {
+        var configured = configuredIntervalMinutes;
         if (configured < 1)
         {
             configured = 1;

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateBackgroundService.cs
@@ -35,14 +35,6 @@ internal sealed class ApplicationUpdateBackgroundService : BackgroundService
 
         while (!stoppingToken.IsCancellationRequested)
         {
-            var operationalSettings = await ReadOperationalSettingsAsync(stoppingToken);
-            var interval = ResolveInterval(operationalSettings.AutomaticUpdateCheckIntervalMinutes);
-            if (!_options.UpdateChecksEnabled || !operationalSettings.EnableAutomaticUpdateChecks)
-            {
-                await Task.Delay(interval, stoppingToken);
-                continue;
-            }
-
             if (!_startupGateRuntimeState.IsOperationalMode)
             {
                 if (!wasPausedByStartupGate)
@@ -61,8 +53,19 @@ internal sealed class ApplicationUpdateBackgroundService : BackgroundService
                 wasPausedByStartupGate = false;
             }
 
+            var interval = ResolveInterval(_options.AutomaticUpdateCheckIntervalMinutes);
+
             try
             {
+                var operationalSettings = await ReadOperationalSettingsAsync(stoppingToken);
+                interval = ResolveInterval(operationalSettings.AutomaticUpdateCheckIntervalMinutes);
+
+                if (!_options.UpdateChecksEnabled || !operationalSettings.EnableAutomaticUpdateChecks)
+                {
+                    await Task.Delay(interval, stoppingToken);
+                    continue;
+                }
+
                 await RunAutomaticCheckAsync(operationalSettings, stoppingToken);
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdaterOperationalSettingsDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdaterOperationalSettingsDto.cs
@@ -1,0 +1,10 @@
+namespace PingMonitor.Web.Services.ApplicationUpdater;
+
+public sealed class ApplicationUpdaterOperationalSettingsDto
+{
+    public bool EnableAutomaticUpdateChecks { get; init; }
+    public int AutomaticUpdateCheckIntervalMinutes { get; init; }
+    public bool AutomaticallyDownloadAndStageUpdates { get; init; }
+    public bool AllowPreviewReleases { get; init; }
+    public DateTimeOffset UpdatedAtUtc { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdaterOperationalSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdaterOperationalSettingsService.cs
@@ -1,0 +1,104 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Options;
+
+namespace PingMonitor.Web.Services.ApplicationUpdater;
+
+internal sealed class ApplicationUpdaterOperationalSettingsService : IApplicationUpdaterOperationalSettingsService
+{
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly ApplicationUpdaterOptions _updaterOptions;
+
+    public ApplicationUpdaterOperationalSettingsService(
+        PingMonitorDbContext dbContext,
+        IOptions<ApplicationUpdaterOptions> updaterOptions)
+    {
+        _dbContext = dbContext;
+        _updaterOptions = updaterOptions.Value;
+    }
+
+    public async Task<ApplicationUpdaterOperationalSettingsDto> GetCurrentAsync(CancellationToken cancellationToken)
+    {
+        var settings = await GetOrCreateEntityAsync(cancellationToken);
+        return ToDto(settings);
+    }
+
+    public async Task<ApplicationUpdaterOperationalSettingsDto> UpdateAsync(
+        UpdateApplicationUpdaterOperationalSettingsCommand command,
+        CancellationToken cancellationToken)
+    {
+        var settings = await GetOrCreateEntityAsync(cancellationToken);
+
+        settings.EnableAutomaticUpdateChecks = command.EnableAutomaticUpdateChecks;
+        settings.AutomaticUpdateCheckIntervalMinutes = ResolveAutomaticCheckInterval(command.AutomaticUpdateCheckIntervalMinutes);
+        settings.AutomaticallyDownloadAndStageUpdates = command.AutomaticallyDownloadAndStageUpdates;
+        settings.AllowPreviewReleases = command.AllowPreviewReleases;
+        settings.UpdaterOperationalSettingsInitializedAtUtc ??= DateTimeOffset.UtcNow;
+        settings.UpdatedAtUtc = DateTimeOffset.UtcNow;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return ToDto(settings);
+    }
+
+    private async Task<ApplicationSettings> GetOrCreateEntityAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _dbContext.ApplicationSettings
+            .SingleOrDefaultAsync(x => x.ApplicationSettingsId == ApplicationSettings.SingletonId, cancellationToken);
+
+        if (settings is null)
+        {
+            settings = new ApplicationSettings
+            {
+                ApplicationSettingsId = ApplicationSettings.SingletonId,
+                SiteUrl = string.Empty,
+                DefaultPingIntervalSeconds = 60,
+                DefaultRetryIntervalSeconds = 5,
+                DefaultTimeoutMs = 1000,
+                DefaultFailureThreshold = 3,
+                DefaultRecoveryThreshold = 2,
+                EnableAutomaticUpdateChecks = _updaterOptions.EnableAutomaticUpdateChecks,
+                AutomaticUpdateCheckIntervalMinutes = ResolveAutomaticCheckInterval(_updaterOptions.AutomaticUpdateCheckIntervalMinutes),
+                AutomaticallyDownloadAndStageUpdates = _updaterOptions.AutomaticallyDownloadAndStageUpdates,
+                AllowPreviewReleases = _updaterOptions.AllowPreviewReleases,
+                UpdaterOperationalSettingsInitializedAtUtc = DateTimeOffset.UtcNow,
+                UpdatedAtUtc = DateTimeOffset.UtcNow
+            };
+
+            _dbContext.ApplicationSettings.Add(settings);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return settings;
+        }
+
+        if (settings.UpdaterOperationalSettingsInitializedAtUtc is null)
+        {
+            settings.EnableAutomaticUpdateChecks = _updaterOptions.EnableAutomaticUpdateChecks;
+            settings.AutomaticUpdateCheckIntervalMinutes = ResolveAutomaticCheckInterval(_updaterOptions.AutomaticUpdateCheckIntervalMinutes);
+            settings.AutomaticallyDownloadAndStageUpdates = _updaterOptions.AutomaticallyDownloadAndStageUpdates;
+            settings.AllowPreviewReleases = _updaterOptions.AllowPreviewReleases;
+            settings.UpdaterOperationalSettingsInitializedAtUtc = DateTimeOffset.UtcNow;
+            settings.UpdatedAtUtc = DateTimeOffset.UtcNow;
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return settings;
+    }
+
+    private static ApplicationUpdaterOperationalSettingsDto ToDto(ApplicationSettings settings)
+    {
+        return new ApplicationUpdaterOperationalSettingsDto
+        {
+            EnableAutomaticUpdateChecks = settings.EnableAutomaticUpdateChecks,
+            AutomaticUpdateCheckIntervalMinutes = ResolveAutomaticCheckInterval(settings.AutomaticUpdateCheckIntervalMinutes),
+            AutomaticallyDownloadAndStageUpdates = settings.AutomaticallyDownloadAndStageUpdates,
+            AllowPreviewReleases = settings.AllowPreviewReleases,
+            UpdatedAtUtc = settings.UpdatedAtUtc
+        };
+    }
+
+    private static int ResolveAutomaticCheckInterval(int configuredIntervalMinutes)
+    {
+        return configuredIntervalMinutes < 1 ? 1 : configuredIntervalMinutes;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdaterOperationalSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdaterOperationalSettingsService.cs
@@ -10,13 +10,16 @@ internal sealed class ApplicationUpdaterOperationalSettingsService : IApplicatio
 {
     private readonly PingMonitorDbContext _dbContext;
     private readonly ApplicationUpdaterOptions _updaterOptions;
+    private readonly AgentProvisioningOptions _provisioningOptions;
 
     public ApplicationUpdaterOperationalSettingsService(
         PingMonitorDbContext dbContext,
-        IOptions<ApplicationUpdaterOptions> updaterOptions)
+        IOptions<ApplicationUpdaterOptions> updaterOptions,
+        IOptions<AgentProvisioningOptions> provisioningOptions)
     {
         _dbContext = dbContext;
         _updaterOptions = updaterOptions.Value;
+        _provisioningOptions = provisioningOptions.Value;
     }
 
     public async Task<ApplicationUpdaterOperationalSettingsDto> GetCurrentAsync(CancellationToken cancellationToken)
@@ -52,7 +55,7 @@ internal sealed class ApplicationUpdaterOperationalSettingsService : IApplicatio
             settings = new ApplicationSettings
             {
                 ApplicationSettingsId = ApplicationSettings.SingletonId,
-                SiteUrl = string.Empty,
+                SiteUrl = BuildInitialSiteUrl(),
                 DefaultPingIntervalSeconds = 60,
                 DefaultRetryIntervalSeconds = 5,
                 DefaultTimeoutMs = 1000,
@@ -83,6 +86,20 @@ internal sealed class ApplicationUpdaterOperationalSettingsService : IApplicatio
         }
 
         return settings;
+    }
+
+
+    private string BuildInitialSiteUrl()
+    {
+        var configuredUrl = _provisioningOptions.ServerUrl?.Trim();
+        if (string.IsNullOrWhiteSpace(configuredUrl))
+        {
+            return string.Empty;
+        }
+
+        return Uri.TryCreate(configuredUrl, UriKind.Absolute, out var uri)
+            ? uri.ToString().TrimEnd('/')
+            : string.Empty;
     }
 
     private static ApplicationUpdaterOperationalSettingsDto ToDto(ApplicationSettings settings)

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/IApplicationUpdaterOperationalSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/IApplicationUpdaterOperationalSettingsService.cs
@@ -1,0 +1,8 @@
+namespace PingMonitor.Web.Services.ApplicationUpdater;
+
+public interface IApplicationUpdaterOperationalSettingsService
+{
+    Task<ApplicationUpdaterOperationalSettingsDto> GetCurrentAsync(CancellationToken cancellationToken);
+
+    Task<ApplicationUpdaterOperationalSettingsDto> UpdateAsync(UpdateApplicationUpdaterOperationalSettingsCommand command, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/UpdateApplicationUpdaterOperationalSettingsCommand.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/UpdateApplicationUpdaterOperationalSettingsCommand.cs
@@ -1,0 +1,9 @@
+namespace PingMonitor.Web.Services.ApplicationUpdater;
+
+public sealed class UpdateApplicationUpdaterOperationalSettingsCommand
+{
+    public bool EnableAutomaticUpdateChecks { get; init; }
+    public int AutomaticUpdateCheckIntervalMinutes { get; init; }
+    public bool AutomaticallyDownloadAndStageUpdates { get; init; }
+    public bool AllowPreviewReleases { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -78,6 +78,22 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "SecurityLogAutoPruneEnabled",
         "UpdatedAtUtc"
     ];
+    private static readonly string[] RequiredApplicationSettingsColumns =
+    [
+        "ApplicationSettingsId",
+        "SiteUrl",
+        "DefaultPingIntervalSeconds",
+        "DefaultRetryIntervalSeconds",
+        "DefaultTimeoutMs",
+        "DefaultFailureThreshold",
+        "DefaultRecoveryThreshold",
+        "EnableAutomaticUpdateChecks",
+        "AutomaticUpdateCheckIntervalMinutes",
+        "AutomaticallyDownloadAndStageUpdates",
+        "AllowPreviewReleases",
+        "UpdaterOperationalSettingsInitializedAtUtc",
+        "UpdatedAtUtc"
+    ];
     private static readonly string[] RequiredNotificationSettingsColumns =
     [
         "NotificationSettingsId",
@@ -256,6 +272,13 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             status.Diagnostics.Add($"SecuritySettings table is missing required columns: {string.Join(", ", missingSecuritySettingsColumns)}.");
             return status;
         }
+        var missingApplicationSettingsColumns = await GetMissingApplicationSettingsColumnsAsync(connection, cancellationToken);
+        if (missingApplicationSettingsColumns.Length > 0)
+        {
+            var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
+            status.Diagnostics.Add($"ApplicationSettings table is missing required columns: {string.Join(", ", missingApplicationSettingsColumns)}.");
+            return status;
+        }
         var missingNotificationSettingsColumns = await GetMissingNotificationSettingsColumnsAsync(connection, cancellationToken);
         if (missingNotificationSettingsColumns.Length > 0)
         {
@@ -397,6 +420,11 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 `DefaultTimeoutMs` int NOT NULL,
                 `DefaultFailureThreshold` int NOT NULL,
                 `DefaultRecoveryThreshold` int NOT NULL,
+                `EnableAutomaticUpdateChecks` tinyint(1) NOT NULL DEFAULT 1,
+                `AutomaticUpdateCheckIntervalMinutes` int NOT NULL DEFAULT 15,
+                `AutomaticallyDownloadAndStageUpdates` tinyint(1) NOT NULL DEFAULT 0,
+                `AllowPreviewReleases` tinyint(1) NOT NULL DEFAULT 0,
+                `UpdaterOperationalSettingsInitializedAtUtc` datetime(6) NULL,
                 `UpdatedAtUtc` datetime(6) NOT NULL,
                 PRIMARY KEY (`ApplicationSettingsId`)
             );
@@ -723,6 +751,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await EnsureEndpointDependenciesColumnsAsync(dbContext, cancellationToken);
         await EnsureEndpointColumnsAsync(dbContext, cancellationToken);
         await EnsureSecuritySettingsColumnsAsync(dbContext, cancellationToken);
+        await EnsureApplicationSettingsColumnsAsync(dbContext, cancellationToken);
         await EnsureNotificationSettingsColumnsAsync(dbContext, cancellationToken);
         await EnsureUserNotificationSettingsColumnsAsync(dbContext, cancellationToken);
         await EnsureAssignmentMetrics24hColumnsAsync(dbContext, cancellationToken);
@@ -875,6 +904,28 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         }
 
         return RequiredSecuritySettingsColumns
+            .Where(column => !existingColumns.Contains(column))
+            .ToArray();
+    }
+
+    private static async Task<string[]> GetMissingApplicationSettingsColumnsAsync(MySqlConnection connection, CancellationToken cancellationToken)
+    {
+        var existingColumns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COLUMN_NAME
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'ApplicationSettings';
+            """;
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            existingColumns.Add(reader.GetString(0));
+        }
+
+        return RequiredApplicationSettingsColumns
             .Where(column => !existingColumns.Contains(column))
             .ToArray();
     }
@@ -1138,6 +1189,65 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 """
                 ALTER TABLE `SecuritySettings`
                 ADD COLUMN `SecurityLogAutoPruneEnabled` tinyint(1) NOT NULL DEFAULT 0;
+                """,
+                cancellationToken);
+        }
+    }
+
+    private static async Task EnsureApplicationSettingsColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
+    {
+        await using var connection = dbContext.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        if (!await HasApplicationSettingsColumnAsync(connection, "EnableAutomaticUpdateChecks", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `ApplicationSettings`
+                ADD COLUMN `EnableAutomaticUpdateChecks` tinyint(1) NOT NULL DEFAULT 1;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasApplicationSettingsColumnAsync(connection, "AutomaticUpdateCheckIntervalMinutes", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `ApplicationSettings`
+                ADD COLUMN `AutomaticUpdateCheckIntervalMinutes` int NOT NULL DEFAULT 15;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasApplicationSettingsColumnAsync(connection, "AutomaticallyDownloadAndStageUpdates", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `ApplicationSettings`
+                ADD COLUMN `AutomaticallyDownloadAndStageUpdates` tinyint(1) NOT NULL DEFAULT 0;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasApplicationSettingsColumnAsync(connection, "AllowPreviewReleases", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `ApplicationSettings`
+                ADD COLUMN `AllowPreviewReleases` tinyint(1) NOT NULL DEFAULT 0;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasApplicationSettingsColumnAsync(connection, "UpdaterOperationalSettingsInitializedAtUtc", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `ApplicationSettings`
+                ADD COLUMN `UpdaterOperationalSettingsInitializedAtUtc` datetime(6) NULL;
                 """,
                 cancellationToken);
         }
@@ -1707,6 +1817,24 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             FROM information_schema.columns
             WHERE table_schema = DATABASE()
               AND table_name = 'SecuritySettings'
+              AND column_name = @columnName;
+            """;
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "@columnName";
+        parameter.Value = columnName;
+        command.Parameters.Add(parameter);
+
+        return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
+    }
+
+    private static async Task<bool> HasApplicationSettingsColumnAsync(System.Data.Common.DbConnection connection, string columnName, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'ApplicationSettings'
               AND column_name = @columnName;
             """;
         var parameter = command.CreateParameter();

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/ApplicationUpdaterPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/ApplicationUpdaterPageViewModel.cs
@@ -1,4 +1,5 @@
 using PingMonitor.Web.Services.ApplicationUpdater;
+using System.ComponentModel.DataAnnotations;
 
 namespace PingMonitor.Web.ViewModels.Admin;
 
@@ -7,9 +8,13 @@ public sealed class ApplicationUpdaterPageViewModel
     public string CurrentVersion { get; init; } = string.Empty;
     public bool AllowPreviewReleases { get; set; }
     public bool UpdateChecksEnabled { get; init; }
-    public bool EnableAutomaticUpdateChecks { get; init; }
-    public bool AutomaticallyDownloadAndStageUpdates { get; init; }
-    public int AutomaticUpdateCheckIntervalMinutes { get; init; }
+    public bool EnableAutomaticUpdateChecks { get; set; }
+    public bool AutomaticallyDownloadAndStageUpdates { get; set; }
+
+    [Range(1, 1440, ErrorMessage = "Automatic check interval must be between 1 and 1440 minutes.")]
+    public int AutomaticUpdateCheckIntervalMinutes { get; set; }
+
+    public bool SettingsSaved { get; init; }
     public string RepositoryOwner { get; init; } = string.Empty;
     public string RepositoryName { get; init; } = string.Empty;
     public bool PowerShellPrerequisiteAvailable { get; init; }

--- a/src/WebApp/PingMonitor.Web/Views/AdminApplicationUpdater/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminApplicationUpdater/Index.cshtml
@@ -59,6 +59,62 @@
             </div>
         </section>
 
+        <form class="stack" method="post" action="/admin/application-updater/settings">
+            @Html.AntiForgeryToken()
+            <section class="card field">
+                <h2>Automatic updater operational settings</h2>
+                @if (Model.SettingsSaved)
+                {
+                    <div class="status status-ok" role="status">Updater operational settings saved.</div>
+                }
+                @if (!ViewData.ModelState.IsValid)
+                {
+                    <div class="status status-error" role="status">
+                        @Html.ValidationSummary(excludePropertyErrors: true)
+                    </div>
+                }
+                <label class="checkbox-row" for="enableAutomaticUpdateChecks">
+                    <input id="enableAutomaticUpdateChecks" name="EnableAutomaticUpdateChecks" type="checkbox" value="true" @(Model.EnableAutomaticUpdateChecks ? "checked" : null) />
+                    <input name="EnableAutomaticUpdateChecks" type="hidden" value="false" />
+                    <span>
+                        <strong>Enable automatic update checks</strong><br />
+                        <span class="muted">When disabled, background automatic updater checks are paused. Manual checks remain available.</span>
+                    </span>
+                </label>
+                <div class="field">
+                    <label for="automaticUpdateCheckIntervalMinutes"><strong>Automatic check interval (minutes)</strong></label>
+                    <input id="automaticUpdateCheckIntervalMinutes" name="AutomaticUpdateCheckIntervalMinutes" type="number" min="1" max="1440" value="@Model.AutomaticUpdateCheckIntervalMinutes" />
+                    @Html.ValidationMessageFor(x => x.AutomaticUpdateCheckIntervalMinutes)
+                    <span class="muted">Allowed range: 1 to 1440 minutes. Very low intervals increase background traffic.</span>
+                </div>
+                <label class="checkbox-row" for="automaticallyDownloadAndStageUpdates">
+                    <input id="automaticallyDownloadAndStageUpdates" name="AutomaticallyDownloadAndStageUpdates" type="checkbox" value="true" @(Model.AutomaticallyDownloadAndStageUpdates ? "checked" : null) />
+                    <input name="AutomaticallyDownloadAndStageUpdates" type="hidden" value="false" />
+                    <span>
+                        <strong>Automatically download and stage updates</strong><br />
+                        <span class="muted">When enabled, the updater stages newly detected releases automatically. Apply is still an explicit admin action.</span>
+                    </span>
+                </label>
+                <label class="checkbox-row" for="allowPreviewReleasesOperational">
+                    <input id="allowPreviewReleasesOperational" name="AllowPreviewReleases" type="checkbox" value="true" @(Model.AllowPreviewReleases ? "checked" : null) />
+                    <input name="AllowPreviewReleases" type="hidden" value="false" />
+                    <span>
+                        <strong>Allow preview releases</strong><br />
+                        <span class="muted">This controls which releases are eligible for both automatic background checks and manual updater actions.</span>
+                    </span>
+                </label>
+                @if (!Model.UpdateChecksEnabled)
+                {
+                    <div class="status status-warn" role="status">
+                        Update checks are globally disabled in deployment configuration. Runtime settings are saved, but checks remain disabled until config re-enables update checks.
+                    </div>
+                }
+                <div class="button-row">
+                    <button class="button" type="submit">Save updater settings</button>
+                </div>
+            </section>
+        </form>
+
         <form class="stack" method="post" action="/admin/application-updater/check">
             @Html.AntiForgeryToken()
             <section class="card field">
@@ -67,7 +123,7 @@
                     <input id="allowPreviewReleases" name="allowPreviewReleases" type="checkbox" value="true" @(Model.AllowPreviewReleases ? "checked" : null) />
                     <span>
                         <strong>Allow preview releases</strong><br />
-                        <span class="muted">When enabled, prerelease GitHub versions are eligible. When disabled, prereleases are ignored.</span>
+                        <span class="muted">Uses current saved operational setting as default. You can override for this one manual check.</span>
                     </span>
                 </label>
                 <div class="button-row">

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 8,
+    "RequiredSchemaVersion": 9,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 8,
+    "RequiredSchemaVersion": 9,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
### Motivation
- Updater operational flags (automatic checks, interval, auto-stage, preview releases) were only configurable via `appsettings.json`, which is not an operator-friendly runtime control surface.
- Operators need ability to adjust runtime updater behavior through the admin UI while preserving deployment-level defaults in config.
- Changes must respect Startup Gate, use the repo’s singleton persisted settings pattern, and avoid redesigning the updater.

### Description
- Added persisted operational updater fields to the existing `ApplicationSettings` singleton: `EnableAutomaticUpdateChecks`, `AutomaticUpdateCheckIntervalMinutes`, `AutomaticallyDownloadAndStageUpdates`, `AllowPreviewReleases`, and a one-time initializer marker `UpdaterOperationalSettingsInitializedAtUtc`.
- Implemented `IApplicationUpdaterOperationalSettingsService` + `ApplicationUpdaterOperationalSettingsService` (DTO + update command) that seeds persisted settings from `ApplicationUpdaterOptions` on first use and thereafter reads/writes DB-backed values.
- Wired the new settings service into DI and updated `ApplicationSettingsService` creation path so a freshly-created singleton row is initialized from config defaults when appropriate.
- Extended the admin updater page to include an “Automatic updater operational settings” form (checkboxes + numeric interval), a `POST /admin/application-updater/settings` handler, validation for the interval, and saved-state feedback.
- Updated background process `ApplicationUpdateBackgroundService` to read the persisted operational settings each loop and to use them (enable/disable automatic checks, interval, preview-release filter, and auto-stage decision), while preserving the global config `UpdateChecksEnabled` hard-disable and Startup Gate pause behavior.
- Added Startup Gate schema checks/repair for the new `ApplicationSettings` columns and bumped the required schema version to 9 so existing databases are validated/repaired for the new columns on startup.
- Files changed (high level): controller, viewmodel, view, models, services (new settings service + interface + DTO + command), background service adjustments, startup schema service, DI registration, and appsettings updates.

### Testing
- Built the web project successfully with .NET 10: `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` (succeeded).
- Ran the project's unit tests: `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` (all tests passed; 27 passed).
- The change preserves Startup Gate behaviour and seeds persisted settings from config only once (the code includes the `UpdaterOperationalSettingsInitializedAtUtc` barrier and Startup Gate schema checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1bea9148832a8a0390ff59576d4b)