### PR TITLE
Updater: separate DEV release discovery from comparison and add guarded DEV auto-stage override

### DIFF
--- a/docs/event-logging.md
+++ b/docs/event-logging.md
@@ -113,6 +113,9 @@ All events are stored in a single table.
 | updater_auto_stage_succeeded      | Automatic staging succeeded (download + checksum verify + stage ready) |
 | updater_auto_stage_failed         | Automatic staging attempt failed |
 | updater_automatic_check_failed    | Automatic update check failed after prior successful checks |
+| updater_dev_build_comparison_skipped | Latest applicable release found on DEV build; semantic comparison skipped |
+| updater_dev_build_auto_stage_skipped | DEV build auto-stage suppressed because DEV override is disabled |
+| updater_dev_build_auto_stage_override_allowed | DEV override enabled; auto-stage proceeded without semantic comparison |
 
 These events are transition-oriented and intentionally avoid per-poll log spam.
 

--- a/docs/manual-application-updater-v1-spec.md
+++ b/docs/manual-application-updater-v1-spec.md
@@ -430,6 +430,7 @@ Configuration knobs:
 - `EnableAutomaticUpdateChecks`
 - `AutomaticUpdateCheckIntervalMinutes`
 - `AutomaticallyDownloadAndStageUpdates`
+- `AllowDevBuildAutoStageWithoutVersionComparison`
 - `AllowPreviewReleases`
 
 Behavior:
@@ -437,6 +438,7 @@ Behavior:
 - Automatic checks run on a background schedule only when Startup Gate is in operational mode.
 - New applicable release detection writes updater events (change-based, no per-loop spam).
 - If `AutomaticallyDownloadAndStageUpdates` is enabled, newly detected releases are downloaded, checksum-verified, and staged automatically.
+- DEV builds still discover latest applicable release, but semantic version comparison is skipped; by default auto-stage is suppressed unless `AllowDevBuildAutoStageWithoutVersionComparison` is explicitly enabled.
 - Automatic staging is bounded to avoid repeated re-attempt loops for the same unchanged release tag.
 - Automatic apply/install is not performed.
 

--- a/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdaterTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdaterTests.cs
@@ -70,6 +70,10 @@ public sealed class ApplicationUpdaterTests
 
         Assert.Equal(ApplicationUpdateCheckState.DevBuildComparisonSkipped, result.State);
         Assert.Equal("V0.1.1", result.LatestApplicableRelease?.TagName);
+        Assert.True(result.ReleaseDiscoverySucceeded);
+        Assert.True(result.IsCurrentBuildDev);
+        Assert.False(result.SemanticComparisonPerformed);
+        Assert.Contains("Latest applicable release V0.1.1 was detected", result.Message);
     }
 
     [Fact]
@@ -89,6 +93,48 @@ public sealed class ApplicationUpdaterTests
         var result = await service.CheckForUpdatesAsync(allowPreviewReleases: false, CancellationToken.None);
 
         Assert.Equal(ApplicationUpdateCheckState.LatestVersionUnknown, result.State);
+    }
+
+    [Fact]
+    public void DetermineAutoStagePlan_DevBuildWithoutOverride_IsSuppressed()
+    {
+        var plan = ApplicationUpdateBackgroundService.DetermineAutoStagePlan(
+            ApplicationUpdateCheckState.DevBuildComparisonSkipped,
+            releaseFound: true,
+            automaticStageEnabled: true,
+            allowDevBuildAutoStageWithoutVersionComparison: false,
+            previousAttemptedTag: null,
+            latestTag: "V0.2.0-preview");
+
+        Assert.Equal(ApplicationUpdateBackgroundService.AutoStagePlan.SuppressDevBuildWithoutOverride, plan);
+    }
+
+    [Fact]
+    public void DetermineAutoStagePlan_DevBuildWithOverride_AllowsStage()
+    {
+        var plan = ApplicationUpdateBackgroundService.DetermineAutoStagePlan(
+            ApplicationUpdateCheckState.DevBuildComparisonSkipped,
+            releaseFound: true,
+            automaticStageEnabled: true,
+            allowDevBuildAutoStageWithoutVersionComparison: true,
+            previousAttemptedTag: null,
+            latestTag: "V0.2.0-preview");
+
+        Assert.Equal(ApplicationUpdateBackgroundService.AutoStagePlan.StageDevBuildWithOverride, plan);
+    }
+
+    [Fact]
+    public void DetermineAutoStagePlan_ReleaseBuildBehavior_Unchanged()
+    {
+        var plan = ApplicationUpdateBackgroundService.DetermineAutoStagePlan(
+            ApplicationUpdateCheckState.UpdateAvailable,
+            releaseFound: true,
+            automaticStageEnabled: true,
+            allowDevBuildAutoStageWithoutVersionComparison: false,
+            previousAttemptedTag: null,
+            latestTag: "V0.2.0");
+
+        Assert.Equal(ApplicationUpdateBackgroundService.AutoStagePlan.StageReleaseBuild, plan);
     }
 
     private static ApplicationUpdateDetectionService BuildService(string currentVersion, GitHubReleaseSummary? release)

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminApplicationUpdaterController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminApplicationUpdaterController.cs
@@ -115,6 +115,7 @@ public sealed class AdminApplicationUpdaterController : Controller
                 EnableAutomaticUpdateChecks = model.EnableAutomaticUpdateChecks,
                 AutomaticUpdateCheckIntervalMinutes = model.AutomaticUpdateCheckIntervalMinutes,
                 AutomaticallyDownloadAndStageUpdates = model.AutomaticallyDownloadAndStageUpdates,
