### PR TITLE
Track outdated-agent warning per agent per bundled version

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AgentOutdatedVersionWarningServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AgentOutdatedVersionWarningServiceTests.cs
@@ -9,31 +9,36 @@ namespace PingMonitor.Web.Tests;
 public sealed class AgentOutdatedVersionWarningServiceTests
 {
     [Fact]
-    public async Task TryWriteWarningAsync_OutdatedAgent_WritesWarningOnce()
+    public async Task TryWriteWarningAsync_MultipleOutdatedAgents_EachLogsOncePerBundledVersion()
     {
-        var registry = new FakeWarningRegistry();
-        var eventLogService = new RecordingEventLogService(registry);
-        var service = BuildService("V0.1.1", registry, eventLogService);
-        var agent = BuildAgent();
+        var eventLogService = new RecordingEventLogService();
+        var service = BuildService("V0.1.1", eventLogService);
+        var firstAgent = BuildAgent("agent-1");
+        var secondAgent = BuildAgent("agent-2");
 
-        await service.TryWriteWarningAsync(agent, "V0.1.0", DateTimeOffset.UtcNow, CancellationToken.None);
+        await service.TryWriteWarningAsync(firstAgent, "V0.1.0", DateTimeOffset.UtcNow, CancellationToken.None);
+        await service.TryWriteWarningAsync(secondAgent, "V0.1.0", DateTimeOffset.UtcNow, CancellationToken.None);
 
-        var warning = Assert.Single(eventLogService.Writes);
-        Assert.Equal(EventCategory.Agent, warning.Category);
-        Assert.Equal(EventSeverity.Warning, warning.Severity);
-        Assert.Equal(EventType.AgentOutdated, warning.EventType);
-        Assert.Contains("agent version V0.1.0", warning.Message, StringComparison.Ordinal);
-        Assert.Contains("bundled version V0.1.1", warning.Message, StringComparison.Ordinal);
-        Assert.Contains("this version brings a fix for a low risk vulnerability in dotenv", warning.Message, StringComparison.Ordinal);
+        Assert.Equal(2, eventLogService.Writes.Count);
+        Assert.All(eventLogService.Writes, warning =>
+        {
+            Assert.Equal(EventCategory.Agent, warning.Category);
+            Assert.Equal(EventSeverity.Warning, warning.Severity);
+            Assert.Equal(EventType.AgentOutdated, warning.EventType);
+            Assert.Contains("agent version V0.1.0", warning.Message, StringComparison.Ordinal);
+            Assert.Contains("bundled version V0.1.1", warning.Message, StringComparison.Ordinal);
+            Assert.Contains("this version brings a fix for a low risk vulnerability in dotenv", warning.Message, StringComparison.Ordinal);
+        });
+        Assert.Equal("V0.1.1", firstAgent.LastUpgradeWarningVersion);
+        Assert.Equal("V0.1.1", secondAgent.LastUpgradeWarningVersion);
     }
 
     [Fact]
     public async Task TryWriteWarningAsync_RepeatedHeartbeat_DoesNotSpam()
     {
-        var registry = new FakeWarningRegistry();
-        var eventLogService = new RecordingEventLogService(registry);
-        var service = BuildService("V0.1.1", registry, eventLogService);
-        var agent = BuildAgent();
+        var eventLogService = new RecordingEventLogService();
+        var service = BuildService("V0.1.1", eventLogService);
+        var agent = BuildAgent("agent-1");
 
         await service.TryWriteWarningAsync(agent, "V0.1.0", DateTimeOffset.UtcNow, CancellationToken.None);
         await service.TryWriteWarningAsync(agent, "V0.1.0", DateTimeOffset.UtcNow, CancellationToken.None);
@@ -42,13 +47,29 @@ public sealed class AgentOutdatedVersionWarningServiceTests
     }
 
     [Fact]
+    public async Task TryWriteWarningAsync_BundledVersionBump_LogsAgainForSameAgent()
+    {
+        var eventLogService = new RecordingEventLogService();
+        var firstService = BuildService("V0.1.1", eventLogService);
+        var secondService = BuildService("V0.1.2", eventLogService);
+        var agent = BuildAgent("agent-1");
+
+        await firstService.TryWriteWarningAsync(agent, "V0.1.0", DateTimeOffset.UtcNow, CancellationToken.None);
+        await secondService.TryWriteWarningAsync(agent, "V0.1.0", DateTimeOffset.UtcNow, CancellationToken.None);
+
+        Assert.Equal(2, eventLogService.Writes.Count);
+        Assert.Equal("V0.1.2", agent.LastUpgradeWarningVersion);
+        Assert.Contains(eventLogService.Writes, x => x.DetailsJson == "bundledVersion=V0.1.1");
+        Assert.Contains(eventLogService.Writes, x => x.DetailsJson == "bundledVersion=V0.1.2");
+    }
+
+    [Fact]
     public async Task TryWriteWarningAsync_UpToDateAgent_DoesNotWarn()
     {
-        var registry = new FakeWarningRegistry();
-        var eventLogService = new RecordingEventLogService(registry);
-        var service = BuildService("V0.1.1", registry, eventLogService);
+        var eventLogService = new RecordingEventLogService();
+        var service = BuildService("V0.1.1", eventLogService);
 
-        await service.TryWriteWarningAsync(BuildAgent(), "V0.1.1", DateTimeOffset.UtcNow, CancellationToken.None);
+        await service.TryWriteWarningAsync(BuildAgent("agent-1"), "V0.1.1", DateTimeOffset.UtcNow, CancellationToken.None);
 
         Assert.Empty(eventLogService.Writes);
     }
@@ -56,32 +77,29 @@ public sealed class AgentOutdatedVersionWarningServiceTests
     [Fact]
     public async Task TryWriteWarningAsync_UnparsableVersion_DoesNotCrash()
     {
-        var registry = new FakeWarningRegistry();
-        var eventLogService = new RecordingEventLogService(registry);
-        var service = BuildService("V0.1.1", registry, eventLogService);
+        var eventLogService = new RecordingEventLogService();
+        var service = BuildService("V0.1.1", eventLogService);
 
-        await service.TryWriteWarningAsync(BuildAgent(), "not-a-version", DateTimeOffset.UtcNow, CancellationToken.None);
+        await service.TryWriteWarningAsync(BuildAgent("agent-1"), "not-a-version", DateTimeOffset.UtcNow, CancellationToken.None);
 
         Assert.Empty(eventLogService.Writes);
     }
 
     private static AgentOutdatedVersionWarningService BuildService(
         string bundledVersion,
-        FakeWarningRegistry registry,
         RecordingEventLogService eventLogService)
     {
         return new AgentOutdatedVersionWarningService(
             new StaticAgentTemplateVersionProvider(bundledVersion),
-            registry,
             eventLogService,
             NullLogger<AgentOutdatedVersionWarningService>.Instance);
     }
 
-    private static Agent BuildAgent()
+    private static Agent BuildAgent(string agentId)
     {
         return new Agent
         {
-            AgentId = "agent-1",
+            AgentId = agentId,
             InstanceId = "LOCAL",
             Name = "LOCAL"
         };
@@ -99,47 +117,13 @@ public sealed class AgentOutdatedVersionWarningServiceTests
         public string? GetBundledAgentVersion() => _bundledVersion;
     }
 
-    private sealed class FakeWarningRegistry : IAgentOutdatedWarningRegistry
-    {
-        private readonly HashSet<string> _warnings = [];
-
-        public Task<bool> HasWarningAsync(string agentId, string bundledVersion, CancellationToken cancellationToken)
-        {
-            return Task.FromResult(_warnings.Contains(GetKey(agentId, bundledVersion)));
-        }
-
-        public void Record(string agentId, string bundledVersion)
-        {
-            _warnings.Add(GetKey(agentId, bundledVersion));
-        }
-
-        private static string GetKey(string agentId, string bundledVersion) => $"{agentId}|{bundledVersion}";
-    }
-
     private sealed class RecordingEventLogService : IEventLogService
     {
-        private readonly FakeWarningRegistry _registry;
-
-        public RecordingEventLogService(FakeWarningRegistry registry)
-        {
-            _registry = registry;
-        }
-
         public List<EventLogWriteRequest> Writes { get; } = [];
 
         public Task WriteAsync(EventLogWriteRequest request, CancellationToken cancellationToken)
         {
             Writes.Add(request);
-
-            if (request.EventType == EventType.AgentOutdated && !string.IsNullOrWhiteSpace(request.AgentId) && !string.IsNullOrWhiteSpace(request.DetailsJson))
-            {
-                const string prefix = "bundledVersion=";
-                if (request.DetailsJson.StartsWith(prefix, StringComparison.Ordinal))
-                {
-                    _registry.Record(request.AgentId, request.DetailsJson[prefix.Length..]);
-                }
-            }
-
             return Task.CompletedTask;
         }
     }

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -74,6 +74,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         agent.Property(x => x.AgentVersion).HasMaxLength(50);
         agent.Property(x => x.Platform).HasMaxLength(50);
         agent.Property(x => x.MachineName).HasMaxLength(255);
+        agent.Property(x => x.LastUpgradeWarningVersion).HasMaxLength(50);
         agent.Property(x => x.CreatedAtUtc).IsRequired();
         agent.Property(x => x.LastHeartbeatEventLoggedAtUtc);
         agent.Property(x => x.ApiKeyCreatedAtUtc).IsRequired();

--- a/src/WebApp/PingMonitor.Web/Models/Agent.cs
+++ b/src/WebApp/PingMonitor.Web/Models/Agent.cs
@@ -16,6 +16,7 @@ public sealed class Agent
     public string? AgentVersion { get; set; }
     public string? Platform { get; set; }
     public string? MachineName { get; set; }
+    public string? LastUpgradeWarningVersion { get; set; }
     public DateTimeOffset CreatedAtUtc { get; set; }
     public DateTimeOffset? LastHeartbeatEventLoggedAtUtc { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
@@ -5,6 +5,6 @@ public sealed class StartupGateOptions
     public const string SectionName = "StartupGate";
 
     public string StorageDirectory { get; set; } = "App_Data/StartupGate";
-    public int RequiredSchemaVersion { get; set; } = 8;
+    public int RequiredSchemaVersion { get; set; } = 10;
     public int DefaultMySqlPort { get; set; } = 3306;
 }

--- a/src/WebApp/PingMonitor.Web/Services/AgentOutdatedVersionWarningService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentOutdatedVersionWarningService.cs
@@ -11,18 +11,15 @@ internal sealed class AgentOutdatedVersionWarningService : IAgentOutdatedVersion
     };
 
     private readonly IAgentTemplateVersionProvider _agentTemplateVersionProvider;
