### PR TITLE
Add bundled Python agent version tracking to deploy/manage flows

### DIFF
--- a/src/Agent/app/main.py
+++ b/src/Agent/app/main.py
@@ -13,6 +13,7 @@ from app.config import load_config
 from app.models import ConfigResponse, HeartbeatRequest, HelloRequest, ResultsRequest
 from app.result_queue import ResultQueue
 from app.scheduler import AssignmentScheduler
+from app.version import AGENT_VERSION
 
 BOOTSTRAP_CONFIG_VERSION = "bootstrap-pending"
 
@@ -29,7 +30,7 @@ def main() -> None:
     started_at = _utc_now()
     hello_response = client.send_hello(
         HelloRequest(
-            agent_version="0.1.0",
+            agent_version=AGENT_VERSION,
             machine_name=platform.node() or config.instance_id,
             platform=platform.system().lower() or "unknown",
             capabilities=["icmp"],
@@ -112,7 +113,7 @@ def main() -> None:
                 try:
                     heartbeat_response = client.send_heartbeat(
                         HeartbeatRequest(
-                            agent_version="0.1.0",
+                            agent_version=AGENT_VERSION,
                             sent_at_utc=_utc_now(),
                             config_version=current_config.config_version,
                             active_assignments=active_assignments,

--- a/src/Agent/app/version.py
+++ b/src/Agent/app/version.py
@@ -1,0 +1,1 @@
+AGENT_VERSION = "0.1.0"

--- a/src/WebApp/PingMonitor.Web.Tests/AgentTemplateVersionProviderTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AgentTemplateVersionProviderTests.cs
@@ -1,0 +1,106 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging.Abstractions;
+using PingMonitor.Web.Services;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class AgentTemplateVersionProviderTests
+{
+    [Fact]
+    public void GetBundledAgentVersion_ReadsVersionFromPublishedLayout()
+    {
+        var contentRoot = CreateTempDirectory();
+        try
+        {
+            var versionFile = Path.Combine(contentRoot, "Agent", "app", "version.py");
+            Directory.CreateDirectory(Path.GetDirectoryName(versionFile)!);
+            File.WriteAllText(versionFile, "AGENT_VERSION = \"1.2.3\"");
+
+            var provider = new AgentTemplateVersionProvider(
+                new StubWebHostEnvironment(contentRoot),
+                NullLogger<AgentTemplateVersionProvider>.Instance);
+
+            var version = provider.GetBundledAgentVersion();
+
+            Assert.Equal("1.2.3", version);
+        }
+        finally
+        {
+            Directory.Delete(contentRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetBundledAgentVersion_ReadsVersionFromDevelopmentLayout()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var contentRoot = Path.Combine(root, "src", "WebApp", "PingMonitor.Web");
+            Directory.CreateDirectory(contentRoot);
+            var versionFile = Path.Combine(root, "src", "Agent", "app", "version.py");
+            Directory.CreateDirectory(Path.GetDirectoryName(versionFile)!);
+            File.WriteAllText(versionFile, "AGENT_VERSION = \"2.0.0\"");
+
+            var provider = new AgentTemplateVersionProvider(
+                new StubWebHostEnvironment(contentRoot),
+                NullLogger<AgentTemplateVersionProvider>.Instance);
+
+            var version = provider.GetBundledAgentVersion();
+
+            Assert.Equal("2.0.0", version);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetBundledAgentVersion_ReturnsNullWhenVersionConstantIsMissing()
+    {
+        var contentRoot = CreateTempDirectory();
+        try
+        {
+            var versionFile = Path.Combine(contentRoot, "Agent", "app", "version.py");
+            Directory.CreateDirectory(Path.GetDirectoryName(versionFile)!);
+            File.WriteAllText(versionFile, "VERSION = \"x\"");
+
+            var provider = new AgentTemplateVersionProvider(
+                new StubWebHostEnvironment(contentRoot),
+                NullLogger<AgentTemplateVersionProvider>.Instance);
+
+            var version = provider.GetBundledAgentVersion();
+
+            Assert.Null(version);
+        }
+        finally
+        {
+            Directory.Delete(contentRoot, recursive: true);
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"ping-monitor-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private sealed class StubWebHostEnvironment : IWebHostEnvironment
+    {
+        public StubWebHostEnvironment(string contentRootPath)
+        {
+            ContentRootPath = contentRootPath;
+        }
+
+        public string EnvironmentName { get; set; } = "Development";
+        public string ApplicationName { get; set; } = "PingMonitor.Web.Tests";
+        public string WebRootPath { get; set; } = string.Empty;
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+        public string ContentRootPath { get; set; }
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
@@ -20,23 +20,27 @@ public sealed class AgentsController : Controller
     private readonly IAgentManagementQueryService _agentManagementQueryService;
     private readonly IEventLogQueryService _eventLogQueryService;
     private readonly IApplicationSettingsService _applicationSettingsService;
+    private readonly IAgentTemplateVersionProvider _agentTemplateVersionProvider;
 
     public AgentsController(
         IAgentProvisioningService agentProvisioningService,
         IAgentManagementQueryService agentManagementQueryService,
         IEventLogQueryService eventLogQueryService,
-        IApplicationSettingsService applicationSettingsService)
+        IApplicationSettingsService applicationSettingsService,
+        IAgentTemplateVersionProvider agentTemplateVersionProvider)
     {
         _agentProvisioningService = agentProvisioningService;
         _agentManagementQueryService = agentManagementQueryService;
         _eventLogQueryService = eventLogQueryService;
         _applicationSettingsService = applicationSettingsService;
+        _agentTemplateVersionProvider = agentTemplateVersionProvider;
     }
 
     [HttpGet("")]
     public async Task<IActionResult> Index(CancellationToken cancellationToken)
     {
         var rows = await _agentManagementQueryService.ListAsync(cancellationToken);
+        var bundledAgentVersion = _agentTemplateVersionProvider.GetBundledAgentVersion();
         var viewModel = new ManageAgentsPageViewModel
         {
             Agents = rows.Select(row => new ManageAgentRowViewModel
@@ -53,8 +57,10 @@ public sealed class AgentsController : Controller
                 Platform = row.Platform,
                 CreatedAtUtc = row.CreatedAtUtc,
                 AssignmentCount = row.AssignmentCount,
-                UptimePercent = row.UptimePercent
+                UptimePercent = row.UptimePercent,
+                IsVersionDifferentFromBundled = IsVersionDifferentFromBundled(row.AgentVersion, bundledAgentVersion)
             }).ToList(),
+            BundledAgentVersion = bundledAgentVersion,
             StatusMessage = TempData[StatusMessageKey] as string,
             ErrorMessage = TempData[ErrorMessageKey] as string
         };
@@ -240,8 +246,24 @@ public sealed class AgentsController : Controller
             SiteUrlSaved = postedModel?.SiteUrlSaved ?? false,
             SiteUrlIsValid = validation.isValid,
             SiteUrlWarningMessage = validation.warningMessage,
-            ErrorMessage = postedModel?.ErrorMessage
+            ErrorMessage = postedModel?.ErrorMessage,
+            BundledAgentVersion = _agentTemplateVersionProvider.GetBundledAgentVersion()
         };
+    }
+
+    private static bool IsVersionDifferentFromBundled(string runtimeVersion, string? bundledVersion)
+    {
+        if (string.IsNullOrWhiteSpace(bundledVersion) || string.IsNullOrWhiteSpace(runtimeVersion))
+        {
+            return false;
+        }
+
+        if (string.Equals(runtimeVersion, "Unknown", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return !string.Equals(runtimeVersion.Trim(), bundledVersion.Trim(), StringComparison.OrdinalIgnoreCase);
     }
 
     private static (bool isValid, string? warningMessage) ValidateDeploySiteUrl(string? siteUrl)

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -189,6 +189,7 @@ builder.Services.AddScoped<IStartupSchemaService, StartupSchemaService>();
 builder.Services.AddScoped<IStartupAdminBootstrapService, StartupAdminBootstrapService>();
 builder.Services.AddScoped<DevelopmentAgentSeeder>();
 builder.Services.AddScoped<IAgentPackageBuilder, AgentPackageBuilder>();
+builder.Services.AddScoped<IAgentTemplateVersionProvider, AgentTemplateVersionProvider>();
 builder.Services.AddScoped<IAgentProvisioningService, AgentProvisioningService>();
 builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsService>();
 builder.Services.AddSingleton<IApplicationMetadataProvider, ApplicationMetadataProvider>();

--- a/src/WebApp/PingMonitor.Web/Services/AgentPackageBuilder.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentPackageBuilder.cs
@@ -68,16 +68,7 @@ internal sealed class AgentPackageBuilder : IAgentPackageBuilder
         return output.ToArray();
     }
 
-    private string ResolveAgentRootPath()
-    {
-        var bundledTemplatePath = Path.Combine(_environment.ContentRootPath, "Agent");
-        if (Directory.Exists(bundledTemplatePath))
-        {
-            return bundledTemplatePath;
-        }
-
-        return Path.GetFullPath(Path.Combine(_environment.ContentRootPath, "..", "..", "Agent"));
-    }
+    private string ResolveAgentRootPath() => AgentTemplateLocator.ResolveAgentRootPath(_environment);
 
     private static string BuildEnvContents(string serverUrl, string instanceId, string apiKey)
     {

--- a/src/WebApp/PingMonitor.Web/Services/AgentTemplateLocator.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentTemplateLocator.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Hosting;
+
+namespace PingMonitor.Web.Services;
+
+internal static class AgentTemplateLocator
+{
+    public static string ResolveAgentRootPath(IWebHostEnvironment environment)
+    {
+        var bundledTemplatePath = Path.Combine(environment.ContentRootPath, "Agent");
+        if (Directory.Exists(bundledTemplatePath))
+        {
+            return bundledTemplatePath;
+        }
+
+        return Path.GetFullPath(Path.Combine(environment.ContentRootPath, "..", "..", "Agent"));
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/AgentTemplateVersionProvider.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentTemplateVersionProvider.cs
@@ -1,0 +1,43 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace PingMonitor.Web.Services;
+
+internal sealed partial class AgentTemplateVersionProvider : IAgentTemplateVersionProvider
+{
+    private readonly IWebHostEnvironment _environment;
+    private readonly ILogger<AgentTemplateVersionProvider> _logger;
+
+    public AgentTemplateVersionProvider(
+        IWebHostEnvironment environment,
+        ILogger<AgentTemplateVersionProvider> logger)
+    {
+        _environment = environment;
+        _logger = logger;
+    }
+
+    public string? GetBundledAgentVersion()
+    {
+        var agentRoot = AgentTemplateLocator.ResolveAgentRootPath(_environment);
+        var versionFilePath = Path.Combine(agentRoot, "app", "version.py");
+        if (!File.Exists(versionFilePath))
+        {
+            _logger.LogWarning("Bundled agent version file was not found at {VersionFilePath}", versionFilePath);
+            return null;
+        }
+
+        var fileContents = File.ReadAllText(versionFilePath);
+        var match = AgentVersionPattern().Match(fileContents);
+        if (!match.Success)
+        {
+            _logger.LogWarning("Bundled agent version could not be read from {VersionFilePath}", versionFilePath);
+            return null;
+        }
+
+        return match.Groups["version"].Value.Trim();
+    }
+
+    [GeneratedRegex("""^\s*AGENT_VERSION\s*=\s*["'](?<version>[^"']+)["']\s*$""", RegexOptions.Multiline | RegexOptions.CultureInvariant)]
+    private static partial Regex AgentVersionPattern();
+}

--- a/src/WebApp/PingMonitor.Web/Services/IAgentTemplateVersionProvider.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IAgentTemplateVersionProvider.cs
@@ -1,0 +1,6 @@
+namespace PingMonitor.Web.Services;
+
+public interface IAgentTemplateVersionProvider
+{
+    string? GetBundledAgentVersion();
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/Agents/DeployAgentPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Agents/DeployAgentPageViewModel.cs
@@ -18,4 +18,6 @@ public sealed class DeployAgentPageViewModel
     public string? SiteUrlWarningMessage { get; set; }
 
     public string? ErrorMessage { get; set; }
+
+    public string? BundledAgentVersion { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Agents/ManageAgentsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Agents/ManageAgentsPageViewModel.cs
@@ -3,6 +3,7 @@ namespace PingMonitor.Web.ViewModels.Agents;
 public sealed class ManageAgentsPageViewModel
 {
     public required IReadOnlyList<ManageAgentRowViewModel> Agents { get; init; }
+    public string? BundledAgentVersion { get; init; }
     public string? StatusMessage { get; init; }
     public string? ErrorMessage { get; init; }
 }
@@ -22,6 +23,7 @@ public sealed class ManageAgentRowViewModel
     public required DateTimeOffset CreatedAtUtc { get; init; }
     public required int AssignmentCount { get; init; }
     public required double? UptimePercent { get; init; }
+    public required bool IsVersionDifferentFromBundled { get; init; }
 }
 
 public sealed class RemoveAgentPageViewModel

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Deploy.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Deploy.cshtml
@@ -49,6 +49,7 @@
     <section class="card stack">
         <h1>Deploy new agent</h1>
         <p class="muted">Create a new agent identity and download a preconfigured standard package. The API key is generated server-side and delivered only in the download.</p>
+        <p class="muted"><strong>Bundled downloadable agent version:</strong> @(string.IsNullOrWhiteSpace(Model.BundledAgentVersion) ? "Unknown" : Model.BundledAgentVersion)</p>
 
         @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
         {

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
@@ -47,6 +47,7 @@
         .ok { background: #e7f6ec; color: var(--success); }
         .notice, .error { border-radius: 10px; padding: .75rem; }
         .notice { border: 1px solid #b7e4c7; background: #ebffee; color: var(--success); }
+        .warning { border-radius: 10px; padding: .75rem; border: 1px solid #fdc589; background: #fff4e5; color: #8a4600; }
         .error { border: 1px solid #fda29b; background: var(--error-bg); color: var(--error-text); }
         .empty { text-align: center; padding: 1rem; border: 1px dashed var(--border); border-radius: 12px; }
         form { margin: 0; }
@@ -63,6 +64,7 @@
         <section class="card">
             <h1>Manage agents</h1>
             <p class="muted">Operational control for registered agents. Actions here do not delete history or assignments.</p>
+            <p class="muted"><strong>Bundled downloadable agent version:</strong> @(string.IsNullOrWhiteSpace(Model.BundledAgentVersion) ? "Unknown" : Model.BundledAgentVersion)</p>
             <div class="button-row">
                 <a class="button-secondary" href="/status">Back to status</a>
                 <a class="button" href="/agents/deploy">Deploy new agent</a>
@@ -116,6 +118,12 @@
                                 <div class="meta-item"><span>Machine name</span><div>@agent.MachineName</div></div>
                                 <div class="meta-item"><span>Platform</span><div>@agent.Platform</div></div>
                             </div>
+                            @if (agent.IsVersionDifferentFromBundled)
+                            {
+                                <div class="warning" role="status" style="margin-top:.7rem;">
+                                    Runtime agent version (@agent.AgentVersion) differs from the currently bundled downloadable version (@Model.BundledAgentVersion).
+                                </div>
+                            }
 
                             <div class="action-row" style="margin-top:.9rem;">
                                 <a class="button-secondary" href="/agents/@agent.AgentId/history">View history</a>


### PR DESCRIPTION
### Motivation
- Provide a single authoritative source for the bundled Python agent version to avoid duplicated hardcoded strings in the agent and to surface the packaged version in the web UI for operator visibility.
- Make the bundled agent version discoverable in both published and development layouts so Deploy and Manage Agents pages can show which package is provided for download.
- Keep behavior read-only and diagnostic only (no forced upgrades, no API contract changes, no DB schema changes) and follow Startup Gate isolation constraints.

### Description
- Add `src/Agent/app/version.py` with `AGENT_VERSION` and update `src/Agent/app/main.py` to use that constant for both hello and heartbeat payloads instead of duplicated literals.
- Introduce `AgentTemplateLocator` and `AgentTemplateVersionProvider` (with `IAgentTemplateVersionProvider`) to read `Agent/app/version.py` from either the published `<ContentRoot>/Agent` layout or the development `../../Agent` layout, and register the provider in DI.
- Reuse the shared template path resolver in `AgentPackageBuilder` so package builds and version resolution consistently locate the same template files.
- Expose bundled agent version to view models and UI: show bundled downloadable version on the Deploy Agent page and Manage Agents page, and add a non-blocking informational warning per-agent when a runtime-reported agent version differs from the bundled version.
- Add focused tests `AgentTemplateVersionProviderTests` covering published layout, development layout, and missing/malformed version handling, and ensure the change is diagnostic-only (no DB writes, no background services, and no dependency bumps).

### Testing
- Ran Python syntax validation with `python -m compileall src/Agent/app` which compiled the agent files including the new `version.py` without errors.
- Ran unit tests with `.NET 10` SDK and `dotnet test` for the web tests which executed `PingMonitor.Web.Tests` and reported all tests passing (37 passed, 0 failed).
- Added `AgentTemplateVersionProviderTests` which cover version discovery in both layouts and malformed file behavior, and these tests passed as part of the test run.
- No runtime or integration changes were performed; feature is read-only and covered by the unit tests above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb24b14cc8832a812dc0e4e57b8327)