+                AllowDevBuildAutoStageWithoutVersionComparison = model.AllowDevBuildAutoStageWithoutVersionComparison,
                 AllowPreviewReleases = model.AllowPreviewReleases
             },
             cancellationToken);
@@ -145,6 +146,7 @@ public sealed class AdminApplicationUpdaterController : Controller
             UpdateChecksEnabled = _updaterOptions.UpdateChecksEnabled,
             EnableAutomaticUpdateChecks = operationalSettings.EnableAutomaticUpdateChecks,
             AutomaticallyDownloadAndStageUpdates = operationalSettings.AutomaticallyDownloadAndStageUpdates,
+            AllowDevBuildAutoStageWithoutVersionComparison = operationalSettings.AllowDevBuildAutoStageWithoutVersionComparison,
             AutomaticUpdateCheckIntervalMinutes = operationalSettings.AutomaticUpdateCheckIntervalMinutes,
             RepositoryOwner = _updaterOptions.GitHubOwner,
             RepositoryName = _updaterOptions.GitHubRepository,
@@ -154,6 +156,8 @@ public sealed class AdminApplicationUpdaterController : Controller
             PowerShellResolvedPath = powerShellStatus.ResolvedExecutablePath,
             State = result.State,
             Message = result.Message,
+            IsCurrentBuildDev = result.IsCurrentBuildDev,
+            SemanticComparisonPerformed = result.SemanticComparisonPerformed,
             LatestVersion = result.LatestApplicableRelease?.TagName,
             LatestReleaseName = result.LatestApplicableRelease?.Name,
             LatestIsPrerelease = result.LatestApplicableRelease?.IsPrerelease,

--- a/src/WebApp/PingMonitor.Web/Models/ApplicationSettings.cs
+++ b/src/WebApp/PingMonitor.Web/Models/ApplicationSettings.cs
@@ -24,6 +24,8 @@ public sealed class ApplicationSettings
 
     public bool AutomaticallyDownloadAndStageUpdates { get; set; }
 
+    public bool AllowDevBuildAutoStageWithoutVersionComparison { get; set; }
+
     public bool AllowPreviewReleases { get; set; }
 
     public DateTimeOffset? UpdaterOperationalSettingsInitializedAtUtc { get; set; }

--- a/src/WebApp/PingMonitor.Web/Models/EventType.cs
+++ b/src/WebApp/PingMonitor.Web/Models/EventType.cs
@@ -38,4 +38,7 @@ public static class EventType
     public const string UpdaterAutoStageSucceeded = "updater_auto_stage_succeeded";
     public const string UpdaterAutoStageFailed = "updater_auto_stage_failed";
     public const string UpdaterAutomaticCheckFailed = "updater_automatic_check_failed";
+    public const string UpdaterDevBuildComparisonSkipped = "updater_dev_build_comparison_skipped";
+    public const string UpdaterDevBuildAutoStageSkipped = "updater_dev_build_auto_stage_skipped";
+    public const string UpdaterDevBuildAutoStageOverrideAllowed = "updater_dev_build_auto_stage_override_allowed";
 }

--- a/src/WebApp/PingMonitor.Web/Options/ApplicationUpdaterOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/ApplicationUpdaterOptions.cs
@@ -8,6 +8,7 @@ public sealed class ApplicationUpdaterOptions
     public bool EnableAutomaticUpdateChecks { get; set; } = true;
     public int AutomaticUpdateCheckIntervalMinutes { get; set; } = 15;
     public bool AutomaticallyDownloadAndStageUpdates { get; set; }
+    public bool AllowDevBuildAutoStageWithoutVersionComparison { get; set; }
     public string GitHubOwner { get; set; } = "ijyates1992";
     public string GitHubRepository { get; set; } = "ping-monitor";
     public string GitHubApiBaseUrl { get; set; } = "https://api.github.com";

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationSettingsService.cs
@@ -66,6 +66,7 @@ internal sealed class ApplicationSettingsService : IApplicationSettingsService
             EnableAutomaticUpdateChecks = _updaterOptions.EnableAutomaticUpdateChecks,
             AutomaticUpdateCheckIntervalMinutes = ResolveAutomaticCheckInterval(_updaterOptions.AutomaticUpdateCheckIntervalMinutes),
             AutomaticallyDownloadAndStageUpdates = _updaterOptions.AutomaticallyDownloadAndStageUpdates,
+            AllowDevBuildAutoStageWithoutVersionComparison = _updaterOptions.AllowDevBuildAutoStageWithoutVersionComparison,
             AllowPreviewReleases = _updaterOptions.AllowPreviewReleases,
             UpdaterOperationalSettingsInitializedAtUtc = DateTimeOffset.UtcNow,
             UpdatedAtUtc = DateTimeOffset.UtcNow

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateBackgroundService.cs
@@ -17,6 +17,14 @@ internal sealed class ApplicationUpdateBackgroundService : BackgroundService
     private readonly ApplicationUpdaterOptions _options;
     private readonly ILogger<ApplicationUpdateBackgroundService> _logger;
 
