### PR TITLE
Isolate profile time zone form validation and surface Europe/London in dropdown

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/DisplayTimeFormatterTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/DisplayTimeFormatterTests.cs
@@ -49,6 +49,7 @@ public sealed class DisplayTimeFormatterTests
         public Task<TimeZoneInfo> GetCurrentUserTimeZoneAsync(CancellationToken cancellationToken) => Task.FromResult(_zone);
         public Task<string> GetCurrentUserTimeZoneIdAsync(CancellationToken cancellationToken) => Task.FromResult(_zone.Id);
         public IReadOnlyList<string> GetSelectableTimeZoneIds() => [_zone.Id];
+        public IReadOnlyList<DisplayTimeZoneOption> GetSelectableTimeZoneOptions() => [new(_zone.Id, _zone.Id)];
         public bool IsSupportedTimeZoneId(string? timeZoneId) => string.Equals(timeZoneId, _zone.Id, StringComparison.Ordinal);
         public TimeZoneInfo ResolveOrUtc(string? timeZoneId) => _zone;
     }

--- a/src/WebApp/PingMonitor.Web.Tests/ProfileDisplayPreferencesTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/ProfileDisplayPreferencesTests.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
+using PingMonitor.Web.Services.Time;
+using PingMonitor.Web.ViewModels.Profile;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class ProfileDisplayPreferencesTests
+{
+    [Fact]
+    public void UpdateProfileDisplayPreferencesInputModel_AllowsPostingWithoutEmail()
+    {
+        var model = new UpdateProfileDisplayPreferencesInputModel
+        {
+            DisplayTimeZoneId = "Europe/London"
+        };
+
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(model, new ValidationContext(model), validationResults, validateAllProperties: true);
+
+        Assert.True(isValid);
+        Assert.Empty(validationResults);
+    }
+
+    [Fact]
+    public void UserTimeZoneService_IncludesUtcAndEuropeLondon_WithoutDuplicates()
+    {
+        var service = new UserTimeZoneService(new HttpContextAccessor(), userManager: null!);
+
+        var options = service.GetSelectableTimeZoneOptions();
+
+        Assert.NotEmpty(options);
+        Assert.Equal("UTC", options[0].Value);
+        Assert.Equal("Europe/London", options[1].Value);
+        Assert.Equal("United Kingdom — London (Europe/London)", options[1].Label);
+        Assert.Equal(1, options.Count(option => string.Equals(option.Value, "Europe/London", StringComparison.Ordinal)));
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/ProfileController.cs
@@ -69,7 +69,7 @@ public sealed class ProfileController : Controller
 
     [HttpPost("account")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> UpdateAccount([FromForm] ProfilePageViewModel model, CancellationToken cancellationToken)
+    public async Task<IActionResult> UpdateAccount([FromForm] UpdateProfileAccountDetailsInputModel model, CancellationToken cancellationToken)
     {
         var user = await RequireUserAsync();
         if (user is null)
@@ -77,14 +77,11 @@ public sealed class ProfileController : Controller
             return Challenge();
         }
 
-        if (string.IsNullOrWhiteSpace(model.Email) || !MailAddress.TryCreate(model.Email, out _))
-        {
-            ModelState.AddModelError(nameof(ProfilePageViewModel.Email), "A valid email address is required.");
-        }
-
         if (!ModelState.IsValid)
         {
-            return View("Index", await BuildModelAsync(cancellationToken, model));
+            var invalidModel = await BuildModelAsync(cancellationToken);
+            invalidModel.Email = model.Email;
+            return View("Index", invalidModel);
         }
 
         var trimmedEmail = model.Email.Trim();
@@ -96,7 +93,9 @@ public sealed class ProfileController : Controller
                 ModelState.AddModelError(string.Empty, error.Description);
             }
 
-            return View("Index", await BuildModelAsync(cancellationToken, model));
+            var invalidModel = await BuildModelAsync(cancellationToken);
+            invalidModel.Email = model.Email;
+            return View("Index", invalidModel);
         }
 
         user.EmailConfirmed = false;
@@ -109,7 +108,9 @@ public sealed class ProfileController : Controller
                 ModelState.AddModelError(string.Empty, error.Description);
             }
 
