### PR TITLE
Per-agent offline Unknown timeout for assigned endpoints

### DIFF
--- a/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
@@ -58,7 +58,8 @@ public sealed class AgentsController : Controller
                 CreatedAtUtc = row.CreatedAtUtc,
                 AssignmentCount = row.AssignmentCount,
                 UptimePercent = row.UptimePercent,
-                IsVersionDifferentFromBundled = IsVersionDifferentFromBundled(row.AgentVersion, bundledAgentVersion)
+                IsVersionDifferentFromBundled = IsVersionDifferentFromBundled(row.AgentVersion, bundledAgentVersion),
+                EndpointUnknownAfterAgentOfflineSeconds = row.EndpointUnknownAfterAgentOfflineSeconds
             }).ToList(),
             BundledAgentVersion = bundledAgentVersion,
             StatusMessage = TempData[StatusMessageKey] as string,
@@ -169,6 +170,31 @@ public sealed class AgentsController : Controller
     public async Task<IActionResult> Disable([FromRoute] string id, CancellationToken cancellationToken)
     {
         return await SetEnabledAsync(id, false, cancellationToken);
+    }
+
+    [HttpPost("{id}/endpoint-unknown-timeout")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> SetEndpointUnknownTimeout([FromRoute] string id, [FromForm] int endpointUnknownAfterAgentOfflineSeconds, CancellationToken cancellationToken)
+    {
+        if (endpointUnknownAfterAgentOfflineSeconds < 30 || endpointUnknownAfterAgentOfflineSeconds > 86400)
+        {
+            TempData[ErrorMessageKey] = "Endpoint Unknown timeout must be between 30 and 86400 seconds.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        try
+        {
+            var changed = await _agentProvisioningService.SetEndpointUnknownAfterAgentOfflineSecondsAsync(id, endpointUnknownAfterAgentOfflineSeconds, cancellationToken);
+            TempData[StatusMessageKey] = changed
+                ? "Agent offline Unknown timeout updated."
+                : "Agent offline Unknown timeout was already set to that value.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData[ErrorMessageKey] = ex.Message;
+        }
+
+        return RedirectToAction(nameof(Index));
     }
 
     [HttpPost("{id}/rotate-package")]

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -77,6 +77,9 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         agent.Property(x => x.CreatedAtUtc).IsRequired();
         agent.Property(x => x.LastHeartbeatEventLoggedAtUtc);
         agent.Property(x => x.ApiKeyCreatedAtUtc).IsRequired();
+        agent.Property(x => x.EndpointUnknownAfterAgentOfflineSeconds)
+            .IsRequired()
+            .HasDefaultValue(Agent.DefaultEndpointUnknownAfterAgentOfflineSeconds);
         agent.Property(x => x.Enabled).HasDefaultValue(true);
         agent.Property(x => x.ApiKeyRevoked).HasDefaultValue(false);
         agent.Property(x => x.Status).HasConversion<string>().HasMaxLength(16);

--- a/src/WebApp/PingMonitor.Web/Models/Agent.cs
+++ b/src/WebApp/PingMonitor.Web/Models/Agent.cs
@@ -2,6 +2,7 @@ namespace PingMonitor.Web.Models;
 
 public sealed class Agent
 {
+    public const int DefaultEndpointUnknownAfterAgentOfflineSeconds = 300;
     public string AgentId { get; set; } = string.Empty;
     public string InstanceId { get; set; } = string.Empty;
     public string? Name { get; set; }
@@ -18,4 +19,5 @@ public sealed class Agent
     public string? MachineName { get; set; }
     public DateTimeOffset CreatedAtUtc { get; set; }
     public DateTimeOffset? LastHeartbeatEventLoggedAtUtc { get; set; }
+    public int EndpointUnknownAfterAgentOfflineSeconds { get; set; } = DefaultEndpointUnknownAfterAgentOfflineSeconds;
 }

--- a/src/WebApp/PingMonitor.Web/Services/AgentProvisioningService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentProvisioningService.cs
@@ -195,6 +195,27 @@ internal sealed class AgentProvisioningService : IAgentProvisioningService
         }
     }
 
