### PR TITLE
Add selectable release targeting and release notes to application updater

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateStagingServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateStagingServiceTests.cs
@@ -220,6 +220,39 @@ public sealed class ApplicationUpdateStagingServiceTests
         }
     }
 
+    [Fact]
+    public async Task StageSelectedApplicableReleaseAsync_StagesSelectedRelease_WhenNotLatest()
+    {
+        var tempRoot = CreateTempRoot();
+        try
+        {
+            var selectedRelease = BuildRelease("V1.2.3");
+            var latestRelease = BuildRelease("V1.2.4");
+            var zipBytes = Encoding.UTF8.GetBytes("selected-release-zip-content");
+            var checksum = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(zipBytes));
+
+            var handler = new MappingHttpMessageHandler(new Dictionary<string, HttpResponseMessage>
+            {
+                ["https://download/release.zip"] = new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(zipBytes) },
+                ["https://download/SHA256.txt"] = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent($"{checksum}  PingMonitor-V1.2.3-win-x64.zip", Encoding.UTF8, "text/plain")
+                }
+            });
+
+            var service = BuildService(tempRoot, new MultiReleaseLookupService([latestRelease, selectedRelease]), handler);
+            var result = await service.StageSelectedApplicableReleaseAsync(false, "V1.2.3", CancellationToken.None);
+
+            Assert.Equal(ApplicationUpdateStagingStatus.Ready, result.State.Status);
+            Assert.Equal("V1.2.3", result.State.ReleaseTag);
+            Assert.Equal("V1.2.4", result.State.LatestApplicableReleaseTag);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
     private static string CreateTempRoot()
     {
         var path = Path.Combine(Path.GetTempPath(), "ping-monitor-stage2-tests", Guid.NewGuid().ToString("N"));
@@ -308,6 +341,12 @@ public sealed class ApplicationUpdateStagingServiceTests
             await _delayTask.WaitAsync(cancellationToken);
             return _release;
         }
+
+        public async Task<IReadOnlyList<GitHubReleaseSummary>> GetApplicableReleasesAsync(bool allowPreviewReleases, int maxResults, CancellationToken cancellationToken)
+        {
+            await _delayTask.WaitAsync(cancellationToken);
+            return [_release];
+        }
     }
 
     private sealed class FakeReleaseLookupService : IGitHubReleaseLookupService
@@ -322,6 +361,35 @@ public sealed class ApplicationUpdateStagingServiceTests
         public Task<GitHubReleaseSummary?> GetLatestApplicableReleaseAsync(bool allowPreviewReleases, CancellationToken cancellationToken)
         {
             return Task.FromResult<GitHubReleaseSummary?>(_release);
+        }
+
+        public Task<IReadOnlyList<GitHubReleaseSummary>> GetApplicableReleasesAsync(bool allowPreviewReleases, int maxResults, CancellationToken cancellationToken)
+        {
+            IReadOnlyList<GitHubReleaseSummary> releases = [_release];
+            return Task.FromResult(releases);
+        }
+    }
+
+    private sealed class MultiReleaseLookupService : IGitHubReleaseLookupService
+    {
+        private readonly IReadOnlyList<GitHubReleaseSummary> _releases;
+
+        public MultiReleaseLookupService(IReadOnlyList<GitHubReleaseSummary> releases)
+        {
+            _releases = releases;
+        }
+
+        public Task<GitHubReleaseSummary?> GetLatestApplicableReleaseAsync(bool allowPreviewReleases, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_releases.FirstOrDefault());
+        }
+
+        public Task<IReadOnlyList<GitHubReleaseSummary>> GetApplicableReleasesAsync(bool allowPreviewReleases, int maxResults, CancellationToken cancellationToken)
+        {
+            IReadOnlyList<GitHubReleaseSummary> releases = maxResults > 0
+                ? _releases.Take(maxResults).ToArray()
+                : _releases;
+            return Task.FromResult(releases);
         }
     }
 

--- a/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdaterTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdaterTests.cs
@@ -183,5 +183,11 @@ public sealed class ApplicationUpdaterTests
         {
             return Task.FromResult(_release);
         }
+
+        public Task<IReadOnlyList<GitHubReleaseSummary>> GetApplicableReleasesAsync(bool allowPreviewReleases, int maxResults, CancellationToken cancellationToken)
+        {
+            IReadOnlyList<GitHubReleaseSummary> releases = _release is null ? [] : [_release];
+            return Task.FromResult(releases);
+        }
     }
 }

