### PR TITLE
Address GitHub code-scanning alerts with minimal, behavior-preserving hardening

### DIFF
--- a/docs/diagnostics/2026-04-24-code-scanning-audit.md
+++ b/docs/diagnostics/2026-04-24-code-scanning-audit.md
@@ -1,0 +1,38 @@
+# Code Scanning Audit – 2026-04-24
+
+Related issue: #455.
+
+## Source
+Open GitHub code scanning alerts for `ijyates1992/ping-monitor` were retrieved on 2026-04-24 via GitHub REST API.
+
+## Alert-by-alert assessment
+
+| Alert(s) | Rule | Location | Summary | Applicability | Decision / rationale |
+|---|---|---|---|---|---|
+| #28, #27, #26 | `cs/web/missing-token-validation` | `AgentResultsController.cs:34`, `AgentHelloController.cs:32`, `AgentHeartbeatController.cs:36` | Missing CSRF token validation | Partially applicable | These are machine-to-machine agent ingestion endpoints using header API-key/bearer authentication, not cookie/browser workflows. Added explicit `[IgnoreAntiforgeryToken]` to make the trust model explicit and satisfy analyzer intent without changing API contract. |
+| #25 | `cs/web/missing-x-frame-options` | `web.config:1` | Missing `X-Frame-Options` header | Applicable | Added `X-Frame-Options: DENY` in IIS `web.config` `customHeaders` as minimal hardening; no API/schema/updater behavior change. |
+| #24, #23, #22, #21 | `cs/log-forging` | `StartupAdminBootstrapService.cs:58, 95, 102, 106` | Log entries created from user input | Applicable | Sanitized user-controlled username values before writing to logs by escaping CR/LF. |
+| #20, #19 | `cs/log-forging` | `SecurityOperatorActionService.cs:261, 229` | Log entries created from user input | Applicable | Sanitized `securityIpBlockId`, `failureReason`, `operatorUserId`, `userId`, `userName` in warning logs. |
+| #18 | `cs/log-forging` | `ResultIngestionService.cs:209` | Log entries created from user input | Applicable | Sanitized `BatchId`, `AgentId`, and assignment IDs array before logging on state-evaluation error path. |
+| #17, #16, #15, #14 | `cs/log-forging` | `DatabaseMaintenanceService.cs:963, 499, 474, 456` | Log entries created from user input | Applicable | Sanitized all request/file/message string values written to maintenance restore logs; no restore flow logic changes. |
+| #13 | `cs/log-forging` | `DatabaseMaintenanceProgressTracker.cs:105` | Log entries created from user input | Applicable | Sanitized snapshot file path before logging read failure. |
+| #12, #11, #10, #9, #8 | `cs/log-forging` | `ConfigurationRestoreService.cs:145, 144, 71, 58, 57` | Log entries created from user input | Applicable | Sanitized file ID references in restore/preview logs; kept restore behavior unchanged. |
+| #7 | `cs/log-forging` | `ConfigurationRestorePreviewService.cs:58` | Log entries created from user input | Applicable | Sanitized file ID in preview log. |
+| #6, #5 | `cs/log-forging` | `ConfigurationBackupManagementService.cs:42, 47` | Log entries created from user input | Applicable | Sanitized `FileId` in delete and not-found logs. |
+| #4, #3 | `cs/log-forging` | `ConfigurationBackupDocumentLoader.cs:138, 125` | Log entries created from user input | Applicable | Sanitized `FileId` and validation message in document validation logs. |
+| #2, #1 | `cs/log-forging` | `StartupGateController.cs:72` | Log entries created from user input | Applicable | Sanitized host/database-name inputs in startup gate database save-attempt log. |
+
+## Minimal-fix notes
+
+- A centralized `LogValueSanitizer.ForLog(string?)` helper was introduced to escape CR (`\r`) and LF (`\n`) before logging external/operator-supplied values.
+- No database schema changes were made.
+- No Startup Gate ordering/isolation behavior was changed.
+- No agent API contract shape or route changes were made.
+- No updater/package/manifest behavior was changed.
+
+## Validation commands and results
+
+- `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -v minimal` ✅
+- `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj -v minimal` ✅
+
+(Executed with .NET SDK `10.0.104` installed locally in this environment.)

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentHeartbeatController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentHeartbeatController.cs
@@ -8,6 +8,7 @@ namespace PingMonitor.Web.Controllers;
 
 [ApiController]
 [AllowAnonymous]
