### PR TITLE
Add jitter-based degraded evaluation

### DIFF
--- a/docs/monitoring-state-machine.md
+++ b/docs/monitoring-state-machine.md
@@ -130,8 +130,10 @@ Important:
   - current evaluation window: 1 hour
   - packet loss increase threshold: +20 percentage points
   - RTT increase threshold: +20%
+  - jitter increase threshold: +20%
   - minimum samples: 10 completed results in both baseline and current windows
 - Baseline comparison excludes the current window so current degradation does not dilute its own baseline.
+- Jitter comparison uses successful RTT samples only and is ignored when either window has insufficient successful samples.
 - `DEGRADED` is non-failure and only applies when the assignment would otherwise be `UP`.
 
 ---
@@ -263,7 +265,7 @@ else:
     else:
         state = current state
 
-    if state == UP and degraded evaluation is enabled and recent RTT or packet loss exceeds baseline thresholds:
+    if state == UP and degraded evaluation is enabled and recent RTT, packet loss, or jitter exceeds baseline thresholds:
         state = DEGRADED
 ```
 
@@ -300,7 +302,7 @@ else:
 ### v1 degraded behaviour
 
 - `DEGRADED` does NOT trigger alerts by default.
-- State transition events are recorded when entering or leaving `DEGRADED`, including the RTT and/or packet-loss reason.
+- State transition events are recorded when entering or leaving `DEGRADED`, including the RTT, packet-loss, and/or jitter reason.
 
 ---
 

--- a/src/WebApp/PingMonitor.Web.Tests/DegradedEndpointEvaluatorTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/DegradedEndpointEvaluatorTests.cs
@@ -44,6 +44,72 @@ public sealed class DegradedEndpointEvaluatorTests
     }
 
     [Fact]
+    public void Evaluate_Degrades_WhenJitterIncreasesMoreThanTwentyPercent()
+    {
+        var results = BuildJitterResults(
+            baselineSuccessfulRtts: AlternatingRtts(100, 100, 101),
+            currentSuccessfulRtts: AlternatingRtts(100, 100, 102));
+
+        var evaluation = DegradedEndpointEvaluator.Evaluate(results, NowUtc, DefaultSettings);
+
+        Assert.True(evaluation.IsDegraded);
+        Assert.True(evaluation.JitterDegraded);
+        Assert.False(evaluation.RttDegraded);
+        Assert.False(evaluation.PacketLossDegraded);
+        Assert.Equal(1d, evaluation.BaselineJitterMs);
+        Assert.Equal(2d, evaluation.CurrentJitterMs);
+        Assert.Contains("jitter increased from 1.0 ms baseline to 2.0 ms current", evaluation.ReasonSummary);
+    }
+
+    [Fact]
+    public void Evaluate_DoesNotDegrade_WhenJitterIsWithinThreshold()
+    {
+        var results = BuildJitterResults(
+            baselineSuccessfulRtts: AlternatingRtts(100, 100, 110),
+            currentSuccessfulRtts: AlternatingRtts(100, 100, 111));
+
+        var evaluation = DegradedEndpointEvaluator.Evaluate(results, NowUtc, DefaultSettings);
+
+        Assert.False(evaluation.IsDegraded);
+        Assert.Equal(10d, evaluation.BaselineJitterMs);
+        Assert.Equal(11d, evaluation.CurrentJitterMs);
+    }
+
+    [Fact]
+    public void Evaluate_DoesNotDegrade_WhenJitterSamplesAreInsufficient()
+    {
+        var results = BuildJitterResults(
+            baselineSuccessfulRtts: AlternatingRtts(9, 100, 101),
+            currentSuccessfulRtts: AlternatingRtts(9, 90, 110));
+
+        var evaluation = DegradedEndpointEvaluator.Evaluate(results, NowUtc, DefaultSettings);
+
+        Assert.False(evaluation.IsDegraded);
+        Assert.Null(evaluation.BaselineJitterMs);
+        Assert.Null(evaluation.CurrentJitterMs);
+        Assert.Equal(9, evaluation.BaselineJitterSampleCount);
+        Assert.Equal(9, evaluation.CurrentJitterSampleCount);
+    }
+
+    [Fact]
+    public void Evaluate_IncludesAllContributingDegradedReasons()
+    {
+        var results = BuildJitterResults(
+            baselineSuccessfulRtts: AlternatingRtts(99, 50, 51),
+            currentSuccessfulRtts: AlternatingRtts(77, 65, 67));
+
+        var evaluation = DegradedEndpointEvaluator.Evaluate(results, NowUtc, DefaultSettings);
+
+        Assert.True(evaluation.IsDegraded);
+        Assert.True(evaluation.RttDegraded);
+        Assert.True(evaluation.PacketLossDegraded);
+        Assert.True(evaluation.JitterDegraded);
+        Assert.Contains("RTT increased", evaluation.ReasonSummary);
+        Assert.Contains("packet loss increased", evaluation.ReasonSummary);
+        Assert.Contains("jitter increased", evaluation.ReasonSummary);
+    }
+
+    [Fact]
     public void Evaluate_DoesNotMarkDegraded_WhenDisabled()
     {
         var results = BuildResults(baselineRtt: 50, currentRtt: 80, baselineFailures: 0, currentFailures: 0);
@@ -154,6 +220,41 @@ public sealed class DegradedEndpointEvaluatorTests
         }
 
         return results;
+    }
+
+    private static List<CheckResult> BuildJitterResults(
+        IReadOnlyList<int> baselineSuccessfulRtts,
+        IReadOnlyList<int> currentSuccessfulRtts,
+        int baselineSamples = 100,
+        int currentSamples = 100)
+    {
+        var results = new List<CheckResult>(baselineSamples + currentSamples);
+        var baselineStart = NowUtc.AddHours(-24);
+        for (var i = 0; i < baselineSamples; i++)
+        {
+            var success = i < baselineSuccessfulRtts.Count;
+            results.Add(NewResult(baselineStart.AddMinutes(i * 10), success, success ? baselineSuccessfulRtts[i] : null));
+        }
+
+        var currentStart = NowUtc.AddHours(-1).AddMinutes(1);
+        for (var i = 0; i < currentSamples; i++)
+        {
+            var success = i < currentSuccessfulRtts.Count;
+            results.Add(NewResult(currentStart.AddSeconds(i * 30), success, success ? currentSuccessfulRtts[i] : null));
+        }
+
+        return results;
+    }
+
+    private static int[] AlternatingRtts(int count, int first, int second)
+    {
+        var values = new int[count];
+        for (var index = 0; index < values.Length; index++)
+        {
+            values[index] = index % 2 == 0 ? first : second;
+        }
+
+        return values;
     }
 
     private static CheckResult NewResult(DateTimeOffset checkedAtUtc, bool success, int? rttMs)

--- a/src/WebApp/PingMonitor.Web.Tests/DegradedEndpointQueryTranslationTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/DegradedEndpointQueryTranslationTests.cs
@@ -22,6 +22,8 @@ public sealed class DegradedEndpointQueryTranslationTests
                 && x.CheckedAtUtc >= windowStartUtc
                 && x.CheckedAtUtc <= nowUtc)
             .OrderBy(x => x.CheckedAtUtc)
+            .ThenBy(x => x.ReceivedAtUtc)
+            .ThenBy(x => x.CheckResultId)
             .Select(x => new
             {
                 x.AssignmentId,
@@ -34,5 +36,7 @@ public sealed class DegradedEndpointQueryTranslationTests
         Assert.Contains("CheckResults", sql);
         Assert.Contains("AssignmentId", sql);
         Assert.Contains("CheckedAtUtc", sql);
+        Assert.Contains("ReceivedAtUtc", sql);
+        Assert.Contains("CheckResultId", sql);
     }
 }

--- a/src/WebApp/PingMonitor.Web.Tests/StateChangeEventLogMessageBuilderTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/StateChangeEventLogMessageBuilderTests.cs
@@ -1,0 +1,30 @@
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class StateChangeEventLogMessageBuilderTests
+{
+    [Fact]
+    public void Build_IncludesJitterReason_WhenEnteringDegraded()
+    {
+        var message = StateChangeEventLogMessageBuilder.Build(
+            "Core switch",
+            EndpointStateKind.Up,
+            EndpointStateKind.Degraded,
+            new DateTimeOffset(2026, 05, 28, 12, 00, 00, TimeSpan.Zero),
+            new DateTimeOffset(2026, 05, 28, 11, 00, 00, TimeSpan.Zero),
+            new DegradedEndpointEvaluationResult
+            {
+                IsDegraded = true,
+                ReasonSummary = "jitter increased from 0.3 ms baseline to 1.2 ms current",
+                JitterDegraded = true,
+                BaselineJitterMs = 0.3d,
+                CurrentJitterMs = 1.2d
+            });
+
+        Assert.Contains("Endpoint \"Core switch\" is degraded", message);
+        Assert.Contains("jitter increased from 0.3 ms baseline to 1.2 ms current", message);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminDefaultEndpointValuesController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminDefaultEndpointValuesController.cs
@@ -48,6 +48,7 @@ public sealed class AdminDefaultEndpointValuesController : Controller
                 DegradedCurrentWindowMinutes = model.DegradedCurrentWindowMinutes,
                 DegradedPacketLossIncreasePercentagePoints = model.DegradedPacketLossIncreasePercentagePoints,
                 DegradedRttIncreasePercent = model.DegradedRttIncreasePercent,
+                DegradedJitterIncreasePercent = model.DegradedJitterIncreasePercent,
                 DegradedMinimumSamples = model.DegradedMinimumSamples
             },
             cancellationToken);
@@ -69,6 +70,7 @@ public sealed class AdminDefaultEndpointValuesController : Controller
             DegradedCurrentWindowMinutes = settings.DegradedCurrentWindowMinutes,
             DegradedPacketLossIncreasePercentagePoints = settings.DegradedPacketLossIncreasePercentagePoints,
             DegradedRttIncreasePercent = settings.DegradedRttIncreasePercent,
+            DegradedJitterIncreasePercent = settings.DegradedJitterIncreasePercent,
             DegradedMinimumSamples = settings.DegradedMinimumSamples,
             UpdatedAtUtc = settings.UpdatedAtUtc,
             Saved = saved

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
@@ -106,6 +106,7 @@ public sealed class AgentsController : Controller
                 DegradedCurrentWindowMinutes = current.DegradedCurrentWindowMinutes,
                 DegradedPacketLossIncreasePercentagePoints = current.DegradedPacketLossIncreasePercentagePoints,
                 DegradedRttIncreasePercent = current.DegradedRttIncreasePercent,
+                DegradedJitterIncreasePercent = current.DegradedJitterIncreasePercent,
                 DegradedMinimumSamples = current.DegradedMinimumSamples
             },
             cancellationToken);

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -317,6 +317,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         appSettings.Property(x => x.DegradedCurrentWindowMinutes).IsRequired();
         appSettings.Property(x => x.DegradedPacketLossIncreasePercentagePoints).IsRequired();
         appSettings.Property(x => x.DegradedRttIncreasePercent).IsRequired();
+        appSettings.Property(x => x.DegradedJitterIncreasePercent).IsRequired();
         appSettings.Property(x => x.DegradedMinimumSamples).IsRequired();
         appSettings.Property(x => x.UpdatedAtUtc).IsRequired();
 

--- a/src/WebApp/PingMonitor.Web/Models/ApplicationSettings.cs
+++ b/src/WebApp/PingMonitor.Web/Models/ApplicationSettings.cs
@@ -28,6 +28,8 @@ public sealed class ApplicationSettings
 
     public double DegradedRttIncreasePercent { get; set; } = 20d;
 
+    public double DegradedJitterIncreasePercent { get; set; } = 20d;
+
     public int DegradedMinimumSamples { get; set; } = 10;
 
     public bool EnableAutomaticUpdateChecks { get; set; } = true;

--- a/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
@@ -5,6 +5,6 @@ public sealed class StartupGateOptions
     public const string SectionName = "StartupGate";
 
     public string StorageDirectory { get; set; } = "App_Data/StartupGate";
-    public int RequiredSchemaVersion { get; set; } = 13;
+    public int RequiredSchemaVersion { get; set; } = 14;
     public int DefaultMySqlPort { get; set; } = 3306;
 }

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationSettingsDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationSettingsDto.cs
@@ -13,6 +13,7 @@ public sealed class ApplicationSettingsDto
     public int DegradedCurrentWindowMinutes { get; init; } = 60;
     public double DegradedPacketLossIncreasePercentagePoints { get; init; } = 20d;
     public double DegradedRttIncreasePercent { get; init; } = 20d;
+    public double DegradedJitterIncreasePercent { get; init; } = 20d;
     public int DegradedMinimumSamples { get; init; } = 10;
     public DateTimeOffset UpdatedAtUtc { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationSettingsService.cs
@@ -43,6 +43,7 @@ internal sealed class ApplicationSettingsService : IApplicationSettingsService
         settings.DegradedCurrentWindowMinutes = command.DegradedCurrentWindowMinutes;
         settings.DegradedPacketLossIncreasePercentagePoints = command.DegradedPacketLossIncreasePercentagePoints;
         settings.DegradedRttIncreasePercent = command.DegradedRttIncreasePercent;
+        settings.DegradedJitterIncreasePercent = command.DegradedJitterIncreasePercent;
         settings.DegradedMinimumSamples = command.DegradedMinimumSamples;
         settings.UpdatedAtUtc = DateTimeOffset.UtcNow;
 
@@ -74,6 +75,7 @@ internal sealed class ApplicationSettingsService : IApplicationSettingsService
             DegradedCurrentWindowMinutes = 60,
             DegradedPacketLossIncreasePercentagePoints = 20d,
             DegradedRttIncreasePercent = 20d,
+            DegradedJitterIncreasePercent = 20d,
             DegradedMinimumSamples = 10,
             EnableAutomaticUpdateChecks = _updaterOptions.EnableAutomaticUpdateChecks,
             AutomaticUpdateCheckIntervalMinutes = ResolveAutomaticCheckInterval(_updaterOptions.AutomaticUpdateCheckIntervalMinutes),
@@ -117,6 +119,7 @@ internal sealed class ApplicationSettingsService : IApplicationSettingsService
             DegradedCurrentWindowMinutes = settings.DegradedCurrentWindowMinutes,
             DegradedPacketLossIncreasePercentagePoints = settings.DegradedPacketLossIncreasePercentagePoints,
             DegradedRttIncreasePercent = settings.DegradedRttIncreasePercent,
+            DegradedJitterIncreasePercent = settings.DegradedJitterIncreasePercent,
             DegradedMinimumSamples = settings.DegradedMinimumSamples,
             UpdatedAtUtc = settings.UpdatedAtUtc
         };

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdaterOperationalSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdaterOperationalSettingsService.cs
@@ -67,6 +67,7 @@ internal sealed class ApplicationUpdaterOperationalSettingsService : IApplicatio
                 DegradedCurrentWindowMinutes = 60,
                 DegradedPacketLossIncreasePercentagePoints = 20d,
                 DegradedRttIncreasePercent = 20d,
+                DegradedJitterIncreasePercent = 20d,
                 DegradedMinimumSamples = 10,
                 EnableAutomaticUpdateChecks = _updaterOptions.EnableAutomaticUpdateChecks,
                 AutomaticUpdateCheckIntervalMinutes = ResolveAutomaticCheckInterval(_updaterOptions.AutomaticUpdateCheckIntervalMinutes),

--- a/src/WebApp/PingMonitor.Web/Services/DegradedEndpointEvaluation.cs
+++ b/src/WebApp/PingMonitor.Web/Services/DegradedEndpointEvaluation.cs
@@ -9,6 +9,7 @@ internal sealed class DegradedEndpointEvaluationSettings
     public int CurrentWindowMinutes { get; init; } = 60;
     public double PacketLossIncreasePercentagePoints { get; init; } = 20d;
     public double RttIncreasePercent { get; init; } = 20d;
+    public double JitterIncreasePercent { get; init; } = 20d;
     public int MinimumSamples { get; init; } = 10;
 }
 
@@ -22,8 +23,13 @@ internal sealed class DegradedEndpointEvaluationResult
     public double CurrentPacketLossPercent { get; init; }
     public double? BaselineAverageRttMs { get; init; }
     public double? CurrentAverageRttMs { get; init; }
+    public double? BaselineJitterMs { get; init; }
+    public double? CurrentJitterMs { get; init; }
+    public int BaselineJitterSampleCount { get; init; }
+    public int CurrentJitterSampleCount { get; init; }
     public bool PacketLossDegraded { get; init; }
     public bool RttDegraded { get; init; }
+    public bool JitterDegraded { get; init; }
 
     public static DegradedEndpointEvaluationResult NotDegraded { get; } = new();
 }
@@ -66,14 +72,20 @@ internal static class DegradedEndpointEvaluator
         var currentLoss = CalculatePacketLossPercent(currentResults);
         var baselineRtt = CalculateAverageSuccessfulRttMs(baselineResults);
         var currentRtt = CalculateAverageSuccessfulRttMs(currentResults);
+        var baselineJitter = CalculateAverageSuccessfulJitterMs(baselineResults, settings.MinimumSamples);
+        var currentJitter = CalculateAverageSuccessfulJitterMs(currentResults, settings.MinimumSamples);
 
         var lossDegraded = currentLoss >= baselineLoss + settings.PacketLossIncreasePercentagePoints;
         var rttDegraded = baselineRtt.HasValue
             && baselineRtt.Value > 0d
             && currentRtt.HasValue
             && currentRtt.Value >= baselineRtt.Value * (1d + (settings.RttIncreasePercent / 100d));
+        var jitterDegraded = baselineJitter.JitterMs.HasValue
+            && baselineJitter.JitterMs.Value > 0d
+            && currentJitter.JitterMs.HasValue
+            && currentJitter.JitterMs.Value >= baselineJitter.JitterMs.Value * (1d + (settings.JitterIncreasePercent / 100d));
 
-        if (!lossDegraded && !rttDegraded)
+        if (!lossDegraded && !rttDegraded && !jitterDegraded)
         {
             return new DegradedEndpointEvaluationResult
             {
@@ -82,11 +94,15 @@ internal static class DegradedEndpointEvaluator
                 BaselinePacketLossPercent = baselineLoss,
                 CurrentPacketLossPercent = currentLoss,
                 BaselineAverageRttMs = baselineRtt,
-                CurrentAverageRttMs = currentRtt
+                CurrentAverageRttMs = currentRtt,
+                BaselineJitterMs = baselineJitter.JitterMs,
+                CurrentJitterMs = currentJitter.JitterMs,
+                BaselineJitterSampleCount = baselineJitter.SampleCount,
+                CurrentJitterSampleCount = currentJitter.SampleCount
             };
         }
 
-        var reasons = new List<string>(capacity: 2);
+        var reasons = new List<string>(capacity: 3);
         if (rttDegraded)
         {
             reasons.Add($"RTT increased from {baselineRtt!.Value:F1} ms baseline to {currentRtt!.Value:F1} ms current");
@@ -95,6 +111,11 @@ internal static class DegradedEndpointEvaluator
         if (lossDegraded)
         {
             reasons.Add($"packet loss increased from {baselineLoss:F1}% baseline to {currentLoss:F1}% current");
+        }
+
+        if (jitterDegraded)
+        {
+            reasons.Add($"jitter increased from {baselineJitter.JitterMs!.Value:F1} ms baseline to {currentJitter.JitterMs!.Value:F1} ms current");
         }
 
         return new DegradedEndpointEvaluationResult
@@ -107,8 +128,13 @@ internal static class DegradedEndpointEvaluator
             CurrentPacketLossPercent = currentLoss,
             BaselineAverageRttMs = baselineRtt,
             CurrentAverageRttMs = currentRtt,
+            BaselineJitterMs = baselineJitter.JitterMs,
+            CurrentJitterMs = currentJitter.JitterMs,
+            BaselineJitterSampleCount = baselineJitter.SampleCount,
+            CurrentJitterSampleCount = currentJitter.SampleCount,
             PacketLossDegraded = lossDegraded,
-            RttDegraded = rttDegraded
+            RttDegraded = rttDegraded,
+            JitterDegraded = jitterDegraded
         };
     }
 
@@ -132,6 +158,28 @@ internal static class DegradedEndpointEvaluator
 
         return successfulRtts.Length == 0 ? null : (double)successfulRtts.Average();
     }
+
+    private static JitterEvaluationWindow CalculateAverageSuccessfulJitterMs(
+        IReadOnlyCollection<CheckResult> results,
+        int minimumSamples)
+    {
+        var successfulRttSamples = results
+            .Where(static x => x.Success && x.RoundTripMs.HasValue)
+            .OrderBy(static x => x.CheckedAtUtc)
+            .Select(static x => new RttJitterSample(x.CheckedAtUtc, (double)x.RoundTripMs!.Value))
+            .ToArray();
+
+        if (successfulRttSamples.Length < Math.Max(2, minimumSamples))
+        {
+            return new JitterEvaluationWindow(null, successfulRttSamples.Length);
+        }
+
+        return new JitterEvaluationWindow(
+            RttJitterCalculator.CalculateAverageAbsoluteDeltaMs(successfulRttSamples),
+            successfulRttSamples.Length);
+    }
+
+    private readonly record struct JitterEvaluationWindow(double? JitterMs, int SampleCount);
 }
 
 internal static class DegradedEndpointStatePriority

--- a/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointPerformanceQueryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Endpoints/EndpointPerformanceQueryService.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
+using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.ViewModels.Endpoints;
 
@@ -111,24 +112,17 @@ internal sealed class EndpointPerformanceQueryService : IEndpointPerformanceQuer
 
     private static IReadOnlyList<JitterPointViewModel> BuildJitterSeries(IReadOnlyList<TimeSeriesPointViewModel> successfulRttSamples)
     {
-        if (successfulRttSamples.Count < 2)
-        {
-            return [];
-        }
+        var orderedSamples = successfulRttSamples
+            .Select(x => new RttJitterSample(x.TimestampUtc, x.Value))
+            .ToArray();
 
-        var jitterPoints = new List<JitterPointViewModel>(successfulRttSamples.Count - 1);
-        for (var index = 1; index < successfulRttSamples.Count; index++)
-        {
-            var current = successfulRttSamples[index];
-            var previous = successfulRttSamples[index - 1];
-            jitterPoints.Add(new JitterPointViewModel
+        return RttJitterCalculator.CalculateAbsoluteDeltas(orderedSamples)
+            .Select(x => new JitterPointViewModel
             {
-                TimestampUtc = current.TimestampUtc,
-                JitterMs = Math.Abs(current.Value - previous.Value)
-            });
-        }
-
-        return jitterPoints;
+                TimestampUtc = x.TimestampUtc,
+                JitterMs = x.JitterMs
+            })
+            .ToArray();
     }
 
     private static IReadOnlyList<FailureBucketViewModel> BuildFailureSeries(

--- a/src/WebApp/PingMonitor.Web/Services/RttJitterCalculator.cs
+++ b/src/WebApp/PingMonitor.Web/Services/RttJitterCalculator.cs
@@ -1,0 +1,44 @@
+namespace PingMonitor.Web.Services;
+
+internal readonly record struct RttJitterSample(DateTimeOffset TimestampUtc, double RttMs);
+
+internal readonly record struct RttJitterDelta(DateTimeOffset TimestampUtc, double JitterMs);
+
+internal static class RttJitterCalculator
+{
+    public static IReadOnlyList<RttJitterDelta> CalculateAbsoluteDeltas(IReadOnlyList<RttJitterSample> orderedSamples)
+    {
+        if (orderedSamples.Count < 2)
+        {
+            return [];
+        }
+
+        var deltas = new List<RttJitterDelta>(orderedSamples.Count - 1);
+        for (var index = 1; index < orderedSamples.Count; index++)
+        {
+            var current = orderedSamples[index];
+            var previous = orderedSamples[index - 1];
+            deltas.Add(new RttJitterDelta(
+                current.TimestampUtc,
+                Math.Abs(current.RttMs - previous.RttMs)));
+        }
+
+        return deltas;
+    }
+
+    public static double? CalculateAverageAbsoluteDeltaMs(IReadOnlyList<RttJitterSample> orderedSamples)
+    {
+        if (orderedSamples.Count < 2)
+        {
+            return null;
+        }
+
+        var deltaSum = 0d;
+        for (var index = 1; index < orderedSamples.Count; index++)
+        {
+            deltaSum += Math.Abs(orderedSamples[index].RttMs - orderedSamples[index - 1].RttMs);
+        }
+
+        return deltaSum / (orderedSamples.Count - 1);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -92,6 +92,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "DegradedCurrentWindowMinutes",
         "DegradedPacketLossIncreasePercentagePoints",
         "DegradedRttIncreasePercent",
+        "DegradedJitterIncreasePercent",
         "DegradedMinimumSamples",
         "EnableAutomaticUpdateChecks",
         "AutomaticUpdateCheckIntervalMinutes",
@@ -445,6 +446,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 `DegradedCurrentWindowMinutes` int NOT NULL DEFAULT 60,
                 `DegradedPacketLossIncreasePercentagePoints` double NOT NULL DEFAULT 20,
                 `DegradedRttIncreasePercent` double NOT NULL DEFAULT 20,
+                `DegradedJitterIncreasePercent` double NOT NULL DEFAULT 20,
                 `DegradedMinimumSamples` int NOT NULL DEFAULT 10,
                 `EnableAutomaticUpdateChecks` tinyint(1) NOT NULL DEFAULT 1,
                 `AutomaticUpdateCheckIntervalMinutes` int NOT NULL DEFAULT 15,
@@ -1387,6 +1389,16 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 """
                 ALTER TABLE `ApplicationSettings`
                 ADD COLUMN `DegradedRttIncreasePercent` double NOT NULL DEFAULT 20;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasApplicationSettingsColumnAsync(connection, "DegradedJitterIncreasePercent", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `ApplicationSettings`
+                ADD COLUMN `DegradedJitterIncreasePercent` double NOT NULL DEFAULT 20;
                 """,
                 cancellationToken);
         }

--- a/src/WebApp/PingMonitor.Web/Services/StateChangeEventLogMessageBuilder.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StateChangeEventLogMessageBuilder.cs
@@ -1,0 +1,45 @@
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services;
+
+internal static class StateChangeEventLogMessageBuilder
+{
+    public static string Build(
+        string endpointName,
+        EndpointStateKind previousState,
+        EndpointStateKind nextState,
+        DateTimeOffset transitionAtUtc,
+        DateTimeOffset previousStateChangedAtUtc,
+        DegradedEndpointEvaluationResult degradedEvaluation)
+    {
+        if (nextState == EndpointStateKind.Down)
+        {
+            return $"Endpoint \"{endpointName}\" went down.";
+        }
+
+        if (previousState == EndpointStateKind.Down && nextState == EndpointStateKind.Up)
+        {
+            var downtime = transitionAtUtc - previousStateChangedAtUtc;
+            return $"Endpoint \"{endpointName}\" recovered after {FormatDuration(downtime)} downtime.";
+        }
+
+        if (nextState == EndpointStateKind.Degraded && degradedEvaluation.IsDegraded && !string.IsNullOrWhiteSpace(degradedEvaluation.ReasonSummary))
+        {
+            return $"Endpoint \"{endpointName}\" is degraded: {degradedEvaluation.ReasonSummary}.";
+        }
+
+        if (previousState == EndpointStateKind.Degraded && nextState == EndpointStateKind.Up)
+        {
+            return $"Endpoint \"{endpointName}\" recovered from degraded performance; current RTT, packet loss, and jitter no longer exceed configured thresholds or there is insufficient comparison data.";
+        }
+
+        return $"Endpoint \"{endpointName}\" state changed from {previousState} to {nextState}.";
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        var safeDuration = duration < TimeSpan.Zero ? TimeSpan.Zero : duration;
+        var hours = (int)safeDuration.TotalHours;
+        return $"{hours:D2}:{safeDuration.Minutes:D2}:{safeDuration.Seconds:D2}";
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StateEvaluationService.cs
@@ -185,7 +185,7 @@ internal sealed class StateEvaluationService : IStateEvaluationService
                     AgentId = assignmentContext.AgentId,
                     EndpointId = assignmentContext.EndpointId,
                     AssignmentId = assignmentContext.AssignmentId,
-                    Message = BuildStateChangeMessage(
+                    Message = StateChangeEventLogMessageBuilder.Build(
                         assignmentContext.EndpointName,
                         previousState,
                         nextState,
@@ -211,8 +211,13 @@ internal sealed class StateEvaluationService : IStateEvaluationService
                             degradedEvaluation.CurrentPacketLossPercent,
                             degradedEvaluation.BaselineAverageRttMs,
                             degradedEvaluation.CurrentAverageRttMs,
+                            degradedEvaluation.BaselineJitterMs,
+                            degradedEvaluation.CurrentJitterMs,
+                            degradedEvaluation.BaselineJitterSampleCount,
+                            degradedEvaluation.CurrentJitterSampleCount,
                             degradedEvaluation.PacketLossDegraded,
-                            degradedEvaluation.RttDegraded
+                            degradedEvaluation.RttDegraded,
+                            degradedEvaluation.JitterDegraded
                         }
                     })
                 },
@@ -336,6 +341,8 @@ internal sealed class StateEvaluationService : IStateEvaluationService
                 && x.CheckedAtUtc >= windowStartUtc
                 && x.CheckedAtUtc <= nowUtc)
             .OrderBy(x => x.CheckedAtUtc)
+            .ThenBy(x => x.ReceivedAtUtc)
+            .ThenBy(x => x.CheckResultId)
             .Select(x => new CheckResult
             {
                 AssignmentId = x.AssignmentId,
@@ -365,6 +372,7 @@ internal sealed class StateEvaluationService : IStateEvaluationService
             CurrentWindowMinutes = Math.Max(1, settings.DegradedCurrentWindowMinutes),
             PacketLossIncreasePercentagePoints = Math.Clamp(settings.DegradedPacketLossIncreasePercentagePoints, 0d, 100d),
             RttIncreasePercent = Math.Max(0d, settings.DegradedRttIncreasePercent),
+            JitterIncreasePercent = Math.Max(0d, settings.DegradedJitterIncreasePercent),
             MinimumSamples = Math.Max(1, settings.DegradedMinimumSamples)
         };
     }
@@ -418,45 +426,6 @@ internal sealed class StateEvaluationService : IStateEvaluationService
         var previousWasDown = previousState == EndpointStateKind.Down;
         var newIsDown = newState == EndpointStateKind.Down;
         return previousWasDown != newIsDown;
-    }
-
-    private static string BuildStateChangeMessage(
-        string endpointName,
-        EndpointStateKind previousState,
-        EndpointStateKind nextState,
-        DateTimeOffset transitionAtUtc,
-        DateTimeOffset previousStateChangedAtUtc,
-        DegradedEndpointEvaluationResult degradedEvaluation)
-    {
-        if (nextState == EndpointStateKind.Down)
-        {
-            return $"Endpoint \"{endpointName}\" went down.";
-        }
-
-        if (previousState == EndpointStateKind.Down && nextState == EndpointStateKind.Up)
-        {
-            var downtime = transitionAtUtc - previousStateChangedAtUtc;
-            return $"Endpoint \"{endpointName}\" recovered after {FormatDuration(downtime)} downtime.";
-        }
-
-        if (nextState == EndpointStateKind.Degraded && degradedEvaluation.IsDegraded && !string.IsNullOrWhiteSpace(degradedEvaluation.ReasonSummary))
-        {
-            return $"Endpoint \"{endpointName}\" is degraded: {degradedEvaluation.ReasonSummary}.";
-        }
-
-        if (previousState == EndpointStateKind.Degraded && nextState == EndpointStateKind.Up)
-        {
-            return $"Endpoint \"{endpointName}\" recovered from degraded performance; current RTT and packet loss no longer exceed configured thresholds or there is insufficient comparison data.";
-        }
-
-        return $"Endpoint \"{endpointName}\" state changed from {previousState} to {nextState}.";
-    }
-
-    private static string FormatDuration(TimeSpan duration)
-    {
-        var safeDuration = duration < TimeSpan.Zero ? TimeSpan.Zero : duration;
-        var hours = (int)safeDuration.TotalHours;
-        return $"{hours:D2}:{safeDuration.Minutes:D2}:{safeDuration.Seconds:D2}";
     }
 
     private static CachedAssignmentState CloneState(CachedAssignmentState state)

--- a/src/WebApp/PingMonitor.Web/Services/UpdateApplicationSettingsCommand.cs
+++ b/src/WebApp/PingMonitor.Web/Services/UpdateApplicationSettingsCommand.cs
@@ -13,5 +13,6 @@ public sealed class UpdateApplicationSettingsCommand
     public int DegradedCurrentWindowMinutes { get; init; } = 60;
     public double DegradedPacketLossIncreasePercentagePoints { get; init; } = 20d;
     public double DegradedRttIncreasePercent { get; init; } = 20d;
+    public double DegradedJitterIncreasePercent { get; init; } = 20d;
     public int DegradedMinimumSamples { get; init; } = 10;
 }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/DefaultEndpointValuesPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/DefaultEndpointValuesPageViewModel.cs
@@ -43,6 +43,10 @@ public sealed class DefaultEndpointValuesPageViewModel : IValidatableObject
     [Display(Name = "RTT increase threshold (percent)")]
     public double DegradedRttIncreasePercent { get; set; }
 
+    [Range(0, 10000, ErrorMessage = "Jitter increase threshold must be zero or greater.")]
+    [Display(Name = "Jitter increase threshold")]
+    public double DegradedJitterIncreasePercent { get; set; }
+
     [Range(1, int.MaxValue, ErrorMessage = "Minimum samples must be at least 1.")]
     [Display(Name = "Minimum samples per window")]
     public int DegradedMinimumSamples { get; set; }

--- a/src/WebApp/PingMonitor.Web/Views/AdminDefaultEndpointValues/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminDefaultEndpointValues/Index.cshtml
@@ -69,7 +69,7 @@
 
             <section class="card">
                 <h2>Degraded evaluation</h2>
-                <p class="muted">Mark endpoint Degraded when recent RTT or packet loss is significantly worse than its baseline.</p>
+                <p class="muted">Mark endpoint Degraded when recent RTT, packet loss, or jitter is significantly worse than its baseline.</p>
                 <div class="field-grid">
                     <div>
                         <div class="checkbox-row">
@@ -107,6 +107,12 @@
                         <input asp-for="DegradedRttIncreasePercent" type="number" min="0" step="0.1" />
                         <p class="field-help">Default: +20% over baseline average successful RTT.</p>
                         <div class="field-error"><span asp-validation-for="DegradedRttIncreasePercent"></span></div>
+                    </div>
+                    <div>
+                        <label asp-for="DegradedJitterIncreasePercent"></label>
+                        <input asp-for="DegradedJitterIncreasePercent" type="number" min="0" step="0.1" />
+                        <p class="field-help">Marks an endpoint Degraded when recent RTT variation is significantly worse than baseline.</p>
+                        <div class="field-error"><span asp-validation-for="DegradedJitterIncreasePercent"></span></div>
                     </div>
                 </div>
             </section>

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 13,
+    "RequiredSchemaVersion": 14,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 13,
+    "RequiredSchemaVersion": 14,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
Introduce jitter detection into degraded endpoint evaluation: calculate RTT jitter, flag degradation when jitter increases beyond the configured percent, and include jitter metrics and reason text in evaluation results. Add RttJitterCalculator and integrate jitter calculation into DegradedEndpointEvaluator, StateEvaluationService, and endpoint performance jitter series. Persist new setting DegradedJitterIncreasePercent (default 20) across models, DTOs, commands, application settings, EF model, and startup schema (bump RequiredSchemaVersion to 14 and add ALTER TABLE migration). Add StateChangeEventLogMessageBuilder and tests, expand degraded evaluation tests for jitter, and update query ordering to include ReceivedAtUtc and CheckResultId for deterministic ordering.