-    private readonly IAgentOutdatedWarningRegistry _warningRegistry;
     private readonly IEventLogService _eventLogService;
     private readonly ILogger<AgentOutdatedVersionWarningService> _logger;
 
     public AgentOutdatedVersionWarningService(
         IAgentTemplateVersionProvider agentTemplateVersionProvider,
-        IAgentOutdatedWarningRegistry warningRegistry,
         IEventLogService eventLogService,
         ILogger<AgentOutdatedVersionWarningService> logger)
     {
         _agentTemplateVersionProvider = agentTemplateVersionProvider;
-        _warningRegistry = warningRegistry;
         _eventLogService = eventLogService;
         _logger = logger;
     }
@@ -57,7 +54,7 @@ internal sealed class AgentOutdatedVersionWarningService : IAgentOutdatedVersion
             return;
         }
 
-        if (await _warningRegistry.HasWarningAsync(agent.AgentId, bundledVersionCanonical, cancellationToken))
+        if (string.Equals(agent.LastUpgradeWarningVersion, bundledVersionCanonical, StringComparison.OrdinalIgnoreCase))
         {
             return;
         }
@@ -79,6 +76,8 @@ internal sealed class AgentOutdatedVersionWarningService : IAgentOutdatedVersion
             Message = message,
             DetailsJson = AgentOutdatedWarningRegistry.BuildDetailsMarker(bundledVersionCanonical)
         }, cancellationToken);