+[IgnoreAntiforgeryToken]
 [Route("api/v1/agent/heartbeat")]
 public sealed class AgentHeartbeatController : ControllerBase
 {

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentHelloController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentHelloController.cs
@@ -8,6 +8,7 @@ namespace PingMonitor.Web.Controllers;
 
 [ApiController]
 [AllowAnonymous]
+[IgnoreAntiforgeryToken]
 [Route("api/v1/agent/hello")]
 public sealed class AgentHelloController : ControllerBase
 {

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentResultsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentResultsController.cs
@@ -8,6 +8,7 @@ namespace PingMonitor.Web.Controllers;
 
 [ApiController]
 [AllowAnonymous]
+[IgnoreAntiforgeryToken]
 [Route("api/v1/agent/results")]
 public sealed class AgentResultsController : ControllerBase
 {

--- a/src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/StartupGateController.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using PingMonitor.Web.Options;
 using PingMonitor.Web.Services.DatabaseStatus;
 using PingMonitor.Web.Services.StartupGate;
+using PingMonitor.Web.Support;
 using PingMonitor.Web.ViewModels.StartupGate;
 
 namespace PingMonitor.Web.Controllers;
@@ -69,7 +70,11 @@ public sealed class StartupGateController : Controller
             return View("Index", await BuildViewModelAsync(status, form, null, null, null, errorMessage: "Database configuration could not be saved.", cancellationToken: cancellationToken));
         }
 
-        _logger.LogInformation("Startup gate database configuration save attempt for {Host}:{Port}/{DatabaseName}.", form.Host, form.Port, form.DatabaseName);
+        _logger.LogInformation(
+            "Startup gate database configuration save attempt for {Host}:{Port}/{DatabaseName}.",
+            LogValueSanitizer.ForLog(form.Host),
+            form.Port,
+            LogValueSanitizer.ForLog(form.DatabaseName));
 
         try
         {

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentLoader.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentLoader.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Options;
 using PingMonitor.Web.Options;
+using PingMonitor.Web.Support;
 
 namespace PingMonitor.Web.Services.Backups;
 
@@ -122,7 +123,7 @@ public sealed class ConfigurationBackupDocumentLoader : IConfigurationBackupDocu
             throw BuildValidationException(fileId, ex.Message);
         }
 
-        _logger.LogInformation("Validated configuration backup {FileId} for restore workflow.", fileId);
+        _logger.LogInformation("Validated configuration backup {FileId} for restore workflow.", LogValueSanitizer.ForLog(fileId));
         return document;
     }
 
@@ -135,7 +136,7 @@ public sealed class ConfigurationBackupDocumentLoader : IConfigurationBackupDocu
 
     private InvalidOperationException BuildValidationException(string fileId, string message)
     {
-        _logger.LogWarning("Backup validation failed for {FileId}: {ValidationMessage}", fileId, message);
+        _logger.LogWarning("Backup validation failed for {FileId}: {ValidationMessage}", LogValueSanitizer.ForLog(fileId), LogValueSanitizer.ForLog(message));
         return new InvalidOperationException(message);
     }
 

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupManagementService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupManagementService.cs
@@ -1,4 +1,5 @@
 namespace PingMonitor.Web.Services.Backups;
+using PingMonitor.Web.Support;
 
 public interface IConfigurationBackupManagementService
 {
@@ -39,12 +40,12 @@ public sealed class ConfigurationBackupManagementService : IConfigurationBackupM
             var fullPath = _documentLoader.ResolveBackupPath(request.FileId);
             File.Delete(fullPath);
             await _catalogService.RemoveAsync(request.FileId, cancellationToken);
-            _logger.LogInformation("Deleted configuration backup file {FileId}.", request.FileId);
+            _logger.LogInformation("Deleted configuration backup file {FileId}.", LogValueSanitizer.ForLog(request.FileId));
             return new DeleteConfigurationBackupResponse { FileId = request.FileId, Deleted = true, Message = "Backup deleted." };
         }
         catch (FileNotFoundException)
         {
-            _logger.LogWarning("Delete request for backup file {FileId} could not be completed because file was not found.", request.FileId);
+            _logger.LogWarning("Delete request for backup file {FileId} could not be completed because file was not found.", LogValueSanitizer.ForLog(request.FileId));
             return new DeleteConfigurationBackupResponse { FileId = request.FileId, Deleted = false, Message = "Backup file was not found." };
         }
     }

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestorePreviewService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestorePreviewService.cs
@@ -1,4 +1,5 @@
 namespace PingMonitor.Web.Services.Backups;