+    public async Task<bool> SetEndpointUnknownAfterAgentOfflineSecondsAsync(string agentId, int seconds, CancellationToken cancellationToken)
+    {
+        var normalizedAgentId = NormalizeAgentId(agentId);
+        var agent = await _dbContext.Agents.SingleOrDefaultAsync(x => x.AgentId == normalizedAgentId, cancellationToken);
+        if (agent is null)
+        {
+            throw new InvalidOperationException("Agent not found.");
+        }
+
+        if (agent.EndpointUnknownAfterAgentOfflineSeconds == seconds)
+        {
+            return false;
+        }
+
+        agent.EndpointUnknownAfterAgentOfflineSeconds = seconds;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        _configurationChangeBackupSignal.NotifyConfigurationChanged("agent-offline-unknown-timeout-updated");
+        _logger.LogInformation("Updated EndpointUnknownAfterAgentOfflineSeconds={Seconds} for agent {AgentId}", seconds, agent.AgentId);
+        return true;
+    }
+
     private static string NormalizeAgentId(string agentId)
     {
         var normalizedAgentId = agentId.Trim();

--- a/src/WebApp/PingMonitor.Web/Services/AgentStatusTransitionBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentStatusTransitionBackgroundService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Services.EventLogs;
+using PingMonitor.Web.Services.State;
 using PingMonitor.Web.Services.StartupGate;
 
 namespace PingMonitor.Web.Services;
@@ -14,15 +15,18 @@ internal sealed class AgentStatusTransitionBackgroundService : BackgroundService
 
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly IStartupGateRuntimeState _startupGateRuntimeState;
+    private readonly IAssignmentProcessingQueue _assignmentProcessingQueue;
     private readonly ILogger<AgentStatusTransitionBackgroundService> _logger;
 
     public AgentStatusTransitionBackgroundService(
         IServiceScopeFactory serviceScopeFactory,
         IStartupGateRuntimeState startupGateRuntimeState,
+        IAssignmentProcessingQueue assignmentProcessingQueue,
         ILogger<AgentStatusTransitionBackgroundService> logger)
     {
         _serviceScopeFactory = serviceScopeFactory;
         _startupGateRuntimeState = startupGateRuntimeState;
+        _assignmentProcessingQueue = assignmentProcessingQueue;
         _logger = logger;
     }
 
@@ -79,13 +83,13 @@ internal sealed class AgentStatusTransitionBackgroundService : BackgroundService
 
         foreach (var agent in agents)
         {
-            if (!agent.LastHeartbeatUtc.HasValue)
+            if (!agent.LastSeenUtc.HasValue)
             {
                 continue;
             }
 
             var previousStatus = agent.Status;
-            var elapsed = now - agent.LastHeartbeatUtc.Value;
+            var elapsed = now - agent.LastSeenUtc.Value;
             var nextStatus = elapsed >= OfflineThreshold
                 ? AgentHealthStatus.Offline
                 : elapsed >= StaleThreshold
@@ -94,6 +98,7 @@ internal sealed class AgentStatusTransitionBackgroundService : BackgroundService
 
             if (nextStatus == previousStatus)
             {
+                await EnqueueAssignedEndpointsForEvaluationIfOfflineWindowElapsedAsync(dbContext, agent, elapsed, cancellationToken);
                 continue;
             }
 
@@ -118,6 +123,29 @@ internal sealed class AgentStatusTransitionBackgroundService : BackgroundService
                         : $"Agent \"{agent.Name ?? agent.InstanceId}\" became offline."
                 },
                 cancellationToken);
+
+            await EnqueueAssignedEndpointsForEvaluationIfOfflineWindowElapsedAsync(dbContext, agent, elapsed, cancellationToken);
         }
