### PR TITLE
Harden release schema-version metadata validation for updater compatibility

### DIFF
--- a/docs/build-and-release.md
+++ b/docs/build-and-release.md
@@ -10,6 +10,7 @@ Both scripts:
 - build and publish the app as self-contained
 - package the app, agent, docs, and sample configs
 - generate an archive and checksum
+- emit schema metadata (`requiredSchemaVersion`) for updater compatibility checks
 
 ---
 
@@ -65,6 +66,22 @@ The release script produces versioned output under:
 Primary release archive example:
 
 `PingMonitor-V0.1.0-win-x64.zip`
+
+### Required schema metadata (release-critical)
+
+Release builds enforce schema metadata consistency for updater safety:
+
+- `scripts/build.ps1` reads `StartupGate.RequiredSchemaVersion` from the **published** `appsettings.json`.
+- The release build fails if `StartupGate.RequiredSchemaVersion` is missing, null, non-numeric, or `< 1`.
+- `manifest.json` must include `requiredSchemaVersion` as an integer `>= 1`.
+- After writing `manifest.json`, the build validates:
+  - `version` matches the requested release version
+  - `requiredSchemaVersion` exists and is a valid integer `>= 1`
+  - `packageFileName` matches the generated zip name
+
+If any validation fails, release packaging stops with an error.
+
+When a release introduces a schema change, increment `StartupGate.RequiredSchemaVersion` before building the release package.
 
 ---
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -27,6 +27,69 @@ function Fail-Build {
     exit 1
 }
 