--- a/src/WebApp/PingMonitor.Web.Tests/GitHubReleaseLookupServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/GitHubReleaseLookupServiceTests.cs
@@ -44,6 +44,24 @@ public sealed class GitHubReleaseLookupServiceTests
         Assert.Equal("V0.2.0", result!.TagName);
     }
 
+    [Fact]
+    public async Task GetApplicableReleasesAsync_ReturnsFilteredList_WithReleaseBody()
+    {
+        var service = BuildService(
+            """
+            [
+              { "tag_name": "V0.2.0", "name": "Preview", "body": "Preview notes", "draft": false, "prerelease": true, "published_at": "2026-04-15T00:00:00Z", "html_url": "https://example/pre", "assets": [] },
+              { "tag_name": "V0.1.1", "name": "Stable", "body": "Stable notes", "draft": false, "prerelease": false, "published_at": "2026-04-10T00:00:00Z", "html_url": "https://example/stable", "assets": [] }
+            ]
+            """);
+
+        var result = await service.GetApplicableReleasesAsync(false, maxResults: 10, CancellationToken.None);
+
+        Assert.Single(result);
+        Assert.Equal("V0.1.1", result[0].TagName);
+        Assert.Equal("Stable notes", result[0].Body);
+    }
+
     private static GitHubReleaseLookupService BuildService(string body)
     {
         var handler = new StubHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminApplicationUpdaterController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminApplicationUpdaterController.cs
@@ -21,6 +21,7 @@ public sealed class AdminApplicationUpdaterController : Controller
     private readonly IApplicationUpdaterRuntimeStateStore _runtimeStateStore;
     private readonly IApplicationUpdaterOperationalSettingsService _operationalSettingsService;
     private readonly IPowerShellPrerequisiteDetector _powerShellPrerequisiteDetector;
+    private readonly IGitHubReleaseLookupService _gitHubReleaseLookupService;
     private readonly ApplicationUpdaterOptions _updaterOptions;
 
     public AdminApplicationUpdaterController(
@@ -31,6 +32,7 @@ public sealed class AdminApplicationUpdaterController : Controller
         IApplicationUpdaterRuntimeStateStore runtimeStateStore,
         IApplicationUpdaterOperationalSettingsService operationalSettingsService,
         IPowerShellPrerequisiteDetector powerShellPrerequisiteDetector,
+        IGitHubReleaseLookupService gitHubReleaseLookupService,
         IOptions<ApplicationUpdaterOptions> updaterOptions)
     {
         _applicationMetadataProvider = applicationMetadataProvider;
@@ -40,6 +42,7 @@ public sealed class AdminApplicationUpdaterController : Controller
         _runtimeStateStore = runtimeStateStore;
         _operationalSettingsService = operationalSettingsService;
         _powerShellPrerequisiteDetector = powerShellPrerequisiteDetector;
+        _gitHubReleaseLookupService = gitHubReleaseLookupService;
         _updaterOptions = updaterOptions.Value;
     }
 
@@ -54,35 +57,38 @@ public sealed class AdminApplicationUpdaterController : Controller
 
         var staged = await _applicationUpdateApplyService.RefreshApplyStateAsync(cancellationToken);
         var runtimeState = await _runtimeStateStore.ReadAsync(cancellationToken);
-        return View("Index", ToViewModel(result, staged, runtimeState, operationalSettings, saved: false));
+        var releaseSelection = await ResolveReleaseSelectionAsync(operationalSettings.AllowPreviewReleases, selectedReleaseTag: null, cancellationToken);
+        return View("Index", ToViewModel(result, staged, runtimeState, operationalSettings, releaseSelection, saved: false));
     }
 
     [HttpPost("check")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Check([FromForm] bool allowPreviewReleases, CancellationToken cancellationToken)
+    public async Task<IActionResult> Check([FromForm] bool allowPreviewReleases, [FromForm] string? selectedReleaseTag, CancellationToken cancellationToken)
     {
         var result = await _applicationUpdateDetectionService.CheckForUpdatesAsync(allowPreviewReleases, cancellationToken);
         var operationalSettings = await _operationalSettingsService.GetCurrentAsync(cancellationToken);
         var staged = await _applicationUpdateApplyService.RefreshApplyStateAsync(cancellationToken);
         var runtimeState = await _runtimeStateStore.ReadAsync(cancellationToken);
-        return View("Index", ToViewModel(result, staged, runtimeState, operationalSettings, saved: false));
+        var releaseSelection = await ResolveReleaseSelectionAsync(allowPreviewReleases, selectedReleaseTag, cancellationToken);
+        return View("Index", ToViewModel(result, staged, runtimeState, operationalSettings, releaseSelection, saved: false));
     }
 
     [HttpPost("stage")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Stage([FromForm] bool allowPreviewReleases, CancellationToken cancellationToken)
+    public async Task<IActionResult> Stage([FromForm] bool allowPreviewReleases, [FromForm] string? selectedReleaseTag, CancellationToken cancellationToken)
     {
-        await _applicationUpdateStagingService.StageLatestApplicableReleaseAsync(allowPreviewReleases, cancellationToken);
+        await _applicationUpdateStagingService.StageSelectedApplicableReleaseAsync(allowPreviewReleases, selectedReleaseTag, cancellationToken);
         var result = await _applicationUpdateDetectionService.CheckForUpdatesAsync(allowPreviewReleases, cancellationToken);
         var operationalSettings = await _operationalSettingsService.GetCurrentAsync(cancellationToken);
         var staged = await _applicationUpdateApplyService.RefreshApplyStateAsync(cancellationToken);
         var runtimeState = await _runtimeStateStore.ReadAsync(cancellationToken);
-        return View("Index", ToViewModel(result, staged, runtimeState, operationalSettings, saved: false));
+        var releaseSelection = await ResolveReleaseSelectionAsync(allowPreviewReleases, selectedReleaseTag, cancellationToken);
+        return View("Index", ToViewModel(result, staged, runtimeState, operationalSettings, releaseSelection, saved: false));
     }
 
     [HttpPost("apply")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Apply([FromForm] bool allowPreviewReleases, CancellationToken cancellationToken)
+    public async Task<IActionResult> Apply([FromForm] bool allowPreviewReleases, [FromForm] string? selectedReleaseTag, CancellationToken cancellationToken)
     {
         var requestedByUserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? User.Identity?.Name ?? "unknown";
         await _applicationUpdateApplyService.RequestApplyAsync(requestedByUserId, cancellationToken);
@@ -90,7 +96,8 @@ public sealed class AdminApplicationUpdaterController : Controller
         var operationalSettings = await _operationalSettingsService.GetCurrentAsync(cancellationToken);
         var staged = await _applicationUpdateApplyService.RefreshApplyStateAsync(cancellationToken);
         var runtimeState = await _runtimeStateStore.ReadAsync(cancellationToken);
-        return View("Index", ToViewModel(result, staged, runtimeState, operationalSettings, saved: false));
+        var releaseSelection = await ResolveReleaseSelectionAsync(allowPreviewReleases, selectedReleaseTag, cancellationToken);
+        return View("Index", ToViewModel(result, staged, runtimeState, operationalSettings, releaseSelection, saved: false));
     }
 
     [HttpPost("settings")]
@@ -106,7 +113,8 @@ public sealed class AdminApplicationUpdaterController : Controller
             var stagedState = await _applicationUpdateApplyService.RefreshApplyStateAsync(cancellationToken);
             var runtimeState = await _runtimeStateStore.ReadAsync(cancellationToken);
             var currentSettings = await _operationalSettingsService.GetCurrentAsync(cancellationToken);
-            return View("Index", ToViewModel(result, stagedState, runtimeState, currentSettings, saved: false));
+            var releaseSelection = await ResolveReleaseSelectionAsync(model.AllowPreviewReleases, model.SelectedReleaseTag, cancellationToken);
+            return View("Index", ToViewModel(result, stagedState, runtimeState, currentSettings, releaseSelection, saved: false));
         }
 
         var updatedSettings = await _operationalSettingsService.UpdateAsync(
@@ -126,7 +134,8 @@ public sealed class AdminApplicationUpdaterController : Controller
 
         var staged = await _applicationUpdateApplyService.RefreshApplyStateAsync(cancellationToken);
         var runtime = await _runtimeStateStore.ReadAsync(cancellationToken);
-        return View("Index", ToViewModel(checkResult, staged, runtime, updatedSettings, saved: true));
+        var releaseSelectionForSaved = await ResolveReleaseSelectionAsync(updatedSettings.AllowPreviewReleases, model.SelectedReleaseTag, cancellationToken);
+        return View("Index", ToViewModel(checkResult, staged, runtime, updatedSettings, releaseSelectionForSaved, saved: true));
     }
 
     private ApplicationUpdaterPageViewModel ToViewModel(
@@ -134,9 +143,11 @@ public sealed class AdminApplicationUpdaterController : Controller
         ApplicationUpdateStagingState? staged,
         ApplicationUpdaterRuntimeState? runtimeState,
         ApplicationUpdaterOperationalSettingsDto operationalSettings,
+        ReleaseSelectionResult releaseSelection,
         bool saved)
     {
-        var decoratedStaged = ApplyLatestComparison(staged, result.LatestApplicableRelease?.TagName);
+        var latestApplicableRelease = releaseSelection.LatestRelease ?? result.LatestApplicableRelease;
+        var decoratedStaged = ApplyLatestComparison(staged, latestApplicableRelease?.TagName);
         var powerShellStatus = _powerShellPrerequisiteDetector.GetStatus();
 
         return new ApplicationUpdaterPageViewModel
@@ -158,13 +169,57 @@ public sealed class AdminApplicationUpdaterController : Controller
             Message = result.Message,
             IsCurrentBuildDev = result.IsCurrentBuildDev,
             SemanticComparisonPerformed = result.SemanticComparisonPerformed,
-            LatestVersion = result.LatestApplicableRelease?.TagName,
-            LatestReleaseName = result.LatestApplicableRelease?.Name,
-            LatestIsPrerelease = result.LatestApplicableRelease?.IsPrerelease,
-            LatestReleaseUrl = result.LatestApplicableRelease?.HtmlUrl,
-            LatestPublishedAtUtc = result.LatestApplicableRelease?.PublishedAtUtc,
+            SelectedReleaseTag = releaseSelection.SelectedRelease?.TagName,
+            SelectedRelease = MapRelease(releaseSelection.SelectedRelease),
+            SelectableReleases = releaseSelection.Releases.Select(MapRelease).OfType<ApplicationUpdaterSelectableReleaseViewModel>().ToArray(),
+            LatestVersion = latestApplicableRelease?.TagName,
+            LatestReleaseName = latestApplicableRelease?.Name,
+            LatestIsPrerelease = latestApplicableRelease?.IsPrerelease,
+            LatestReleaseUrl = latestApplicableRelease?.HtmlUrl,
+            LatestPublishedAtUtc = latestApplicableRelease?.PublishedAtUtc,
             RuntimeState = runtimeState,
             StagedUpdate = decoratedStaged
+        };
+    }
+
+    private async Task<ReleaseSelectionResult> ResolveReleaseSelectionAsync(bool allowPreviewReleases, string? selectedReleaseTag, CancellationToken cancellationToken)
+    {
+        if (!_updaterOptions.UpdateChecksEnabled)
+        {
+            return new ReleaseSelectionResult([], null, null);
+        }
+
+        try
+        {
+            var releases = await _gitHubReleaseLookupService.GetApplicableReleasesAsync(allowPreviewReleases, maxResults: 20, cancellationToken);
+            var latest = releases.FirstOrDefault();
+            var selected = string.IsNullOrWhiteSpace(selectedReleaseTag)
+                ? latest
+                : releases.FirstOrDefault(release => string.Equals(release.TagName, selectedReleaseTag, StringComparison.OrdinalIgnoreCase)) ?? latest;
+
+            return new ReleaseSelectionResult(releases, selected, latest);
+        }
+        catch
+        {
+            return new ReleaseSelectionResult([], null, null);
+        }
+    }
+
+    private static ApplicationUpdaterSelectableReleaseViewModel? MapRelease(GitHubReleaseSummary? release)
+    {
+        if (release is null)
+        {
+            return null;
+        }
+
+        return new ApplicationUpdaterSelectableReleaseViewModel
+        {
+            TagName = release.TagName,
+            Name = release.Name,
+            Body = release.Body,
+            IsPrerelease = release.IsPrerelease,
+            HtmlUrl = release.HtmlUrl,
+            PublishedAtUtc = release.PublishedAtUtc
         };
     }
 
@@ -231,4 +286,9 @@ public sealed class AdminApplicationUpdaterController : Controller
             LastUpdatedAtUtc = staged.LastUpdatedAtUtc
         };
     }