-            return View("Index", await BuildModelAsync(cancellationToken, model));
+            var invalidModel = await BuildModelAsync(cancellationToken);
+            invalidModel.Email = model.Email;
+            return View("Index", invalidModel);
         }
 
         var sendResult = await SendVerificationEmailAsync(user, cancellationToken);
@@ -193,7 +194,7 @@ public sealed class ProfileController : Controller
 
     [HttpPost("display-preferences")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> UpdateDisplayPreferences([FromForm] ProfilePageViewModel model, CancellationToken cancellationToken)
+    public async Task<IActionResult> UpdateDisplayPreferences([FromForm] UpdateProfileDisplayPreferencesInputModel model, CancellationToken cancellationToken)
     {
         var user = await RequireUserAsync();
         if (user is null)
@@ -203,12 +204,14 @@ public sealed class ProfileController : Controller
 
         if (!_userTimeZoneService.IsSupportedTimeZoneId(model.DisplayTimeZoneId))
         {
-            ModelState.AddModelError(nameof(ProfilePageViewModel.DisplayTimeZoneId), "Select a valid display time zone.");
+            ModelState.AddModelError(nameof(UpdateProfileDisplayPreferencesInputModel.DisplayTimeZoneId), "Select a valid display time zone.");
         }
 
         if (!ModelState.IsValid)
         {
-            return View("Index", await BuildModelAsync(cancellationToken, model));
+            var invalidModel = await BuildModelAsync(cancellationToken);
+            invalidModel.DisplayTimeZoneId = model.DisplayTimeZoneId;
+            return View("Index", invalidModel);
         }
 
         user.DisplayTimeZoneId = model.DisplayTimeZoneId.Trim();
@@ -220,7 +223,9 @@ public sealed class ProfileController : Controller
                 ModelState.AddModelError(string.Empty, error.Description);
             }
 
-            return View("Index", await BuildModelAsync(cancellationToken, model));
+            var invalidModel = await BuildModelAsync(cancellationToken);
+            invalidModel.DisplayTimeZoneId = model.DisplayTimeZoneId;
+            return View("Index", invalidModel);
         }
 
         var refreshed = await BuildModelAsync(cancellationToken);
@@ -352,7 +357,7 @@ public sealed class ProfileController : Controller
             ? await _telegramBotIdentityResolver.ResolveBotIdentifierAsync(telegramChannelSettings.TelegramBotToken!, cancellationToken)
             : null;
 
