### PR TITLE
Add per-user display time zone preference for UI timestamps

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/DisplayTimeFormatterTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/DisplayTimeFormatterTests.cs
@@ -1,0 +1,55 @@
+using PingMonitor.Web.Services.Time;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class DisplayTimeFormatterTests
+{
+    [Fact]
+    public void FormatForTimeZone_UsesDstOffset_ForEuropeLondonSummer()
+    {
+        var formatter = new DisplayTimeFormatter(new StubUserTimeZoneService(TimeZoneInfo.Utc));
+        var london = TimeZoneInfo.FindSystemTimeZoneById("Europe/London");
+
+        var formatted = formatter.FormatForTimeZone(new DateTimeOffset(2026, 7, 1, 12, 0, 0, TimeSpan.Zero), london);
+
+        Assert.Contains("2026-07-01 13:00:00", formatted, StringComparison.Ordinal);
+        Assert.Contains("+01:00 Europe/London", formatted, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task FormatForCurrentUserAsync_UsesUtc_WhenUserPreferenceUtc()
+    {
+        var formatter = new DisplayTimeFormatter(new StubUserTimeZoneService(TimeZoneInfo.Utc));
+
+        var formatted = await formatter.FormatForCurrentUserAsync(new DateTimeOffset(2026, 4, 24, 13, 42, 10, TimeSpan.Zero));
+
+        Assert.Equal("2026-04-24 13:42:10 +00:00 UTC", formatted);
+    }
+
+    [Fact]
+    public async Task FormatForCurrentUserAsync_FallsBackToUtc_WhenServiceReturnsUtcForInvalidId()
+    {
+        var formatter = new DisplayTimeFormatter(new StubUserTimeZoneService(TimeZoneInfo.Utc));
+
+        var formatted = await formatter.FormatForCurrentUserAsync(new DateTimeOffset(2026, 12, 25, 0, 0, 0, TimeSpan.Zero));
+
+        Assert.Equal("2026-12-25 00:00:00 +00:00 UTC", formatted);
+    }
+
+    private sealed class StubUserTimeZoneService : IUserTimeZoneService
+    {
+        private readonly TimeZoneInfo _zone;
+
+        public StubUserTimeZoneService(TimeZoneInfo zone)
+        {
+            _zone = zone;
+        }
+
+        public Task<TimeZoneInfo> GetCurrentUserTimeZoneAsync(CancellationToken cancellationToken) => Task.FromResult(_zone);
+        public Task<string> GetCurrentUserTimeZoneIdAsync(CancellationToken cancellationToken) => Task.FromResult(_zone.Id);
+        public IReadOnlyList<string> GetSelectableTimeZoneIds() => [_zone.Id];
+        public bool IsSupportedTimeZoneId(string? timeZoneId) => string.Equals(timeZoneId, _zone.Id, StringComparison.Ordinal);
+        public TimeZoneInfo ResolveOrUtc(string? timeZoneId) => _zone;
+    }
+}

--- a/src/WebApp/PingMonitor.Web.Tests/DisplayTimeFormatterTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/DisplayTimeFormatterTests.cs
@@ -49,6 +49,7 @@ public sealed class DisplayTimeFormatterTests
         public Task<TimeZoneInfo> GetCurrentUserTimeZoneAsync(CancellationToken cancellationToken) => Task.FromResult(_zone);
         public Task<string> GetCurrentUserTimeZoneIdAsync(CancellationToken cancellationToken) => Task.FromResult(_zone.Id);
         public IReadOnlyList<string> GetSelectableTimeZoneIds() => [_zone.Id];
+        public IReadOnlyList<DisplayTimeZoneOption> GetSelectableTimeZoneOptions() => [new(_zone.Id, _zone.Id)];
         public bool IsSupportedTimeZoneId(string? timeZoneId) => string.Equals(timeZoneId, _zone.Id, StringComparison.Ordinal);
         public TimeZoneInfo ResolveOrUtc(string? timeZoneId) => _zone;
     }

--- a/src/WebApp/PingMonitor.Web.Tests/ProfileDisplayPreferencesTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/ProfileDisplayPreferencesTests.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
+using PingMonitor.Web.Services.Time;
+using PingMonitor.Web.ViewModels.Profile;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class ProfileDisplayPreferencesTests
+{
+    [Fact]
+    public void UpdateProfileDisplayPreferencesInputModel_AllowsPostingWithoutEmail()
+    {
+        var model = new UpdateProfileDisplayPreferencesInputModel
+        {
+            DisplayTimeZoneId = "Europe/London"
+        };
+
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(model, new ValidationContext(model), validationResults, validateAllProperties: true);
+
+        Assert.True(isValid);
+        Assert.Empty(validationResults);
+    }
+
+    [Fact]
+    public void UserTimeZoneService_IncludesUtcAndEuropeLondon_WithoutDuplicates()
+    {
+        var service = new UserTimeZoneService(new HttpContextAccessor(), userManager: null!);
+
+        var options = service.GetSelectableTimeZoneOptions();
+
+        Assert.NotEmpty(options);
+        Assert.Equal("UTC", options[0].Value);
+        Assert.Equal("Europe/London", options[1].Value);
+        Assert.Equal("United Kingdom — London (Europe/London)", options[1].Label);
+        Assert.Equal(1, options.Count(option => string.Equals(option.Value, "Europe/London", StringComparison.Ordinal)));
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
@@ -69,7 +69,7 @@ public sealed class ProfileController : Controller
 
     [HttpPost("account")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> UpdateAccount([FromForm] ProfilePageViewModel model, CancellationToken cancellationToken)
+    public async Task<IActionResult> UpdateAccount([FromForm] UpdateProfileAccountDetailsInputModel model, CancellationToken cancellationToken)
     {
         var user = await RequireUserAsync();
         if (user is null)
@@ -77,14 +77,11 @@ public sealed class ProfileController : Controller
             return Challenge();
         }
 
-        if (string.IsNullOrWhiteSpace(model.Email) || !MailAddress.TryCreate(model.Email, out _))
-        {
-            ModelState.AddModelError(nameof(ProfilePageViewModel.Email), "A valid email address is required.");
-        }
-
         if (!ModelState.IsValid)
         {
-            return View("Index", await BuildModelAsync(cancellationToken, model));
+            var invalidModel = await BuildModelAsync(cancellationToken);
+            invalidModel.Email = model.Email;
+            return View("Index", invalidModel);
         }
 
         var trimmedEmail = model.Email.Trim();
@@ -96,7 +93,9 @@ public sealed class ProfileController : Controller
                 ModelState.AddModelError(string.Empty, error.Description);
             }
 
-            return View("Index", await BuildModelAsync(cancellationToken, model));
+            var invalidModel = await BuildModelAsync(cancellationToken);
+            invalidModel.Email = model.Email;
+            return View("Index", invalidModel);
         }
 
         user.EmailConfirmed = false;
@@ -109,7 +108,9 @@ public sealed class ProfileController : Controller
                 ModelState.AddModelError(string.Empty, error.Description);
             }
 
-            return View("Index", await BuildModelAsync(cancellationToken, model));
+            var invalidModel = await BuildModelAsync(cancellationToken);
+            invalidModel.Email = model.Email;
+            return View("Index", invalidModel);
         }
 
         var sendResult = await SendVerificationEmailAsync(user, cancellationToken);
@@ -193,7 +194,7 @@ public sealed class ProfileController : Controller
 
     [HttpPost("display-preferences")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> UpdateDisplayPreferences([FromForm] ProfilePageViewModel model, CancellationToken cancellationToken)
+    public async Task<IActionResult> UpdateDisplayPreferences([FromForm] UpdateProfileDisplayPreferencesInputModel model, CancellationToken cancellationToken)
     {
         var user = await RequireUserAsync();
         if (user is null)
@@ -203,12 +204,14 @@ public sealed class ProfileController : Controller
 
         if (!_userTimeZoneService.IsSupportedTimeZoneId(model.DisplayTimeZoneId))
         {
-            ModelState.AddModelError(nameof(ProfilePageViewModel.DisplayTimeZoneId), "Select a valid display time zone.");
+            ModelState.AddModelError(nameof(UpdateProfileDisplayPreferencesInputModel.DisplayTimeZoneId), "Select a valid display time zone.");
         }
 
         if (!ModelState.IsValid)
         {
-            return View("Index", await BuildModelAsync(cancellationToken, model));
+            var invalidModel = await BuildModelAsync(cancellationToken);
+            invalidModel.DisplayTimeZoneId = model.DisplayTimeZoneId;
+            return View("Index", invalidModel);
         }
 
         user.DisplayTimeZoneId = model.DisplayTimeZoneId.Trim();
@@ -220,7 +223,9 @@ public sealed class ProfileController : Controller
                 ModelState.AddModelError(string.Empty, error.Description);
             }
 
-            return View("Index", await BuildModelAsync(cancellationToken, model));
+            var invalidModel = await BuildModelAsync(cancellationToken);
+            invalidModel.DisplayTimeZoneId = model.DisplayTimeZoneId;
+            return View("Index", invalidModel);
         }
 
         var refreshed = await BuildModelAsync(cancellationToken);
@@ -352,7 +357,7 @@ public sealed class ProfileController : Controller
             ? await _telegramBotIdentityResolver.ResolveBotIdentifierAsync(telegramChannelSettings.TelegramBotToken!, cancellationToken)
             : null;
 