+
+    private sealed record ReleaseSelectionResult(
+        IReadOnlyList<GitHubReleaseSummary> Releases,
+        GitHubReleaseSummary? SelectedRelease,
+        GitHubReleaseSummary? LatestRelease);
 }

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateDetectionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateDetectionService.cs
@@ -233,6 +233,7 @@ public sealed class GitHubReleaseSummary
 {
     public string TagName { get; init; } = string.Empty;
     public string? Name { get; init; }
+    public string? Body { get; init; }
     public bool IsPrerelease { get; init; }
     public string? HtmlUrl { get; init; }
     public DateTimeOffset? PublishedAtUtc { get; init; }

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateStagingService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateStagingService.cs
@@ -9,6 +9,7 @@ namespace PingMonitor.Web.Services.ApplicationUpdater;
 public interface IApplicationUpdateStagingService
 {
     Task<ApplicationUpdateStagingResult> StageLatestApplicableReleaseAsync(bool allowPreviewReleases, CancellationToken cancellationToken);
+    Task<ApplicationUpdateStagingResult> StageSelectedApplicableReleaseAsync(bool allowPreviewReleases, string? selectedReleaseTag, CancellationToken cancellationToken);
 }
 
 internal sealed partial class ApplicationUpdateStagingService : IApplicationUpdateStagingService
@@ -34,6 +35,11 @@ internal sealed partial class ApplicationUpdateStagingService : IApplicationUpda
     }
 
     public async Task<ApplicationUpdateStagingResult> StageLatestApplicableReleaseAsync(bool allowPreviewReleases, CancellationToken cancellationToken)