+    }
+
+    private async Task EnqueueAssignedEndpointsForEvaluationIfOfflineWindowElapsedAsync(
+        PingMonitorDbContext dbContext,
+        Agent agent,
+        TimeSpan elapsedSinceLastSeen,
+        CancellationToken cancellationToken)
+    {
+        var unknownTimeout = TimeSpan.FromSeconds(agent.EndpointUnknownAfterAgentOfflineSeconds);
+        if (elapsedSinceLastSeen < unknownTimeout)
+        {
+            return;
+        }
+
+        var assignmentIds = await dbContext.MonitorAssignments
+            .AsNoTracking()
+            .Where(x => x.AgentId == agent.AgentId && x.Enabled)
+            .Select(x => x.AssignmentId)
+            .ToArrayAsync(cancellationToken);
+
+        _assignmentProcessingQueue.EnqueueAssignments(assignmentIds);
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementQueryService.cs
@@ -43,7 +43,8 @@ internal sealed class AgentManagementQueryService : IAgentManagementQueryService
                 agent.AgentVersion,
                 agent.MachineName,
                 agent.Platform,
-                agent.CreatedAtUtc
+                agent.CreatedAtUtc,
+                agent.EndpointUnknownAfterAgentOfflineSeconds
             })
             .ToListAsync(cancellationToken);
 
@@ -65,7 +66,8 @@ internal sealed class AgentManagementQueryService : IAgentManagementQueryService
                 Platform = agent.Platform ?? "Unknown",
                 CreatedAtUtc = agent.CreatedAtUtc,
                 AssignmentCount = assignmentCounts.GetValueOrDefault(agent.AgentId, 0),
-                UptimePercent = uptimeByAgentId.GetValueOrDefault(agent.AgentId)?.UptimePercent
+                UptimePercent = uptimeByAgentId.GetValueOrDefault(agent.AgentId)?.UptimePercent,
+                EndpointUnknownAfterAgentOfflineSeconds = agent.EndpointUnknownAfterAgentOfflineSeconds
             })
             .ToList();
     }

--- a/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementRow.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementRow.cs
@@ -15,6 +15,7 @@ public sealed class AgentManagementRow
     public required DateTimeOffset CreatedAtUtc { get; init; }
     public required int AssignmentCount { get; init; }
     public double? UptimePercent { get; init; }
+    public required int EndpointUnknownAfterAgentOfflineSeconds { get; init; }
 }
 
 public sealed class RemoveAgentDetails

--- a/src/WebApp/PingMonitor.Web/Services/IAgentProvisioningService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IAgentProvisioningService.cs
@@ -6,4 +6,5 @@ public interface IAgentProvisioningService
     Task<bool> SetEnabledAsync(string agentId, bool enabled, CancellationToken cancellationToken);
     Task<bool> RemoveAsync(string agentId, CancellationToken cancellationToken);
     Task<AgentProvisioningResult> RotatePackageAsync(string agentId, CancellationToken cancellationToken);
+    Task<bool> SetEndpointUnknownAfterAgentOfflineSecondsAsync(string agentId, int seconds, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/Services/State/AssignmentTopologyCache.cs
+++ b/src/WebApp/PingMonitor.Web/Services/State/AssignmentTopologyCache.cs
@@ -99,7 +99,9 @@ internal sealed class AssignmentTopologyCache : IAssignmentTopologyCache
                 AgentId = x.AgentId,
                 Enabled = x.Enabled,
                 ApiKeyRevoked = x.ApiKeyRevoked,
-                Status = x.Status
+                Status = x.Status,
+                LastSeenUtc = x.LastSeenUtc,
+                EndpointUnknownAfterAgentOfflineSeconds = x.EndpointUnknownAfterAgentOfflineSeconds
             })
             .ToDictionaryAsync(x => x.AgentId, StringComparer.Ordinal, cancellationToken);
 