+using PingMonitor.Web.Support;
 
 public interface IConfigurationRestorePreviewService
 {
@@ -55,7 +56,7 @@ public sealed class ConfigurationRestorePreviewService : IConfigurationRestorePr
 
         _logger.LogInformation(
             "Loaded restore preview for {FileId}. Included sections: {Sections}.",
-            fileId,
+            LogValueSanitizer.ForLog(fileId),
             string.Join(",", includedSections));
 
         return preview;

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Models.Identity;
+using PingMonitor.Web.Support;
 using EndpointModel = PingMonitor.Web.Models.Endpoint;
 
 namespace PingMonitor.Web.Services.Backups;
@@ -55,7 +56,7 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
         _logger.LogInformation(
             "Starting configuration restore in {RestoreMode} mode for {FileId}. Sections: {Sections}.",
             restoreMode,
-            request.FileId,
+            LogValueSanitizer.ForLog(request.FileId),
             string.Join(",", selectedSections));
 
         var sectionResults = new List<RestoreSectionResult>();
@@ -68,7 +69,7 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
         {
             _logger.LogInformation(
                 "Destructive replace restore confirmed for {FileId}. Sections: {Sections}.",
-                request.FileId,
+                LogValueSanitizer.ForLog(request.FileId),
                 string.Join(",", selectedSections));
 
             await ApplyReplaceDeletesAsync(selectedSections, deletedCounts, cancellationToken);

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceProgressTracker.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceProgressTracker.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using PingMonitor.Web.Support;
 
 namespace PingMonitor.Web.Services.DatabaseStatus;
 
@@ -102,7 +103,7 @@ internal sealed class DatabaseMaintenanceProgressTracker : IDatabaseMaintenanceP
         }
         catch (Exception exception)
         {
-            _logger.LogWarning(exception, "Failed to read DATABASE maintenance progress snapshot {Path}.", historyPath);
+            _logger.LogWarning(exception, "Failed to read DATABASE maintenance progress snapshot {Path}.", LogValueSanitizer.ForLog(historyPath));
             return null;
         }
     }

--- a/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DatabaseStatus/DatabaseMaintenanceService.cs
@@ -12,6 +12,7 @@ using PingMonitor.Web.Models;
 using PingMonitor.Web.Options;
 using PingMonitor.Web.Services.EventLogs;
 using PingMonitor.Web.Services.StartupGate;
+using PingMonitor.Web.Support;
 
 namespace PingMonitor.Web.Services.DatabaseStatus;
 