+    internal enum AutoStagePlan
+    {
+        Skip = 0,
+        StageReleaseBuild = 1,
+        StageDevBuildWithOverride = 2,
+        SuppressDevBuildWithoutOverride = 3
+    }
+
     public ApplicationUpdateBackgroundService(
         IServiceScopeFactory scopeFactory,
         IStartupGateRuntimeState startupGateRuntimeState,
@@ -124,42 +132,127 @@ internal sealed class ApplicationUpdateBackgroundService : BackgroundService
             lastAutomaticCheckFailureMessage: null);
 
         var latestTag = result.LatestApplicableRelease?.TagName;
-        if (result.State == ApplicationUpdateCheckState.UpdateAvailable &&
-            !string.IsNullOrWhiteSpace(latestTag) &&
-            !string.Equals(previousState?.LastDetectedApplicableReleaseTag, latestTag, StringComparison.OrdinalIgnoreCase))
+        var releaseFound = !string.IsNullOrWhiteSpace(latestTag) && result.ReleaseDiscoverySucceeded;
+        var releaseChanged = releaseFound &&
+            !string.Equals(previousState?.LastDetectedApplicableReleaseTag, latestTag, StringComparison.OrdinalIgnoreCase);
+
+        if (releaseChanged)
         {
             nextState = Clone(nextState,
                 lastDetectedApplicableReleaseTag: latestTag,
                 lastDetectedApplicableReleaseAtUtc: now);
 
-            await eventLogService.WriteAsync(new EventLogWriteRequest
+            if (result.State == ApplicationUpdateCheckState.UpdateAvailable)
             {
-                Category = EventCategory.System,
-                EventType = EventType.UpdaterUpdateAvailableDetected,
-                Severity = EventSeverity.Info,
-                Message = $"A new applicable application update was detected: {latestTag}.",
-                DetailsJson = JsonSerializer.Serialize(new
+                await eventLogService.WriteAsync(new EventLogWriteRequest
                 {
-                    latestTag,
-                    result.AllowPreviewReleases,
-                    releaseUrl = result.LatestApplicableRelease?.HtmlUrl
-                }, DetailsJsonOptions)
-            }, cancellationToken);
+                    Category = EventCategory.System,
+                    EventType = EventType.UpdaterUpdateAvailableDetected,
+                    Severity = EventSeverity.Info,
+                    Message = $"A new applicable application update was detected: {latestTag}.",
+                    DetailsJson = JsonSerializer.Serialize(new
+                    {
+                        latestTag,
+                        result.AllowPreviewReleases,
+                        releaseUrl = result.LatestApplicableRelease?.HtmlUrl
+                    }, DetailsJsonOptions)
+                }, cancellationToken);
+            }
+            else if (result.State == ApplicationUpdateCheckState.DevBuildComparisonSkipped)
+            {
+                nextState = Clone(nextState,
+                    lastDevComparisonSkippedReleaseTag: latestTag,
+                    lastDevComparisonSkippedAtUtc: now);
 
-            if (operationalSettings.AutomaticallyDownloadAndStageUpdates)
-            {
-                var alreadyAttempted = string.Equals(previousState?.LastAutoStageAttemptedReleaseTag, latestTag, StringComparison.OrdinalIgnoreCase);
-                if (!alreadyAttempted)
+                await eventLogService.WriteAsync(new EventLogWriteRequest
                 {
-                    nextState = await RunAutoStageAsync(
-                        stagingService,
-                        eventLogService,
-                        nextState,
+                    Category = EventCategory.System,
+                    EventType = EventType.UpdaterDevBuildComparisonSkipped,
+                    Severity = EventSeverity.Warning,
+                    Message = $"Latest applicable release {latestTag} was detected, but this instance is running a DEV build, so semantic comparison was skipped.",
+                    DetailsJson = JsonSerializer.Serialize(new
+                    {
                         latestTag,
                         operationalSettings.AllowPreviewReleases,
-                        now,
-                        cancellationToken);
-                }
+                        devBuild = true,
+                        semanticComparisonSkipped = true
+                    }, DetailsJsonOptions)
+                }, cancellationToken);
+            }
+        }
+
+        var autoStagePlan = DetermineAutoStagePlan(
+            result.State,
+            releaseFound,
+            operationalSettings.AutomaticallyDownloadAndStageUpdates,
+            operationalSettings.AllowDevBuildAutoStageWithoutVersionComparison,
+            previousState?.LastAutoStageAttemptedReleaseTag,
+            latestTag);
+
+        if (releaseFound && autoStagePlan != AutoStagePlan.Skip)
+        {
+            if (autoStagePlan == AutoStagePlan.StageReleaseBuild)
+            {
+                nextState = await RunAutoStageAsync(
+                    stagingService,
+                    eventLogService,
+                    nextState,
+                    latestTag!,
+                    operationalSettings.AllowPreviewReleases,
+                    now,
+                    cancellationToken);
+            }
+            else if (autoStagePlan == AutoStagePlan.StageDevBuildWithOverride)
+            {
+                nextState = Clone(nextState,
+                    lastDevAutoStageOverrideAllowedReleaseTag: latestTag,
+                    lastDevAutoStageOverrideAllowedAtUtc: now);
+
+                await eventLogService.WriteAsync(new EventLogWriteRequest
+                {
+                    Category = EventCategory.System,
+                    EventType = EventType.UpdaterDevBuildAutoStageOverrideAllowed,
+                    Severity = EventSeverity.Warning,
+                    Message = $"DEV-build override enabled: automatic staging is proceeding for {latestTag} without semantic version comparison.",
+                    DetailsJson = JsonSerializer.Serialize(new
+                    {
+                        latestTag,
+                        devBuild = true,
+                        overrideEnabled = true,
+                        semanticComparisonSkipped = true
+                    }, DetailsJsonOptions)
+                }, cancellationToken);
+
+                nextState = await RunAutoStageAsync(
+                    stagingService,
+                    eventLogService,
+                    nextState,
+                    latestTag!,
+                    operationalSettings.AllowPreviewReleases,
+                    now,
+                    cancellationToken);
+            }
+            else if (autoStagePlan == AutoStagePlan.SuppressDevBuildWithoutOverride)
+            {
+                nextState = Clone(nextState,
+                    lastDevAutoStageSuppressedReleaseTag: latestTag,
+                    lastDevAutoStageSuppressedAtUtc: now,
+                    lastAutoStageFailureMessage: "Automatic staging was skipped because this instance is running a DEV build and DEV override is disabled.");
+
+                await eventLogService.WriteAsync(new EventLogWriteRequest
+                {
+                    Category = EventCategory.System,
+                    EventType = EventType.UpdaterDevBuildAutoStageSkipped,
+                    Severity = EventSeverity.Info,
+                    Message = $"Automatic staging was skipped for {latestTag} because this instance is running a DEV build and the DEV override is disabled.",
+                    DetailsJson = JsonSerializer.Serialize(new
+                    {
+                        latestTag,
+                        devBuild = true,
+                        overrideEnabled = false,
+                        semanticComparisonSkipped = true
+                    }, DetailsJsonOptions)
+                }, cancellationToken);
             }
         }
 
