### PR TITLE
Add per-agent stale timeout to mark assigned endpoints Unknown after agent offline

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AgentOfflineStateEvaluatorTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AgentOfflineStateEvaluatorTests.cs
@@ -1,0 +1,46 @@
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.State;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class AgentOfflineStateEvaluatorTests
+{
+    [Fact]
+    public void OfflineBelowThreshold_DoesNotForceUnknown()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var shouldForceUnknown = AgentOfflineStateEvaluator.ShouldForceUnknown(true, false, AgentHealthStatus.Stale, now.AddSeconds(-120), 300, now);
+        Assert.False(shouldForceUnknown);
+    }
+
+    [Fact]
+    public void OfflineBeyondThreshold_ForcesUnknown()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var shouldForceUnknown = AgentOfflineStateEvaluator.ShouldForceUnknown(true, false, AgentHealthStatus.Offline, now.AddSeconds(-301), 300, now);
+        Assert.True(shouldForceUnknown);
+    }
+
+    [Fact]
+    public void MultipleAgents_OnlyStaleAgentWouldForceUnknown()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var stale = AgentOfflineStateEvaluator.ShouldForceUnknown(true, false, AgentHealthStatus.Offline, now.AddSeconds(-600), 300, now);
+        var healthy = AgentOfflineStateEvaluator.ShouldForceUnknown(true, false, AgentHealthStatus.Online, now.AddSeconds(-600), 300, now);
+
+        Assert.True(stale);
+        Assert.False(healthy);
+    }
+
+    [Fact]
+    public void PerAgentTimeoutOverride_IsApplied()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var shorter = AgentOfflineStateEvaluator.ShouldForceUnknown(true, false, AgentHealthStatus.Stale, now.AddSeconds(-65), 60, now);
+        var longer = AgentOfflineStateEvaluator.ShouldForceUnknown(true, false, AgentHealthStatus.Stale, now.AddSeconds(-65), 600, now);
+
+        Assert.True(shorter);
+        Assert.False(longer);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.Agents;
 using PingMonitor.Web.Services.EventLogs;
@@ -21,19 +23,22 @@ public sealed class AgentsController : Controller
     private readonly IEventLogQueryService _eventLogQueryService;
     private readonly IApplicationSettingsService _applicationSettingsService;
     private readonly IAgentTemplateVersionProvider _agentTemplateVersionProvider;
+    private readonly PingMonitorDbContext _dbContext;
 
     public AgentsController(
         IAgentProvisioningService agentProvisioningService,
         IAgentManagementQueryService agentManagementQueryService,
         IEventLogQueryService eventLogQueryService,
         IApplicationSettingsService applicationSettingsService,
-        IAgentTemplateVersionProvider agentTemplateVersionProvider)
+        IAgentTemplateVersionProvider agentTemplateVersionProvider,
+        PingMonitorDbContext dbContext)
     {
         _agentProvisioningService = agentProvisioningService;
         _agentManagementQueryService = agentManagementQueryService;
         _eventLogQueryService = eventLogQueryService;
         _applicationSettingsService = applicationSettingsService;
         _agentTemplateVersionProvider = agentTemplateVersionProvider;
+        _dbContext = dbContext;
     }
 
     [HttpGet("")]
@@ -58,7 +63,8 @@ public sealed class AgentsController : Controller
                 CreatedAtUtc = row.CreatedAtUtc,
                 AssignmentCount = row.AssignmentCount,
                 UptimePercent = row.UptimePercent,
-                IsVersionDifferentFromBundled = IsVersionDifferentFromBundled(row.AgentVersion, bundledAgentVersion)
+                IsVersionDifferentFromBundled = IsVersionDifferentFromBundled(row.AgentVersion, bundledAgentVersion),
+                EndpointUnknownAfterAgentOfflineSeconds = row.EndpointUnknownAfterAgentOfflineSeconds
             }).ToList(),
             BundledAgentVersion = bundledAgentVersion,
             StatusMessage = TempData[StatusMessageKey] as string,