+    {
+        return await StageSelectedApplicableReleaseAsync(allowPreviewReleases, selectedReleaseTag: null, cancellationToken);
+    }
+
+    public async Task<ApplicationUpdateStagingResult> StageSelectedApplicableReleaseAsync(bool allowPreviewReleases, string? selectedReleaseTag, CancellationToken cancellationToken)
     {
         var repository = $"{_options.GitHubOwner}/{_options.GitHubRepository}";
         var now = DateTimeOffset.UtcNow;
@@ -74,10 +80,10 @@ internal sealed partial class ApplicationUpdateStagingService : IApplicationUpda
                 currentState), cancellationToken);
         }
 
-        GitHubReleaseSummary? release;
+        IReadOnlyList<GitHubReleaseSummary> releases;
         try
         {
-            release = await _gitHubReleaseLookupService.GetLatestApplicableReleaseAsync(allowPreviewReleases, cancellationToken);
+            releases = await _gitHubReleaseLookupService.GetApplicableReleasesAsync(allowPreviewReleases, maxResults: 20, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -90,7 +96,8 @@ internal sealed partial class ApplicationUpdateStagingService : IApplicationUpda
                 currentState), cancellationToken);
         }
 
-        if (release is null)
+        var latestRelease = releases.FirstOrDefault();
+        if (latestRelease is null)
         {
             return await WriteAndReturnAsync(BuildState(
                 repository,
@@ -101,6 +108,7 @@ internal sealed partial class ApplicationUpdateStagingService : IApplicationUpda
                 currentState), cancellationToken);
         }
 