@@ -249,6 +342,40 @@ internal sealed class ApplicationUpdateBackgroundService : BackgroundService
         return TimeSpan.FromMinutes(configured);
     }
 
+    internal static AutoStagePlan DetermineAutoStagePlan(
+        ApplicationUpdateCheckState state,
+        bool releaseFound,
+        bool automaticStageEnabled,
+        bool allowDevBuildAutoStageWithoutVersionComparison,
+        string? previousAttemptedTag,
+        string? latestTag)
+    {
+        if (!automaticStageEnabled || !releaseFound || string.IsNullOrWhiteSpace(latestTag))
+        {
+            return AutoStagePlan.Skip;
+        }
+
+        var alreadyAttempted = string.Equals(previousAttemptedTag, latestTag, StringComparison.OrdinalIgnoreCase);
+        if (alreadyAttempted)
+        {
+            return AutoStagePlan.Skip;
+        }
+
+        if (state == ApplicationUpdateCheckState.UpdateAvailable)
+        {
+            return AutoStagePlan.StageReleaseBuild;
+        }
+
+        if (state == ApplicationUpdateCheckState.DevBuildComparisonSkipped)
+        {
+            return allowDevBuildAutoStageWithoutVersionComparison
+                ? AutoStagePlan.StageDevBuildWithOverride
+                : AutoStagePlan.SuppressDevBuildWithoutOverride;
+        }
+
+        return AutoStagePlan.Skip;
+    }
+
     private static ApplicationUpdaterRuntimeState Clone(
         ApplicationUpdaterRuntimeState? state,
         DateTimeOffset? lastAutomaticCheckAtUtc = null,
@@ -261,7 +388,13 @@ internal sealed class ApplicationUpdateBackgroundService : BackgroundService
         DateTimeOffset? lastAutoStageAttemptedAtUtc = null,
         string? lastAutoStageFailureMessage = null,
         string? lastAutoStagedReleaseTag = null,
-        DateTimeOffset? lastAutoStagedAtUtc = null)
+        DateTimeOffset? lastAutoStagedAtUtc = null,
+        string? lastDevComparisonSkippedReleaseTag = null,
+        DateTimeOffset? lastDevComparisonSkippedAtUtc = null,
+        string? lastDevAutoStageSuppressedReleaseTag = null,
+        DateTimeOffset? lastDevAutoStageSuppressedAtUtc = null,
+        string? lastDevAutoStageOverrideAllowedReleaseTag = null,
+        DateTimeOffset? lastDevAutoStageOverrideAllowedAtUtc = null)
     {
         return new ApplicationUpdaterRuntimeState
         {
@@ -276,6 +409,12 @@ internal sealed class ApplicationUpdateBackgroundService : BackgroundService
             LastAutoStageFailureMessage = lastAutoStageFailureMessage ?? state?.LastAutoStageFailureMessage,
             LastAutoStagedReleaseTag = lastAutoStagedReleaseTag ?? state?.LastAutoStagedReleaseTag,
             LastAutoStagedAtUtc = lastAutoStagedAtUtc ?? state?.LastAutoStagedAtUtc,
+            LastDevComparisonSkippedReleaseTag = lastDevComparisonSkippedReleaseTag ?? state?.LastDevComparisonSkippedReleaseTag,
+            LastDevComparisonSkippedAtUtc = lastDevComparisonSkippedAtUtc ?? state?.LastDevComparisonSkippedAtUtc,
+            LastDevAutoStageSuppressedReleaseTag = lastDevAutoStageSuppressedReleaseTag ?? state?.LastDevAutoStageSuppressedReleaseTag,
+            LastDevAutoStageSuppressedAtUtc = lastDevAutoStageSuppressedAtUtc ?? state?.LastDevAutoStageSuppressedAtUtc,
+            LastDevAutoStageOverrideAllowedReleaseTag = lastDevAutoStageOverrideAllowedReleaseTag ?? state?.LastDevAutoStageOverrideAllowedReleaseTag,
+            LastDevAutoStageOverrideAllowedAtUtc = lastDevAutoStageOverrideAllowedAtUtc ?? state?.LastDevAutoStageOverrideAllowedAtUtc,
             LastUpdatedAtUtc = DateTimeOffset.UtcNow
         };
     }

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateDetectionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateDetectionService.cs
@@ -105,6 +105,10 @@ public sealed class ApplicationUpdateCheckResult
     public ApplicationUpdateCheckState State { get; init; }
     public string CurrentVersion { get; init; } = string.Empty;
     public bool AllowPreviewReleases { get; init; }