-        var selectableTimeZones = _userTimeZoneService.GetSelectableTimeZoneIds();
+        var selectableTimeZones = _userTimeZoneService.GetSelectableTimeZoneOptions();
         var selectedDisplayTimeZoneId = source?.DisplayTimeZoneId ?? user.DisplayTimeZoneId ?? "UTC";
         if (!_userTimeZoneService.IsSupportedTimeZoneId(selectedDisplayTimeZoneId))
         {
@@ -365,7 +370,13 @@ public sealed class ProfileController : Controller
             Email = source?.Email ?? user.Email ?? string.Empty,
             EmailVerified = user.EmailConfirmed,
             DisplayTimeZoneId = selectedDisplayTimeZoneId,
-            AvailableDisplayTimeZoneIds = selectableTimeZones,
+            AvailableDisplayTimeZoneOptions = selectableTimeZones
+                .Select(option => new DisplayTimeZoneOptionViewModel
+                {
+                    Value = option.Value,
+                    Label = option.Label
+                })
+                .ToList(),
             BrowserNotificationsEnabled = source?.BrowserNotificationsEnabled ?? settings.BrowserNotificationsEnabled,
             BrowserNotifyEndpointDown = source?.BrowserNotifyEndpointDown ?? settings.BrowserNotifyEndpointDown,
             BrowserNotifyEndpointRecovered = source?.BrowserNotifyEndpointRecovered ?? settings.BrowserNotifyEndpointRecovered,

--- a/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
@@ -10,6 +10,7 @@ using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.EventLogs;
 using PingMonitor.Web.Services.SmtpNotifications;
 using PingMonitor.Web.Services.Telegram;
+using PingMonitor.Web.Services.Time;
 using PingMonitor.Web.ViewModels.Profile;
 using System.Text;
 using System.Text.Json;
@@ -27,6 +28,7 @@ public sealed class ProfileController : Controller
     private readonly ITelegramBotIdentityResolver _telegramBotIdentityResolver;
     private readonly ISmtpNotificationSender _smtpNotificationSender;
     private readonly IEventLogService _eventLogService;
+    private readonly IUserTimeZoneService _userTimeZoneService;
     private readonly ILogger<ProfileController> _logger;
 
     public ProfileController(
@@ -37,6 +39,7 @@ public sealed class ProfileController : Controller
         ITelegramBotIdentityResolver telegramBotIdentityResolver,
         ISmtpNotificationSender smtpNotificationSender,
         IEventLogService eventLogService,
+        IUserTimeZoneService userTimeZoneService,
         ILogger<ProfileController> logger)
     {
         _userManager = userManager;
@@ -46,6 +49,7 @@ public sealed class ProfileController : Controller
         _telegramBotIdentityResolver = telegramBotIdentityResolver;
         _smtpNotificationSender = smtpNotificationSender;
         _eventLogService = eventLogService;
+        _userTimeZoneService = userTimeZoneService;
         _logger = logger;
     }
 
@@ -187,6 +191,43 @@ public sealed class ProfileController : Controller
         return View("Index", refreshed);
     }
 
+    [HttpPost("display-preferences")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UpdateDisplayPreferences([FromForm] ProfilePageViewModel model, CancellationToken cancellationToken)
+    {
+        var user = await RequireUserAsync();
+        if (user is null)
+        {
+            return Challenge();
+        }
+
+        if (!_userTimeZoneService.IsSupportedTimeZoneId(model.DisplayTimeZoneId))
+        {
+            ModelState.AddModelError(nameof(ProfilePageViewModel.DisplayTimeZoneId), "Select a valid display time zone.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return View("Index", await BuildModelAsync(cancellationToken, model));
+        }
+
+        user.DisplayTimeZoneId = model.DisplayTimeZoneId.Trim();
+        var result = await _userManager.UpdateAsync(user);
+        if (!result.Succeeded)
+        {
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
+
+            return View("Index", await BuildModelAsync(cancellationToken, model));
+        }
+
+        var refreshed = await BuildModelAsync(cancellationToken);
+        refreshed.DisplayPreferencesSaved = true;
+        return View("Index", refreshed);
+    }
+
     [HttpPost("notification-settings")]
     [HttpPost("notifications")]
     [ValidateAntiForgeryToken]
@@ -311,11 +352,20 @@ public sealed class ProfileController : Controller
             ? await _telegramBotIdentityResolver.ResolveBotIdentifierAsync(telegramChannelSettings.TelegramBotToken!, cancellationToken)
             : null;
 
+        var selectableTimeZones = _userTimeZoneService.GetSelectableTimeZoneIds();
+        var selectedDisplayTimeZoneId = source?.DisplayTimeZoneId ?? user.DisplayTimeZoneId ?? "UTC";
+        if (!_userTimeZoneService.IsSupportedTimeZoneId(selectedDisplayTimeZoneId))
+        {
+            selectedDisplayTimeZoneId = "UTC";
+        }
+
         return new ProfilePageViewModel
         {
             UserName = user.UserName ?? string.Empty,
             Email = source?.Email ?? user.Email ?? string.Empty,
             EmailVerified = user.EmailConfirmed,
+            DisplayTimeZoneId = selectedDisplayTimeZoneId,
+            AvailableDisplayTimeZoneIds = selectableTimeZones,
             BrowserNotificationsEnabled = source?.BrowserNotificationsEnabled ?? settings.BrowserNotificationsEnabled,
             BrowserNotifyEndpointDown = source?.BrowserNotifyEndpointDown ?? settings.BrowserNotifyEndpointDown,
             BrowserNotifyEndpointRecovered = source?.BrowserNotifyEndpointRecovered ?? settings.BrowserNotifyEndpointRecovered,

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -257,6 +257,12 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         assignmentStateInterval.HasIndex(x => new { x.AssignmentId, x.StartedAtUtc });
         assignmentStateInterval.HasIndex(x => new { x.AssignmentId, x.EndedAtUtc });
 
+        var applicationUser = modelBuilder.Entity<ApplicationUser>();
+        applicationUser.Property(x => x.DisplayTimeZoneId)
+            .HasMaxLength(128)
+            .IsRequired()
+            .HasDefaultValue("UTC");
+
         var eventLog = modelBuilder.Entity<EventLog>();
         eventLog.ToTable("EventLogs");
         eventLog.HasKey(x => x.EventLogId);

--- a/src/WebApp/PingMonitor.Web/Models/Identity/ApplicationUser.cs
+++ b/src/WebApp/PingMonitor.Web/Models/Identity/ApplicationUser.cs
@@ -4,4 +4,5 @@ namespace PingMonitor.Web.Models.Identity;
 
 public sealed class ApplicationUser : IdentityUser
 {
+    public string DisplayTimeZoneId { get; set; } = "UTC";
 }

--- a/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
@@ -5,6 +5,6 @@ public sealed class StartupGateOptions
     public const string SectionName = "StartupGate";
 
     public string StorageDirectory { get; set; } = "App_Data/StartupGate";
-    public int RequiredSchemaVersion { get; set; } = 8;
+    public int RequiredSchemaVersion { get; set; } = 10;
     public int DefaultMySqlPort { get; set; } = 3306;
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -30,6 +30,7 @@ using PingMonitor.Web.Services.ApplicationMetadata;
 using PingMonitor.Web.Services.ApplicationUpdater;
 using PingMonitor.Web.Services.Diagnostics;
 using PingMonitor.Web.Services.Telegram;
+using PingMonitor.Web.Services.Time;
 using PingMonitor.Web.Support;
 using Microsoft.Extensions.Options;
 
@@ -214,6 +215,8 @@ builder.Services.AddScoped<IDatabaseMaintenanceService, DatabaseMaintenanceServi
 builder.Services.AddSingleton<IDatabaseMaintenanceProgressTracker, DatabaseMaintenanceProgressTracker>();
 builder.Services.AddScoped<INotificationSettingsService, NotificationSettingsService>();
 builder.Services.AddScoped<IUserNotificationSettingsService, UserNotificationSettingsService>();
+builder.Services.AddScoped<IUserTimeZoneService, UserTimeZoneService>();
+builder.Services.AddScoped<IDisplayTimeFormatter, DisplayTimeFormatter>();
 builder.Services.AddScoped<INotificationSuppressionService, NotificationSuppressionService>();
 builder.Services.AddScoped<ISmtpNotificationSender, SmtpNotificationSender>();
 builder.Services.AddScoped<IBrowserNotificationQueryService, BrowserNotificationQueryService>();

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -192,6 +192,11 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "ReceivedAtUtc",
         "BatchId"
     ];
+    private static readonly string[] RequiredAspNetUsersColumns =
+    [
+        "Id",
+        "DisplayTimeZoneId"
+    ];
 
     private readonly IDbContextFactory<PingMonitorDbContext> _dbContextFactory;
     private readonly IStartupDatabaseConfigurationStore _configurationStore;
@@ -300,6 +305,14 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         {
             var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
             status.Diagnostics.Add($"AssignmentMetrics24h table is missing required columns: {string.Join(", ", missingAssignmentMetrics24hColumns)}.");
+            return status;
+        }
+
+        var missingAspNetUsersColumns = await GetMissingAspNetUsersColumnsAsync(connection, cancellationToken);
+        if (missingAspNetUsersColumns.Length > 0)
+        {
+            var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
+            status.Diagnostics.Add($"AspNetUsers table is missing required columns: {string.Join(", ", missingAspNetUsersColumns)}.");
             return status;
         }
 
@@ -758,6 +771,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await EnsureUserNotificationSettingsColumnsAsync(dbContext, cancellationToken);
         await EnsureAssignmentMetrics24hColumnsAsync(dbContext, cancellationToken);
         await EnsureAgentColumnsAsync(dbContext, cancellationToken);
+        await EnsureAspNetUsersColumnsAsync(dbContext, cancellationToken);
         await EnsureCheckResultsNormalizedSchemaAsync(dbContext, cancellationToken);
         await EnsureMetricsIndexesAsync(dbContext, cancellationToken);
         await MigrateLegacyEndpointDependenciesAsync(dbContext, cancellationToken);
@@ -1020,6 +1034,28 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             .ToArray();
     }
 
+    private static async Task<string[]> GetMissingAspNetUsersColumnsAsync(MySqlConnection connection, CancellationToken cancellationToken)
+    {
+        var existingColumns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COLUMN_NAME
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'AspNetUsers';
+            """;
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            existingColumns.Add(reader.GetString(0));
+        }
+
+        return RequiredAspNetUsersColumns
+            .Where(column => !existingColumns.Contains(column))
+            .ToArray();
+    }
+
     private static async Task EnsureEndpointDependenciesColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
     {
         await using var connection = dbContext.Database.GetDbConnection();
@@ -1152,6 +1188,25 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 """
                 ALTER TABLE `Agents`
                 ADD COLUMN `LastHeartbeatEventLoggedAtUtc` datetime(6) NULL;
+                """,
+                cancellationToken);
+        }
+    }
+
+    private static async Task EnsureAspNetUsersColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
+    {
+        await using var connection = dbContext.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        if (!await HasAspNetUsersColumnAsync(connection, "DisplayTimeZoneId", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `AspNetUsers`
+                ADD COLUMN `DisplayTimeZoneId` varchar(128) NOT NULL DEFAULT 'UTC';
                 """,
                 cancellationToken);
         }