@@ -185,6 +191,27 @@ public sealed class AgentsController : Controller
             TempData[ErrorMessageKey] = ex.Message;
             return RedirectToAction(nameof(Index));
         }
+    }
+
+
+    [HttpPost("{id}/stale-timeout")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UpdateStaleTimeout([FromRoute] string id, [FromForm] int endpointUnknownAfterAgentOfflineSeconds, CancellationToken cancellationToken)
+    {
+        var normalizedAgentId = id.Trim();
+        var agent = await _dbContext.Agents.SingleOrDefaultAsync(x => x.AgentId == normalizedAgentId, cancellationToken);
+        if (agent is null)
+        {
+            TempData[ErrorMessageKey] = "Agent not found.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        var normalizedValue = Math.Clamp(endpointUnknownAfterAgentOfflineSeconds, 30, 86400);
+        agent.EndpointUnknownAfterAgentOfflineSeconds = normalizedValue;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        TempData[StatusMessageKey] = $"Updated stale endpoint timeout for agent '{agent.Name ?? agent.InstanceId}' to {normalizedValue} seconds.";
+        return RedirectToAction(nameof(Index));
     }
 
     [HttpGet("{id}/remove")]

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -79,6 +79,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         agent.Property(x => x.ApiKeyCreatedAtUtc).IsRequired();
         agent.Property(x => x.Enabled).HasDefaultValue(true);
         agent.Property(x => x.ApiKeyRevoked).HasDefaultValue(false);
+        agent.Property(x => x.EndpointUnknownAfterAgentOfflineSeconds).IsRequired().HasDefaultValue(300);
         agent.Property(x => x.Status).HasConversion<string>().HasMaxLength(16);
         agent.HasIndex(x => x.InstanceId).IsUnique();
 

--- a/src/WebApp/PingMonitor.Web/Models/Agent.cs
+++ b/src/WebApp/PingMonitor.Web/Models/Agent.cs
@@ -17,5 +17,6 @@ public sealed class Agent
     public string? Platform { get; set; }
     public string? MachineName { get; set; }
     public DateTimeOffset CreatedAtUtc { get; set; }
+    public int EndpointUnknownAfterAgentOfflineSeconds { get; set; } = 300;
     public DateTimeOffset? LastHeartbeatEventLoggedAtUtc { get; set; }
 }

--- a/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
@@ -5,6 +5,6 @@ public sealed class StartupGateOptions
     public const string SectionName = "StartupGate";
 
     public string StorageDirectory { get; set; } = "App_Data/StartupGate";
-    public int RequiredSchemaVersion { get; set; } = 10;
+    public int RequiredSchemaVersion { get; set; } = 11;
     public int DefaultMySqlPort { get; set; } = 3306;
 }

--- a/src/WebApp/PingMonitor.Web/Services/AgentProvisioningService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentProvisioningService.cs
@@ -62,7 +62,8 @@ internal sealed class AgentProvisioningService : IAgentProvisioningService
             MachineName = null,
             CreatedAtUtc = now,
             ApiKeyCreatedAtUtc = now,
-            ApiKeyHash = string.Empty
+            ApiKeyHash = string.Empty,
+            EndpointUnknownAfterAgentOfflineSeconds = 300
         };
 
         agent.ApiKeyHash = _apiKeyHasher.Hash(agent, plainTextApiKey);

--- a/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementQueryService.cs
@@ -43,7 +43,8 @@ internal sealed class AgentManagementQueryService : IAgentManagementQueryService
                 agent.AgentVersion,
                 agent.MachineName,
                 agent.Platform,
-                agent.CreatedAtUtc
+                agent.CreatedAtUtc,
+                agent.EndpointUnknownAfterAgentOfflineSeconds
             })
             .ToListAsync(cancellationToken);
 
@@ -65,7 +66,8 @@ internal sealed class AgentManagementQueryService : IAgentManagementQueryService
                 Platform = agent.Platform ?? "Unknown",
                 CreatedAtUtc = agent.CreatedAtUtc,
                 AssignmentCount = assignmentCounts.GetValueOrDefault(agent.AgentId, 0),
