### PR TITLE
Add outdated-agent warning logs with per-version suppression

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AgentOutdatedVersionWarningServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AgentOutdatedVersionWarningServiceTests.cs
@@ -1,0 +1,146 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.EventLogs;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class AgentOutdatedVersionWarningServiceTests
+{
+    [Fact]
+    public async Task TryWriteWarningAsync_OutdatedAgent_WritesWarningOnce()
+    {
+        var registry = new FakeWarningRegistry();
+        var eventLogService = new RecordingEventLogService(registry);
+        var service = BuildService("V0.1.1", registry, eventLogService);
+        var agent = BuildAgent();
+
+        await service.TryWriteWarningAsync(agent, "V0.1.0", DateTimeOffset.UtcNow, CancellationToken.None);
+
+        var warning = Assert.Single(eventLogService.Writes);
+        Assert.Equal(EventCategory.Agent, warning.Category);
+        Assert.Equal(EventSeverity.Warning, warning.Severity);
+        Assert.Equal(EventType.AgentOutdated, warning.EventType);
+        Assert.Contains("agent version V0.1.0", warning.Message, StringComparison.Ordinal);
+        Assert.Contains("bundled version V0.1.1", warning.Message, StringComparison.Ordinal);
+        Assert.Contains("this version brings a fix for a low risk vulnerability in dotenv", warning.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TryWriteWarningAsync_RepeatedHeartbeat_DoesNotSpam()
+    {
+        var registry = new FakeWarningRegistry();
+        var eventLogService = new RecordingEventLogService(registry);
+        var service = BuildService("V0.1.1", registry, eventLogService);
+        var agent = BuildAgent();
+
+        await service.TryWriteWarningAsync(agent, "V0.1.0", DateTimeOffset.UtcNow, CancellationToken.None);
+        await service.TryWriteWarningAsync(agent, "V0.1.0", DateTimeOffset.UtcNow, CancellationToken.None);
+
+        Assert.Single(eventLogService.Writes);
+    }
+
+    [Fact]
+    public async Task TryWriteWarningAsync_UpToDateAgent_DoesNotWarn()
+    {
+        var registry = new FakeWarningRegistry();
+        var eventLogService = new RecordingEventLogService(registry);
+        var service = BuildService("V0.1.1", registry, eventLogService);
+
+        await service.TryWriteWarningAsync(BuildAgent(), "V0.1.1", DateTimeOffset.UtcNow, CancellationToken.None);
+
+        Assert.Empty(eventLogService.Writes);
+    }
+
+    [Fact]
+    public async Task TryWriteWarningAsync_UnparsableVersion_DoesNotCrash()
+    {
+        var registry = new FakeWarningRegistry();
+        var eventLogService = new RecordingEventLogService(registry);
+        var service = BuildService("V0.1.1", registry, eventLogService);
+
+        await service.TryWriteWarningAsync(BuildAgent(), "not-a-version", DateTimeOffset.UtcNow, CancellationToken.None);
+
+        Assert.Empty(eventLogService.Writes);
+    }
+
+    private static AgentOutdatedVersionWarningService BuildService(
+        string bundledVersion,
+        FakeWarningRegistry registry,
+        RecordingEventLogService eventLogService)
+    {
+        return new AgentOutdatedVersionWarningService(
+            new StaticAgentTemplateVersionProvider(bundledVersion),
+            registry,
+            eventLogService,
+            NullLogger<AgentOutdatedVersionWarningService>.Instance);
+    }
+
+    private static Agent BuildAgent()
+    {
+        return new Agent
+        {
+            AgentId = "agent-1",
+            InstanceId = "LOCAL",
+            Name = "LOCAL"
+        };
+    }
+
+    private sealed class StaticAgentTemplateVersionProvider : IAgentTemplateVersionProvider
+    {
+        private readonly string _bundledVersion;
+
+        public StaticAgentTemplateVersionProvider(string bundledVersion)
+        {
+            _bundledVersion = bundledVersion;
+        }
+
+        public string? GetBundledAgentVersion() => _bundledVersion;
+    }
+
+    private sealed class FakeWarningRegistry : IAgentOutdatedWarningRegistry
+    {
+        private readonly HashSet<string> _warnings = [];
+
+        public Task<bool> HasWarningAsync(string agentId, string bundledVersion, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_warnings.Contains(GetKey(agentId, bundledVersion)));
+        }
+
+        public void Record(string agentId, string bundledVersion)
+        {
+            _warnings.Add(GetKey(agentId, bundledVersion));
+        }
+
+        private static string GetKey(string agentId, string bundledVersion) => $"{agentId}|{bundledVersion}";
+    }
+
+    private sealed class RecordingEventLogService : IEventLogService
+    {
+        private readonly FakeWarningRegistry _registry;
+
+        public RecordingEventLogService(FakeWarningRegistry registry)
+        {
+            _registry = registry;
+        }
+
+        public List<EventLogWriteRequest> Writes { get; } = [];
+
+        public Task WriteAsync(EventLogWriteRequest request, CancellationToken cancellationToken)
+        {
+            Writes.Add(request);
+
+            if (request.EventType == EventType.AgentOutdated && !string.IsNullOrWhiteSpace(request.AgentId) && !string.IsNullOrWhiteSpace(request.DetailsJson))
+            {
+                const string prefix = "bundledVersion=";
+                if (request.DetailsJson.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    _registry.Record(request.AgentId, request.DetailsJson[prefix.Length..]);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Models/EventType.cs
+++ b/src/WebApp/PingMonitor.Web/Models/EventType.cs
@@ -10,6 +10,7 @@ public static class EventType
     public const string AgentBecameStale = "agent_became_stale";
     public const string AgentBecameOffline = "agent_became_offline";
     public const string AgentConfigFetched = "agent_config_fetched";
+    public const string AgentOutdated = "agent_outdated";
     public const string SecuritySettingsUpdated = "security_settings_updated";
     public const string SecurityManualIpBlockAdded = "security_manual_ip_block_added";
     public const string SecurityIpBlockRemoved = "security_ip_block_removed";

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -166,6 +166,8 @@ builder.Services.AddScoped<IResultIngestionService, ResultIngestionService>();
 builder.Services.AddSingleton<IngestRateTracker>();
 builder.Services.AddSingleton<IBufferedResultIngestionService, BufferedResultIngestionService>();
 builder.Services.AddScoped<IHeartbeatService, AgentHeartbeatService>();
+builder.Services.AddScoped<IAgentOutdatedVersionWarningService, AgentOutdatedVersionWarningService>();
+builder.Services.AddScoped<IAgentOutdatedWarningRegistry, AgentOutdatedWarningRegistry>();
 builder.Services.AddScoped<IStateEvaluationService, StateEvaluationService>();
 builder.Services.AddSingleton<IAssignmentTopologyCache, AssignmentTopologyCache>();
 builder.Services.AddSingleton<IAssignmentCurrentStateCache, AssignmentCurrentStateCache>();

--- a/src/WebApp/PingMonitor.Web/Services/AgentHeartbeatService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentHeartbeatService.cs
@@ -10,15 +10,18 @@ internal sealed class AgentHeartbeatService : IHeartbeatService
     private readonly PingMonitorDbContext _dbContext;
     private readonly IAgentConfigurationService _configurationService;
     private readonly IEventLogService _eventLogService;
+    private readonly IAgentOutdatedVersionWarningService _outdatedVersionWarningService;
 
     public AgentHeartbeatService(
         PingMonitorDbContext dbContext,
         IAgentConfigurationService configurationService,
-        IEventLogService eventLogService)
+        IEventLogService eventLogService,
+        IAgentOutdatedVersionWarningService outdatedVersionWarningService)
     {
         _dbContext = dbContext;
         _configurationService = configurationService;
         _eventLogService = eventLogService;
+        _outdatedVersionWarningService = outdatedVersionWarningService;
     }
 
     public async Task<AgentHeartbeatResponse> ProcessHeartbeatAsync(Agent agent, AgentHeartbeatRequest request, CancellationToken cancellationToken)
@@ -40,6 +43,8 @@ internal sealed class AgentHeartbeatService : IHeartbeatService
         });
 
         await _dbContext.SaveChangesAsync(cancellationToken);
+
+        await _outdatedVersionWarningService.TryWriteWarningAsync(agent, request.AgentVersion, now, cancellationToken);
 
         if (!wasOnline)
         {

--- a/src/WebApp/PingMonitor.Web/Services/AgentHelloService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentHelloService.cs
@@ -12,12 +12,18 @@ internal sealed class AgentHelloService : IAgentHelloService
     private readonly PingMonitorDbContext _dbContext;
     private readonly AgentApiOptions _options;
     private readonly IEventLogService _eventLogService;
+    private readonly IAgentOutdatedVersionWarningService _outdatedVersionWarningService;
 
-    public AgentHelloService(PingMonitorDbContext dbContext, IOptions<AgentApiOptions> options, IEventLogService eventLogService)
+    public AgentHelloService(
+        PingMonitorDbContext dbContext,
+        IOptions<AgentApiOptions> options,
+        IEventLogService eventLogService,
+        IAgentOutdatedVersionWarningService outdatedVersionWarningService)
     {
         _dbContext = dbContext;
         _options = options.Value;
         _eventLogService = eventLogService;
+        _outdatedVersionWarningService = outdatedVersionWarningService;
     }
 
     public async Task<AgentHelloResponse> ProcessHelloAsync(Agent agent, AgentHelloRequest request, CancellationToken cancellationToken)
@@ -42,6 +48,9 @@ internal sealed class AgentHelloService : IAgentHelloService
             AgentId = agent.AgentId,
             Message = $"Agent \"{agent.Name ?? agent.InstanceId}\" authenticated successfully (hello)."
         }, cancellationToken);
+
+
+        await _outdatedVersionWarningService.TryWriteWarningAsync(agent, request.AgentVersion, now, cancellationToken);
 
         if (!wasOnline)
         {

--- a/src/WebApp/PingMonitor.Web/Services/AgentOutdatedVersionWarningService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentOutdatedVersionWarningService.cs
@@ -1,0 +1,109 @@
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.EventLogs;
+
+namespace PingMonitor.Web.Services;
+
+internal sealed class AgentOutdatedVersionWarningService : IAgentOutdatedVersionWarningService
+{
+    private static readonly IReadOnlyDictionary<string, string> ReleaseUpgradeNotes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["V0.1.1"] = "this version brings a fix for a low risk vulnerability in dotenv"
+    };
+
+    private readonly IAgentTemplateVersionProvider _agentTemplateVersionProvider;
+    private readonly IAgentOutdatedWarningRegistry _warningRegistry;
+    private readonly IEventLogService _eventLogService;
+    private readonly ILogger<AgentOutdatedVersionWarningService> _logger;
+
+    public AgentOutdatedVersionWarningService(
+        IAgentTemplateVersionProvider agentTemplateVersionProvider,
+        IAgentOutdatedWarningRegistry warningRegistry,
+        IEventLogService eventLogService,
+        ILogger<AgentOutdatedVersionWarningService> logger)
+    {
+        _agentTemplateVersionProvider = agentTemplateVersionProvider;
+        _warningRegistry = warningRegistry;
+        _eventLogService = eventLogService;
+        _logger = logger;
+    }
+
+    public async Task TryWriteWarningAsync(Agent agent, string reportedAgentVersion, DateTimeOffset occurredAtUtc, CancellationToken cancellationToken)
+    {
+        var bundledVersionRaw = _agentTemplateVersionProvider.GetBundledAgentVersion();
+        if (string.IsNullOrWhiteSpace(bundledVersionRaw) || string.IsNullOrWhiteSpace(reportedAgentVersion))
+        {
+            return;
+        }
+
+        if (!TryParseVersion(bundledVersionRaw, out var bundledVersion, out var bundledVersionCanonical))
+        {
+            _logger.LogWarning(
+                "Skipping outdated-agent comparison because bundled agent version could not be parsed: {BundledVersion}",
+                bundledVersionRaw);
+            return;
+        }
+
+        if (!TryParseVersion(reportedAgentVersion, out var reportedVersion, out var reportedVersionCanonical))
+        {
+            _logger.LogWarning(
+                "Skipping outdated-agent comparison because reported version could not be parsed for agent {AgentId}: {ReportedVersion}",
+                agent.AgentId,
+                reportedAgentVersion);
+            return;
+        }
+
+        if (reportedVersion >= bundledVersion)
+        {
+            return;
+        }
+
+        if (await _warningRegistry.HasWarningAsync(agent.AgentId, bundledVersionCanonical, cancellationToken))
+        {
+            return;
+        }
+
+        var upgradeNote = ReleaseUpgradeNotes.TryGetValue(bundledVersionCanonical, out var configuredNote)
+            ? $"; {configuredNote}."
+            : ".";
+
+        var agentDisplay = agent.Name ?? agent.InstanceId;
+        var message = $"Agent \"{agentDisplay}\" is running agent version {reportedVersionCanonical}, older than the currently bundled version {bundledVersionCanonical}. Please re-deploy this instance to upgrade to agent {bundledVersionCanonical}{upgradeNote}";
+
+        await _eventLogService.WriteAsync(new EventLogWriteRequest
+        {
+            OccurredAtUtc = occurredAtUtc,
+            Category = EventCategory.Agent,
+            EventType = EventType.AgentOutdated,
+            Severity = EventSeverity.Warning,
+            AgentId = agent.AgentId,
+            Message = message,
+            DetailsJson = AgentOutdatedWarningRegistry.BuildDetailsMarker(bundledVersionCanonical)
+        }, cancellationToken);
+    }
+
+    private static bool TryParseVersion(string value, out Version version, out string canonicalVersion)
+    {
+        version = new Version();
+        canonicalVersion = string.Empty;
+
+        var normalized = value.Trim();
+        if (normalized.StartsWith("V", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = normalized[1..];
+        }
+
+        if (!Version.TryParse(normalized, out var parsedVersion))
+        {
+            return false;
+        }
+
+        version = parsedVersion;
+
+        var major = version.Major;
+        var minor = version.Minor >= 0 ? version.Minor : 0;
+        var build = version.Build >= 0 ? version.Build : 0;
+        version = new Version(major, minor, build);
+        canonicalVersion = $"V{major}.{minor}.{build}";
+        return true;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/AgentOutdatedWarningRegistry.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentOutdatedWarningRegistry.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services;
+
+internal sealed class AgentOutdatedWarningRegistry : IAgentOutdatedWarningRegistry
+{
+    private readonly PingMonitorDbContext _dbContext;
+
+    public AgentOutdatedWarningRegistry(PingMonitorDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Task<bool> HasWarningAsync(string agentId, string bundledVersion, CancellationToken cancellationToken)
+    {
+        return _dbContext.EventLogs.AnyAsync(
+            x => x.AgentId == agentId
+                 && x.EventType == EventType.AgentOutdated
+                 && x.DetailsJson == BuildDetailsMarker(bundledVersion),
+            cancellationToken);
+    }
+
+    public static string BuildDetailsMarker(string bundledVersion)
+    {
+        return $"bundledVersion={bundledVersion}";
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/IAgentOutdatedVersionWarningService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IAgentOutdatedVersionWarningService.cs
@@ -1,0 +1,8 @@
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services;
+
+public interface IAgentOutdatedVersionWarningService
+{
+    Task TryWriteWarningAsync(Agent agent, string reportedAgentVersion, DateTimeOffset occurredAtUtc, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/IAgentOutdatedWarningRegistry.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IAgentOutdatedWarningRegistry.cs
@@ -1,0 +1,6 @@
+namespace PingMonitor.Web.Services;
+
+public interface IAgentOutdatedWarningRegistry
+{
+    Task<bool> HasWarningAsync(string agentId, string bundledVersion, CancellationToken cancellationToken);
+}


### PR DESCRIPTION
### Motivation
- Operators need a clear, non-spammy server-side warning when an agent reports a runtime version older than the currently bundled agent template so instances can be redeployed to fix known issues. 
- Warnings must be release-specific (upgrade note per bundled version), robust to informal version strings (optional leading `V`), and must not crash on unparsable versions. 
- Duplicate warnings must be suppressed to avoid log spam while ensuring a `hello` may surface the message immediately.

### Description
- Add `AgentOutdatedVersionWarningService` which normalizes/parses reported and bundled versions, compares them semantically, attaches a release-specific upgrade note for `V0.1.1`, and writes an event log with `Category=Agent`, `Severity=Warning`, and new `EventType=agent_outdated` when an agent is older. 
- Add `AgentOutdatedWarningRegistry` that queries `EventLogs` (using a deterministic `DetailsJson` marker) to suppress duplicate warnings at most once per agent per bundled target version. 
- Wire the warning service into the agent processing paths so it runs during both `hello` and `heartbeat` processing and register both services in DI. 
- Add unit tests `AgentOutdatedVersionWarningServiceTests` covering outdated `V0.1.0` vs bundled `V0.1.1` logging once, duplicate-suppression across repeated calls, no warning when up-to-date, and safe handling of unparsable reported versions. 
- Fixes #453.

### Testing
- Added `AgentOutdatedVersionWarningServiceTests` which includes tests: `OutdatedAgent_WritesWarningOnce`, `RepeatedHeartbeat_DoesNotSpam`, `UpToDateAgent_DoesNotWarn`, and `UnparsableVersion_DoesNotCrash`. 
- Installed .NET 10 SDK and ran `dotnet test` for the test project and the full test run passed: `Passed - Failed: 0, Passed: 41, Skipped: 0, Total: 41`. 
- The runtime DB query used for suppression is a simple equality predicate on `EventLogs` (`AgentId`, `EventType`, `DetailsJson`) and was implemented to remain provider-safe for MySQL translation (no client-eval fallbacks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3c256ff8832a9414e9a146f08f68)