@@ -1901,6 +1956,24 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             FROM information_schema.columns
             WHERE table_schema = DATABASE()
               AND table_name = 'Agents'
+              AND column_name = @columnName;
+            """;
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "@columnName";
+        parameter.Value = columnName;
+        command.Parameters.Add(parameter);
+
+        return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken)) > 0;
+    }
+
+    private static async Task<bool> HasAspNetUsersColumnAsync(System.Data.Common.DbConnection connection, string columnName, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'AspNetUsers'
               AND column_name = @columnName;
             """;
         var parameter = command.CreateParameter();

--- a/src/WebApp/PingMonitor.Web/Services/Time/DisplayTimeFormatter.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Time/DisplayTimeFormatter.cs
@@ -1,0 +1,39 @@
+namespace PingMonitor.Web.Services.Time;
+
+public sealed class DisplayTimeFormatter : IDisplayTimeFormatter
+{
+    private readonly IUserTimeZoneService _userTimeZoneService;
+
+    public DisplayTimeFormatter(IUserTimeZoneService userTimeZoneService)
+    {
+        _userTimeZoneService = userTimeZoneService;
+    }
+
+    public async Task<string> FormatForCurrentUserAsync(DateTimeOffset? utcValue, string nullDisplay = "n/a", CancellationToken cancellationToken = default)
+    {
+        if (!utcValue.HasValue)
+        {
+            return nullDisplay;
+        }
+
+        var timeZone = await _userTimeZoneService.GetCurrentUserTimeZoneAsync(cancellationToken);
+        return FormatForTimeZone(utcValue.Value, timeZone);
+    }
+
+    public string FormatForTimeZone(DateTimeOffset utcValue, TimeZoneInfo timeZone)
+    {
+        var utcNormalized = utcValue.ToUniversalTime();
+        var localTime = TimeZoneInfo.ConvertTime(utcNormalized, timeZone);
+        return $"{localTime:yyyy-MM-dd HH:mm:ss zzz} {timeZone.Id}";
+    }
+
+    public string FormatUtc(DateTimeOffset? utcValue, string nullDisplay = "n/a")
+    {
+        if (!utcValue.HasValue)
+        {
+            return nullDisplay;
+        }
+
+        return $"{utcValue.Value.UtcDateTime:yyyy-MM-dd HH:mm:ss} +00:00 UTC";
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Time/IDisplayTimeFormatter.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Time/IDisplayTimeFormatter.cs
@@ -1,0 +1,8 @@
+namespace PingMonitor.Web.Services.Time;
+
+public interface IDisplayTimeFormatter
+{
+    Task<string> FormatForCurrentUserAsync(DateTimeOffset? utcValue, string nullDisplay = "n/a", CancellationToken cancellationToken = default);
+    string FormatForTimeZone(DateTimeOffset utcValue, TimeZoneInfo timeZone);
+    string FormatUtc(DateTimeOffset? utcValue, string nullDisplay = "n/a");
+}

--- a/src/WebApp/PingMonitor.Web/Services/Time/IUserTimeZoneService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Time/IUserTimeZoneService.cs
@@ -1,10 +1,13 @@
 namespace PingMonitor.Web.Services.Time;
 
+public sealed record DisplayTimeZoneOption(string Value, string Label);
+
 public interface IUserTimeZoneService
 {
     Task<TimeZoneInfo> GetCurrentUserTimeZoneAsync(CancellationToken cancellationToken);
     Task<string> GetCurrentUserTimeZoneIdAsync(CancellationToken cancellationToken);
     IReadOnlyList<string> GetSelectableTimeZoneIds();
+    IReadOnlyList<DisplayTimeZoneOption> GetSelectableTimeZoneOptions();
     bool IsSupportedTimeZoneId(string? timeZoneId);
     TimeZoneInfo ResolveOrUtc(string? timeZoneId);
 }

--- a/src/WebApp/PingMonitor.Web/Services/Time/IUserTimeZoneService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Time/IUserTimeZoneService.cs
@@ -1,0 +1,10 @@
+namespace PingMonitor.Web.Services.Time;
+
+public interface IUserTimeZoneService
+{
+    Task<TimeZoneInfo> GetCurrentUserTimeZoneAsync(CancellationToken cancellationToken);
+    Task<string> GetCurrentUserTimeZoneIdAsync(CancellationToken cancellationToken);
+    IReadOnlyList<string> GetSelectableTimeZoneIds();
+    bool IsSupportedTimeZoneId(string? timeZoneId);
+    TimeZoneInfo ResolveOrUtc(string? timeZoneId);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Time/UserTimeZoneService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Time/UserTimeZoneService.cs
@@ -1,0 +1,92 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using PingMonitor.Web.Models.Identity;
+
+namespace PingMonitor.Web.Services.Time;
+
+public sealed class UserTimeZoneService : IUserTimeZoneService
+{
+    private const string UtcTimeZoneId = "UTC";
+
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IReadOnlyList<string> _selectableTimeZoneIds;
+
+    public UserTimeZoneService(IHttpContextAccessor httpContextAccessor, UserManager<ApplicationUser> userManager)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _userManager = userManager;
+
+        var ids = TimeZoneInfo
+            .GetSystemTimeZones()
+            .Select(x => x.Id)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToList();
+
+        if (!ids.Contains(UtcTimeZoneId, StringComparer.Ordinal))
+        {
+            ids.Insert(0, UtcTimeZoneId);
+        }
+        else
+        {
+            ids.RemoveAll(id => string.Equals(id, UtcTimeZoneId, StringComparison.Ordinal));
+            ids.Insert(0, UtcTimeZoneId);
+        }
+
+        _selectableTimeZoneIds = ids;
+    }
+
+    public async Task<TimeZoneInfo> GetCurrentUserTimeZoneAsync(CancellationToken cancellationToken)
+    {
+        var id = await GetCurrentUserTimeZoneIdAsync(cancellationToken);
+        return ResolveOrUtc(id);
+    }
+
+    public async Task<string> GetCurrentUserTimeZoneIdAsync(CancellationToken cancellationToken)
+    {
+        var context = _httpContextAccessor.HttpContext;
+        if (context?.User?.Identity?.IsAuthenticated != true)
+        {
+            return UtcTimeZoneId;
+        }
+
+        var user = await _userManager.GetUserAsync(context.User);
+        if (user is null)
+        {
+            return UtcTimeZoneId;
+        }
+
+        return IsSupportedTimeZoneId(user.DisplayTimeZoneId) ? user.DisplayTimeZoneId! : UtcTimeZoneId;
+    }
+
+    public IReadOnlyList<string> GetSelectableTimeZoneIds() => _selectableTimeZoneIds;
+
+    public bool IsSupportedTimeZoneId(string? timeZoneId)
+    {
+        if (string.IsNullOrWhiteSpace(timeZoneId))
+        {
+            return false;
+        }
+
+        return _selectableTimeZoneIds.Contains(timeZoneId.Trim(), StringComparer.Ordinal);
+    }
+
+    public TimeZoneInfo ResolveOrUtc(string? timeZoneId)
+    {
+        if (string.IsNullOrWhiteSpace(timeZoneId))
+        {
+            return TimeZoneInfo.Utc;
+        }
+
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId.Trim());
+        }
+        catch
+        {
+            return TimeZoneInfo.Utc;
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Time/UserTimeZoneService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Time/UserTimeZoneService.cs
@@ -11,6 +11,7 @@ public sealed class UserTimeZoneService : IUserTimeZoneService
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly IReadOnlyList<string> _selectableTimeZoneIds;
+    private readonly IReadOnlyList<DisplayTimeZoneOption> _selectableTimeZoneOptions;
 
     public UserTimeZoneService(IHttpContextAccessor httpContextAccessor, UserManager<ApplicationUser> userManager)
     {
@@ -35,7 +36,14 @@ public sealed class UserTimeZoneService : IUserTimeZoneService
             ids.Insert(0, UtcTimeZoneId);
         }
 
+        const string londonTimeZoneId = "Europe/London";
+        if (!ids.Contains(londonTimeZoneId, StringComparer.Ordinal))
+        {
+            ids.Insert(1, londonTimeZoneId);
+        }
+
         _selectableTimeZoneIds = ids;
+        _selectableTimeZoneOptions = BuildSelectableTimeZoneOptions(ids);
     }
 
     public async Task<TimeZoneInfo> GetCurrentUserTimeZoneAsync(CancellationToken cancellationToken)
@@ -62,6 +70,7 @@ public sealed class UserTimeZoneService : IUserTimeZoneService
     }
 
     public IReadOnlyList<string> GetSelectableTimeZoneIds() => _selectableTimeZoneIds;
+    public IReadOnlyList<DisplayTimeZoneOption> GetSelectableTimeZoneOptions() => _selectableTimeZoneOptions;
 
     public bool IsSupportedTimeZoneId(string? timeZoneId)
     {
@@ -88,5 +97,34 @@ public sealed class UserTimeZoneService : IUserTimeZoneService
         {
             return TimeZoneInfo.Utc;
         }
+    }
+
+    private static IReadOnlyList<DisplayTimeZoneOption> BuildSelectableTimeZoneOptions(IReadOnlyList<string> ids)
+    {
+        const string londonTimeZoneId = "Europe/London";
+        var options = new List<DisplayTimeZoneOption>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        if (seen.Add(UtcTimeZoneId))
+        {
+            options.Add(new DisplayTimeZoneOption(UtcTimeZoneId, "UTC (Coordinated Universal Time)"));
+        }
+
+        if (ids.Contains(londonTimeZoneId, StringComparer.Ordinal) && seen.Add(londonTimeZoneId))
+        {
+            options.Add(new DisplayTimeZoneOption(londonTimeZoneId, "United Kingdom — London (Europe/London)"));
+        }
+
+        foreach (var id in ids)
+        {
+            if (!seen.Add(id))
+            {
+                continue;
+            }
+
+            options.Add(new DisplayTimeZoneOption(id, id));
+        }
+
+        return options;
     }
 }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