+        var release = ResolveSelectedRelease(releases, selectedReleaseTag) ?? latestRelease;
         if (CanReuseCurrentStage(currentState, release.TagName) &&
             await ValidateExistingStagedArtifactsAsync(currentState!, cancellationToken))
         {
@@ -111,7 +119,7 @@ internal sealed partial class ApplicationUpdateStagingService : IApplicationUpda
                 $"Release {release.TagName} is already staged and verified. No staging changes were required.",
                 DateTimeOffset.UtcNow,
                 currentState,
-                latestApplicableReleaseTag: release.TagName,
+                latestApplicableReleaseTag: latestRelease.TagName,
                 stageOperationWasNoOp: true), cancellationToken);
         }
 
@@ -157,7 +165,7 @@ internal sealed partial class ApplicationUpdateStagingService : IApplicationUpda
                 checksumAsset.Name,
                 zipPath,
                 checksumPath,
-                latestApplicableReleaseTag: release.TagName), cancellationToken);
+                latestApplicableReleaseTag: latestRelease.TagName), cancellationToken);
         }
 
         string expectedHash;
@@ -181,7 +189,7 @@ internal sealed partial class ApplicationUpdateStagingService : IApplicationUpda
                 checksumAsset.Name,
                 zipPath,
                 checksumPath,