@@ -180,6 +182,8 @@ internal sealed class AssignmentTopologyCache : IAssignmentTopologyCache
                 AgentEnabled = agent?.Enabled ?? false,
                 AgentApiKeyRevoked = agent?.ApiKeyRevoked ?? true,
                 AgentStatus = agent?.Status ?? AgentHealthStatus.Offline,
+                AgentLastSeenUtc = agent?.LastSeenUtc,
+                EndpointUnknownAfterAgentOfflineSeconds = agent?.EndpointUnknownAfterAgentOfflineSeconds ?? Agent.DefaultEndpointUnknownAfterAgentOfflineSeconds,
                 ParentDependencies = parentDependencies,
                 ChildAssignmentIds = childAssignments
             };
@@ -212,6 +216,8 @@ internal sealed class AssignmentTopologyCache : IAssignmentTopologyCache
         public required bool Enabled { get; init; }
         public required bool ApiKeyRevoked { get; init; }
         public required AgentHealthStatus Status { get; init; }
+        public required DateTimeOffset? LastSeenUtc { get; init; }
+        public required int EndpointUnknownAfterAgentOfflineSeconds { get; init; }
     }
 
     private sealed class DependencyRow

--- a/src/WebApp/PingMonitor.Web/Services/State/IAssignmentTopologyCache.cs
+++ b/src/WebApp/PingMonitor.Web/Services/State/IAssignmentTopologyCache.cs
@@ -20,6 +20,8 @@ public sealed class AssignmentTopologyContext
     public required bool AgentEnabled { get; init; }
     public required bool AgentApiKeyRevoked { get; init; }
     public required AgentHealthStatus AgentStatus { get; init; }
+    public required DateTimeOffset? AgentLastSeenUtc { get; init; }
+    public required int EndpointUnknownAfterAgentOfflineSeconds { get; init; }
     public required IReadOnlyList<AssignmentParentDependency> ParentDependencies { get; init; }
     public required IReadOnlyList<string> ChildAssignmentIds { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
@@ -274,7 +274,18 @@ internal sealed class StateEvaluationService : IStateEvaluationService
             return EndpointStateKind.Unknown;
         }
 
-        if (!assignment.AgentEnabled || assignment.AgentApiKeyRevoked || assignment.AgentStatus != AgentHealthStatus.Online)
+        if (!assignment.AgentEnabled || assignment.AgentApiKeyRevoked)
+        {
+            return EndpointStateKind.Unknown;
+        }
+
+        if (!assignment.AgentLastSeenUtc.HasValue)
+        {
+            return EndpointStateKind.Unknown;
+        }
+
+        var unknownAfterOffline = TimeSpan.FromSeconds(assignment.EndpointUnknownAfterAgentOfflineSeconds);
+        if (DateTimeOffset.UtcNow - assignment.AgentLastSeenUtc.Value >= unknownAfterOffline)
         {
             return EndpointStateKind.Unknown;
         }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Agents/ManageAgentsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Agents/ManageAgentsPageViewModel.cs
@@ -24,6 +24,7 @@ public sealed class ManageAgentRowViewModel
     public required int AssignmentCount { get; init; }
     public required double? UptimePercent { get; init; }
     public required bool IsVersionDifferentFromBundled { get; init; }
+    public required int EndpointUnknownAfterAgentOfflineSeconds { get; init; }
 }
 
 public sealed class RemoveAgentPageViewModel

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
@@ -116,6 +116,7 @@
                                 <div class="meta-item"><span>Agent version</span><div>@agent.AgentVersion</div></div>
                                 <div class="meta-item"><span>Machine name</span><div>@agent.MachineName</div></div>
                                 <div class="meta-item"><span>Platform</span><div>@agent.Platform</div></div>