@@ -10,6 +10,8 @@ public sealed class ProfilePageViewModel
     [EmailAddress]
     public string Email { get; set; } = string.Empty;
     public bool EmailVerified { get; set; }
+    public string DisplayTimeZoneId { get; set; } = "UTC";
+    public IReadOnlyList<string> AvailableDisplayTimeZoneIds { get; set; } = Array.Empty<string>();
 
     [DataType(DataType.Password)]
     public string CurrentPassword { get; set; } = string.Empty;
@@ -45,6 +47,7 @@ public sealed class ProfilePageViewModel
     public bool AccountSaved { get; set; }
     public bool PasswordSaved { get; set; }
     public bool NotificationsSaved { get; set; }
+    public bool DisplayPreferencesSaved { get; set; }
 
     public string? ActiveTelegramCode { get; set; }
     public DateTimeOffset? ActiveTelegramCodeExpiresAtUtc { get; set; }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
@@ -11,7 +11,7 @@ public sealed class ProfilePageViewModel
     public string Email { get; set; } = string.Empty;
     public bool EmailVerified { get; set; }
     public string DisplayTimeZoneId { get; set; } = "UTC";
-    public IReadOnlyList<string> AvailableDisplayTimeZoneIds { get; set; } = Array.Empty<string>();
+    public IReadOnlyList<DisplayTimeZoneOptionViewModel> AvailableDisplayTimeZoneOptions { get; set; } = Array.Empty<DisplayTimeZoneOptionViewModel>();
 
     [DataType(DataType.Password)]
     public string CurrentPassword { get; set; } = string.Empty;
@@ -62,4 +62,23 @@ public sealed class ProfilePageViewModel
     public string? TelegramBotIdentifier { get; set; }
     public bool EmailVerificationResendSucceeded { get; set; }
     public string? EmailVerificationMessage { get; set; }
+}
+
+public sealed class DisplayTimeZoneOptionViewModel
+{
+    public string Value { get; set; } = string.Empty;
+    public string Label { get; set; } = string.Empty;
+}
+
+public sealed class UpdateProfileAccountDetailsInputModel
+{
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+}
+
+public sealed class UpdateProfileDisplayPreferencesInputModel
+{
+    [Required]
+    public string DisplayTimeZoneId { get; set; } = "UTC";
 }

--- a/src/WebApp/PingMonitor.Web/Views/AdminApplicationUpdater/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminApplicationUpdater/Index.cshtml
@@ -255,7 +255,7 @@
                 }
                 <dl style="margin-top:1rem;">
                     <div><dt>Release title</dt><dd>@(string.IsNullOrWhiteSpace(Model.LatestReleaseName) ? "(not provided)" : Model.LatestReleaseName)</dd></div>
-                    <div><dt>Published</dt><dd>@(Model.LatestPublishedAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "Unknown")</dd></div>
+                    <div><dt>Published</dt><dd>@await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.LatestPublishedAtUtc, "Unknown")</dd></div>
                     <div><dt>Semantic comparison performed</dt><dd>@(Model.SemanticComparisonPerformed ? "Yes" : "No")</dd></div>
                     @if (!string.IsNullOrWhiteSpace(Model.LatestReleaseUrl))
                     {
@@ -280,7 +280,7 @@
                 <div class="summary-grid">
                     <div><strong>Tag/version:</strong> @Model.SelectedRelease.TagName</div>
                     <div><strong>Title:</strong> @(string.IsNullOrWhiteSpace(Model.SelectedRelease.Name) ? "(not provided)" : Model.SelectedRelease.Name)</div>
-                    <div><strong>Published:</strong> @(Model.SelectedRelease.PublishedAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "Unknown")</div>
+                    <div><strong>Published:</strong> @await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.SelectedRelease.PublishedAtUtc, "Unknown")</div>
                     <div><strong>Type:</strong> @(Model.SelectedRelease.IsPrerelease ? "Preview/prerelease" : "Stable")</div>
                     <div><strong>Required schema version (release metadata):</strong> @(Model.SelectedRelease.RequiredSchemaVersion?.ToString() ?? "(not declared)")</div>
                     <div><strong>Current database schema version:</strong> @(Model.CurrentDatabaseSchemaVersion?.ToString() ?? "(unknown)")</div>
@@ -320,8 +320,8 @@
                 <details @(stageHasError ? "open" : null)>
                     <summary>@(stageHasError ? "Hide details" : "Show details")</summary>
                     <dl style="margin-top:1rem;">
-                        <div><dt>Last updated</dt><dd>@Model.StagedUpdate.LastUpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</dd></div>
-                        <div><dt>Last stage attempt</dt><dd>@(Model.StagedUpdate.LastStageAttemptAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "(none)")</dd></div>
+                        <div><dt>Last updated</dt><dd>@await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.StagedUpdate.LastUpdatedAtUtc)</dd></div>
+                        <div><dt>Last stage attempt</dt><dd>@await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.StagedUpdate.LastStageAttemptAtUtc, "(none)")</dd></div>
                         <div><dt>Latest applicable release tag</dt><dd>@(Model.StagedUpdate.LatestApplicableReleaseTag ?? "(unknown)")</dd></div>
                         <div><dt>Release title</dt><dd>@(Model.StagedUpdate.ReleaseTitle ?? "(none)")</dd></div>
                         <div><dt>Selected archive</dt><dd>@(Model.StagedUpdate.SelectedAssetName ?? "(none)")</dd></div>
@@ -332,7 +332,7 @@
                         <div><dt>Checksum file path</dt><dd>@(Model.StagedUpdate.StagedChecksumPath ?? "(none)")</dd></div>
                         <div><dt>Expected SHA256</dt><dd>@(Model.StagedUpdate.ExpectedSha256 ?? "(none)")</dd></div>
                         <div><dt>Actual SHA256</dt><dd>@(Model.StagedUpdate.ActualSha256 ?? "(none)")</dd></div>
-                        <div><dt>Staged at</dt><dd>@(Model.StagedUpdate.StagedAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "(not staged)")</dd></div>
+                        <div><dt>Staged at</dt><dd>@await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.StagedUpdate.StagedAtUtc, "(not staged)")</dd></div>
                         <div><dt>Failure message</dt><dd>@(Model.StagedUpdate.FailureMessage ?? "(none)")</dd></div>
                     </dl>
                 </details>
@@ -357,9 +357,9 @@
                     <summary>@(applyHasError ? "Hide details" : "Show details")</summary>
                     <dl style="margin-top:1rem;">
                         <div><dt>Apply message</dt><dd>@(Model.StagedUpdate.ApplyOperationMessage ?? "(none)")</dd></div>
-                        <div><dt>Requested at</dt><dd>@(Model.StagedUpdate.ApplyRequestedAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "(none)")</dd></div>
-                        <div><dt>Handoff started at</dt><dd>@(Model.StagedUpdate.ApplyHandoffStartedAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "(none)")</dd></div>
-                        <div><dt>Apply completed at</dt><dd>@(Model.StagedUpdate.ApplyCompletedAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "(none)")</dd></div>
+                        <div><dt>Requested at</dt><dd>@await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.StagedUpdate.ApplyRequestedAtUtc, "(none)")</dd></div>
+                        <div><dt>Handoff started at</dt><dd>@await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.StagedUpdate.ApplyHandoffStartedAtUtc, "(none)")</dd></div>
+                        <div><dt>Apply completed at</dt><dd>@await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.StagedUpdate.ApplyCompletedAtUtc, "(none)")</dd></div>
                         <div><dt>Bootstrapper path</dt><dd>@(Model.StagedUpdate.BootstrapperScriptPath ?? "(none)")</dd></div>
                         <div><dt>Bootstrapper source</dt><dd>@(Model.StagedUpdate.BootstrapperSource ?? "(none)")</dd></div>
                         <div><dt>Bootstrapper source details</dt><dd>@(Model.StagedUpdate.BootstrapperSelectionMessage ?? "(none)")</dd></div>
@@ -373,7 +373,7 @@
                         <div><dt>External updater status path</dt><dd>@(Model.StagedUpdate.ExternalUpdaterStatusPath ?? "(none)")</dd></div>
                         <div><dt>External updater log path</dt><dd>@(Model.StagedUpdate.ExternalUpdaterLogPath ?? "(none)")</dd></div>
                         <div><dt>Bootstrapper process id</dt><dd>@(Model.StagedUpdate.BootstrapperProcessId?.ToString() ?? "(none)")</dd></div>