+    public bool IsCurrentBuildDev { get; init; }
+    public bool SemanticComparisonPerformed { get; init; }
+    public bool SemanticComparisonSkipped => !SemanticComparisonPerformed;
+    public bool ReleaseDiscoverySucceeded => LatestApplicableRelease is not null;
     public string Message { get; init; } = string.Empty;
     public GitHubReleaseSummary? LatestApplicableRelease { get; init; }
 
@@ -115,6 +119,7 @@ public sealed class ApplicationUpdateCheckResult
             State = ApplicationUpdateCheckState.CheckNotPerformed,
             CurrentVersion = currentVersion,
             AllowPreviewReleases = allowPreviewReleases,
+            IsCurrentBuildDev = ReleaseVersionParser.ParseCurrent(currentVersion).IsDevBuild,
             Message = "No update check has been performed yet."
         };
     }
@@ -126,6 +131,7 @@ public sealed class ApplicationUpdateCheckResult
             State = ApplicationUpdateCheckState.UpdateCheckDisabled,
             CurrentVersion = currentVersion,
             AllowPreviewReleases = allowPreviewReleases,
+            IsCurrentBuildDev = ReleaseVersionParser.ParseCurrent(currentVersion).IsDevBuild,
             Message = "Update checks are disabled by configuration."
         };
     }
@@ -137,6 +143,7 @@ public sealed class ApplicationUpdateCheckResult
             State = ApplicationUpdateCheckState.CheckFailed,
             CurrentVersion = currentVersion,
             AllowPreviewReleases = allowPreviewReleases,
+            IsCurrentBuildDev = ReleaseVersionParser.ParseCurrent(currentVersion).IsDevBuild,
             Message = message,
         };
     }
@@ -152,6 +159,7 @@ public sealed class ApplicationUpdateCheckResult
             State = ApplicationUpdateCheckState.NoApplicableRelease,
             CurrentVersion = currentVersion,
             AllowPreviewReleases = allowPreviewReleases,
+            IsCurrentBuildDev = parsedCurrentVersion.IsDevBuild,
             Message = $"No applicable GitHub release was found for the current preview-release filter. {currentVersionDescriptor}"
         };
     }
@@ -163,6 +171,7 @@ public sealed class ApplicationUpdateCheckResult
             State = ApplicationUpdateCheckState.UpdateAvailable,
             CurrentVersion = currentVersion,
             AllowPreviewReleases = allowPreviewReleases,
+            SemanticComparisonPerformed = true,
             Message = "A newer release is available.",
             LatestApplicableRelease = latestRelease
         };
@@ -175,6 +184,7 @@ public sealed class ApplicationUpdateCheckResult
             State = ApplicationUpdateCheckState.UpToDate,
             CurrentVersion = currentVersion,
             AllowPreviewReleases = allowPreviewReleases,
+            SemanticComparisonPerformed = true,
             Message = "Current version is already up to date.",
             LatestApplicableRelease = latestRelease
         };
@@ -187,8 +197,9 @@ public sealed class ApplicationUpdateCheckResult
             State = ApplicationUpdateCheckState.DevBuildComparisonSkipped,
             CurrentVersion = currentVersion,
             AllowPreviewReleases = allowPreviewReleases,
+            IsCurrentBuildDev = true,
             LatestApplicableRelease = latestRelease,
-            Message = "This instance is running a DEV build. Semantic comparison against release tags is skipped; latest GitHub release is shown for operator reference only."
+            Message = $"Latest applicable release {latestRelease.TagName} was detected, but this instance is running a DEV build, so semantic version comparison was skipped."
         };
     }
 
@@ -200,7 +211,7 @@ public sealed class ApplicationUpdateCheckResult
             CurrentVersion = currentVersion,
             AllowPreviewReleases = allowPreviewReleases,
             LatestApplicableRelease = latestRelease,
-            Message = "Current version format is not recognized as strict Vx.x.x and is not a DEV build. Comparison could not be performed safely."
+            Message = $"Latest applicable release {latestRelease.TagName} was detected, but current version format is not recognized as strict Vx.x.x and is not a DEV build. Comparison could not be performed safely."
         };
     }
 
@@ -212,7 +223,8 @@ public sealed class ApplicationUpdateCheckResult
             CurrentVersion = currentVersion,
             AllowPreviewReleases = allowPreviewReleases,
             LatestApplicableRelease = latestRelease,
