### PR TITLE
Fix updater lock recovery after successful apply

### DIFF
--- a/docs/diagnostics/2026-05-29-updater-lock-recovery.md
+++ b/docs/diagnostics/2026-05-29-updater-lock-recovery.md
@@ -1,0 +1,32 @@
+# Application updater lock recovery
+
+## Summary
+
+The application updater keeps active state in `App_Data/Updater/state/staged-update.json` and reads the external bootstrapper result from `App_Data/Updater/state/external-updater-status.json` when the web application starts or when the updater page refreshes.
+
+A successful external update can restart the application while the active staged state still says that handoff/apply is in progress. Operators previously had to delete `App_Data/Updater` manually to make future update actions available again.
+
+## Recovery behavior
+
+During updater status refresh, the web application now reconciles the preserved updater state instead of leaving it silently locked forever:
+
+1. If the bootstrapper status reports success and the running application version matches the staged release tag, the app marks the previous update as `ApplySucceeded`.
+2. The active staging/in-progress flag is cleared so a future check, stage, or apply cycle is not blocked by the previous successful update.
+3. The updater page shows that the previous update succeeded and that no update is currently staged for apply.
+4. The bootstrapper status and log paths remain visible for diagnostics.
+5. If the bootstrapper still reports `in_progress` but is stale and success cannot be confirmed, the app marks the state as `ApplyInterruptedNeedsAttention` instead of treating it as success.
+
+## Safety notes
+
+The app does **not** blindly delete updater state on startup. It only reconciles success when both of these are true:
+
+- the bootstrapper status indicates success, and
+- the running application version matches the target staged release.
+
+If those conditions are not met, stale in-progress state is surfaced as needing operator attention. The updater is unlocked for recovery actions such as re-checking or re-staging, but the previous update is not marked successful.
+
+## Operator guidance
+
+- For `ApplySucceeded`, no manual deletion of `App_Data/Updater` is required before checking or staging future updates.
+- For `ApplyInterruptedNeedsAttention`, inspect `external-updater-status.json` and `external-updater.log` from the paths shown on the updater page before retrying.
+- Preserve `App_Data/Updater` when collecting diagnostics; it contains the staged metadata, bootstrapper status, and log references needed to understand the previous apply attempt.

--- a/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateApplyServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/ApplicationUpdateApplyServiceTests.cs
@@ -220,6 +220,156 @@ public sealed class ApplicationUpdateApplyServiceTests
         }
     }
 