+                                <div class="meta-item"><span>Unknown after offline</span><div>@agent.EndpointUnknownAfterAgentOfflineSeconds seconds</div></div>
                             </div>
                             @if (agent.IsVersionDifferentFromBundled)
                             {
@@ -125,6 +126,14 @@
                             }
 
                             <div class="action-row" style="margin-top:.9rem;">
+                                <form method="post" action="/agents/@agent.AgentId/endpoint-unknown-timeout">
+                                    @Html.AntiForgeryToken()
+                                    <label for="timeout-@agent.AgentId" class="muted" style="display:block;">If this agent stops reporting for this long, its assigned endpoints are marked Unknown.</label>
+                                    <div style="display:flex; gap:.4rem; align-items:center; margin-top:.3rem;">
+                                        <input id="timeout-@agent.AgentId" name="endpointUnknownAfterAgentOfflineSeconds" type="number" min="30" max="86400" value="@agent.EndpointUnknownAfterAgentOfflineSeconds" style="min-height:42px; padding:.45rem; border:1px solid var(--border); border-radius:8px; width:120px;" />
+                                        <button class="button-secondary" type="submit">Save timeout</button>
+                                    </div>
+                                </form>
                                 <a class="button-secondary" href="/agents/@agent.AgentId/history">View history</a>
                                 @if (agent.Enabled)
                                 {


### PR DESCRIPTION
### Motivation
- Endpoints assigned to an agent that stops reporting remained in their previous state indefinitely, which is misleading when the agent is stale.  
- Provide a per-agent configurable timeout (`EndpointUnknownAfterAgentOfflineSeconds`, default 300s) so endpoints are marked Unknown only after the operator-configured offline window elapses.  
- Implement the change server-side only and preserve safety invariants: no agent API contract changes, timestamps remain UTC, endpoints are never marked Down because an agent is offline, and dependency suppression behaviour is preserved.  

### Description
- Added a per-agent setting `EndpointUnknownAfterAgentOfflineSeconds` on the `Agent` model with a `DefaultEndpointUnknownAfterAgentOfflineSeconds` constant and EF mapping using a required default value.  
- Exposed UI and controller support: the agents listing shows the timeout and includes an editable numeric field plus explanatory text, and a `POST /agents/{id}/endpoint-unknown-timeout` handler persists changes via a new service method.  
- Server-side state: `AssignmentTopologyCache` now includes agent `LastSeenUtc` and the per-agent timeout, and `StateEvaluationService` checks the agent last-seen + timeout so assignments transition to `Unknown` only after the configured delay.  
- Background handling: `AgentStatusTransitionBackgroundService` enqueues the agent’s active assignments for reevaluation once the configured offline window has elapsed (queue coalescing prevents repeated spam), and `AgentProvisioningService` exposes a method to update the per-agent timeout.  

### Testing
- Unit/integration tests could not be executed here because `dotnet` is not available in this environment (`dotnet test` was attempted and failed).  
- Touched query/runtime paths (reviewed for provider-safe usage): `AgentManagementQueryService.ListAsync`, `AssignmentTopologyCache.BuildSnapshotAsync` (agents selection), `AgentStatusTransitionBackgroundService.EvaluateTransitionsAsync`, and assignment enqueue paths were updated and only add simple scalar columns to existing projections to avoid client-eval or provider-specific mapping issues.  
- Deterministic reproduction checklist (manual / automated tests to add): 1) Create an agent and assignment and confirm an endpoint is Up; 2) Simulate agent going silent with LastSeenUtc set to now minus less than the configured timeout and verify endpoint state stays unchanged; 3) Advance LastSeenUtc to exceed the configured timeout (or wait) and ensure the assignment transitions to `Unknown` and a single state-transition event is logged; 4) Bring the agent back and submit fresh results to verify the endpoint moves from `Unknown` to `Up`/`Down` per results; 5) Repeat with multiple agents to confirm only assignments for the stale agent are affected; 6) Confirm repeated background evaluations do not create duplicate Unknown events.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1620684fcc832aa1b0fd7ad4c410ff)