### PR TITLE
Per-agent offline timeout: mark assigned endpoints Unknown after configurable delay

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AgentOfflineUnknownTimeoutTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AgentOfflineUnknownTimeoutTests.cs
@@ -1,0 +1,62 @@
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class AgentOfflineUnknownTimeoutTests
+{
+    [Fact]
+    public void ShouldTransitionAssignmentsToUnknown_False_WhenBelowConfiguredDelay()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var agent = new Agent
+        {
+            AgentId = "a1",
+            InstanceId = "i1",
+            ApiKeyHash = "h",
+            ApiKeyCreatedAtUtc = now,
+            CreatedAtUtc = now,
+            EndpointUnknownAfterAgentOfflineSeconds = 300,
+            LastSeenUtc = now.AddSeconds(-299)
+        };
+
+        Assert.False(AgentStatusTransitionBackgroundService.ShouldTransitionAssignmentsToUnknown(agent, now));
+    }
+
+    [Fact]
+    public void ShouldTransitionAssignmentsToUnknown_True_WhenBeyondConfiguredDelay()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var agent = new Agent
+        {
+            AgentId = "a1",
+            InstanceId = "i1",
+            ApiKeyHash = "h",
+            ApiKeyCreatedAtUtc = now,
+            CreatedAtUtc = now,
+            EndpointUnknownAfterAgentOfflineSeconds = 300,
+            LastSeenUtc = now.AddSeconds(-301)
+        };
+
+        Assert.True(AgentStatusTransitionBackgroundService.ShouldTransitionAssignmentsToUnknown(agent, now));
+    }
+
+    [Fact]
+    public void ShouldTransitionAssignmentsToUnknown_UsesDefault_WhenConfiguredTimeoutInvalid()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var agent = new Agent
+        {
+            AgentId = "a1",
+            InstanceId = "i1",
+            ApiKeyHash = "h",
+            ApiKeyCreatedAtUtc = now,
+            CreatedAtUtc = now,
+            EndpointUnknownAfterAgentOfflineSeconds = 0,
+            LastSeenUtc = now.AddSeconds(-301)
+        };
+
+        Assert.True(AgentStatusTransitionBackgroundService.ShouldTransitionAssignmentsToUnknown(agent, now));
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
@@ -58,7 +58,8 @@ public sealed class AgentsController : Controller
                 CreatedAtUtc = row.CreatedAtUtc,
                 AssignmentCount = row.AssignmentCount,
                 UptimePercent = row.UptimePercent,
-                IsVersionDifferentFromBundled = IsVersionDifferentFromBundled(row.AgentVersion, bundledAgentVersion)
+                IsVersionDifferentFromBundled = IsVersionDifferentFromBundled(row.AgentVersion, bundledAgentVersion),
+                EndpointUnknownAfterAgentOfflineSeconds = row.EndpointUnknownAfterAgentOfflineSeconds
             }).ToList(),
             BundledAgentVersion = bundledAgentVersion,
             StatusMessage = TempData[StatusMessageKey] as string,
@@ -169,6 +170,31 @@ public sealed class AgentsController : Controller
     public async Task<IActionResult> Disable([FromRoute] string id, CancellationToken cancellationToken)
     {
         return await SetEnabledAsync(id, false, cancellationToken);
+    }
+
+    [HttpPost("{id}/offline-unknown-timeout")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> SetOfflineUnknownTimeout(
+        [FromRoute] string id,
+        [FromForm] int endpointUnknownAfterAgentOfflineSeconds,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var changed = await _agentProvisioningService.SetEndpointUnknownAfterOfflineSecondsAsync(
+                id,
+                endpointUnknownAfterAgentOfflineSeconds,
+                cancellationToken);
+            TempData[StatusMessageKey] = changed
+                ? "Agent offline Unknown timeout updated."
+                : "Agent offline Unknown timeout was already set to that value.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData[ErrorMessageKey] = ex.Message;
+        }
+
+        return RedirectToAction(nameof(Index));
     }
 
     [HttpPost("{id}/rotate-package")]

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -77,6 +77,9 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         agent.Property(x => x.CreatedAtUtc).IsRequired();
         agent.Property(x => x.LastHeartbeatEventLoggedAtUtc);
         agent.Property(x => x.ApiKeyCreatedAtUtc).IsRequired();