-            Message = "Latest release tag is not a strict Vx.x.x version. Comparison could not be performed safely."
+            SemanticComparisonPerformed = true,
+            Message = $"Latest applicable release {latestRelease.TagName} was detected, but its tag is not a strict Vx.x.x version. Comparison could not be performed safely."
         };
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdaterOperationalSettingsDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdaterOperationalSettingsDto.cs
@@ -5,6 +5,7 @@ public sealed class ApplicationUpdaterOperationalSettingsDto
     public bool EnableAutomaticUpdateChecks { get; init; }
     public int AutomaticUpdateCheckIntervalMinutes { get; init; }
     public bool AutomaticallyDownloadAndStageUpdates { get; init; }
+    public bool AllowDevBuildAutoStageWithoutVersionComparison { get; init; }
     public bool AllowPreviewReleases { get; init; }
     public DateTimeOffset UpdatedAtUtc { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdaterOperationalSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdaterOperationalSettingsService.cs
@@ -37,6 +37,7 @@ internal sealed class ApplicationUpdaterOperationalSettingsService : IApplicatio
         settings.EnableAutomaticUpdateChecks = command.EnableAutomaticUpdateChecks;
         settings.AutomaticUpdateCheckIntervalMinutes = ResolveAutomaticCheckInterval(command.AutomaticUpdateCheckIntervalMinutes);
         settings.AutomaticallyDownloadAndStageUpdates = command.AutomaticallyDownloadAndStageUpdates;
+        settings.AllowDevBuildAutoStageWithoutVersionComparison = command.AllowDevBuildAutoStageWithoutVersionComparison;
         settings.AllowPreviewReleases = command.AllowPreviewReleases;
         settings.UpdaterOperationalSettingsInitializedAtUtc ??= DateTimeOffset.UtcNow;
         settings.UpdatedAtUtc = DateTimeOffset.UtcNow;
@@ -64,6 +65,7 @@ internal sealed class ApplicationUpdaterOperationalSettingsService : IApplicatio
                 EnableAutomaticUpdateChecks = _updaterOptions.EnableAutomaticUpdateChecks,
                 AutomaticUpdateCheckIntervalMinutes = ResolveAutomaticCheckInterval(_updaterOptions.AutomaticUpdateCheckIntervalMinutes),
                 AutomaticallyDownloadAndStageUpdates = _updaterOptions.AutomaticallyDownloadAndStageUpdates,
+                AllowDevBuildAutoStageWithoutVersionComparison = _updaterOptions.AllowDevBuildAutoStageWithoutVersionComparison,
                 AllowPreviewReleases = _updaterOptions.AllowPreviewReleases,
                 UpdaterOperationalSettingsInitializedAtUtc = DateTimeOffset.UtcNow,
                 UpdatedAtUtc = DateTimeOffset.UtcNow
@@ -79,6 +81,7 @@ internal sealed class ApplicationUpdaterOperationalSettingsService : IApplicatio
             settings.EnableAutomaticUpdateChecks = _updaterOptions.EnableAutomaticUpdateChecks;
             settings.AutomaticUpdateCheckIntervalMinutes = ResolveAutomaticCheckInterval(_updaterOptions.AutomaticUpdateCheckIntervalMinutes);
             settings.AutomaticallyDownloadAndStageUpdates = _updaterOptions.AutomaticallyDownloadAndStageUpdates;
+            settings.AllowDevBuildAutoStageWithoutVersionComparison = _updaterOptions.AllowDevBuildAutoStageWithoutVersionComparison;
             settings.AllowPreviewReleases = _updaterOptions.AllowPreviewReleases;
             settings.UpdaterOperationalSettingsInitializedAtUtc = DateTimeOffset.UtcNow;
             settings.UpdatedAtUtc = DateTimeOffset.UtcNow;
@@ -109,6 +112,7 @@ internal sealed class ApplicationUpdaterOperationalSettingsService : IApplicatio
             EnableAutomaticUpdateChecks = settings.EnableAutomaticUpdateChecks,
             AutomaticUpdateCheckIntervalMinutes = ResolveAutomaticCheckInterval(settings.AutomaticUpdateCheckIntervalMinutes),
             AutomaticallyDownloadAndStageUpdates = settings.AutomaticallyDownloadAndStageUpdates,
+            AllowDevBuildAutoStageWithoutVersionComparison = settings.AllowDevBuildAutoStageWithoutVersionComparison,
             AllowPreviewReleases = settings.AllowPreviewReleases,
             UpdatedAtUtc = settings.UpdatedAtUtc
         };

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdaterRuntimeState.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdaterRuntimeState.cs
@@ -18,6 +18,12 @@ public sealed class ApplicationUpdaterRuntimeState
     public string? LastAutoStageFailureMessage { get; init; }
     public string? LastAutoStagedReleaseTag { get; init; }
     public DateTimeOffset? LastAutoStagedAtUtc { get; init; }
+    public string? LastDevComparisonSkippedReleaseTag { get; init; }
+    public DateTimeOffset? LastDevComparisonSkippedAtUtc { get; init; }
+    public string? LastDevAutoStageSuppressedReleaseTag { get; init; }
+    public DateTimeOffset? LastDevAutoStageSuppressedAtUtc { get; init; }
+    public string? LastDevAutoStageOverrideAllowedReleaseTag { get; init; }
+    public DateTimeOffset? LastDevAutoStageOverrideAllowedAtUtc { get; init; }
     public DateTimeOffset LastUpdatedAtUtc { get; init; }
 }
 

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/UpdateApplicationUpdaterOperationalSettingsCommand.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/UpdateApplicationUpdaterOperationalSettingsCommand.cs
@@ -5,5 +5,6 @@ public sealed class UpdateApplicationUpdaterOperationalSettingsCommand
     public bool EnableAutomaticUpdateChecks { get; init; }
     public int AutomaticUpdateCheckIntervalMinutes { get; init; }
     public bool AutomaticallyDownloadAndStageUpdates { get; init; }