+function Resolve-RequiredSchemaVersion {
+    param(
+        [Parameter(Mandatory = $true)]
+        [psobject]$SettingsObject,
+        [Parameter(Mandatory = $true)]
+        [string]$SourcePath
+    )
+
+    if (-not ($SettingsObject.PSObject.Properties.Name -contains 'StartupGate') -or
+        $null -eq $SettingsObject.StartupGate) {
+        Fail-Build "Required schema version metadata missing: StartupGate section was not found in '$SourcePath'."
+    }
+
+    if (-not ($SettingsObject.StartupGate.PSObject.Properties.Name -contains 'RequiredSchemaVersion')) {
+        Fail-Build "Required schema version metadata missing: StartupGate.RequiredSchemaVersion was not found in '$SourcePath'."
+    }
+
+    $rawRequiredSchemaVersion = $SettingsObject.StartupGate.RequiredSchemaVersion
+    if ($null -eq $rawRequiredSchemaVersion) {
+        Fail-Build "Required schema version metadata is null in '$SourcePath' (StartupGate.RequiredSchemaVersion)."
+    }
+
+    $parsedRequiredSchemaVersion = 0
+    if (-not [int]::TryParse($rawRequiredSchemaVersion.ToString(), [ref]$parsedRequiredSchemaVersion)) {
+        Fail-Build "Required schema version metadata is invalid in '$SourcePath' (StartupGate.RequiredSchemaVersion='$rawRequiredSchemaVersion'). Expected integer >= 1."
+    }
+
+    if ($parsedRequiredSchemaVersion -lt 1) {
+        Fail-Build "Required schema version metadata is invalid in '$SourcePath' (StartupGate.RequiredSchemaVersion=$parsedRequiredSchemaVersion). Expected integer >= 1."
+    }
+
+    return $parsedRequiredSchemaVersion
+}
+
+function Resolve-ManifestRequiredSchemaVersion {
+    param(
+        [Parameter(Mandatory = $true)]
+        [psobject]$ManifestObject,
+        [Parameter(Mandatory = $true)]
+        [string]$ManifestSourcePath
+    )
+
+    if (-not ($ManifestObject.PSObject.Properties.Name -contains 'requiredSchemaVersion')) {
+        Fail-Build "manifest.json validation failed: requiredSchemaVersion was not found in '$ManifestSourcePath'."
+    }
+
+    $rawRequiredSchemaVersion = $ManifestObject.requiredSchemaVersion
+    if ($null -eq $rawRequiredSchemaVersion) {
+        Fail-Build "manifest.json validation failed: requiredSchemaVersion is null in '$ManifestSourcePath'."
+    }
+
+    $parsedRequiredSchemaVersion = 0
+    if (-not [int]::TryParse($rawRequiredSchemaVersion.ToString(), [ref]$parsedRequiredSchemaVersion)) {
+        Fail-Build "manifest.json validation failed: requiredSchemaVersion value '$rawRequiredSchemaVersion' is invalid. Expected integer >= 1."
+    }
+
+    if ($parsedRequiredSchemaVersion -lt 1) {
+        Fail-Build "manifest.json validation failed: requiredSchemaVersion value '$parsedRequiredSchemaVersion' is invalid. Expected integer >= 1."
+    }
+
+    return $parsedRequiredSchemaVersion
+}
+
 function Invoke-External {
     param(
         [Parameter(Mandatory = $true)]
@@ -227,10 +290,8 @@ if (-not $injectedSettings.ApplicationMetadata -or $injectedSettings.Application
     Fail-Build 'Version injection failed. ApplicationMetadata.Version was not updated as expected.'
 }
 
-$requiredSchemaVersion = $injectedSettings.StartupGate.RequiredSchemaVersion
-if ($null -eq $requiredSchemaVersion -or [int]$requiredSchemaVersion -lt 1) {
-    Fail-Build "Required schema version was missing or invalid in appsettings.json StartupGate.RequiredSchemaVersion."
-}
+$requiredSchemaVersion = Resolve-RequiredSchemaVersion -SettingsObject $injectedSettings -SourcePath $appSettingsPath
+Write-Info "Resolved required schema version: $requiredSchemaVersion"
 
 if ((Get-Content -LiteralPath $appSettingsPath -Raw) -match 'Internal dev build') {
     Fail-Build "Version injection verification failed. 'Internal dev build' label is still present in appsettings.json."
@@ -264,6 +325,20 @@ $manifest | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $manifestPath -E
 if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
     Fail-Build "manifest.json was not created at '$manifestPath'."
 }
+
+$manifestFromDisk = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+if ($manifestFromDisk.version -ne $Version) {
+    Fail-Build "manifest.json validation failed. version '$($manifestFromDisk.version)' did not match requested release version '$Version'."
+}
+
+$validatedManifestSchemaVersion = Resolve-ManifestRequiredSchemaVersion -ManifestObject $manifestFromDisk -ManifestSourcePath $manifestPath
+
+$expectedPackageFileName = Split-Path -Leaf $zipPath
+if ($manifestFromDisk.packageFileName -ne $expectedPackageFileName) {
+    Fail-Build "manifest.json validation failed. packageFileName '$($manifestFromDisk.packageFileName)' did not match generated archive '$expectedPackageFileName'."
+}
+
+Write-Info "Validated manifest required schema version: $validatedManifestSchemaVersion"
 
 if (-not (Test-Path -LiteralPath $appStagingPath -PathType Container)) {
     Fail-Build "Staging app directory missing at '$appStagingPath'."

--- a/src/WebApp/PingMonitor.Web.Tests/ReleaseSchemaMetadataServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/ReleaseSchemaMetadataServiceTests.cs
@@ -72,6 +72,64 @@ public sealed class ReleaseSchemaMetadataServiceTests
         Assert.Null(enriched[0].RequiredSchemaVersion);
     }
 
+    [Fact]
+    public async Task PopulateRequiredSchemaVersionsAsync_LeavesSchemaVersionNull_WhenManifestSchemaVersionIsZero()
+    {
+        var zipBytes = BuildZipWithManifest("""{"requiredSchemaVersion":0}""");
+        var service = BuildService(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(zipBytes)
+        });
+
+        var releases = new[]
+        {
+            new GitHubReleaseSummary
+            {
+                TagName = "V1.2.3",
+                Assets = new[]
+                {
+                    new GitHubReleaseAssetSummary
+                    {
+                        Name = "PingMonitor-V1.2.3-win-x64.zip",
+                        BrowserDownloadUrl = "https://example.test/download.zip"
+                    }
+                }
+            }
+        };
+
+        var enriched = await service.PopulateRequiredSchemaVersionsAsync(releases, CancellationToken.None);
+        Assert.Null(enriched[0].RequiredSchemaVersion);
+    }
+
+    [Fact]
+    public async Task PopulateRequiredSchemaVersionsAsync_LeavesSchemaVersionNull_WhenManifestSchemaVersionIsNegative()
+    {
+        var zipBytes = BuildZipWithManifest("""{"requiredSchemaVersion":-2}""");
+        var service = BuildService(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(zipBytes)
+        });
+
+        var releases = new[]
+        {
+            new GitHubReleaseSummary
+            {
+                TagName = "V1.2.3",
+                Assets = new[]
+                {
+                    new GitHubReleaseAssetSummary
+                    {
+                        Name = "PingMonitor-V1.2.3-win-x64.zip",
+                        BrowserDownloadUrl = "https://example.test/download.zip"
+                    }
+                }
+            }
+        };
+
+        var enriched = await service.PopulateRequiredSchemaVersionsAsync(releases, CancellationToken.None);
+        Assert.Null(enriched[0].RequiredSchemaVersion);
+    }
+
     private static ReleaseSchemaMetadataService BuildService(HttpResponseMessage response)
     {
         var options = Microsoft.Extensions.Options.Options.Create(new ApplicationUpdaterOptions

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ReleaseSchemaMetadataService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ReleaseSchemaMetadataService.cs
@@ -114,6 +114,12 @@ internal sealed class ReleaseSchemaMetadataService : IReleaseSchemaMetadataServi
                 return null;
             }
 
+            if (parsed < 1)
+            {
+                _logger.LogWarning("Release {ReleaseTag} manifest contains out-of-range requiredSchemaVersion {RequiredSchemaVersion}.", selectedRelease.TagName, parsed);
+                return null;
+            }
+
             return parsed;
         }
         catch (Exception ex)