+        agent.Property(x => x.EndpointUnknownAfterAgentOfflineSeconds)
+            .IsRequired()
+            .HasDefaultValue(Agent.DefaultEndpointUnknownAfterAgentOfflineSeconds);
         agent.Property(x => x.Enabled).HasDefaultValue(true);
         agent.Property(x => x.ApiKeyRevoked).HasDefaultValue(false);
         agent.Property(x => x.Status).HasConversion<string>().HasMaxLength(16);

--- a/src/WebApp/PingMonitor.Web/Models/Agent.cs
+++ b/src/WebApp/PingMonitor.Web/Models/Agent.cs
@@ -2,6 +2,7 @@ namespace PingMonitor.Web.Models;
 
 public sealed class Agent
 {
+    public const int DefaultEndpointUnknownAfterAgentOfflineSeconds = 300;
     public string AgentId { get; set; } = string.Empty;
     public string InstanceId { get; set; } = string.Empty;
     public string? Name { get; set; }
@@ -18,4 +19,5 @@ public sealed class Agent
     public string? MachineName { get; set; }
     public DateTimeOffset CreatedAtUtc { get; set; }
     public DateTimeOffset? LastHeartbeatEventLoggedAtUtc { get; set; }
+    public int EndpointUnknownAfterAgentOfflineSeconds { get; set; } = DefaultEndpointUnknownAfterAgentOfflineSeconds;
 }

--- a/src/WebApp/PingMonitor.Web/Models/StateTransitionReasonCodes.cs
+++ b/src/WebApp/PingMonitor.Web/Models/StateTransitionReasonCodes.cs
@@ -8,4 +8,5 @@ public static class StateTransitionReasonCodes
     public const string DependencyCleared = "dependency_cleared";
     public const string AdministrativeReset = "administrative_reset";
     public const string AgentContextLost = "agent_context_lost";
+    public const string AgentOfflineTimeout = "agent_offline_timeout";
 }

--- a/src/WebApp/PingMonitor.Web/Services/AgentProvisioningService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentProvisioningService.cs
@@ -62,7 +62,8 @@ internal sealed class AgentProvisioningService : IAgentProvisioningService
             MachineName = null,
             CreatedAtUtc = now,
             ApiKeyCreatedAtUtc = now,
-            ApiKeyHash = string.Empty
+            ApiKeyHash = string.Empty,
+            EndpointUnknownAfterAgentOfflineSeconds = Agent.DefaultEndpointUnknownAfterAgentOfflineSeconds
         };
 
         agent.ApiKeyHash = _apiKeyHasher.Hash(agent, plainTextApiKey);
@@ -106,6 +107,37 @@ internal sealed class AgentProvisioningService : IAgentProvisioningService
         await _dbContext.SaveChangesAsync(cancellationToken);
         _configurationChangeBackupSignal.NotifyConfigurationChanged("agent-enabled-state-changed");
         _logger.LogInformation("Set enabled={Enabled} for agent {AgentId}", enabled, agent.AgentId);
+        return true;
+    }
+
+    public async Task<bool> SetEndpointUnknownAfterOfflineSecondsAsync(string agentId, int seconds, CancellationToken cancellationToken)
+    {
+        var normalizedAgentId = NormalizeAgentId(agentId);
+        var agent = await _dbContext.Agents.SingleOrDefaultAsync(x => x.AgentId == normalizedAgentId, cancellationToken);
+        if (agent is null)
+        {
+            throw new InvalidOperationException("Agent not found.");
+        }
+
+        if (seconds < 30)
+        {
+            throw new InvalidOperationException("Offline Unknown timeout must be at least 30 seconds.");
+        }
+
+        if (seconds > 86400)
+        {
+            throw new InvalidOperationException("Offline Unknown timeout must be 86400 seconds or less.");
+        }
+
+        if (agent.EndpointUnknownAfterAgentOfflineSeconds == seconds)
+        {
+            return false;
+        }
+
+        agent.EndpointUnknownAfterAgentOfflineSeconds = seconds;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        _configurationChangeBackupSignal.NotifyConfigurationChanged("agent-offline-unknown-timeout-changed");
+        _logger.LogInformation("Set EndpointUnknownAfterAgentOfflineSeconds={Seconds} for agent {AgentId}", seconds, agent.AgentId);
         return true;
     }
 

--- a/src/WebApp/PingMonitor.Web/Services/AgentStatusTransitionBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentStatusTransitionBackgroundService.cs
@@ -150,9 +150,8 @@ internal sealed class AgentStatusTransitionBackgroundService : BackgroundService
             return;
         }
 