-                latestApplicableReleaseTag: release.TagName), cancellationToken);
+                latestApplicableReleaseTag: latestRelease.TagName), cancellationToken);
         }
 
         if (!string.Equals(expectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
@@ -201,7 +209,7 @@ internal sealed partial class ApplicationUpdateStagingService : IApplicationUpda
                 expectedHash,
                 actualHash,
                 false,
-                latestApplicableReleaseTag: release.TagName), cancellationToken);
+                latestApplicableReleaseTag: latestRelease.TagName), cancellationToken);
         }
 
         return await WriteAndReturnAsync(BuildState(
@@ -220,7 +228,17 @@ internal sealed partial class ApplicationUpdateStagingService : IApplicationUpda
             actualHash,
             true,
             DateTimeOffset.UtcNow,
-            latestApplicableReleaseTag: release.TagName), cancellationToken);
+            latestApplicableReleaseTag: latestRelease.TagName), cancellationToken);
+    }
+
+    private static GitHubReleaseSummary? ResolveSelectedRelease(IReadOnlyList<GitHubReleaseSummary> releases, string? selectedReleaseTag)
+    {
+        if (string.IsNullOrWhiteSpace(selectedReleaseTag))
+        {
+            return null;
+        }
+
+        return releases.FirstOrDefault(release => string.Equals(release.TagName, selectedReleaseTag, StringComparison.OrdinalIgnoreCase));
     }
 
     private static FileStream? TryAcquireStageLock(string lockPath)

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/GitHubReleaseLookupService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/GitHubReleaseLookupService.cs
@@ -9,6 +9,7 @@ namespace PingMonitor.Web.Services.ApplicationUpdater;
 public interface IGitHubReleaseLookupService
 {
     Task<GitHubReleaseSummary?> GetLatestApplicableReleaseAsync(bool allowPreviewReleases, CancellationToken cancellationToken);
+    Task<IReadOnlyList<GitHubReleaseSummary>> GetApplicableReleasesAsync(bool allowPreviewReleases, int maxResults, CancellationToken cancellationToken);
 }
 
 internal sealed class GitHubReleaseLookupService : IGitHubReleaseLookupService
@@ -25,6 +26,12 @@ internal sealed class GitHubReleaseLookupService : IGitHubReleaseLookupService
     }
 
     public async Task<GitHubReleaseSummary?> GetLatestApplicableReleaseAsync(bool allowPreviewReleases, CancellationToken cancellationToken)
+    {
+        var releases = await GetApplicableReleasesAsync(allowPreviewReleases, maxResults: 1, cancellationToken);
+        return releases.FirstOrDefault();
+    }
+
+    public async Task<IReadOnlyList<GitHubReleaseSummary>> GetApplicableReleasesAsync(bool allowPreviewReleases, int maxResults, CancellationToken cancellationToken)
     {
         var client = _httpClientFactory.CreateClient(nameof(GitHubReleaseLookupService));
         using var request = new HttpRequestMessage(HttpMethod.Get, BuildReleasesUrl());
@@ -47,6 +54,7 @@ internal sealed class GitHubReleaseLookupService : IGitHubReleaseLookupService
             throw new InvalidOperationException("GitHub API response did not return an array of releases.");
         }
 
+        var results = new List<GitHubReleaseSummary>();
         foreach (var release in document.RootElement.EnumerateArray())
         {
             var isDraft = GetBoolean(release, "draft");
@@ -67,19 +75,25 @@ internal sealed class GitHubReleaseLookupService : IGitHubReleaseLookupService
                 continue;
             }
 
-            return new GitHubReleaseSummary
+            results.Add(new GitHubReleaseSummary
             {
                 TagName = tagName.Trim(),
                 Name = GetString(release, "name")?.Trim(),
                 IsPrerelease = isPrerelease,
                 HtmlUrl = GetString(release, "html_url")?.Trim(),
                 PublishedAtUtc = TryGetDateTimeOffset(release, "published_at"),
+                Body = GetString(release, "body"),
                 AssetsApiUrl = GetString(release, "assets_url")?.Trim(),
                 Assets = ParseAssets(release)
-            };
+            });
+
+            if (maxResults > 0 && results.Count >= maxResults)
+            {
+                break;
+            }
         }
 
-        return null;
+        return results;
     }
 
     private string BuildReleasesUrl()

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/ApplicationUpdaterPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/ApplicationUpdaterPageViewModel.cs
@@ -25,6 +25,9 @@ public sealed class ApplicationUpdaterPageViewModel
     public string PowerShellPrerequisiteMessage { get; init; } = string.Empty;
     public ApplicationUpdateCheckState State { get; init; }
     public string Message { get; init; } = string.Empty;