-                UptimePercent = uptimeByAgentId.GetValueOrDefault(agent.AgentId)?.UptimePercent
+                UptimePercent = uptimeByAgentId.GetValueOrDefault(agent.AgentId)?.UptimePercent,
+                EndpointUnknownAfterAgentOfflineSeconds = agent.EndpointUnknownAfterAgentOfflineSeconds
             })
             .ToList();
     }

--- a/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementRow.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementRow.cs
@@ -15,6 +15,7 @@ public sealed class AgentManagementRow
     public required DateTimeOffset CreatedAtUtc { get; init; }
     public required int AssignmentCount { get; init; }
     public double? UptimePercent { get; init; }
+    public required int EndpointUnknownAfterAgentOfflineSeconds { get; init; }
 }
 
 public sealed class RemoveAgentDetails

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -1191,6 +1191,16 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 """,
                 cancellationToken);
         }
+
+        if (!await HasAgentColumnAsync(connection, "EndpointUnknownAfterAgentOfflineSeconds", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `Agents`
+                ADD COLUMN `EndpointUnknownAfterAgentOfflineSeconds` int NOT NULL DEFAULT 300;
+                """,
+                cancellationToken);
+        }
     }
 
     private static async Task EnsureAspNetUsersColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)

--- a/src/WebApp/PingMonitor.Web/Services/State/AgentOfflineStateEvaluator.cs
+++ b/src/WebApp/PingMonitor.Web/Services/State/AgentOfflineStateEvaluator.cs
@@ -1,0 +1,26 @@
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.State;
+
+internal static class AgentOfflineStateEvaluator
+{
+    public static bool ShouldForceUnknown(bool agentEnabled, bool apiKeyRevoked, AgentHealthStatus status, DateTimeOffset? lastSeenUtc, int unknownAfterSeconds, DateTimeOffset now)
+    {
+        if (!agentEnabled || apiKeyRevoked)
+        {
+            return true;
+        }
+
+        if (status == AgentHealthStatus.Online)
+        {
+            return false;
+        }
+
+        if (!lastSeenUtc.HasValue)
+        {
+            return true;
+        }
+
+        return now - lastSeenUtc.Value >= TimeSpan.FromSeconds(Math.Max(1, unknownAfterSeconds));
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/State/AssignmentTopologyCache.cs
+++ b/src/WebApp/PingMonitor.Web/Services/State/AssignmentTopologyCache.cs
@@ -99,7 +99,9 @@ internal sealed class AssignmentTopologyCache : IAssignmentTopologyCache
                 AgentId = x.AgentId,
                 Enabled = x.Enabled,
                 ApiKeyRevoked = x.ApiKeyRevoked,
-                Status = x.Status
+                Status = x.Status,
+                LastSeenUtc = x.LastSeenUtc,
+                EndpointUnknownAfterAgentOfflineSeconds = x.EndpointUnknownAfterAgentOfflineSeconds
             })
             .ToDictionaryAsync(x => x.AgentId, StringComparer.Ordinal, cancellationToken);
 
@@ -180,6 +182,8 @@ internal sealed class AssignmentTopologyCache : IAssignmentTopologyCache
                 AgentEnabled = agent?.Enabled ?? false,
                 AgentApiKeyRevoked = agent?.ApiKeyRevoked ?? true,
                 AgentStatus = agent?.Status ?? AgentHealthStatus.Offline,
+                AgentLastSeenUtc = agent?.LastSeenUtc,
+                AgentEndpointUnknownAfterOfflineSeconds = agent?.EndpointUnknownAfterAgentOfflineSeconds ?? 300,
                 ParentDependencies = parentDependencies,
                 ChildAssignmentIds = childAssignments
             };
@@ -212,6 +216,8 @@ internal sealed class AssignmentTopologyCache : IAssignmentTopologyCache
         public required bool Enabled { get; init; }
         public required bool ApiKeyRevoked { get; init; }
         public required AgentHealthStatus Status { get; init; }