-        var assignmentIds = assignments.Select(x => x.AssignmentId).ToArray();
         var states = await dbContext.EndpointStates
-            .Where(x => assignmentIds.Contains(x.AssignmentId))
+            .Where(x => x.AgentId == agent.AgentId)
             .ToDictionaryAsync(x => x.AssignmentId, x => x, cancellationToken);
 
         foreach (var assignment in assignments)

--- a/src/WebApp/PingMonitor.Web/Services/AgentStatusTransitionBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentStatusTransitionBackgroundService.cs
@@ -2,7 +2,9 @@ using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Services.EventLogs;
+using PingMonitor.Web.Services.State;
 using PingMonitor.Web.Services.StartupGate;
+using System.Text.Json;
 
 namespace PingMonitor.Web.Services;
 
@@ -118,6 +120,112 @@ internal sealed class AgentStatusTransitionBackgroundService : BackgroundService
                         : $"Agent \"{agent.Name ?? agent.InstanceId}\" became offline."
                 },
                 cancellationToken);
+
+            if (nextStatus == AgentHealthStatus.Offline)
+            {
+                await TransitionAssignedEndpointsToUnknownAsync(dbContext, eventLogService, agent, now, cancellationToken);
+            }
         }
+    }
+
+    internal static async Task TransitionAssignedEndpointsToUnknownAsync(
+        PingMonitorDbContext dbContext,
+        IEventLogService eventLogService,
+        Agent agent,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        if (!ShouldTransitionAssignmentsToUnknown(agent, now))
+        {
+            return;
+        }
+
+        var assignments = await dbContext.MonitorAssignments
+            .Where(x => x.AgentId == agent.AgentId && x.Enabled)
+            .Select(x => new { x.AssignmentId, x.EndpointId })
+            .ToListAsync(cancellationToken);
+
+        if (assignments.Count == 0)
+        {
+            return;
+        }
+
+        var assignmentIds = assignments.Select(x => x.AssignmentId).ToArray();
+        var states = await dbContext.EndpointStates
+            .Where(x => assignmentIds.Contains(x.AssignmentId))
+            .ToDictionaryAsync(x => x.AssignmentId, x => x, cancellationToken);
+
+        foreach (var assignment in assignments)
+        {
+            if (states.TryGetValue(assignment.AssignmentId, out var state)
+                && state.CurrentState == EndpointStateKind.Unknown)
+            {
+                continue;
+            }
+
+            var previousState = states.TryGetValue(assignment.AssignmentId, out var existingState)
+                ? existingState.CurrentState
+                : EndpointStateKind.Unknown;
+
+            var nextState = existingState ?? new EndpointState
+            {
+                AssignmentId = assignment.AssignmentId,
+                AgentId = agent.AgentId,
+                EndpointId = assignment.EndpointId
+            };
+
+            nextState.CurrentState = EndpointStateKind.Unknown;
+            nextState.SuppressedByEndpointId = null;
+            nextState.LastStateChangeUtc = now;
+
+            if (existingState is null)
+            {
+                dbContext.EndpointStates.Add(nextState);
+            }
+
+            dbContext.StateTransitions.Add(new StateTransition
+            {
+                TransitionId = Guid.NewGuid().ToString(),
+                AssignmentId = assignment.AssignmentId,
+                AgentId = agent.AgentId,
+                EndpointId = assignment.EndpointId,
+                PreviousState = previousState,
+                NewState = EndpointStateKind.Unknown,
+                TransitionAtUtc = now,
+                ReasonCode = StateTransitionReasonCodes.AgentOfflineTimeout
+            });
+
+            await eventLogService.WriteAsync(new EventLogWriteRequest
+            {
+                OccurredAtUtc = now,
+                Category = EventCategory.Endpoint,
+                EventType = EventType.EndpointStateChanged,
+                Severity = EventSeverity.Info,
+                AgentId = agent.AgentId,
+                EndpointId = assignment.EndpointId,
+                AssignmentId = assignment.AssignmentId,
+                Message = "Endpoint state changed to Unknown because its assigned agent is offline beyond the configured timeout.",
+                DetailsJson = JsonSerializer.Serialize(new
+                {
+                    assignment.AssignmentId,
+                    assignment.EndpointId,
+                    previousState = previousState.ToString(),
+                    newState = EndpointStateKind.Unknown.ToString(),
+                    reasonCode = StateTransitionReasonCodes.AgentOfflineTimeout,
+                    agent.EndpointUnknownAfterAgentOfflineSeconds
+                })
+            }, cancellationToken);
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    internal static bool ShouldTransitionAssignmentsToUnknown(Agent agent, DateTimeOffset now)
+    {
+        var staleAfter = TimeSpan.FromSeconds(agent.EndpointUnknownAfterAgentOfflineSeconds <= 0
+            ? Agent.DefaultEndpointUnknownAfterAgentOfflineSeconds
+            : agent.EndpointUnknownAfterAgentOfflineSeconds);
+        var lastSeenUtc = agent.LastSeenUtc ?? agent.LastHeartbeatUtc;
+        return lastSeenUtc.HasValue && now - lastSeenUtc.Value >= staleAfter;
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementQueryService.cs
@@ -43,7 +43,8 @@ internal sealed class AgentManagementQueryService : IAgentManagementQueryService
                 agent.AgentVersion,
                 agent.MachineName,
                 agent.Platform,
-                agent.CreatedAtUtc
+                agent.CreatedAtUtc,
+                agent.EndpointUnknownAfterAgentOfflineSeconds
             })
             .ToListAsync(cancellationToken);
 
@@ -65,7 +66,8 @@ internal sealed class AgentManagementQueryService : IAgentManagementQueryService
                 Platform = agent.Platform ?? "Unknown",
                 CreatedAtUtc = agent.CreatedAtUtc,
                 AssignmentCount = assignmentCounts.GetValueOrDefault(agent.AgentId, 0),
-                UptimePercent = uptimeByAgentId.GetValueOrDefault(agent.AgentId)?.UptimePercent
+                UptimePercent = uptimeByAgentId.GetValueOrDefault(agent.AgentId)?.UptimePercent,
+                EndpointUnknownAfterAgentOfflineSeconds = agent.EndpointUnknownAfterAgentOfflineSeconds
             })
             .ToList();
     }