+
+        agent.LastUpgradeWarningVersion = bundledVersionCanonical;
     }
 
     private static bool TryParseVersion(string value, out Version version, out string canonicalVersion)

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -1155,6 +1155,16 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 """,
                 cancellationToken);
         }
+
+        if (!await HasAgentColumnAsync(connection, "LastUpgradeWarningVersion", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `Agents`
+                ADD COLUMN `LastUpgradeWarningVersion` varchar(50) NULL;
+                """,
+                cancellationToken);
+        }
     }
 
     private static async Task EnsureSecuritySettingsColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 9,
+    "RequiredSchemaVersion": 10,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 9,
+    "RequiredSchemaVersion": 10,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
### Motivation
- The previous suppression used a global/event-log lookup which could prevent each outdated agent from receiving its own upgrade warning for a given bundled target version.
- The change ensures warnings are recorded per-agent so each outdated agent gets one warning per bundled version while keeping logic inside hello/heartbeat processing.
- This change is tied to a traceability issue: `Fixes #457` (issue created during rollout).

### Description
- Added a nullable `LastUpgradeWarningVersion` property to the `Agent` model and EF mapping (`varchar(50) NULL`) to persist the per-agent marker (`Agent.LastUpgradeWarningVersion`).
- Replaced the global registry lookup with per-agent suppression in `AgentOutdatedVersionWarningService.TryWriteWarningAsync` so the service checks `agent.LastUpgradeWarningVersion` and sets it to the bundled canonical version after writing the event.
- Added startup-gate schema update logic to apply `ALTER TABLE Agents ADD COLUMN LastUpgradeWarningVersion varchar(50) NULL;` when missing and bumped the startup-gate required schema version to `10` in `appsettings` and `StartupGateOptions`.
- Updated and expanded unit tests in `AgentOutdatedVersionWarningServiceTests` to cover multiple outdated agents, repeated heartbeats, bundled-version bump, and up-to-date agent behavior.

### Testing
- Ran the targeted unit tests with `dotnet test --filter AgentOutdatedVersionWarningServiceTests` and observed the filtered tests passed (`Passed: 5`), demonstrating the new per-agent behavior.
- Ran the full webapp test project with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and observed all tests passed (`Passed: 42`), indicating no regressions in the test suite.
- Automated tests assert that each outdated agent logs once per bundled version, repeated heartbeats do not spam, bundled version bumps re-trigger logging, and up-to-date agents do not produce warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4542eeb4832aac8029287b55a0de)