-        var selectableTimeZones = _userTimeZoneService.GetSelectableTimeZoneIds();
+        var selectableTimeZones = _userTimeZoneService.GetSelectableTimeZoneOptions();
         var selectedDisplayTimeZoneId = source?.DisplayTimeZoneId ?? user.DisplayTimeZoneId ?? "UTC";
         if (!_userTimeZoneService.IsSupportedTimeZoneId(selectedDisplayTimeZoneId))
         {
@@ -365,7 +370,13 @@ public sealed class ProfileController : Controller
             Email = source?.Email ?? user.Email ?? string.Empty,
             EmailVerified = user.EmailConfirmed,
             DisplayTimeZoneId = selectedDisplayTimeZoneId,
-            AvailableDisplayTimeZoneIds = selectableTimeZones,
+            AvailableDisplayTimeZoneOptions = selectableTimeZones
+                .Select(option => new DisplayTimeZoneOptionViewModel
+                {
+                    Value = option.Value,
+                    Label = option.Label
+                })
+                .ToList(),
             BrowserNotificationsEnabled = source?.BrowserNotificationsEnabled ?? settings.BrowserNotificationsEnabled,
             BrowserNotifyEndpointDown = source?.BrowserNotifyEndpointDown ?? settings.BrowserNotifyEndpointDown,
             BrowserNotifyEndpointRecovered = source?.BrowserNotifyEndpointRecovered ?? settings.BrowserNotifyEndpointRecovered,

--- a/src/WebApp/PingMonitor.Web/Services/Time/IUserTimeZoneService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Time/IUserTimeZoneService.cs
@@ -1,10 +1,13 @@
 namespace PingMonitor.Web.Services.Time;
 
+public sealed record DisplayTimeZoneOption(string Value, string Label);
+
 public interface IUserTimeZoneService
 {
     Task<TimeZoneInfo> GetCurrentUserTimeZoneAsync(CancellationToken cancellationToken);
     Task<string> GetCurrentUserTimeZoneIdAsync(CancellationToken cancellationToken);
     IReadOnlyList<string> GetSelectableTimeZoneIds();
+    IReadOnlyList<DisplayTimeZoneOption> GetSelectableTimeZoneOptions();
     bool IsSupportedTimeZoneId(string? timeZoneId);
     TimeZoneInfo ResolveOrUtc(string? timeZoneId);
 }

--- a/src/WebApp/PingMonitor.Web/Services/Time/UserTimeZoneService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Time/UserTimeZoneService.cs
@@ -11,6 +11,7 @@ public sealed class UserTimeZoneService : IUserTimeZoneService
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly IReadOnlyList<string> _selectableTimeZoneIds;
+    private readonly IReadOnlyList<DisplayTimeZoneOption> _selectableTimeZoneOptions;
 
     public UserTimeZoneService(IHttpContextAccessor httpContextAccessor, UserManager<ApplicationUser> userManager)
     {
@@ -35,7 +36,14 @@ public sealed class UserTimeZoneService : IUserTimeZoneService
             ids.Insert(0, UtcTimeZoneId);
         }
 
+        const string londonTimeZoneId = "Europe/London";
+        if (!ids.Contains(londonTimeZoneId, StringComparer.Ordinal))
+        {
+            ids.Insert(1, londonTimeZoneId);
+        }
+
         _selectableTimeZoneIds = ids;
+        _selectableTimeZoneOptions = BuildSelectableTimeZoneOptions(ids);
     }
 
     public async Task<TimeZoneInfo> GetCurrentUserTimeZoneAsync(CancellationToken cancellationToken)
@@ -62,6 +70,7 @@ public sealed class UserTimeZoneService : IUserTimeZoneService
     }
 
     public IReadOnlyList<string> GetSelectableTimeZoneIds() => _selectableTimeZoneIds;
+    public IReadOnlyList<DisplayTimeZoneOption> GetSelectableTimeZoneOptions() => _selectableTimeZoneOptions;
 
     public bool IsSupportedTimeZoneId(string? timeZoneId)
     {
@@ -88,5 +97,34 @@ public sealed class UserTimeZoneService : IUserTimeZoneService
         {
             return TimeZoneInfo.Utc;
         }
+    }
+
+    private static IReadOnlyList<DisplayTimeZoneOption> BuildSelectableTimeZoneOptions(IReadOnlyList<string> ids)
+    {
+        const string londonTimeZoneId = "Europe/London";
+        var options = new List<DisplayTimeZoneOption>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        if (seen.Add(UtcTimeZoneId))
+        {
+            options.Add(new DisplayTimeZoneOption(UtcTimeZoneId, "UTC (Coordinated Universal Time)"));
+        }
+
+        if (ids.Contains(londonTimeZoneId, StringComparer.Ordinal) && seen.Add(londonTimeZoneId))
+        {
+            options.Add(new DisplayTimeZoneOption(londonTimeZoneId, "United Kingdom — London (Europe/London)"));
+        }
+
+        foreach (var id in ids)
+        {
+            if (!seen.Add(id))
+            {
+                continue;
+            }
+
+            options.Add(new DisplayTimeZoneOption(id, id));
+        }
+
+        return options;
     }
 }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Profile/ProfilePageViewModel.cs
@@ -11,7 +11,7 @@ public sealed class ProfilePageViewModel
     public string Email { get; set; } = string.Empty;
     public bool EmailVerified { get; set; }
     public string DisplayTimeZoneId { get; set; } = "UTC";