### PR DESCRIPTION
### Motivation

- Ensure release packages reliably include `requiredSchemaVersion` so the updater can make safe compatibility decisions and warn operators when metadata is missing or invalid. 
- Prevent silent or ambiguous metadata (null, non-numeric, zero, negative) from bypassing updater safety checks.
- Make the release build fail loudly and provide clear diagnostics when schema metadata is absent or invalid to avoid unsafe releases.

### Description

- Added strict schema metadata extraction and validation helpers to `scripts/build.ps1` (`Resolve-RequiredSchemaVersion` and `Resolve-ManifestRequiredSchemaVersion`) that fail the build when `StartupGate.RequiredSchemaVersion` or `manifest.json.requiredSchemaVersion` is missing, null, non-numeric, or < 1, and print the resolved/validated schema version to the build output.
- Added post-write `manifest.json` integrity checks in `scripts/build.ps1` to assert `version` matches the requested release `-Version`, `requiredSchemaVersion` is a valid integer `>= 1`, and `packageFileName` matches the generated ZIP name.
- Hardened updater metadata ingestion in `ReleaseSchemaMetadataService` to treat out-of-range values (e.g. `0`, negative) as invalid and continue to use the strong-warning/null path when metadata is missing or invalid.
- Added unit tests (`ReleaseSchemaMetadataServiceTests`) covering invalid-but-numeric manifest values (`0` and negative) so malformed metadata remains on the safe warning path.
- Updated release docs `docs/build-and-release.md` to require `requiredSchemaVersion` in release artifacts and document the build's hard-fail behavior for invalid/missing schema metadata.
- Issue linkage: Fixes #462

### Testing

- Ran targeted tests: `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj --filter ReleaseSchemaMetadataServiceTests` and observed the tests pass (release metadata parsing tests passed).
- Ran full web-app test suite: `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and observed all tests passed in this environment.
- Attempted to run an end-to-end `pwsh` release script validation but `pwsh` (PowerShell 7) was not available in the environment package sources, so `scripts/build.ps1` was not executed here; unit tests exercise the manifest parsing and updater metadata behavior and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb54985448832aa7a6981960f09fe8)