### PR TITLE
Polish Application Updater title and render release notes as Markdown

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/AdminApplicationUpdaterController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminApplicationUpdaterController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Markdig;
 using System.Security.Claims;
 using PingMonitor.Web.Options;
 using PingMonitor.Web.Services.ApplicationMetadata;
@@ -237,6 +238,7 @@ public sealed class AdminApplicationUpdaterController : Controller
             TagName = release.TagName,
             Name = release.Name,
             Body = release.Body,
+            BodyHtml = string.IsNullOrWhiteSpace(release.Body) ? null : Markdown.ToHtml(release.Body),
             IsPrerelease = release.IsPrerelease,
             HtmlUrl = release.HtmlUrl,
             PublishedAtUtc = release.PublishedAtUtc,

--- a/src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj
+++ b/src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Markdig" Version="0.40.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="10.0.1" />

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/ApplicationUpdaterPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/ApplicationUpdaterPageViewModel.cs
@@ -46,6 +46,7 @@ public sealed class ApplicationUpdaterSelectableReleaseViewModel
     public string TagName { get; init; } = string.Empty;
     public string? Name { get; init; }
     public string? Body { get; init; }
+    public string? BodyHtml { get; init; }
     public bool IsPrerelease { get; init; }
     public string? HtmlUrl { get; init; }
     public DateTimeOffset? PublishedAtUtc { get; init; }

--- a/src/WebApp/PingMonitor.Web/Views/AdminApplicationUpdater/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminApplicationUpdater/Index.cshtml
@@ -18,7 +18,11 @@
         input[type=checkbox]{width:20px;height:20px;margin-top:.2rem;} dl{margin:0;display:grid;gap:.6rem;} dt{font-weight:700;} dd{margin:0;word-break:break-word;}
         .controls-group{display:grid;gap:1rem;padding-top:.75rem;border-top:1px solid var(--border);} .controls-group:first-of-type{border-top:0;padding-top:0;}
         details{margin-top:.75rem;} summary{cursor:pointer;font-weight:700;} .summary-grid{display:grid;gap:.6rem;margin-top:1rem;}
-        .release-notes{background:rgba(0,0,0,.03);border:1px solid var(--border);border-radius:10px;padding:.75rem;max-height:260px;overflow:auto;white-space:pre-wrap;word-break:break-word;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:.9rem;}
+        .release-notes{background:rgba(0,0,0,.03);border:1px solid var(--border);border-radius:10px;padding:.75rem;max-height:260px;overflow:auto;line-height:1.45;word-break:break-word;}
+        .release-notes :first-child{margin-top:0;} .release-notes :last-child{margin-bottom:0;}
+        .release-notes h1,.release-notes h2,.release-notes h3,.release-notes h4{line-height:1.25;margin:1rem 0 .5rem;}
+        .release-notes p{margin:.5rem 0;} .release-notes ul,.release-notes ol{margin:.5rem 0 .5rem 1.25rem;}
+        .release-notes li{margin:.25rem 0;} .release-notes code{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;}
     </style>
 </head>
 <body>
@@ -66,7 +70,7 @@
 
     <div class="stack">
         <section class="card">
-            <h1>Application updater (Stage 4)</h1>
+            <h1>Application updater</h1>
             <p class="muted">Manual admin flow for release detection, conservative staging, and external updater handoff. Applying an update restarts the application.</p>
             <div class="button-row">
                 <a class="button-secondary" href="/admin">Back to Admin settings</a>
@@ -287,7 +291,14 @@
                 </div>
                 <details>
                     <summary>Release notes</summary>
-                    <div class="release-notes">@(string.IsNullOrWhiteSpace(Model.SelectedRelease.Body) ? "No release notes were provided for this release." : Model.SelectedRelease.Body)</div>
+                    @if (string.IsNullOrWhiteSpace(Model.SelectedRelease.BodyHtml))
+                    {
+                        <div class="release-notes">No release notes were provided for this release.</div>
+                    }
+                    else
+                    {
+                        <div class="release-notes">@Html.Raw(Model.SelectedRelease.BodyHtml)</div>
+                    }
                 </details>
             }
         </section>


### PR DESCRIPTION
### Motivation
- Improve the admin updater page readability by removing internal staging suffix from the page header so operators see a clean title.
- Present GitHub release notes as formatted Markdown instead of raw plain text so headings, lists and inline formatting render correctly.
- Keep changes strictly UI/presentation-only and avoid touching any updater detection/stage/apply behavior.

### Description
- Added `Markdig` package and converted each release `Body` to HTML in `AdminApplicationUpdaterController.MapRelease(...)` and exposed it as `BodyHtml` on the selectable release view model (`ApplicationUpdaterSelectableReleaseViewModel`).
- Updated the Razor view `Views/AdminApplicationUpdater/Index.cshtml` to remove the `(Stage X)` suffix from the `<h1>` header and to render release notes using `@Html.Raw(Model.SelectedRelease.BodyHtml)` with a safe fallback message when notes are missing.
- Adjusted release-notes CSS (line-height, margins, list/heading styles) to display Markdown content cleanly in the existing layout without using a monospace `<pre>` block.
- This PR is linked to the tracking issue and intended fix: `Fixes #447`.

### Testing
- Successfully built `src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` using .NET SDK `10.0.104` with no build errors.
- Verified the updater page header no longer includes the `(Stage X)` suffix by inspecting the updated Razor view.
- Verified Markdown conversion and rendering paths by confirming `Markdig` usage in `AdminApplicationUpdaterController`, `BodyHtml` on the view model, and `@Html.Raw(...)` in the view using repository searches.
- No automated functional updater tests were modified and no updater behavior was changed; visual/browser verification was not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea67690cb8832a9aa3b5f8caed3b35)