@@ -453,10 +454,10 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         {
             _logger.LogWarning(
                 "Database backup restore rejected before execution. FileId: {FileId}, FileName: {FileName}, ValidationMessage: {ValidationMessage}, RequestedBy: {RequestedBy}",
-                request.FileId,
-                backupFileInfo.Name,
-                validationMessage,
-                request.RequestedBy);
+                LogValueSanitizer.ForLog(request.FileId),
+                LogValueSanitizer.ForLog(backupFileInfo.Name),
+                LogValueSanitizer.ForLog(validationMessage),
+                LogValueSanitizer.ForLog(request.RequestedBy));
 
             return new DatabaseBackupRestoreResult
             {
@@ -471,11 +472,11 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 
         _logger.LogInformation(
             "Database backup restore started. FileId: {FileId}, FileName: {FileName}, BackupMode: {BackupMode}, FileSizeBytes: {FileSizeBytes}, RequestedBy: {RequestedBy}",
-            request.FileId,
-            backupFileInfo.Name,
+            LogValueSanitizer.ForLog(request.FileId),
+            LogValueSanitizer.ForLog(backupFileInfo.Name),
             backupDescriptor.Mode,
             backupFileInfo.Length,
-            request.RequestedBy);
+            LogValueSanitizer.ForLog(request.RequestedBy));
 
         _startupGateDiagnosticsLogger.Write(
             "database-restore.pre-restore-backup.start",
@@ -496,10 +497,10 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
         {
             _logger.LogWarning(
                 "Database backup restore aborted because pre-restore backup failed. FileId: {FileId}, FileName: {FileName}, PreRestoreBackupMessage: {PreRestoreBackupMessage}, RequestedBy: {RequestedBy}",
-                request.FileId,
-                backupFileInfo.Name,
-                preRestoreBackup.Message,
-                request.RequestedBy);
+                LogValueSanitizer.ForLog(request.FileId),
+                LogValueSanitizer.ForLog(backupFileInfo.Name),
+                LogValueSanitizer.ForLog(preRestoreBackup.Message),
+                LogValueSanitizer.ForLog(request.RequestedBy));
 
             _progressTracker.CompleteFailure(
                 request.OperationId ?? string.Empty,
@@ -960,13 +961,13 @@ internal sealed class DatabaseMaintenanceService : IDatabaseMaintenanceService
 
         _logger.LogWarning(
             "Database backup restore failed before completion. FileId: {FileId}, FileName: {FileName}, BackupMode: {BackupMode}, PreRestoreBackupCreated: {PreRestoreBackupCreated}, PreRestoreBackupFileName: {PreRestoreBackupFileName}, RequestedBy: {RequestedBy}, Message: {Message}",
-            request.FileId,
-            backupFileInfo.Name,
+            LogValueSanitizer.ForLog(request.FileId),
+            LogValueSanitizer.ForLog(backupFileInfo.Name),
             backupMode,
             preRestoreBackupCreated,
-            preRestoreBackupFileName,
-            request.RequestedBy,
-            message);
+            LogValueSanitizer.ForLog(preRestoreBackupFileName),
+            LogValueSanitizer.ForLog(request.RequestedBy),
+            LogValueSanitizer.ForLog(message));
 
         return Task.FromResult(new DatabaseBackupRestoreResult
         {

--- a/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ResultIngestionService.cs
@@ -3,10 +3,10 @@ using PingMonitor.Web.Contracts.Results;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Options;
+using PingMonitor.Web.Support;
 using PingMonitor.Web.Services.BufferedResults;
 using PingMonitor.Web.Services.EventLogs;
 using PingMonitor.Web.Services.Metrics;
-using PingMonitor.Web.Support;
 using Microsoft.Extensions.Options;
 
 namespace PingMonitor.Web.Services;
@@ -206,9 +206,9 @@ internal sealed class ResultIngestionService : IResultIngestionService
                     _logger.LogError(
                         ex,
                         "Result ingestion persisted batch {BatchId} for agent {AgentId}, but state evaluation failed for assignments: {AssignmentIds}.",
-                        normalizedBatchId,
-                        agent.AgentId,
-                        affectedAssignmentIds);
+                        LogValueSanitizer.ForLog(normalizedBatchId),
+                        LogValueSanitizer.ForLog(agent.AgentId),
+                        affectedAssignmentIds.Select(LogValueSanitizer.ForLog).ToArray());
                 }
             }
 

--- a/src/WebApp/PingMonitor.Web/Services/Security/SecurityOperatorActionService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Security/SecurityOperatorActionService.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
+using PingMonitor.Web.Support;
 using PingMonitor.Web.Models.Identity;
 using PingMonitor.Web.Services.EventLogs;
 
@@ -226,9 +227,9 @@ internal sealed class SecurityOperatorActionService : ISecurityOperatorActionSer
 
         _logger.LogWarning(
             "Manual IP unblock rejected. SecurityIpBlockId={SecurityIpBlockId} Reason={FailureReason} OperatorUserId={OperatorUserId}",
-            securityIpBlockId,
-            failureReason,
-            string.IsNullOrWhiteSpace(operatorUserId) ? "n/a" : operatorUserId.Trim());
+            LogValueSanitizer.ForLog(securityIpBlockId),
+            LogValueSanitizer.ForLog(failureReason),
+            string.IsNullOrWhiteSpace(operatorUserId) ? "n/a" : LogValueSanitizer.ForLog(operatorUserId.Trim()));
     }
 
     private async Task WriteUnlockAuditAsync(
@@ -258,9 +259,9 @@ internal sealed class SecurityOperatorActionService : ISecurityOperatorActionSer
 
         _logger.LogWarning(
             "Manual user unlock rejected. UserId={UserId} UserName={UserName} Reason={FailureReason} OperatorUserId={OperatorUserId}",
-            userId,
-            string.IsNullOrWhiteSpace(userName) ? "n/a" : userName,
-            failureReason,
-            string.IsNullOrWhiteSpace(operatorUserId) ? "n/a" : operatorUserId.Trim());
+            LogValueSanitizer.ForLog(userId),
+            string.IsNullOrWhiteSpace(userName) ? "n/a" : LogValueSanitizer.ForLog(userName),
+            LogValueSanitizer.ForLog(failureReason),
+            string.IsNullOrWhiteSpace(operatorUserId) ? "n/a" : LogValueSanitizer.ForLog(operatorUserId.Trim()));
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupAdminBootstrapService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupAdminBootstrapService.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models.Identity;
 using PingMonitor.Web.Services.Identity;