-    public IReadOnlyList<string> AvailableDisplayTimeZoneIds { get; set; } = Array.Empty<string>();
+    public IReadOnlyList<DisplayTimeZoneOptionViewModel> AvailableDisplayTimeZoneOptions { get; set; } = Array.Empty<DisplayTimeZoneOptionViewModel>();
 
     [DataType(DataType.Password)]
     public string CurrentPassword { get; set; } = string.Empty;
@@ -62,4 +62,23 @@ public sealed class ProfilePageViewModel
     public string? TelegramBotIdentifier { get; set; }
     public bool EmailVerificationResendSucceeded { get; set; }
     public string? EmailVerificationMessage { get; set; }
+}
+
+public sealed class DisplayTimeZoneOptionViewModel
+{
+    public string Value { get; set; } = string.Empty;
+    public string Label { get; set; } = string.Empty;
+}
+
+public sealed class UpdateProfileAccountDetailsInputModel
+{
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+}
+
+public sealed class UpdateProfileDisplayPreferencesInputModel
+{
+    [Required]
+    public string DisplayTimeZoneId { get; set; } = "UTC";
 }

--- a/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Profile/Index.cshtml
@@ -55,9 +55,9 @@
         <div>
             <label asp-for="DisplayTimeZoneId">Display time zone</label>
             <select asp-for="DisplayTimeZoneId" style="width:100%;min-height:44px;border:1px solid var(--border);border-radius:8px;padding:.6rem .7rem;font:inherit;">
-                @foreach (var zoneId in Model.AvailableDisplayTimeZoneIds)
+                @foreach (var option in Model.AvailableDisplayTimeZoneOptions)
                 {
-                    <option value="@zoneId">@zoneId</option>
+                    <option value="@option.Value">@option.Label</option>
                 }
             </select>
             <div class="field-error"><span asp-validation-for="DisplayTimeZoneId"></span></div>


### PR DESCRIPTION
### Motivation
- The profile page was validating the whole page model for each POST, causing saving display preferences to fail when unrelated `Email` validation fired.
- Users had trouble finding London/UK time because `Europe/London` was not clearly surfaced near the top of the time zone list.
- The intent is to isolate form binding/validation per-section so each form validates only its own inputs, and improve the time zone dropdown UX while keeping the stored value as the IANA ID.

### Description
- Introduced separate POST input models `UpdateProfileAccountDetailsInputModel` and `UpdateProfileDisplayPreferencesInputModel` and wired them into `ProfileController` so account updates and display-preference updates validate independently (no cross-field Email validation on display-preferences POST). (changes: `ProfilePageViewModel.cs`, `ProfileController.cs`).
- Added typed display option support: `DisplayTimeZoneOption` record and `GetSelectableTimeZoneOptions()` on `IUserTimeZoneService`, with `UserTimeZoneService` building labeled options and deduplicating entries. `UTC` is forced to the top and `Europe/London` is inserted/labelled near the top as `United Kingdom — London (Europe/London)`. (changes: `IUserTimeZoneService.cs`, `UserTimeZoneService.cs`).
- Updated the profile view to render option labels (`AvailableDisplayTimeZoneOptions`) and preserved the stored values as the IANA IDs (`Europe/London`, `UTC`). (changes: `Index.cshtml`, `ProfilePageViewModel.cs`).
- Updated tests: adapted `DisplayTimeFormatterTests` stub to the new options API and added `ProfileDisplayPreferencesTests` covering that the display-preferences input model validates without email and that `Europe/London` appears once and is ordered/labelled as expected. (added `ProfileDisplayPreferencesTests.cs`, modified `DisplayTimeFormatterTests.cs`).
- Kept existing behavior: invalid time zone IDs are rejected by the display preferences handler and users without a selection still default to `UTC` via existing service logic.

### Testing
- Ran unit tests with: `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj`; all tests passed (46 passed, 0 failed). ✅
- Built the web project with: `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj -c Debug`; build succeeded. ✅
- Added automated tests that verify posting the display-preferences input model succeeds without Email, and that `Europe/London` is present, labelled, ordered near the top, and not duplicated; these tests passed as part of the test run. ✅

Fixes #459

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb50792340832a816b38ccd193511d)