--- a/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementRow.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Agents/AgentManagementRow.cs
@@ -15,6 +15,7 @@ public sealed class AgentManagementRow
     public required DateTimeOffset CreatedAtUtc { get; init; }
     public required int AssignmentCount { get; init; }
     public double? UptimePercent { get; init; }
+    public required int EndpointUnknownAfterAgentOfflineSeconds { get; init; }
 }
 
 public sealed class RemoveAgentDetails

--- a/src/WebApp/PingMonitor.Web/Services/IAgentProvisioningService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IAgentProvisioningService.cs
@@ -4,6 +4,7 @@ public interface IAgentProvisioningService
 {
     Task<AgentProvisioningResult> ProvisionAsync(string agentName, CancellationToken cancellationToken);
     Task<bool> SetEnabledAsync(string agentId, bool enabled, CancellationToken cancellationToken);
+    Task<bool> SetEndpointUnknownAfterOfflineSecondsAsync(string agentId, int seconds, CancellationToken cancellationToken);
     Task<bool> RemoveAsync(string agentId, CancellationToken cancellationToken);
     Task<AgentProvisioningResult> RotatePackageAsync(string agentId, CancellationToken cancellationToken);
 }

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -1191,6 +1191,16 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 """,
                 cancellationToken);
         }
+
+        if (!await HasAgentColumnAsync(connection, "EndpointUnknownAfterAgentOfflineSeconds", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `Agents`
+                ADD COLUMN `EndpointUnknownAfterAgentOfflineSeconds` int NOT NULL DEFAULT 300;
+                """,
+                cancellationToken);
+        }
     }
 
     private static async Task EnsureAspNetUsersColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)

--- a/src/WebApp/PingMonitor.Web/ViewModels/Agents/ManageAgentsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Agents/ManageAgentsPageViewModel.cs
@@ -24,6 +24,7 @@ public sealed class ManageAgentRowViewModel
     public required int AssignmentCount { get; init; }
     public required double? UptimePercent { get; init; }
     public required bool IsVersionDifferentFromBundled { get; init; }
+    public required int EndpointUnknownAfterAgentOfflineSeconds { get; init; }
 }
 
 public sealed class RemoveAgentPageViewModel

--- a/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Agents/Index.cshtml
@@ -116,6 +116,7 @@
                                 <div class="meta-item"><span>Agent version</span><div>@agent.AgentVersion</div></div>
                                 <div class="meta-item"><span>Machine name</span><div>@agent.MachineName</div></div>
                                 <div class="meta-item"><span>Platform</span><div>@agent.Platform</div></div>