+using PingMonitor.Web.Support;
 
 namespace PingMonitor.Web.Services.StartupGate;
 
@@ -55,7 +56,7 @@ internal sealed class StartupAdminBootstrapService : IStartupAdminBootstrapServi
 
     public async Task<(bool Succeeded, IReadOnlyList<string> Errors)> CreateInitialAdminAsync(StartupAdminBootstrapForm form, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Startup gate initial admin creation requested for username {Username}.", form.Username);
+        _logger.LogInformation("Startup gate initial admin creation requested for username {Username}.", LogValueSanitizer.ForLog(form.Username));
 
         var existingStatus = await GetStatusAsync(cancellationToken);
         if (existingStatus.AdminExists)
@@ -92,18 +93,18 @@ internal sealed class StartupAdminBootstrapService : IStartupAdminBootstrapServi
         var createResult = await _userManager.CreateAsync(user, form.Password);
         if (!createResult.Succeeded)
         {
-            _logger.LogWarning("Startup gate initial admin creation failed for username {Username}.", form.Username);
+            _logger.LogWarning("Startup gate initial admin creation failed for username {Username}.", LogValueSanitizer.ForLog(form.Username));
             return (false, createResult.Errors.Select(error => error.Description).ToArray());
         }
 
         var roleAssignResult = await _userManager.AddToRoleAsync(user, AdminRoleName);
         if (!roleAssignResult.Succeeded)
         {
-            _logger.LogWarning("Startup gate failed to assign the Admin role to username {Username}.", form.Username);
+            _logger.LogWarning("Startup gate failed to assign the Admin role to username {Username}.", LogValueSanitizer.ForLog(form.Username));
             return (false, roleAssignResult.Errors.Select(error => error.Description).ToArray());
         }
 
-        _logger.LogInformation("Startup gate initial admin creation succeeded for username {Username}.", form.Username);
+        _logger.LogInformation("Startup gate initial admin creation succeeded for username {Username}.", LogValueSanitizer.ForLog(form.Username));
         return (true, Array.Empty<string>());
     }
 }

--- a/src/WebApp/PingMonitor.Web/Support/LogValueSanitizer.cs
+++ b/src/WebApp/PingMonitor.Web/Support/LogValueSanitizer.cs
@@ -1,0 +1,16 @@
+namespace PingMonitor.Web.Support;
+
+public static class LogValueSanitizer
+{
+    public static string ForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        return value
+            .Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/web.config
+++ b/src/WebApp/PingMonitor.Web/web.config
@@ -2,6 +2,11 @@
 <configuration>
   <location path="." inheritInChildApplications="false">
     <system.webServer>
+      <httpProtocol>
+        <customHeaders>
+          <add name="X-Frame-Options" value="DENY" />
+        </customHeaders>
+      </httpProtocol>
       <handlers>
         <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
       </handlers>


### PR DESCRIPTION
### Motivation

- Reduce actionable security/quality findings reported by GitHub code scanning while preserving existing runtime behavior, agent API contracts, and Startup Gate rules. 

### Description

- Added explicit antiforgery opt-out attributes to agent machine-to-machine controllers by applying `[IgnoreAntiforgeryToken]` to `AgentHelloController`, `AgentHeartbeatController`, and `AgentResultsController` so the analyzer intent is satisfied without changing the API contract. 
- Added `X-Frame-Options: DENY` to `src/WebApp/PingMonitor.Web/web.config` to address clickjacking header recommendations. 
- Introduced a small centralized helper `LogValueSanitizer.ForLog(string?)` in `src/WebApp/PingMonitor.Web/Support/LogValueSanitizer.cs` that escapes CR/LF, and applied it at the code-scanning-flagged logging call sites across startup gate, backup/restore, database maintenance, ingestion, and security services to mitigate log-forging risks without changing semantics. 
- Added a diagnostic audit note at `docs/diagnostics/2026-04-24-code-scanning-audit.md` recording each alert, applicability decision, rationale, and validation outputs, and opened tracking issue `#455` to tie the work to repository traceability. 

### Testing

- Built the web app with the pinned SDK using `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -v minimal` and the build succeeded. 
- Ran unit tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj -v minimal` and all tests passed (`41` tests). 
- No behavioral, routing, database schema, or agent API contract changes were made and automated validations returned success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb414674a0832a882b04c5ff9e375f)