### PR TITLE
Fix MySQL type-mapping failure in offline endpoint transition evaluation

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/AgentStatusTransitionBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AgentStatusTransitionBackgroundService.cs
@@ -150,9 +150,8 @@ internal sealed class AgentStatusTransitionBackgroundService : BackgroundService
             return;
         }
 
-        var assignmentIds = assignments.Select(x => x.AssignmentId).ToArray();
         var states = await dbContext.EndpointStates
-            .Where(x => assignmentIds.Contains(x.AssignmentId))
+            .Where(x => x.AgentId == agent.AgentId)
             .ToDictionaryAsync(x => x.AssignmentId, x => x, cancellationToken);
 
         foreach (var assignment in assignments)


### PR DESCRIPTION
### Motivation
- Fix an EF Core/MySQL translation error that caused `TransitionAssignedEndpointsToUnknownAsync` to throw `Expression "@assignmentIds" in the SQL tree does not have a type mapping assigned.` and prevented assigned endpoints from being transitioned to `Unknown` when an agent went offline.

### Description
- Replace the provider-dependent `assignmentIds.Contains(...)` query against `EndpointStates` with a provider-safe query that loads endpoint states scoped by `AgentId` and maps them in-memory by `AssignmentId`, preserving the original transition logic (change in `src/WebApp/PingMonitor.Web/Services/AgentStatusTransitionBackgroundService.cs`); Fixes #472.

### Testing
- Attempted to run `dotnet build` via `dotnet --version && dotnet build -v minimal`, but the build could not be executed in this environment because `dotnet` is not installed (build not validated here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a174bc062dc832ab201773353d40428)