+                                <div class="meta-item"><span>Unknown after offline</span><div>@agent.EndpointUnknownAfterAgentOfflineSeconds seconds</div></div>
                             </div>
                             @if (agent.IsVersionDifferentFromBundled)
                             {
@@ -125,6 +126,14 @@
                             }
 
                             <div class="action-row" style="margin-top:.9rem;">
+                                <form method="post" action="/agents/@agent.AgentId/offline-unknown-timeout">
+                                    @Html.AntiForgeryToken()
+                                    <label for="offline-timeout-@agent.AgentId" class="muted" style="display:block;margin-bottom:.2rem;">If this agent stops reporting for this long, its assigned endpoints are marked Unknown.</label>
+                                    <div style="display:flex;gap:.4rem;align-items:center;">
+                                        <input id="offline-timeout-@agent.AgentId" name="endpointUnknownAfterAgentOfflineSeconds" type="number" min="30" max="86400" step="1" value="@agent.EndpointUnknownAfterAgentOfflineSeconds" style="min-height:46px;max-width:140px;padding:.5rem;border:1px solid var(--border);border-radius:10px;" />
+                                        <button class="button-secondary" type="submit">Save timeout</button>
+                                    </div>
+                                </form>
                                 <a class="button-secondary" href="/agents/@agent.AgentId/history">View history</a>
                                 @if (agent.Enabled)
                                 {

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 10,
+    "RequiredSchemaVersion": 11,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 10,
+    "RequiredSchemaVersion": 11,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
### Motivation
- Endpoints assigned to an agent remained in their last-known state when the agent stopped reporting, making their true status unknown and misleading operators. 
- The goal is a server-side, per-agent configurable delay after which assignments for a stale/offline agent are moved to `Unknown` without treating them as `Down` and while preserving dependency/suppression semantics. 
- Changes must be safe for production, respect Startup Gate/DB schema rules, and be observable in logs.

### Description
- Added a per-agent setting `EndpointUnknownAfterAgentOfflineSeconds` with default `300` via `Agent.DefaultEndpointUnknownAfterAgentOfflineSeconds` and the `Agent` model property `EndpointUnknownAfterAgentOfflineSeconds`, and mapped it in `PingMonitorDbContext` with a default value. 
- Added startup-gate schema apply support to add `Agents.EndpointUnknownAfterAgentOfflineSeconds` (and bumped the required schema version in `appsettings.json`/`appsettings.Development.json` to `11`) so upgrades can add the column safely. 
- Implemented server-side handling in `AgentStatusTransitionBackgroundService` to call `TransitionAssignedEndpointsToUnknownAsync` when an agent transitions to `Offline`, with `ShouldTransitionAssignmentsToUnknown` enforcing the per-agent delay and avoiding duplicate Unknown transitions; transitions create a `StateTransition` row and an `EventLog` entry using new reason code `StateTransitionReasonCodes.AgentOfflineTimeout`. 
- Exposed editability in the management UI and controller: `Manage agents` view shows `Unknown after offline` and allows editing via a new `POST /agents/{id}/offline-unknown-timeout` action that calls `AgentProvisioningService.SetEndpointUnknownAfterOfflineSecondsAsync` (validated bounds `30..86400`). 
- Added `IAgentProvisioningService.SetEndpointUnknownAfterOfflineSecondsAsync` and service implementation to persist per-agent overrides, and updated agent provisioning to initialize the new setting. 
- Touched query path note: `AgentManagementQueryService.ListAsync` now selects the new `EndpointUnknownAfterAgentOfflineSeconds` column and must be validated against MySQL provider translation in CI before merge.

### Testing
- Added focused unit tests at `src/WebApp/PingMonitor.Web.Tests/AgentOfflineUnknownTimeoutTests.cs` that exercise `AgentStatusTransitionBackgroundService.ShouldTransitionAssignmentsToUnknown` for below-threshold, beyond-threshold, and default-fallback cases. 
- Attempted to run `dotnet test src/WebApp/PingMonitor.WebApp.slnx -v minimal` in this environment but the run failed because `dotnet` is not installed here, so automated tests were not executed in this run. 
- Schema migration SQL was added to the startup-gate schema application code, but live MySQL translation/upgrade verification was not performed in this environment and should be validated in CI or a staging environment prior to production roll-out.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1712b9a78c832a991ace445cb3daa0)