+    public bool AllowDevBuildAutoStageWithoutVersionComparison { get; init; }
     public bool AllowPreviewReleases { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -90,6 +90,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "EnableAutomaticUpdateChecks",
         "AutomaticUpdateCheckIntervalMinutes",
         "AutomaticallyDownloadAndStageUpdates",
+        "AllowDevBuildAutoStageWithoutVersionComparison",
         "AllowPreviewReleases",
         "UpdaterOperationalSettingsInitializedAtUtc",
         "UpdatedAtUtc"
@@ -423,6 +424,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 `EnableAutomaticUpdateChecks` tinyint(1) NOT NULL DEFAULT 1,
                 `AutomaticUpdateCheckIntervalMinutes` int NOT NULL DEFAULT 15,
                 `AutomaticallyDownloadAndStageUpdates` tinyint(1) NOT NULL DEFAULT 0,
+                `AllowDevBuildAutoStageWithoutVersionComparison` tinyint(1) NOT NULL DEFAULT 0,
                 `AllowPreviewReleases` tinyint(1) NOT NULL DEFAULT 0,
                 `UpdaterOperationalSettingsInitializedAtUtc` datetime(6) NULL,
                 `UpdatedAtUtc` datetime(6) NOT NULL,
@@ -1228,6 +1230,16 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 """
                 ALTER TABLE `ApplicationSettings`
                 ADD COLUMN `AutomaticallyDownloadAndStageUpdates` tinyint(1) NOT NULL DEFAULT 0;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasApplicationSettingsColumnAsync(connection, "AllowDevBuildAutoStageWithoutVersionComparison", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `ApplicationSettings`
+                ADD COLUMN `AllowDevBuildAutoStageWithoutVersionComparison` tinyint(1) NOT NULL DEFAULT 0;
                 """,
                 cancellationToken);
         }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/ApplicationUpdaterPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/ApplicationUpdaterPageViewModel.cs
@@ -10,6 +10,9 @@ public sealed class ApplicationUpdaterPageViewModel
     public bool UpdateChecksEnabled { get; init; }
     public bool EnableAutomaticUpdateChecks { get; set; }
     public bool AutomaticallyDownloadAndStageUpdates { get; set; }
+    public bool AllowDevBuildAutoStageWithoutVersionComparison { get; set; }
+    public bool IsCurrentBuildDev { get; init; }
+    public bool SemanticComparisonPerformed { get; init; }
 
     [Range(1, 1440, ErrorMessage = "Automatic check interval must be between 1 and 1440 minutes.")]
     public int AutomaticUpdateCheckIntervalMinutes { get; set; }

--- a/src/WebApp/PingMonitor.Web/Views/AdminApplicationUpdater/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminApplicationUpdater/Index.cshtml
@@ -49,6 +49,13 @@
                     <dt>Automatic stage</dt>
                     <dd>@(Model.AutomaticallyDownloadAndStageUpdates ? "Enabled" : "Disabled")</dd>
                 </div>
+                @if (Model.IsCurrentBuildDev)
+                {
+                    <div>
+                        <dt>DEV auto-stage override</dt>
+                        <dd>@(Model.AllowDevBuildAutoStageWithoutVersionComparison ? "Enabled (comparison bypass)" : "Disabled (safe default)")</dd>
+                    </div>
+                }
                 <div>
                     <dt>PowerShell 7 (`pwsh`) prerequisite</dt>
                     <dd>@(Model.PowerShellPrerequisiteAvailable ? "Available" : "Missing")</dd>
@@ -95,6 +102,17 @@
                         <span class="muted">When enabled, the updater stages newly detected releases automatically. Apply is still an explicit admin action.</span>
                     </span>
                 </label>
+                @if (Model.IsCurrentBuildDev)
+                {
+                    <label class="checkbox-row" for="allowDevBuildAutoStageWithoutVersionComparison">
+                        <input id="allowDevBuildAutoStageWithoutVersionComparison" name="AllowDevBuildAutoStageWithoutVersionComparison" type="checkbox" value="true" @(Model.AllowDevBuildAutoStageWithoutVersionComparison ? "checked" : null) />
+                        <input name="AllowDevBuildAutoStageWithoutVersionComparison" type="hidden" value="false" />
+                        <span>
+                            <strong>Allow automatic staging on DEV builds without semantic comparison</strong><br />
+                            <span class="muted">Warning: this bypasses normal installed-versus-latest version comparison. Keep disabled unless you explicitly want DEV build auto-stage behavior.</span>
+                        </span>
+                    </label>
+                }
                 <label class="checkbox-row" for="allowPreviewReleasesOperational">
                     <input id="allowPreviewReleasesOperational" name="AllowPreviewReleases" type="checkbox" value="true" @(Model.AllowPreviewReleases ? "checked" : null) />
                     <input name="AllowPreviewReleases" type="hidden" value="false" />