+        public required DateTimeOffset? LastSeenUtc { get; init; }
+        public required int EndpointUnknownAfterAgentOfflineSeconds { get; init; }
     }
 
     private sealed class DependencyRow

--- a/src/WebApp/PingMonitor.Web/Services/State/IAssignmentTopologyCache.cs
+++ b/src/WebApp/PingMonitor.Web/Services/State/IAssignmentTopologyCache.cs
@@ -20,6 +20,8 @@ public sealed class AssignmentTopologyContext
     public required bool AgentEnabled { get; init; }
     public required bool AgentApiKeyRevoked { get; init; }
     public required AgentHealthStatus AgentStatus { get; init; }
+    public required DateTimeOffset? AgentLastSeenUtc { get; init; }
+    public required int AgentEndpointUnknownAfterOfflineSeconds { get; init; }
     public required IReadOnlyList<AssignmentParentDependency> ParentDependencies { get; init; }
     public required IReadOnlyList<string> ChildAssignmentIds { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
@@ -126,7 +126,8 @@ internal sealed class StateEvaluationService : IStateEvaluationService
 
         var previousState = mutableState.CurrentState;
         var previousStateChangedAtUtc = mutableState.LastStateChangeUtc ?? DateTimeOffset.UtcNow;
-        var nextState = DetermineNextState(assignmentContext, mutableState, parentContext);
+        var now = DateTimeOffset.UtcNow;
+        var nextState = DetermineNextState(assignmentContext, mutableState, parentContext, now);
         var reasonCode = GetReasonCode(previousState, nextState, parentContext.DependencyDown);
 
         mutableState.CurrentState = nextState;
@@ -137,7 +138,7 @@ internal sealed class StateEvaluationService : IStateEvaluationService
         DateTimeOffset? transitionAtUtc = null;
         if (previousState != nextState)
         {
-            transitionAtUtc = DateTimeOffset.UtcNow;
+            transitionAtUtc = now;
             mutableState.LastStateChangeUtc = transitionAtUtc.Value;
 
             _dbContext.StateTransitions.Add(new StateTransition
@@ -233,7 +234,7 @@ internal sealed class StateEvaluationService : IStateEvaluationService
             mutableState.CurrentState,
             transitionAtUtc,
             previousStateChangedAtUtc,
-            DateTimeOffset.UtcNow,
+            now,
             cancellationToken);
 
         if (CrossedDownBoundary(previousState, nextState))
@@ -267,14 +268,21 @@ internal sealed class StateEvaluationService : IStateEvaluationService
     private static EndpointStateKind DetermineNextState(
         AssignmentTopologyContext assignment,
         CachedAssignmentState state,
-        ParentStateContext parentContext)
+        ParentStateContext parentContext,
+        DateTimeOffset now)
     {
         if (!assignment.AssignmentEnabled)
         {
             return EndpointStateKind.Unknown;
         }
 
-        if (!assignment.AgentEnabled || assignment.AgentApiKeyRevoked || assignment.AgentStatus != AgentHealthStatus.Online)
+        if (AgentOfflineStateEvaluator.ShouldForceUnknown(
+                assignment.AgentEnabled,
+                assignment.AgentApiKeyRevoked,
+                assignment.AgentStatus,
+                assignment.AgentLastSeenUtc,
+                assignment.AgentEndpointUnknownAfterOfflineSeconds,
+                now))
         {
             return EndpointStateKind.Unknown;
         }
@@ -299,6 +307,7 @@ internal sealed class StateEvaluationService : IStateEvaluationService
 
         return state.CurrentState;
     }
+
 
     private static string? GetReasonCode(EndpointStateKind previousState, EndpointStateKind newState, bool dependencyDown)
     {

--- a/src/WebApp/PingMonitor.Web/ViewModels/Agents/ManageAgentsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Agents/ManageAgentsPageViewModel.cs
@@ -24,6 +24,7 @@ public sealed class ManageAgentRowViewModel
     public required int AssignmentCount { get; init; }
     public required double? UptimePercent { get; init; }
     public required bool IsVersionDifferentFromBundled { get; init; }
+    public required int EndpointUnknownAfterAgentOfflineSeconds { get; init; }
 }
 
 public sealed class RemoveAgentPageViewModel

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
@@ -116,6 +116,7 @@
                                 <div class="meta-item"><span>Agent version</span><div>@agent.AgentVersion</div></div>
                                 <div class="meta-item"><span>Machine name</span><div>@agent.MachineName</div></div>
                                 <div class="meta-item"><span>Platform</span><div>@agent.Platform</div></div>
+                                <div class="meta-item"><span>Unknown after offline</span><div>@agent.EndpointUnknownAfterAgentOfflineSeconds sec</div></div>
                             </div>
                             @if (agent.IsVersionDifferentFromBundled)
                             {
@@ -126,6 +127,15 @@
 
                             <div class="action-row" style="margin-top:.9rem;">
                                 <a class="button-secondary" href="/agents/@agent.AgentId/history">View history</a>
+                                <form method="post" action="/agents/@agent.AgentId/stale-timeout">
+                                    @Html.AntiForgeryToken()
+                                    <label for="stale-timeout-@agent.AgentId" class="muted" style="display:block; margin-bottom:.25rem;">If this agent stops reporting for this long, its assigned endpoints are marked Unknown.</label>
+                                    <div class="action-row">
+                                        <input id="stale-timeout-@agent.AgentId" name="endpointUnknownAfterAgentOfflineSeconds" type="number" min="30" max="86400" value="@agent.EndpointUnknownAfterAgentOfflineSeconds" style="min-height:46px; padding:.5rem; border:1px solid var(--border); border-radius:10px;" />
+                                        <button class="button-secondary" type="submit">Save stale timeout</button>
+                                    </div>
+                                </form>
+
                                 @if (agent.Enabled)
                                 {
                                     <form method="post" action="/agents/@agent.AgentId/disable">

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 10,
+    "RequiredSchemaVersion": 11,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 10,
+    "RequiredSchemaVersion": 11,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
### Motivation
- Endpoints assigned to an agent remain in their previous known state indefinitely when the agent stops reporting, making their true state unknown to operators. 
- The intent is to make endpoint state explicit: after a configurable per-agent delay with no agent heartbeats, assigned endpoints should transition to `Unknown` rather than remaining misleadingly `Up`/`Down`. 
- Implementation must be server-side only, preserve UTC timestamps, avoid marking endpoints `Down` because an agent is offline, and remain per-agent scoped.

### Description
- Added a new per-agent persisted setting `EndpointUnknownAfterAgentOfflineSeconds` (default `300`) to the `Agent` model and EF mapping, and added a Startup Gate schema upgrade to add the `Agents.EndpointUnknownAfterAgentOfflineSeconds` column while bumping the required schema version to `11`.
- Updated state evaluation to consult the per-agent timeout via a new `AgentOfflineStateEvaluator` helper and only force an assignment to `Unknown` when the agent’s last-seen time exceeds that agent’s configured delay; existing transition/event deduping behavior is preserved.
- Exposed the setting in the Agent management UI with an editable numeric field and a controller action (`POST /agents/{id}/stale-timeout`) that clamps values for safety and persists changes server-side.
- Added focused unit tests (`AgentOfflineStateEvaluatorTests`) that cover below-threshold (no change), beyond-threshold (force Unknown), multi-agent isolation, and per-agent timeout override behavior, and made no changes to the agent API contract.

### Testing
- New automated tests added: `src/WebApp/PingMonitor.Web.Tests/AgentOfflineStateEvaluatorTests.cs` covering the offline/timeout decision logic (created but not executed in this environment).
- Attempted to run `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj`, but the test run failed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).
- Please run the test suite in CI or locally with `dotnet test` (and confirm MySQL-backed provider compatibility where relevant) before merging, and link the PR to an appropriate issue per repository rules (an automated attempt to create an issue from this environment was unsuccessful).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17081cb014832aa74d27d3897080aa)