+    public string? SelectedReleaseTag { get; init; }
+    public ApplicationUpdaterSelectableReleaseViewModel? SelectedRelease { get; init; }
+    public IReadOnlyList<ApplicationUpdaterSelectableReleaseViewModel> SelectableReleases { get; init; } = [];
     public string? LatestVersion { get; init; }
     public string? LatestReleaseName { get; init; }
     public bool? LatestIsPrerelease { get; init; }
@@ -32,4 +35,14 @@ public sealed class ApplicationUpdaterPageViewModel
     public DateTimeOffset? LatestPublishedAtUtc { get; init; }
     public ApplicationUpdaterRuntimeState? RuntimeState { get; init; }
     public ApplicationUpdateStagingState? StagedUpdate { get; init; }
+}
+
+public sealed class ApplicationUpdaterSelectableReleaseViewModel
+{
+    public string TagName { get; init; } = string.Empty;
+    public string? Name { get; init; }
+    public string? Body { get; init; }
+    public bool IsPrerelease { get; init; }
+    public string? HtmlUrl { get; init; }
+    public DateTimeOffset? PublishedAtUtc { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Views/AdminApplicationUpdater/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminApplicationUpdater/Index.cshtml
@@ -18,6 +18,7 @@
         input[type=checkbox]{width:20px;height:20px;margin-top:.2rem;} dl{margin:0;display:grid;gap:.6rem;} dt{font-weight:700;} dd{margin:0;word-break:break-word;}
         .controls-group{display:grid;gap:1rem;padding-top:.75rem;border-top:1px solid var(--border);} .controls-group:first-of-type{border-top:0;padding-top:0;}
         details{margin-top:.75rem;} summary{cursor:pointer;font-weight:700;} .summary-grid{display:grid;gap:.6rem;margin-top:1rem;}
+        .release-notes{background:rgba(0,0,0,.03);border:1px solid var(--border);border-radius:10px;padding:.75rem;max-height:260px;overflow:auto;white-space:pre-wrap;word-break:break-word;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:.9rem;}
     </style>
 </head>
 <body>
@@ -68,6 +69,7 @@
 
             <form class="controls-group" method="post" action="/admin/application-updater/settings">
                 @Html.AntiForgeryToken()
+                <input type="hidden" name="SelectedReleaseTag" value="@Model.SelectedReleaseTag" />
                 <h3>Operational settings</h3>
                 @if (Model.SettingsSaved)
                 {
@@ -131,6 +133,23 @@
             <form class="controls-group" method="post" action="/admin/application-updater/check">
                 @Html.AntiForgeryToken()
                 <input type="hidden" name="allowPreviewReleases" value="@(Model.AllowPreviewReleases ? "true" : "false")" />
+                <div class="field">
+                    <label for="selectedReleaseTagCheck"><strong>Target release</strong></label>
+                    <select id="selectedReleaseTagCheck" name="selectedReleaseTag">
+                        @if (Model.SelectableReleases.Count == 0)
+                        {
+                            <option value="">(No applicable releases)</option>
+                        }
+                        else
+                        {
+                            foreach (var release in Model.SelectableReleases)
+                            {
+                                <option value="@release.TagName" selected="@(string.Equals(Model.SelectedReleaseTag, release.TagName, StringComparison.OrdinalIgnoreCase) ? "selected" : null)">@release.TagName @(release.IsPrerelease ? "(preview)" : "(stable)")</option>
+                            }
+                        }
+                    </select>
+                    <p class="muted">Latest applicable under current filter: @(Model.LatestVersion ?? "(none)")</p>
+                </div>
                 <h3>Manual actions</h3>
                 <div class="button-row">
                     <button class="button" type="submit" @(Model.UpdateChecksEnabled ? null : "disabled")>Check now</button>
@@ -144,6 +163,7 @@
             <form class="controls-group" method="post" action="/admin/application-updater/stage">
                 @Html.AntiForgeryToken()
                 <input type="hidden" name="allowPreviewReleases" value="@(Model.AllowPreviewReleases ? "true" : "false")" />
+                <input type="hidden" name="selectedReleaseTag" value="@Model.SelectedReleaseTag" />
                 <div class="button-row">
                     <button class="button" type="submit" @((Model.UpdateChecksEnabled && Model.StagedUpdate?.StagingInProgress != true) ? null : "disabled")>Download, verify, and stage</button>
                 </div>
@@ -156,6 +176,7 @@
             <form class="controls-group" method="post" action="/admin/application-updater/apply">
                 @Html.AntiForgeryToken()
                 <input type="hidden" name="allowPreviewReleases" value="@(Model.AllowPreviewReleases ? "true" : "false")" />
+                <input type="hidden" name="selectedReleaseTag" value="@Model.SelectedReleaseTag" />
                 <div class="status status-warn" role="status">
                     Confirm operator intent before proceeding. This action is fire-and-forget and may restart the application.
                 </div>
@@ -219,6 +240,35 @@
                     }
                 </dl>
             </details>
+        </section>
+
+        <section class="card">
+            <h2>Selected release details</h2>
+            @if (Model.SelectedRelease is null)
+            {
+                <div class="status status-warn" role="status">No applicable release is currently selected under the active preview-release filter.</div>
+            }
+            else
+            {
+                @if (!string.IsNullOrWhiteSpace(Model.LatestVersion) && !string.Equals(Model.SelectedRelease.TagName, Model.LatestVersion, StringComparison.OrdinalIgnoreCase))
+                {
+                    <div class="status status-warn" role="status">The selected release is not the latest applicable release. This may intentionally skip newer versions.</div>
+                }
+                <div class="summary-grid">
+                    <div><strong>Tag/version:</strong> @Model.SelectedRelease.TagName</div>
+                    <div><strong>Title:</strong> @(string.IsNullOrWhiteSpace(Model.SelectedRelease.Name) ? "(not provided)" : Model.SelectedRelease.Name)</div>
+                    <div><strong>Published:</strong> @(Model.SelectedRelease.PublishedAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "Unknown")</div>
+                    <div><strong>Type:</strong> @(Model.SelectedRelease.IsPrerelease ? "Preview/prerelease" : "Stable")</div>
+                    @if (!string.IsNullOrWhiteSpace(Model.SelectedRelease.HtmlUrl))
+                    {
+                        <div><strong>Release URL:</strong> <a href="@Model.SelectedRelease.HtmlUrl" rel="noopener noreferrer" target="_blank">@Model.SelectedRelease.HtmlUrl</a></div>
+                    }
+                </div>
+                <details>
+                    <summary>Release notes</summary>
+                    <div class="release-notes">@(string.IsNullOrWhiteSpace(Model.SelectedRelease.Body) ? "No release notes were provided for this release." : Model.SelectedRelease.Body)</div>
+                </details>
+            }
         </section>
 
         <section class="card">


### PR DESCRIPTION
### Motivation
- Operators need to choose a specific release to stage/apply and read release notes instead of being forced to act only on the latest applicable release.
- Add minimal UI and data-model surface to support deliberate selection while preserving existing safety, staging, and apply flows.
- Keep preview-release filtering and the existing conservative staging/apply invariants intact and visible to operators.

### Description
- Extend the GitHub release lookup to return a filtered list of applicable releases and include the GitHub `body` (release notes) in `GitHubReleaseSummary` via `GetApplicableReleasesAsync` while preserving preview-release filtering rules.
- Add selected-release support to the page model and controller, exposing `SelectedReleaseTag`, `SelectedRelease`, and `SelectableReleases` to the view and defaulting selection to the latest applicable release when no explicit selection is present.
- Wire the updater UI to present a release dropdown, show a compact release-notes panel and selected-release metadata, and surface a warning when the selected release is not the latest applicable release.
- Change staging to target the selected applicable release (`StageSelectedApplicableReleaseAsync`) while still recording the latest-applicable tag in staged state and keeping stage lock/checksum verification/no-op restage logic unchanged.
- Add unit tests and test fakes for the new lookup method and selected-release staging behavior to prevent regressions in release selection and staging logic.
- Files with the main changes: `AdminApplicationUpdaterController.cs`, `GitHubReleaseLookupService.cs`, `ApplicationUpdateStagingService.cs`, `ApplicationUpdateDetectionService.cs`, `ApplicationUpdaterPageViewModel.cs`, `Index.cshtml`, and related tests under `src/WebApp/PingMonitor.Web.Tests`.
- Linkage: Fixes #441.

### Testing
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which succeeded without warnings or errors.
- Ran unit tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj --filter "GitHubReleaseLookupServiceTests|ApplicationUpdateStagingServiceTests|ApplicationUpdaterTests"` and the selected test groups passed (22 passed, 0 failed).
- New/updated tests cover: release-list retrieval and body mapping, selected-release staging behavior (selected vs latest), and updated fakes for the new lookup API to ensure deterministic behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3fde2ce0832a8ce0694f4a79fe8a)