@@ -151,6 +169,20 @@
                 };
             }
             <div class="status @statusClass" role="status">@Model.Message</div>
+            @if (Model.IsCurrentBuildDev)
+            {
+                <div class="status status-warn" role="status" style="margin-top:0.75rem;">
+                    DEV build detected. Semantic version comparison is skipped for release eligibility.
+                    @if (Model.AllowDevBuildAutoStageWithoutVersionComparison)
+                    {
+                        <span> Automatic stage/check override is enabled for DEV mode.</span>
+                    }
+                    else
+                    {
+                        <span> Automatic staging is suppressed while the DEV override is disabled.</span>
+                    }
+                </div>
+            }
 
             @if (!string.IsNullOrWhiteSpace(Model.LatestVersion))
             {
@@ -283,6 +315,9 @@
                 <div><dt>Last auto-detected release</dt><dd>@(Model.RuntimeState?.LastDetectedApplicableReleaseTag ?? "(none)")</dd></div>
                 <div><dt>Last auto-staged release</dt><dd>@(Model.RuntimeState?.LastAutoStagedReleaseTag ?? "(none)")</dd></div>
                 <div><dt>Last auto-stage failure</dt><dd>@(Model.RuntimeState?.LastAutoStageFailureMessage ?? "(none)")</dd></div>
+                <div><dt>Last DEV comparison-skipped release</dt><dd>@(Model.RuntimeState?.LastDevComparisonSkippedReleaseTag ?? "(none)")</dd></div>
+                <div><dt>Last DEV auto-stage suppression</dt><dd>@(Model.RuntimeState?.LastDevAutoStageSuppressedReleaseTag ?? "(none)")</dd></div>
+                <div><dt>Last DEV override auto-stage release</dt><dd>@(Model.RuntimeState?.LastDevAutoStageOverrideAllowedReleaseTag ?? "(none)")</dd></div>
             </dl>
         </section>
 

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -76,6 +76,7 @@
     "EnableAutomaticUpdateChecks": true,
     "AutomaticUpdateCheckIntervalMinutes": 15,
     "AutomaticallyDownloadAndStageUpdates": false,
+    "AllowDevBuildAutoStageWithoutVersionComparison": false,
     "GitHubOwner": "ijyates1992",
     "GitHubRepository": "ping-monitor",
     "GitHubApiBaseUrl": "https://api.github.com",


### PR DESCRIPTION
### Motivation

- DEV builds could discover a latest applicable release but appeared to find nothing because semantic version comparison failed against `DEV-*` versions, confusing operators.
- The updater must still report discovered releases on DEV builds, clearly indicate when semantic comparison is skipped, and optionally allow a DEV-only override to permit automatic staging despite skipped comparison.

### Description

- Split release discovery from semantic comparison by adding `ReleaseDiscoverySucceeded`, `SemanticComparisonPerformed`, and `IsCurrentBuildDev` to `ApplicationUpdateCheckResult` and returning an explicit `DevBuildComparisonSkipped` state when applicable; check messages were updated to be explicit. (changes in `ApplicationUpdateDetectionService.cs`).
- Introduced a new persisted setting `AllowDevBuildAutoStageWithoutVersionComparison` (default `false`) and wired it through `ApplicationUpdaterOptions`, operational DTO/command/service, `ApplicationSettings`, and startup schema migration. (options, DTOs, service, schema, and appsettings changes).
- Updated the automatic background flow to treat release discovery as a distinct transition and to compute an `AutoStagePlan` that handles: normal release staging, DEV build suppression when override is OFF, and DEV override-allowed staging when ON; added transition-based event logging and runtime state fields for DEV-specific transitions. (changes in `ApplicationUpdateBackgroundService.cs`, `ApplicationUpdaterRuntimeState.cs`, `EventType.cs`).
- Exposed DEV-only override and DEV-specific status/messages in the admin updater UI/viewmodel/controller so operators see that a release was discovered and that comparison was skipped and whether auto-stage is suppressed or permitted. (changes in `AdminApplicationUpdaterController.cs`, `ApplicationUpdaterPageViewModel.cs`, `Index.cshtml`).
- Added three new updater event types for meaningful transition logging: `updater_dev_build_comparison_skipped`, `updater_dev_build_auto_stage_skipped`, and `updater_dev_build_auto_stage_override_allowed`, and updated docs. (changes in `EventType.cs`, `docs/event-logging.md`, `docs/manual-application-updater-v1-spec.md`).
- Added deterministic unit tests for DEV-detection and auto-stage decision logic and updated an existing DEV comparison test to assert discovery + skipped-comparison visibility. (changes in `ApplicationUpdaterTests.cs`).

### Testing

- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`, which succeeded with zero errors or warnings.
- Ran unit tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj`, and all tests passed: `Passed - Failed: 0, Passed: 30, Skipped: 0, Total: 30`.
- The test suite includes new assertions that DEV builds still report discovered releases while `SemanticComparisonPerformed` is false, and new deterministic tests for `DetermineAutoStagePlan` covering DEV+override OFF (suppressed), DEV+override ON (allowed), and release-build behavior (unchanged), all of which passed.
- Verified release-build behavior is unchanged by keeping the original `UpdateAvailable` staging path intact and adding a dedicated path for DEV states; no release-build logic was modified beyond the separation of discovery vs comparison.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2889cf7c832ab0ef3529b4b1996d)