+
+    [Fact]
+    public async Task RefreshApplyStateAsync_ReconcilesStaleInProgressSuccess_WhenCurrentVersionMatchesTarget()
+    {
+        var contentRoot = CreateTempRoot();
+        try
+        {
+            var stagingRoot = Path.Combine(contentRoot, "App_Data", "Updater");
+            Directory.CreateDirectory(Path.Combine(stagingRoot, "state"));
+
+            var statusPath = Path.Combine(stagingRoot, "state", "external-updater-status.json");
+            await File.WriteAllTextAsync(statusPath, JsonSerializer.Serialize(new
+            {
+                stage = "copy_payload",
+                succeeded = true,
+                resultCode = "in_progress"
+            }));
+
+            var oldTimestamp = DateTime.UtcNow.AddMinutes(-20);
+            File.SetLastWriteTimeUtc(statusPath, oldTimestamp);
+
+            var store = BuildStateStore(contentRoot);
+            await store.WriteAsync(new ApplicationUpdateStagingState
+            {
+                SourceRepository = "ijyates1992/ping-monitor",
+                ReleaseTag = "V1.2.3",
+                ChecksumVerified = true,
+                StagingInProgress = true,
+                Status = ApplicationUpdateStagingStatus.ApplyHandoffStarted,
+                ExternalUpdaterStatusPath = statusPath,
+                LastUpdatedAtUtc = DateTimeOffset.UtcNow.AddMinutes(-20)
+            }, CancellationToken.None);
+
+            var service = BuildService(
+                contentRoot,
+                store,
+                new RecordingLauncher(),
+                currentVersion: "V1.2.3",
+                startupMode: StartupMode.Normal);
+
+            var refreshed = await service.RefreshApplyStateAsync(CancellationToken.None);
+
+            Assert.NotNull(refreshed);
+            Assert.Equal(ApplicationUpdateStagingStatus.ApplySucceeded, refreshed!.Status);
+            Assert.False(refreshed.StagingInProgress);
+            Assert.Null(refreshed.FailureMessage);
+            Assert.Contains("Stale in-progress updater state was reconciled", refreshed.ApplyOperationMessage);
+        }
+        finally
+        {
+            Directory.Delete(contentRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RefreshApplyStateAsync_MarksStaleInProgressNeedsAttention_WhenSuccessCannotBeConfirmed()
+    {
+        var contentRoot = CreateTempRoot();
+        try
+        {
+            var stagingRoot = Path.Combine(contentRoot, "App_Data", "Updater");
+            Directory.CreateDirectory(Path.Combine(stagingRoot, "state"));
+
+            var statusPath = Path.Combine(stagingRoot, "state", "external-updater-status.json");
+            await File.WriteAllTextAsync(statusPath, JsonSerializer.Serialize(new
+            {
+                stage = "stop_site",
+                succeeded = false,
+                resultCode = "in_progress"
+            }));
+            File.SetLastWriteTimeUtc(statusPath, DateTime.UtcNow.AddMinutes(-20));
+
+            var store = BuildStateStore(contentRoot);
+            await store.WriteAsync(new ApplicationUpdateStagingState
+            {
+                SourceRepository = "ijyates1992/ping-monitor",
+                ReleaseTag = "V1.2.3",
+                ChecksumVerified = true,
+                Status = ApplicationUpdateStagingStatus.ApplyHandoffStarted,
+                ExternalUpdaterStatusPath = statusPath,
+                LastUpdatedAtUtc = DateTimeOffset.UtcNow.AddMinutes(-20)
+            }, CancellationToken.None);
+
+            var service = BuildService(
+                contentRoot,
+                store,
+                new RecordingLauncher(),
+                currentVersion: "V1.0.0",
+                startupMode: StartupMode.Normal);
+
+            var refreshed = await service.RefreshApplyStateAsync(CancellationToken.None);
+
+            Assert.NotNull(refreshed);
+            Assert.Equal(ApplicationUpdateStagingStatus.ApplyInterruptedNeedsAttention, refreshed!.Status);
+            Assert.Contains("success cannot be confirmed", refreshed.FailureMessage);
+            Assert.False(refreshed.StagingInProgress);
+        }
+        finally
+        {
+            Directory.Delete(contentRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RefreshApplyStateAsync_DoesNotMarkFreshInProgressStateAsInterrupted()
+    {
+        var contentRoot = CreateTempRoot();
+        try
+        {
+            var stagingRoot = Path.Combine(contentRoot, "App_Data", "Updater");
+            Directory.CreateDirectory(Path.Combine(stagingRoot, "state"));
+
+            var statusPath = Path.Combine(stagingRoot, "state", "external-updater-status.json");
+            await File.WriteAllTextAsync(statusPath, JsonSerializer.Serialize(new
+            {
+                stage = "stop_site",
+                succeeded = false,
+                resultCode = "in_progress"
+            }));
+
+            var store = BuildStateStore(contentRoot);
+            await store.WriteAsync(new ApplicationUpdateStagingState
+            {
+                SourceRepository = "ijyates1992/ping-monitor",
+                ReleaseTag = "V1.2.3",
+                ChecksumVerified = true,
+                Status = ApplicationUpdateStagingStatus.ApplyHandoffStarted,
+                ExternalUpdaterStatusPath = statusPath,
+                LastUpdatedAtUtc = DateTimeOffset.UtcNow
+            }, CancellationToken.None);
+
+            var service = BuildService(
+                contentRoot,
+                store,
+                new RecordingLauncher(),
+                currentVersion: "V1.0.0",
+                startupMode: StartupMode.Normal);
+
+            var refreshed = await service.RefreshApplyStateAsync(CancellationToken.None);
+
+            Assert.NotNull(refreshed);
+            Assert.Equal(ApplicationUpdateStagingStatus.Applying, refreshed!.Status);
+            Assert.Null(refreshed.FailureMessage);
+        }
+        finally
+        {
+            Directory.Delete(contentRoot, recursive: true);
+        }
+    }
+
     [Fact]
     public async Task RequestApplyAsync_ThrowsWhenPowerShellHostCannotBeResolved()
     {

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateApplyService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateApplyService.cs
@@ -337,6 +337,8 @@ internal sealed class IisMetadataReader : IIisMetadataReader
 
 internal sealed class ApplicationUpdateApplyService : IApplicationUpdateApplyService
 {
+    private static readonly TimeSpan StaleInProgressThreshold = TimeSpan.FromMinutes(10);
+
     private static readonly JsonSerializerOptions ExternalStatusSerializerOptions = new()
     {
         PropertyNameCaseInsensitive = true
@@ -609,40 +611,52 @@ internal sealed class ApplicationUpdateApplyService : IApplicationUpdateApplySer
         var applyMessage = current.ApplyOperationMessage;
         var failureMessage = current.FailureMessage;
         DateTimeOffset? applyCompletedAtUtc = current.ApplyCompletedAtUtc;
+        var currentVersionMatchesTarget = IsCurrentVersionMatchingRelease(current.ReleaseTag, currentVersion);
 
-        var isCompleted = !string.IsNullOrWhiteSpace(externalStatus.CompletedAtUtc) &&
-                          !string.Equals(externalStatus.ResultCode, "in_progress", StringComparison.OrdinalIgnoreCase);
+        var externalResultCode = externalStatus.ResultCode?.Trim();
+        var isInProgressResult = string.IsNullOrWhiteSpace(externalResultCode) ||
+                                 string.Equals(externalResultCode, "in_progress", StringComparison.OrdinalIgnoreCase);
+        var isCompleted = !string.IsNullOrWhiteSpace(externalStatus.CompletedAtUtc) && !isInProgressResult;
+        var hasConfirmedBootstrapperSuccess = externalStatus.Succeeded && (isCompleted || currentVersionMatchesTarget);
 
-        if (isCompleted)
+        if (hasConfirmedBootstrapperSuccess)
         {
             applyCompletedAtUtc = now;
-            if (externalStatus.Succeeded)
+            if (_startupGateRuntimeState.CurrentMode == StartupMode.Gate)
             {
-                if (_startupGateRuntimeState.CurrentMode == StartupMode.Gate)
-                {
-                    status = ApplicationUpdateStagingStatus.ApplyStartupGateActionRequired;
-                    applyMessage = "Update applied, but startup gate action is required before normal mode.";
-                    failureMessage = null;
-                }
-                else if (!string.IsNullOrWhiteSpace(current.ReleaseTag) &&
-                         string.Equals(current.ReleaseTag, currentVersion, StringComparison.OrdinalIgnoreCase))
-                {
-                    status = ApplicationUpdateStagingStatus.ApplySucceeded;
-                    applyMessage = $"Update applied successfully. Installed version is now {currentVersion}.";
-                    failureMessage = null;
-                }
-                else
-                {
-                    status = ApplicationUpdateStagingStatus.Applying;
-                    applyMessage = "External updater reported success. Waiting for updated app metadata to reflect the staged release.";
-                }
+                status = ApplicationUpdateStagingStatus.ApplyStartupGateActionRequired;
+                applyMessage = "Update applied, but startup gate action is required before normal mode.";
+                failureMessage = null;
+            }
+            else if (currentVersionMatchesTarget)
+            {
+                status = ApplicationUpdateStagingStatus.ApplySucceeded;
+                applyMessage = $"Update applied successfully. Installed version is now {currentVersion}. Stale in-progress updater state was reconciled and cleared after confirming bootstrapper success.";
+                failureMessage = null;
+                _logger.LogInformation(
+                    "Application updater reconciled stale in-progress state as successful for release '{ReleaseTag}' because bootstrapper status reported success and current version is '{CurrentVersion}'.",
+                    current.ReleaseTag,
+                    currentVersion);
             }
             else
             {
-                status = ApplicationUpdateStagingStatus.ApplyFailed;
-                failureMessage = externalStatus.Error?.Message ?? "External updater reported failure.";
-                applyMessage = "Update apply failed. Review external updater status/log for details.";
+                status = ApplicationUpdateStagingStatus.Applying;
+                applyMessage = "External updater reported success. Waiting for updated app metadata to reflect the staged release.";
+                failureMessage = null;
             }
+        }
+        else if (isCompleted)
+        {
+            applyCompletedAtUtc = now;
+            status = ApplicationUpdateStagingStatus.ApplyFailed;
+            failureMessage = externalStatus.Error?.Message ?? "External updater reported failure.";
+            applyMessage = "Update apply failed. Review external updater status/log for details.";
+        }
+        else if (IsStaleInProgressState(current, statusPath, now))
+        {
+            status = ApplicationUpdateStagingStatus.ApplyInterruptedNeedsAttention;
+            failureMessage = "External updater status is still in progress and success cannot be confirmed. Review the bootstrapper status/log, then restage the release or retry apply when safe.";
+            applyMessage = "Update apply may have been interrupted. The updater is unlocked for recovery actions, but this update was not marked successful.";
         }
         else
         {
@@ -663,6 +677,39 @@ internal sealed class ApplicationUpdateApplyService : IApplicationUpdateApplySer
 
         await _stagingStateStore.WriteAsync(updated, cancellationToken);
         return updated;
+    }
+
+
+    private static bool IsCurrentVersionMatchingRelease(string? releaseTag, string? currentVersion)
+    {
+        if (string.IsNullOrWhiteSpace(releaseTag) || string.IsNullOrWhiteSpace(currentVersion))
+        {
+            return false;
+        }
+
+        if (string.Equals(releaseTag.Trim(), currentVersion.Trim(), StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return ReleaseVersionParser.TryParseReleaseVersion(releaseTag, out var targetReleaseVersion) &&
+               ReleaseVersionParser.TryParseReleaseVersion(currentVersion, out var currentReleaseVersion) &&
+               targetReleaseVersion.CompareTo(currentReleaseVersion) == 0;
+    }
+
+    private static bool IsStaleInProgressState(ApplicationUpdateStagingState state, string statusPath, DateTimeOffset now)
+    {
+        var lastProgressAt = state.LastUpdatedAtUtc;
+        if (File.Exists(statusPath))
+        {
+            var statusLastWrite = File.GetLastWriteTimeUtc(statusPath);
+            if (statusLastWrite > lastProgressAt.UtcDateTime)
+            {
+                lastProgressAt = new DateTimeOffset(statusLastWrite, TimeSpan.Zero);
+            }
+        }
+
+        return now - lastProgressAt >= StaleInProgressThreshold;
     }
 
     private static void ValidateApplyPrerequisites(ApplicationUpdateStagingState state, string stagedMetadataPath)

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateStagingModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdateStagingModels.cs
@@ -18,7 +18,8 @@ public enum ApplicationUpdateStagingStatus
     Applying = 11,
     ApplySucceeded = 12,
     ApplyFailed = 13,
-    ApplyStartupGateActionRequired = 14
+    ApplyStartupGateActionRequired = 14,
+    ApplyInterruptedNeedsAttention = 15
 }
 
 public sealed class ApplicationUpdateStagingState

--- a/src/WebApp/PingMonitor.Web/Views/AdminApplicationUpdater/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminApplicationUpdater/Index.cshtml
@@ -40,12 +40,17 @@
             _ => "status-ok"
         };
 
-        var stagedStatusClass = Model.StagedUpdate?.Status == PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.Ready
-            ? "status-ok"
-            : Model.StagedUpdate?.Status is PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.StagingInProgress
-                or PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.StagingBlocked
-                ? "status-warn"
-                : "status-error";
+        var stagedStatusClass = Model.StagedUpdate is null
+            ? "status-warn"
+            : Model.StagedUpdate.Status is PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.Ready
+                or PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.ApplySucceeded
+                ? "status-ok"
+                : Model.StagedUpdate.Status is PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.StagingInProgress
+                    or PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.StagingBlocked
+                    or PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.Applying
+                    or PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.ApplyInterruptedNeedsAttention
+                    ? "status-warn"
+                    : "status-error";
 
         var applyStatusClass = Model.StagedUpdate?.Status is PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.ApplySucceeded
             ? "status-ok"
@@ -55,7 +60,8 @@
 
         var checkHasError = Model.State == PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateCheckState.CheckFailed;
         var stageHasError = !string.IsNullOrWhiteSpace(Model.StagedUpdate?.FailureMessage) || Model.StagedUpdate?.Status == PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.StagingFailed;
-        var applyHasError = Model.StagedUpdate?.Status == PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.ApplyFailed;
+        var applyHasError = Model.StagedUpdate?.Status is PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.ApplyFailed
+            or PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.ApplyInterruptedNeedsAttention;
         var runtimeHasError = !string.IsNullOrWhiteSpace(Model.RuntimeState?.LastAutomaticCheckFailureMessage) || !string.IsNullOrWhiteSpace(Model.RuntimeState?.LastAutoStageFailureMessage);
         var schemaStatusClass = Model.SchemaCompatibilityState switch
         {
@@ -312,8 +318,26 @@
             else
             {
                 <div class="status @stagedStatusClass" role="status">Status: @Model.StagedUpdate.Status</div>
+                @if (Model.StagedUpdate.Status == PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.ApplySucceeded)
+                {
+                    <div class="status status-ok" role="status" style="margin-top:0.75rem;">Previous update succeeded. No update is currently staged for apply; run a new check/stage cycle for future updates.</div>
+                }
+                else if (Model.StagedUpdate.Status == PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.ApplyInterruptedNeedsAttention)
+                {
+                    <div class="status status-warn" role="status" style="margin-top:0.75rem;">Previous update failed or was interrupted and needs attention. The updater is unlocked for recovery actions, but the prior apply was not marked successful.</div>
+                }
+                else if (Model.StagedUpdate.Status == PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.Ready)
+                {
+                    <div class="status status-ok" role="status" style="margin-top:0.75rem;">Update staged and ready to apply.</div>
+                }
+                else if (Model.StagedUpdate.Status is PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.ApplyRequested
+                    or PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.ApplyHandoffStarted
+                    or PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.Applying)
+                {
+                    <div class="status status-warn" role="status" style="margin-top:0.75rem;">Update apply is in progress.</div>
+                }
                 <div class="summary-grid">
-                    <div><strong>Staged release tag:</strong> @(Model.StagedUpdate.ReleaseTag ?? "(none)")</div>
+                    <div><strong>Staged release tag:</strong> @(Model.StagedUpdate.Status == PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.ApplySucceeded ? "(none - previous update completed)" : (Model.StagedUpdate.ReleaseTag ?? "(none)"))</div>
                     <div><strong>Checksum verified:</strong> @(Model.StagedUpdate.ChecksumVerified ? "Yes" : "No")</div>
                     <div><strong>Ready to apply:</strong> @(Model.StagedUpdate.Status == PingMonitor.Web.Services.ApplicationUpdater.ApplicationUpdateStagingStatus.Ready ? "Yes" : "No")</div>
                 </div>


### PR DESCRIPTION
### Motivation
- The updater remained locked after a successful external apply because preserved on-disk apply state (`App_Data/Updater/state/staged-update.json`) and the bootstrapper status could leave the runtime believing an apply was still in-progress after the app restarted. This required manual deletion of `App_Data/Updater` to recover.
- The change reconciles on-post-restart state to automatically clear stale in-progress locks when success can be confirmed while preserving diagnostics and safety for genuinely interrupted or failed updates (no blind deletion).

### Description
- Add reconciliation logic in `ApplicationUpdateApplyService.RefreshApplyStateAsync` to consider external bootstrapper success plus the running app version: when bootstrapper reported success and the current application version matches the staged release tag, the staged state is marked `ApplySucceeded` and in-progress flags are cleared, with an informational log entry.  (See `ApplicationUpdateApplyService.cs`.)
- Introduce an explicit staging status `ApplyInterruptedNeedsAttention` so stale in-progress markers that cannot be confirmed as successful are surfaced as recoverable attention-needed state instead of silently blocking updates. (See `ApplicationUpdateStagingModels.cs`.)
- Update the updater admin page (`AdminApplicationUpdater/Index.cshtml`) to present distinct states and operator guidance for: no staged update, staged-ready, in-progress, previous update succeeded (and no update staged), and interrupted/needs-attention.
- Add unit tests that cover: completed/normal success mapping, reconciliation of stale in-progress success when current version matches release, marking stale unconfirmed in-progress as interrupted, and preserving fresh in-progress state.
- Add diagnostics doc `docs/diagnostics/2026-05-29-updater-lock-recovery.md` describing recovery behavior, safety conditions, and operator guidance.
- This change references issue: Fixes #487.

### Testing
- Ran the full unit test suite with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj`, and all tests passed (90 passed, 0 failed). 
- New regression tests added exercise the reconciliation and stale-state behaviors and passed as part of the test run.
- Performed static checks (`git diff --check`) and basic repository validation; no trailing whitespace or obvious diff-check failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f47cdea4832aa0e1279a49d85ec3)