-                        <div><dt>Bootstrapper started at</dt><dd>@(Model.StagedUpdate.BootstrapperStartedAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "(none)")</dd></div>
+                        <div><dt>Bootstrapper started at</dt><dd>@await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.StagedUpdate.BootstrapperStartedAtUtc, "(none)")</dd></div>
                         <div><dt>Failure message</dt><dd>@(Model.StagedUpdate.FailureMessage ?? "(none)")</dd></div>
                     </dl>
                 </details>
@@ -385,7 +385,7 @@
             <div class="summary-grid">
                 <div><strong>Automatic checks:</strong> @(Model.EnableAutomaticUpdateChecks ? "Enabled" : "Disabled")</div>
                 <div><strong>Check interval:</strong> @Model.AutomaticUpdateCheckIntervalMinutes minute(s)</div>
-                <div><strong>Last automatic check:</strong> @(Model.RuntimeState?.LastAutomaticCheckAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "(none)")</div>
+                <div><strong>Last automatic check:</strong> @await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.RuntimeState?.LastAutomaticCheckAtUtc, "(none)")</div>
                 @if (!string.IsNullOrWhiteSpace(Model.RuntimeState?.LastAutomaticCheckFailureMessage) || !string.IsNullOrWhiteSpace(Model.RuntimeState?.LastAutoStageFailureMessage))
                 {
                     <div><strong>Failure state:</strong> @(Model.RuntimeState?.LastAutomaticCheckFailureMessage ?? Model.RuntimeState?.LastAutoStageFailureMessage)</div>
@@ -394,8 +394,8 @@
             <details @(runtimeHasError ? "open" : null)>
                 <summary>@(runtimeHasError ? "Hide details" : "Show details")</summary>
                 <dl style="margin-top:1rem;">
-                    <div><dt>Last successful automatic check</dt><dd>@(Model.RuntimeState?.LastAutomaticCheckSucceededAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "(none)")</dd></div>
-                    <div><dt>Last failed automatic check</dt><dd>@(Model.RuntimeState?.LastAutomaticCheckFailedAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") ?? "(none)")</dd></div>
+                    <div><dt>Last successful automatic check</dt><dd>@await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.RuntimeState?.LastAutomaticCheckSucceededAtUtc, "(none)")</dd></div>
+                    <div><dt>Last failed automatic check</dt><dd>@await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.RuntimeState?.LastAutomaticCheckFailedAtUtc, "(none)")</dd></div>
                     <div><dt>Last check failure message</dt><dd>@(Model.RuntimeState?.LastAutomaticCheckFailureMessage ?? "(none)")</dd></div>
                     <div><dt>Last auto-detected release</dt><dd>@(Model.RuntimeState?.LastDetectedApplicableReleaseTag ?? "(none)")</dd></div>
                     <div><dt>Last auto-staged release</dt><dd>@(Model.RuntimeState?.LastAutoStagedReleaseTag ?? "(none)")</dd></div>

--- a/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
@@ -160,7 +160,7 @@
                         <h3>Selected backup preview</h3>
                         <p><strong>Backup:</strong> @Model.Preview.BackupName</p>
                         <p><strong>File:</strong> @Model.Preview.FileId</p>
-                        <p><strong>Exported:</strong> @Model.Preview.ExportedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</p>
+                        <p><strong>Exported:</strong> @await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.Preview.ExportedAtUtc)</p>
                         <p><strong>App version:</strong> @Model.Preview.AppVersion</p>
                         <p><strong>Format version:</strong> @Model.Preview.FormatVersion</p>
                         <p><strong>Included sections:</strong> @string.Join(", ", Model.Preview.IncludedSections)</p>
@@ -353,11 +353,11 @@
                                     <td>
                                         @if (backup.ExportedAtUtc.HasValue)
                                         {
-                                            @backup.ExportedAtUtc.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")
+                                            @await DisplayTimeFormatter.FormatForCurrentUserAsync(backup.ExportedAtUtc.Value)
                                         }
                                         else
                                         {
-                                            @backup.FileCreatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")
+                                            @await DisplayTimeFormatter.FormatForCurrentUserAsync(backup.FileCreatedAtUtc)
                                         }
                                     </td>
                                     <td>@(backup.AppVersion ?? "(unknown)")</td>

--- a/src/WebApp/PingMonitor.Web/Views/AdminDatabase/Maintenance.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminDatabase/Maintenance.cshtml
@@ -72,7 +72,7 @@
 
             @if (Model.PrunePreview is not null)
             {
-                <p><strong>Preview:</strong> @Model.PrunePreview.Target rows older than <strong>@DisplayFormatting.FormatUtcDateTime(Model.PrunePreview.CutoffUtc)</strong>. Eligible rows: <strong>@Model.PrunePreview.EligibleRowCount</strong>.</p>
+                <p><strong>Preview:</strong> @Model.PrunePreview.Target rows older than <strong>@await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.PrunePreview.CutoffUtc)</strong>. Eligible rows: <strong>@Model.PrunePreview.EligibleRowCount</strong>.</p>
             }
 
             <form method="post" action="/admin/database/prune/execute" class="form-grid">
@@ -126,13 +126,13 @@
             <h3>DATABASE backup files</h3>
             <div class="table-wrap">
                 <table>
-                    <thead><tr><th>File</th><th>Created/Exported (UTC)</th><th>Size</th><th>Type</th><th>Source</th><th>Metadata</th><th>Actions</th></tr></thead>
+                    <thead><tr><th>File</th><th>Created/Exported</th><th>Size</th><th>Type</th><th>Source</th><th>Metadata</th><th>Actions</th></tr></thead>
                     <tbody>
                     @foreach (var backup in Model.Backups)
                     {
                         <tr>
                             <td>@backup.FileName</td>
-                            <td>@DisplayFormatting.FormatUtcDateTime(backup.CreatedAtUtc)</td>
+                            <td>@await DisplayTimeFormatter.FormatForCurrentUserAsync(backup.CreatedAtUtc)</td>
                             <td>@DisplayFormatting.FormatBytes(backup.SizeBytes)</td>
                             <td>@backup.BackupModeDisplayName</td>
                             <td>@backup.BackupSource</td>
@@ -158,7 +158,7 @@
                             <option value="">-- Select DATABASE backup --</option>
                             @foreach (var backup in Model.Backups)
                             {
-                                <option value="@backup.FileId">@backup.FileName (@backup.BackupSource, @backup.BackupModeDisplayName, @DisplayFormatting.FormatUtcDateTime(backup.CreatedAtUtc))</option>
+                                <option value="@backup.FileId">@backup.FileName (@backup.BackupSource, @backup.BackupModeDisplayName, @await DisplayTimeFormatter.FormatForCurrentUserAsync(backup.CreatedAtUtc))</option>
                             }
                         </select>
                     </label>
@@ -180,7 +180,7 @@
                             <option value="">-- Select DATABASE backup --</option>
                             @foreach (var backup in Model.Backups)
                             {
-                                <option value="@backup.FileId">@backup.FileName (@DisplayFormatting.FormatUtcDateTime(backup.CreatedAtUtc))</option>
+                                <option value="@backup.FileId">@backup.FileName (@await DisplayTimeFormatter.FormatForCurrentUserAsync(backup.CreatedAtUtc))</option>
                             }
                         </select>
                     </label>

--- a/src/WebApp/PingMonitor.Web/Views/AdminDatabase/Status.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminDatabase/Status.cshtml
@@ -67,7 +67,7 @@
                         <th>Avg write ms</th>
                         <th>Errors (recent / lifetime)</th>
                         <th>Write rows</th>
-                        <th>Last activity (UTC)</th>
+                        <th>Last activity</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -82,7 +82,7 @@
                             <td>@row.LifetimeAverageWriteDurationMs.ToString("0.##")</td>
                             <td>@row.RecentErrorCount / @row.LifetimeErrorCount</td>
                             <td>@row.LifetimeWriteRows</td>
-                            <td>@(row.LastActivityAtUtc is null ? "n/a" : DisplayFormatting.FormatUtcDateTime(row.LastActivityAtUtc.Value))</td>
+                            <td>@(row.LastActivityAtUtc is null ? "n/a" : await DisplayTimeFormatter.FormatForCurrentUserAsync(row.LastActivityAtUtc.Value))</td>
                         </tr>
                     }
                     </tbody>
@@ -100,11 +100,11 @@
                 <div class="metric"><div class="label">Queue utilization</div><div class="value">@Model.RuntimeBuffer.QueueUtilizationPercent.ToString("0.##")%</div></div>
                 <div class="metric"><div class="label">Configured max batch size</div><div class="value">@Model.RuntimeBuffer.ConfiguredMaxBatchSize</div></div>
                 <div class="metric"><div class="label">Configured flush interval</div><div class="value">@Model.RuntimeBuffer.ConfiguredFlushIntervalSeconds sec</div></div>
-                <div class="metric"><div class="label">Last flush time (UTC)</div><div class="value">@(Model.RuntimeBuffer.LastFlushCompletedAtUtc is null ? "n/a" : DisplayFormatting.FormatUtcDateTime(Model.RuntimeBuffer.LastFlushCompletedAtUtc.Value))</div></div>
+                <div class="metric"><div class="label">Last flush time</div><div class="value">@(Model.RuntimeBuffer.LastFlushCompletedAtUtc is null ? "n/a" : await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.RuntimeBuffer.LastFlushCompletedAtUtc.Value))</div></div>
                 <div class="metric"><div class="label">Last persist duration</div><div class="value">@Model.RuntimeBuffer.LastPersistDurationMs ms</div></div>
                 <div class="metric"><div class="label">Last flush result</div><div class="value">@Model.RuntimeBuffer.LastFlushPersistedCount / @Model.RuntimeBuffer.LastFlushAttemptedCount persisted</div></div>
                 <div class="metric"><div class="label">Assignments enqueued (last flush)</div><div class="value">@Model.RuntimeBuffer.LastEnqueuedAssignmentCount</div></div>
-                <div class="metric"><div class="label">Last assignment enqueue time (UTC)</div><div class="value">@(Model.RuntimeBuffer.LastAssignmentsEnqueuedAtUtc is null ? "n/a" : DisplayFormatting.FormatUtcDateTime(Model.RuntimeBuffer.LastAssignmentsEnqueuedAtUtc.Value))</div></div>
+                <div class="metric"><div class="label">Last assignment enqueue time</div><div class="value">@(Model.RuntimeBuffer.LastAssignmentsEnqueuedAtUtc is null ? "n/a" : await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.RuntimeBuffer.LastAssignmentsEnqueuedAtUtc.Value))</div></div>
                 <div class="metric"><div class="label">Dropped-result count</div><div class="value">@Model.RuntimeBuffer.DroppedResultCount</div></div>
                 <div class="metric"><div class="label">Drop rate</div><div class="value">@Model.RuntimeBuffer.BufferDropRatePercent.ToString("0.##")%</div></div>
                 <div class="metric"><div class="label">Flush success rate</div><div class="value">@Model.RuntimeBuffer.FlushSuccessRatePercent.ToString("0.##")%</div></div>
@@ -127,8 +127,8 @@
                 <div class="metric"><div class="label">Coalesced duplicates</div><div class="value">@Model.RuntimeBuffer.AssignmentProcessingQueue.CoalescedDuplicateCount</div></div>
                 <div class="metric"><div class="label">Processed count</div><div class="value">@Model.RuntimeBuffer.AssignmentProcessingQueue.ProcessedCount</div></div>
                 <div class="metric"><div class="label">Failed count</div><div class="value">@Model.RuntimeBuffer.AssignmentProcessingQueue.FailedCount</div></div>
-                <div class="metric"><div class="label">Last processed (UTC)</div><div class="value">@(Model.RuntimeBuffer.AssignmentProcessingQueue.LastProcessedAtUtc is null ? "n/a" : DisplayFormatting.FormatUtcDateTime(Model.RuntimeBuffer.AssignmentProcessingQueue.LastProcessedAtUtc.Value))</div></div>
-                <div class="metric"><div class="label">Last failure (UTC)</div><div class="value">@(Model.RuntimeBuffer.AssignmentProcessingQueue.LastFailureAtUtc is null ? "n/a" : DisplayFormatting.FormatUtcDateTime(Model.RuntimeBuffer.AssignmentProcessingQueue.LastFailureAtUtc.Value))</div></div>
+                <div class="metric"><div class="label">Last processed</div><div class="value">@(Model.RuntimeBuffer.AssignmentProcessingQueue.LastProcessedAtUtc is null ? "n/a" : await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.RuntimeBuffer.AssignmentProcessingQueue.LastProcessedAtUtc.Value))</div></div>
+                <div class="metric"><div class="label">Last failure</div><div class="value">@(Model.RuntimeBuffer.AssignmentProcessingQueue.LastFailureAtUtc is null ? "n/a" : await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.RuntimeBuffer.AssignmentProcessingQueue.LastFailureAtUtc.Value))</div></div>
             </div>
             @if (!string.IsNullOrWhiteSpace(Model.RuntimeBuffer.AssignmentProcessingQueue.LastFailureError))
             {

--- a/src/WebApp/PingMonitor.Web/Views/AdminDefaultEndpointValues/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminDefaultEndpointValues/Index.cshtml
@@ -64,7 +64,7 @@
                         <div class="field-error"><span asp-validation-for="DefaultRecoveryThreshold"></span></div>
                     </div>
                 </div>
-                <p class="muted">Last updated: @Model.UpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</p>
+                <p class="muted">Last updated: @await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.UpdatedAtUtc)</p>
             </section>
 
             <div class="button-row"><button class="button" type="submit">Save default endpoint values</button></div>

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnblockIp.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnblockIp.cshtml
@@ -22,8 +22,8 @@
         <dt>Auth type</dt><dd>@Model.AuthType</dd>
         <dt>IP address</dt><dd>@Model.IpAddress</dd>
         <dt>Block type</dt><dd>@Model.BlockType</dd>
-        <dt>Blocked at (UTC)</dt><dd>@Model.BlockedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")</dd>
-        <dt>Expires at (UTC)</dt><dd>@(Model.ExpiresAtUtc.HasValue ? Model.ExpiresAtUtc.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss") : "n/a")</dd>
+        <dt>Blocked at </dt><dd>@await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.BlockedAtUtc)</dd>
+        <dt>Expires at </dt><dd>@await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.ExpiresAtUtc)</dd>
     </dl>
 
     <form method="post" action="/admin/security/ip-blocks/@Model.SecurityIpBlockId/remove" style="display:grid;gap:.6rem;">

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnlockUser.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/ConfirmUnlockUser.cshtml
@@ -21,7 +21,7 @@
     <dl>
         <dt>User name</dt><dd>@Model.UserName</dd>
         <dt>Email</dt><dd>@(string.IsNullOrWhiteSpace(Model.Email) ? "n/a" : Model.Email)</dd>
-        <dt>Lockout ends (UTC)</dt><dd>@Model.LockoutEndUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")</dd>
+        <dt>Lockout ends </dt><dd>@await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.LockoutEndUtc)</dd>
     </dl>
 
     <form method="post" action="/admin/security/users/@Model.UserId/unlock" style="display:grid;gap:.6rem;">

--- a/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminSecurity/Index.cshtml
@@ -109,7 +109,7 @@
                 <tr>
                     <th>User name</th>
                     <th>Email</th>
-                    <th>Lockout ends (UTC)</th>
+                    <th>Lockout ends </th>
                     <th>Action</th>
                 </tr>
                 </thead>
@@ -127,7 +127,7 @@
                         <tr>
                             <td>@user.UserName</td>
                             <td>@(string.IsNullOrWhiteSpace(user.Email) ? "n/a" : user.Email)</td>
-                            <td>@user.LockoutEndUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")</td>
+                            <td>@await DisplayTimeFormatter.FormatForCurrentUserAsync(user.LockoutEndUtc)</td>
                             <td>
                                 <a class="button-secondary" href="/admin/security/users/@user.UserId/unlock?includeSuccessfulUsers=@Model.LogFilterForm.IncludeSuccessfulUsers.ToString().ToLowerInvariant()&includeSuccessfulAgents=@Model.LogFilterForm.IncludeSuccessfulAgents.ToString().ToLowerInvariant()">Unlock user</a>
                             </td>
@@ -219,7 +219,7 @@
                     </div>
                 </section>
             </div>
-            <p class="muted">Last updated: @Model.SettingsForm.UpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</p>
+            <p class="muted">Last updated: @await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.SettingsForm.UpdatedAtUtc)</p>
             <div class="button-row">
                 <button class="button-primary" type="submit">Save security settings</button>
             </div>
@@ -279,8 +279,8 @@
                     <th>Auth type</th>
                     <th>IP address</th>
                     <th>Block type</th>
-                    <th>Blocked at (UTC)</th>
-                    <th>Expires at (UTC)</th>
+                    <th>Blocked at </th>
+                    <th>Expires at </th>
                     <th>Reason</th>
                     <th>Action</th>
                 </tr>
@@ -300,8 +300,8 @@
                             <td>@block.AuthType</td>
                             <td>@block.IpAddress</td>
                             <td>@block.BlockType</td>
-                            <td>@block.BlockedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")</td>
-                            <td>@(block.ExpiresAtUtc.HasValue ? block.ExpiresAtUtc.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss") : "n/a")</td>
+                            <td>@await DisplayTimeFormatter.FormatForCurrentUserAsync(block.BlockedAtUtc)</td>
+                            <td>@await DisplayTimeFormatter.FormatForCurrentUserAsync(block.ExpiresAtUtc)</td>
                             <td>@(string.IsNullOrWhiteSpace(block.Reason) ? "n/a" : block.Reason)</td>
                             <td>
                                 <a class="button-secondary" href="/admin/security/ip-blocks/@block.SecurityIpBlockId/remove?LogFilterForm.IncludeSuccessfulUsers=@Model.LogFilterForm.IncludeSuccessfulUsers.ToString().ToLowerInvariant()&LogFilterForm.IncludeSuccessfulAgents=@Model.LogFilterForm.IncludeSuccessfulAgents.ToString().ToLowerInvariant()&LogFilterForm.SearchText=@Model.LogFilterForm.SearchText&LogFilterForm.FromUtc=@Model.LogFilterForm.FromUtc&LogFilterForm.ToUtc=@Model.LogFilterForm.ToUtc">Remove block</a>
@@ -332,7 +332,7 @@
                 <div><strong>Retention days:</strong> @Model.RetentionPreview.RetentionDays</div>
                 <div><strong>Auto-prune enabled:</strong> @(Model.RetentionPreview.AutoPruneEnabled ? "Yes" : "No")</div>
                 <div><strong>Eligible auth log rows:</strong> @Model.RetentionPreview.EligibleAuthLogRows</div>
-                <div style="grid-column: 1 / -1;"><strong>Current cutoff (UTC):</strong> @(Model.RetentionPreview.CutoffUtc.HasValue ? Model.RetentionPreview.CutoffUtc.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") : "n/a")</div>
+                <div style="grid-column: 1 / -1;"><strong>Current cutoff:</strong> @await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.RetentionPreview.CutoffUtc)</div>
                 @if (Model.RetentionPreview.PruneSkipped && !string.IsNullOrWhiteSpace(Model.RetentionPreview.SkipReason))
                 {
                     <div class="muted" style="grid-column: 1 / -1;">Prune preview skipped: @Model.RetentionPreview.SkipReason</div>
@@ -408,7 +408,7 @@
                 {
                     <div class="log-item @entry.SeverityCssClass">
                         <div class="entry-meta">
-                            <div><strong>@entry.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</strong></div>
+                            <div><strong>@await DisplayTimeFormatter.FormatForCurrentUserAsync(entry.OccurredAtUtc)</strong></div>
                             <div>Subject: @entry.SubjectIdentifier</div>
                             <div>Source IP: @(string.IsNullOrWhiteSpace(entry.SourceIpAddress) ? "n/a" : entry.SourceIpAddress)</div>
                             <div>Status: <span class="@(entry.VisualSeverity == PingMonitor.Web.Models.LogVisualSeverity.Error ? "severity-text-error" : entry.VisualSeverity == PingMonitor.Web.Models.LogVisualSeverity.Warning ? "severity-text-warning" : "severity-text-info")">@(entry.Success ? "SUCCESS" : "FAILED")</span></div>
@@ -436,7 +436,7 @@
                 {
                     <div class="log-item @entry.SeverityCssClass">
                         <div class="entry-meta">
-                            <div><strong>@entry.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</strong></div>
+                            <div><strong>@await DisplayTimeFormatter.FormatForCurrentUserAsync(entry.OccurredAtUtc)</strong></div>
                             <div>Subject: @entry.SubjectIdentifier</div>
                             <div>Source IP: @(string.IsNullOrWhiteSpace(entry.SourceIpAddress) ? "n/a" : entry.SourceIpAddress)</div>
                             <div>Status: <span class="@(entry.VisualSeverity == PingMonitor.Web.Models.LogVisualSeverity.Error ? "severity-text-error" : entry.VisualSeverity == PingMonitor.Web.Models.LogVisualSeverity.Warning ? "severity-text-warning" : "severity-text-info")">@(entry.Success ? "SUCCESS" : "FAILED")</span></div>

--- a/src/WebApp/PingMonitor.Web/Views/Agents/History.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/History.cshtml
@@ -1,6 +1,6 @@
 @model PingMonitor.Web.ViewModels.EventLogs.EventLogHistoryPageViewModel
 @{
-    static string FormatDate(DateTimeOffset value) => value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'");
+    static string FormatDateInput(DateTimeOffset? value) => value?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm") ?? string.Empty;
     static string FormatRelated(string? endpointId, string? endpointName, string? agentId, string? agentName)
     {
         var parts = new List<string>();
@@ -77,11 +77,11 @@
                     </div>
                     <div>
                         <label for="dateFromUtc">Date from (UTC)</label>
-                        <input id="dateFromUtc" type="datetime-local" name="dateFromUtc" value="@Model.Filters.DateFromUtc?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm")" />
+                        <input id="dateFromUtc" type="datetime-local" name="dateFromUtc" value="@FormatDateInput(Model.Filters.DateFromUtc)" />
                     </div>
                     <div>
                         <label for="dateToUtc">Date to (UTC)</label>
-                        <input id="dateToUtc" type="datetime-local" name="dateToUtc" value="@Model.Filters.DateToUtc?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm")" />
+                        <input id="dateToUtc" type="datetime-local" name="dateToUtc" value="@FormatDateInput(Model.Filters.DateToUtc)" />
                     </div>
                     <div>
                         <label for="pageSize">Page size</label>
@@ -124,7 +124,7 @@
                             @foreach (var row in Model.Rows)
                             {
                                 <tr class="@row.SeverityCssClass">
-                                    <td>@FormatDate(row.OccurredAtUtc)</td>
+                                    <td>@await DisplayTimeFormatter.FormatForCurrentUserAsync(row.OccurredAtUtc)</td>
                                     <td>@row.EventType</td>
                                     <td>@row.Category</td>
                                     <td><strong>@row.Severity</strong></td>

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
@@ -1,6 +1,5 @@
 @model PingMonitor.Web.ViewModels.Agents.ManageAgentsPageViewModel
 @{
-    static string FormatDate(DateTimeOffset? value) => value.HasValue ? value.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") : "Never";
     static string FormatPercent(double? value) => value.HasValue ? $"{value.Value:F1}%" : "Unknown";
 }
 <!DOCTYPE html>
@@ -110,9 +109,9 @@
 
                             <div class="row-meta">
                                 <div class="meta-item"><span>Assignments</span><div>@agent.AssignmentCount</div></div>
-                                <div class="meta-item"><span>Created</span><div>@FormatDate(agent.CreatedAtUtc)</div></div>
-                                <div class="meta-item"><span>Last seen</span><div>@FormatDate(agent.LastSeenUtc)</div></div>
-                                <div class="meta-item"><span>Last heartbeat</span><div>@FormatDate(agent.LastHeartbeatUtc)</div></div>
+                                <div class="meta-item"><span>Created</span><div>@await DisplayTimeFormatter.FormatForCurrentUserAsync(agent.CreatedAtUtc, "Never")</div></div>
+                                <div class="meta-item"><span>Last seen</span><div>@await DisplayTimeFormatter.FormatForCurrentUserAsync(agent.LastSeenUtc, "Never")</div></div>
+                                <div class="meta-item"><span>Last heartbeat</span><div>@await DisplayTimeFormatter.FormatForCurrentUserAsync(agent.LastHeartbeatUtc, "Never")</div></div>
                                 <div class="meta-item"><span>Agent uptime (24h)</span><div>@FormatPercent(agent.UptimePercent)</div></div>
                                 <div class="meta-item"><span>Agent version</span><div>@agent.AgentVersion</div></div>
                                 <div class="meta-item"><span>Machine name</span><div>@agent.MachineName</div></div>

--- a/src/WebApp/PingMonitor.Web/Views/Endpoints/History.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Endpoints/History.cshtml
@@ -1,6 +1,6 @@
 @model PingMonitor.Web.ViewModels.EventLogs.EventLogHistoryPageViewModel
 @{
-    static string FormatDate(DateTimeOffset value) => value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'");
+    static string FormatDateInput(DateTimeOffset? value) => value?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm") ?? string.Empty;
     static string FormatRelated(string? endpointId, string? endpointName, string? agentId, string? agentName)
     {
         var parts = new List<string>();
@@ -77,11 +77,11 @@
                     </div>
                     <div>
                         <label for="dateFromUtc">Date from (UTC)</label>
-                        <input id="dateFromUtc" type="datetime-local" name="dateFromUtc" value="@Model.Filters.DateFromUtc?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm")" />
+                        <input id="dateFromUtc" type="datetime-local" name="dateFromUtc" value="@FormatDateInput(Model.Filters.DateFromUtc)" />
                     </div>
                     <div>
                         <label for="dateToUtc">Date to (UTC)</label>
-                        <input id="dateToUtc" type="datetime-local" name="dateToUtc" value="@Model.Filters.DateToUtc?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm")" />
+                        <input id="dateToUtc" type="datetime-local" name="dateToUtc" value="@FormatDateInput(Model.Filters.DateToUtc)" />
                     </div>
                     <div>
                         <label for="pageSize">Page size</label>
@@ -124,7 +124,7 @@
                             @foreach (var row in Model.Rows)
                             {
                                 <tr class="@row.SeverityCssClass">
-                                    <td>@FormatDate(row.OccurredAtUtc)</td>
+                                    <td>@await DisplayTimeFormatter.FormatForCurrentUserAsync(row.OccurredAtUtc)</td>
                                     <td>@row.EventType</td>
                                     <td>@row.Category</td>
                                     <td><strong>@row.Severity</strong></td>

--- a/src/WebApp/PingMonitor.Web/Views/Groups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Groups/Index.cshtml
@@ -49,7 +49,7 @@
                     <article class="row">
                         <div><strong>@row.Name</strong></div>
                         <div class="muted">@(string.IsNullOrWhiteSpace(row.Description) ? "No description" : row.Description)</div>
-                        <div class="muted">Created @row.CreatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</div>
+                        <div class="muted">Created @await DisplayTimeFormatter.FormatForCurrentUserAsync(row.CreatedAtUtc)</div>
                         <div class="button-row"><a class="button-secondary" asp-controller="Groups" asp-action="Edit" asp-route-id="@row.GroupId">Edit group</a></div>
                     </article>
                 }

--- a/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NotificationSettings/Index.cshtml
@@ -82,7 +82,7 @@
             </section>
 
             <section class="card">
-                <p class="muted">Last updated: @Model.UpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</p>
+                <p class="muted">Last updated: @await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.UpdatedAtUtc)</p>
                 @if (!string.IsNullOrWhiteSpace(Model.UpdatedByUserId)) { <p class="muted">Last updated by: @Model.UpdatedByUserId</p> }
                 <div class="button-row"><button class="button" type="submit">Save notification infrastructure settings</button></div>
             </section>

--- a/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
@@ -23,7 +23,8 @@
 <div class="stack">
 <section class="card">
     <h1>My profile</h1>
-    <p class="muted">Manage your account details. Notification preferences are on a dedicated page.</p>
+        <p class="muted">Manage your account details. Notification preferences are on a dedicated page.</p>
+        <p class="muted">Operator timestamps in the web UI are rendered using your selected display time zone.</p>
     <div class="button-row">
         <a class="button-secondary" href="/profile/notification-settings">Notification settings</a>
         <a class="button-secondary" href="/status">Back to status</a>
@@ -44,6 +45,25 @@
             <p class="muted">SMTP notifications are delivered only after email verification succeeds.</p>
         }
         <div class="button-row"><button class="button" type="submit">Save account details</button></div>
+    </form>
+</section>
+<section class="card stack">
+    <h2>Display preferences</h2>
+    @if (Model.DisplayPreferencesSaved) { <div class="saved">Display preferences saved.</div> }
+    <form method="post" action="/profile/display-preferences" class="stack">
+        @Html.AntiForgeryToken()
+        <div>
+            <label asp-for="DisplayTimeZoneId">Display time zone</label>
+            <select asp-for="DisplayTimeZoneId" style="width:100%;min-height:44px;border:1px solid var(--border);border-radius:8px;padding:.6rem .7rem;font:inherit;">
+                @foreach (var zoneId in Model.AvailableDisplayTimeZoneIds)
+                {
+                    <option value="@zoneId">@zoneId</option>
+                }
+            </select>
+            <div class="field-error"><span asp-validation-for="DisplayTimeZoneId"></span></div>
+        </div>
+        <p class="muted">UTC is recommended for incident and audit workflows.</p>
+        <div class="button-row"><button class="button" type="submit">Save display preferences</button></div>
     </form>
 </section>
 <section class="card stack" id="change-password">

--- a/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
@@ -55,9 +55,9 @@
         <div>
             <label asp-for="DisplayTimeZoneId">Display time zone</label>
             <select asp-for="DisplayTimeZoneId" style="width:100%;min-height:44px;border:1px solid var(--border);border-radius:8px;padding:.6rem .7rem;font:inherit;">
-                @foreach (var zoneId in Model.AvailableDisplayTimeZoneIds)
+                @foreach (var option in Model.AvailableDisplayTimeZoneOptions)
                 {
-                    <option value="@zoneId">@zoneId</option>
+                    <option value="@option.Value">@option.Label</option>
                 }
             </select>
             <div class="field-error"><span asp-validation-for="DisplayTimeZoneId"></span></div>

--- a/src/WebApp/PingMonitor.Web/Views/Profile/NotificationSettings.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Profile/NotificationSettings.cshtml
@@ -76,7 +76,7 @@
         <div class="switch-row"><input asp-for="QuietHoursSuppressBrowserNotifications" type="checkbox" /><label asp-for="QuietHoursSuppressBrowserNotifications">Suppress browser during quiet hours</label></div>
         <div class="switch-row"><input asp-for="QuietHoursSuppressSmtpNotifications" type="checkbox" /><label asp-for="QuietHoursSuppressSmtpNotifications">Suppress SMTP during quiet hours</label></div>
         <div class="switch-row"><input asp-for="QuietHoursSuppressTelegramNotifications" type="checkbox" /><label asp-for="QuietHoursSuppressTelegramNotifications">Suppress Telegram during quiet hours</label></div>
-        <p class="muted">Settings last updated at @Model.NotificationSettingsUpdatedAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'").</p>
+        <p class="muted">Settings last updated at @await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.NotificationSettingsUpdatedAtUtc).</p>
         <div class="button-row"><button class="button" type="submit">Save notification preferences</button></div>
     </form>
 </section>
@@ -102,7 +102,7 @@
     @if (Model.TelegramAccountRemoved) { <div class="saved">Telegram account removed.</div> }
     @if (!string.IsNullOrWhiteSpace(Model.ActiveTelegramCode))
     {
-        <p><strong>Active code:</strong> @Model.ActiveTelegramCode (expires @Model.ActiveTelegramCodeExpiresAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'"))</p>
+        <p><strong>Active code:</strong> @Model.ActiveTelegramCode (expires @await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.ActiveTelegramCodeExpiresAtUtc))</p>
     }
     @if (Model.TelegramLinked)
     {

--- a/src/WebApp/PingMonitor.Web/Views/Status/_AssignmentsSection.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/_AssignmentsSection.cshtml
@@ -2,7 +2,6 @@
 @using PingMonitor.Web.Models
 @using PingMonitor.Web.Services.Endpoints
 @{
-    static string FormatDate(DateTimeOffset? value) => value.HasValue ? value.Value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'") : "No checks yet";
     static string FormatDependencies(IReadOnlyList<string> endpointIds, IReadOnlyList<string> endpointNames, string emptyText) => endpointIds.Count == 0
         ? emptyText
         : endpointNames.Count == 0
@@ -76,8 +75,8 @@
                             <div class="row-meta">
                                 <div class="meta-item"><span>Agent / instance</span><div>@row.AgentName <span class="muted">(@row.AgentInstanceId)</span></div></div>
                                 <div class="meta-item"><span>Check type</span><div>@row.CheckType</div></div>
-                                <div class="meta-item"><span>Last check</span><div class="nowrap">@FormatDate(row.LastCheckUtc)</div></div>
-                                <div class="meta-item"><span>Last state change</span><div class="nowrap">@FormatDate(row.LastStateChangeUtc)</div></div>
+                                <div class="meta-item"><span>Last check</span><div class="nowrap">@await DisplayTimeFormatter.FormatForCurrentUserAsync(row.LastCheckUtc, "No checks yet")</div></div>
+                                <div class="meta-item"><span>Last state change</span><div class="nowrap">@await DisplayTimeFormatter.FormatForCurrentUserAsync(row.LastStateChangeUtc, "No checks yet")</div></div>
                                 <div class="meta-item"><span>Current state duration</span><div>@row.CurrentStateDurationDisplay</div></div>
                                 <div class="meta-item"><span>Consecutive failures</span><div>@row.ConsecutiveFailureCount</div></div>
                                 <div class="meta-item"><span>Consecutive successes</span><div>@row.ConsecutiveSuccessCount</div></div>

--- a/src/WebApp/PingMonitor.Web/Views/Status/_RecentEventsSection.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Status/_RecentEventsSection.cshtml
@@ -48,6 +48,7 @@
         <div class="recent-events">
             @foreach (var recentEvent in Model.RecentEvents)
             {
+                var occurredAtDisplay = await DisplayTimeFormatter.FormatForCurrentUserAsync(recentEvent.OccurredAtUtc);
                 var destination = GetRecentEventDestination(recentEvent);
                 var severityClassName = recentEvent.SeverityCssClass;
                 var rowClassName = destination is null
@@ -57,7 +58,7 @@
                 if (destination is null)
                 {
                     <div class="@rowClassName">
-                        <div><strong>@recentEvent.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</strong> · @recentEvent.EventType (@recentEvent.Category)</div>
+                        <div><strong>@occurredAtDisplay</strong> · @recentEvent.EventType (@recentEvent.Category)</div>
                         <div>@recentEvent.Message</div>
                         <div class="muted">
                             @if (!string.IsNullOrWhiteSpace(recentEvent.EndpointId))
@@ -73,8 +74,8 @@
                 }
                 else
                 {
-                    <a class="@rowClassName" href="@destination" aria-label="Open details for @recentEvent.EventType event at @recentEvent.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")">
-                        <div><strong>@recentEvent.OccurredAtUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss 'UTC'")</strong> · @recentEvent.EventType (@recentEvent.Category)</div>
+                    <a class="@rowClassName" href="@destination" aria-label="Open details for @recentEvent.EventType event at @occurredAtDisplay">
+                        <div><strong>@occurredAtDisplay</strong> · @recentEvent.EventType (@recentEvent.Category)</div>
                         <div>@recentEvent.Message</div>
                         <div class="muted">
                             @if (!string.IsNullOrWhiteSpace(recentEvent.EndpointId))

--- a/src/WebApp/PingMonitor.Web/Views/_ViewImports.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/_ViewImports.cshtml
@@ -1,1 +1,3 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@using PingMonitor.Web.Services.Time
+@inject IDisplayTimeFormatter DisplayTimeFormatter

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 9,
+    "RequiredSchemaVersion": 10,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 9,
+    "RequiredSchemaVersion": 10,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
### Motivation
- Operators need timestamps rendered in their preferred IANA time zone while keeping all stored timestamps, logs, agent payloads, and processing UTC-only.
- Centralise display-time conversion to avoid ad-hoc formatting across Razor views and to make future changes safe and consistent.
- Ensure startup-gate and schema rules are respected when introducing an additive identity column.

### Description
- Added a per-user preference `DisplayTimeZoneId` to `ApplicationUser` (default "UTC") and mapped it in EF without changing existing timestamp semantics. 
- Implemented `IUserTimeZoneService` and `IDisplayTimeFormatter` with `UserTimeZoneService` and `DisplayTimeFormatter` to resolve the authenticated user’s display zone (safe UTC fallback) and format UTC timestamps at the view boundary (shows offset + zone id). 
- Exposed the formatter to Razor views (`_ViewImports`) and updated operator-facing views (status, recent events, assignments, agents, endpoint history, event logs, admin DB/backup/maintenance/security/updater pages, profile/notification pages, and shared partials) to use the shared formatter only when rendering UI. 
- Added a Profile “Display preferences” section and controller handler to select and persist a safe list/dropdown of IANA time zones per user with validation and UTC fallback. 
- Added Startup Gate schema guards and an additive migration for `AspNetUsers.DisplayTimeZoneId`, and bumped `StartupGateOptions.RequiredSchemaVersion` / appsettings to `10` to reflect the schema change. 
- Added unit tests `DisplayTimeFormatterTests` that validate DST conversion (Europe/London), UTC passthrough, and fallback-safe behavior. 
- Fixes #459

### Testing
- Ran `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` which executed the test suite including the new `DisplayTimeFormatterTests` and all tests passed (Passed: 44, Failed: 0). 
- Verified runtime SDK availability with `dotnet --version` (used to run the tests) and tests executed successfully under .NET 10.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4abe82ac832a8825ce485b26097f)