### PR TITLE
[codex] Add network diagrams editor shell

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -309,6 +309,7 @@ Represents singleton control-plane settings managed from the admin page.
 - `defaultTimeoutMs`
 - `defaultFailureThreshold`
 - `defaultRecoveryThreshold`
+- `networkDiagramsEnabled` (default `false`; gates the placeholder Network diagrams UI)
 - `updatedAtUtc`
 
 ---

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -10,6 +10,7 @@ The authenticated top navigation uses dropdown menus with this structure:
   - Operational status → `/status`
   - Manage endpoints → `/endpoints`
   - Manage groups → `/groups` (Admin only)
+  - Network diagrams → `/network-diagrams` (Admin only, only when enabled)
 - **Agents** (Admin only)
   - Manage agents → `/agents`
   - Deploy new agent → `/agents/deploy`

--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -36,3 +36,36 @@ Network diagrams are visual documentation/status-overlay only. They must not alt
 - endpoint or assignment configuration
 
 Future diagram editor work must keep monitoring relationships separate from visual topology data.
+
+## Follow-up editor shell slice
+
+Issue: #493
+
+The next safe slice replaces the placeholder content at `/network-diagrams` with a basic editor shell while keeping the same feature gate.
+
+Included:
+
+- responsive full-height editor layout
+- top editor toolbar, left toolbox, main canvas, and bottom status bar
+- toolbox sections for monitored endpoints, custom devices, and notes
+- temporary client-side draft nodes for routers, switches, firewalls, servers, generic devices, and notes
+- pointer-event dragging for draft nodes within the visible canvas
+- `ResizeObserver` sizing for the canvas host
+
+Still excluded:
+
+- no saved diagrams yet
+- no diagram, node, or link database tables
+- no link drawing yet
+- no live monitored endpoint nodes yet
+- no endpoint monitoring, state evaluation, dependency suppression, alerting, or agent behaviour changes
+
+Manual regression checklist for the shell:
+
+- Open `/network-diagrams` at 1920x1080.
+- Open `/network-diagrams` at 1366x768.
+- Resize the browser smaller and larger.
+- Confirm the canvas fills available space without desktop page-level scrolling.
+- Confirm draft nodes can be added and dragged.
+- Confirm draft nodes stay within the visible workspace.
+- Confirm disabling `NetworkDiagramsEnabled` hides navigation and blocks direct access.

--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -1,0 +1,38 @@
+# Network diagrams V0.1.1 groundwork
+
+Issue: #492
+
+## Scope
+
+This first slice adds only the operational groundwork for future network diagrams:
+
+- an admin enable/disable setting: `NetworkDiagramsEnabled`
+- a gated placeholder page at `/network-diagrams`
+- a Monitoring navigation link shown only to admins when the setting is enabled
+- schema version 15, adding `ApplicationSettings.NetworkDiagramsEnabled`
+
+The feature flag defaults to `false`.
+
+## Explicit non-goals
+
+This slice does not add diagram storage or editing behavior.
+
+- no topology canvas
+- no node, link, or diagram tables
+- no endpoint drag/drop
+- no automatic topology discovery
+- no SNMP
+- no automatic endpoint creation
+- no automatic dependency creation
+
+## Monitoring safety
+
+Network diagrams are visual documentation/status-overlay only. They must not alter:
+
+- monitoring state
+- dependency suppression
+- alerting
+- agent behavior
+- endpoint or assignment configuration
+
+Future diagram editor work must keep monitoring relationships separate from visual topology data.

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -3,6 +3,7 @@ using PingMonitor.Web.Controllers;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.ViewModels.Admin;
+using PingMonitor.Web.ViewModels.NetworkDiagrams;
 using Xunit;
 
 namespace PingMonitor.Web.Tests;
@@ -66,7 +67,7 @@ public sealed class NetworkDiagramsFeatureTests
     }
 
     [Fact]
-    public async Task NetworkDiagramsIndex_ReturnsPlaceholderView_WhenFeatureEnabled()
+    public async Task NetworkDiagramsIndex_ReturnsEditorShellView_WhenFeatureEnabled()
     {
         var controller = new NetworkDiagramsController(new FakeApplicationSettingsService(
             new ApplicationSettingsDto { NetworkDiagramsEnabled = true }));
@@ -75,6 +76,51 @@ public sealed class NetworkDiagramsFeatureTests
 
         var view = Assert.IsType<ViewResult>(result);
         Assert.Equal("Index", view.ViewName);
+        var model = Assert.IsType<NetworkDiagramsEditorPageViewModel>(view.Model);
+        Assert.Equal("Network diagrams", model.PageTitle);
+        Assert.Equal(NetworkDiagramsEditorPageViewModel.DocumentationOnlyNotice, model.Notice);
+        Assert.False(model.LayoutIsSaved);
+    }
+
+    [Fact]
+    public void NetworkDiagramsIndex_ViewIncludesEditorShellElements()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var viewPath = Path.Combine(
+            repoRoot,
+            "src",
+            "WebApp",
+            "PingMonitor.Web",
+            "Views",
+            "NetworkDiagrams",
+            "Index.cshtml");
+
+        var viewMarkup = File.ReadAllText(viewPath);
+
+        Assert.Contains("data-network-diagram-editor", viewMarkup);
+        Assert.Contains("data-diagram-canvas-host", viewMarkup);
+        Assert.Contains("Network diagram toolbox", viewMarkup);
+        Assert.Contains("Layout is not saved yet", viewMarkup);
+        Assert.Contains("/js/network-diagrams-editor.js", viewMarkup);
+        Assert.Contains("/css/network-diagrams.css", viewMarkup);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "AGENTS.md")) &&
+                Directory.Exists(Path.Combine(directory.FullName, "src", "WebApp")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root.");
     }
 
     private sealed class FakeApplicationSettingsService : IApplicationSettingsService

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Controllers;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services;
+using PingMonitor.Web.ViewModels.Admin;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class NetworkDiagramsFeatureTests
+{
+    [Fact]
+    public void ApplicationSettings_DefaultsNetworkDiagramsDisabled()
+    {
+        var settings = new ApplicationSettings();
+
+        Assert.False(settings.NetworkDiagramsEnabled);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task AdminFeatureSettings_CanEnableAndDisableNetworkDiagrams(bool enabled)
+    {
+        var service = new FakeApplicationSettingsService(new ApplicationSettingsDto
+        {
+            SiteUrl = "https://ping.example",
+            DefaultPingIntervalSeconds = 60,
+            DefaultRetryIntervalSeconds = 5,
+            DefaultTimeoutMs = 1000,
+            DefaultFailureThreshold = 3,
+            DefaultRecoveryThreshold = 2,
+            DegradedEvaluationEnabled = true,
+            DegradedBaselineLookbackMinutes = 1440,
+            DegradedCurrentWindowMinutes = 60,
+            DegradedPacketLossIncreasePercentagePoints = 20d,
+            DegradedRttIncreasePercent = 20d,
+            DegradedJitterIncreasePercent = 20d,
+            DegradedMinimumSamples = 10,
+            NetworkDiagramsEnabled = !enabled,
+            UpdatedAtUtc = DateTimeOffset.UtcNow
+        });
+        var controller = new AdminController(service);
+
+        var result = await controller.SaveApplicationFeatures(
+            new ApplicationFeatureSettingsPageViewModel { NetworkDiagramsEnabled = enabled },
+            CancellationToken.None);
+
+        var view = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<ApplicationFeatureSettingsPageViewModel>(view.Model);
+        Assert.True(model.Saved);
+        Assert.Equal(enabled, model.NetworkDiagramsEnabled);
+        Assert.Equal(enabled, service.Current.NetworkDiagramsEnabled);
+    }
+
+    [Fact]
+    public async Task NetworkDiagramsIndex_ReturnsNotFound_WhenFeatureDisabled()
+    {
+        var controller = new NetworkDiagramsController(new FakeApplicationSettingsService(
+            new ApplicationSettingsDto { NetworkDiagramsEnabled = false }));
+
+        var result = await controller.Index(CancellationToken.None);
+
+        var notFound = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal("Network diagrams are not enabled.", notFound.Value);
+    }
+
+    [Fact]
+    public async Task NetworkDiagramsIndex_ReturnsPlaceholderView_WhenFeatureEnabled()
+    {
+        var controller = new NetworkDiagramsController(new FakeApplicationSettingsService(
+            new ApplicationSettingsDto { NetworkDiagramsEnabled = true }));
+
+        var result = await controller.Index(CancellationToken.None);
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Equal("Index", view.ViewName);
+    }
+
+    private sealed class FakeApplicationSettingsService : IApplicationSettingsService
+    {
+        public FakeApplicationSettingsService(ApplicationSettingsDto current)
+        {
+            Current = current;
+        }
+
+        public ApplicationSettingsDto Current { get; private set; }
+
+        public Task<ApplicationSettingsDto> GetCurrentAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Current);
+        }
+
+        public Task<ApplicationSettingsDto> UpdateAsync(UpdateApplicationSettingsCommand command, CancellationToken cancellationToken)
+        {
+            Current = new ApplicationSettingsDto
+            {
+                SiteUrl = command.SiteUrl,
+                DefaultPingIntervalSeconds = command.DefaultPingIntervalSeconds,
+                DefaultRetryIntervalSeconds = command.DefaultRetryIntervalSeconds,
+                DefaultTimeoutMs = command.DefaultTimeoutMs,
+                DefaultFailureThreshold = command.DefaultFailureThreshold,
+                DefaultRecoveryThreshold = command.DefaultRecoveryThreshold,
+                DegradedEvaluationEnabled = command.DegradedEvaluationEnabled,
+                DegradedBaselineLookbackMinutes = command.DegradedBaselineLookbackMinutes,
+                DegradedCurrentWindowMinutes = command.DegradedCurrentWindowMinutes,
+                DegradedPacketLossIncreasePercentagePoints = command.DegradedPacketLossIncreasePercentagePoints,
+                DegradedRttIncreasePercent = command.DegradedRttIncreasePercent,
+                DegradedJitterIncreasePercent = command.DegradedJitterIncreasePercent,
+                DegradedMinimumSamples = command.DegradedMinimumSamples,
+                NetworkDiagramsEnabled = command.NetworkDiagramsEnabled,
+                UpdatedAtUtc = DateTimeOffset.UtcNow
+            };
+
+            return Task.FromResult(Current);
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.Identity;
+using PingMonitor.Web.ViewModels.Admin;
 
 namespace PingMonitor.Web.Controllers;
 
@@ -8,9 +10,62 @@ namespace PingMonitor.Web.Controllers;
 [Route("admin")]
 public sealed class AdminController : Controller
 {
-    [HttpGet]
-    public IActionResult Index()
+    private readonly IApplicationSettingsService _applicationSettingsService;
+
+    public AdminController(IApplicationSettingsService applicationSettingsService)
     {
-        return View("Index");
+        _applicationSettingsService = applicationSettingsService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Index(CancellationToken cancellationToken)
+    {
+        var settings = await _applicationSettingsService.GetCurrentAsync(cancellationToken);
+        return View("Index", ToViewModel(settings, saved: false));
+    }
+
+    [HttpPost("application-features")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> SaveApplicationFeatures(
+        [FromForm] ApplicationFeatureSettingsPageViewModel model,
+        CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            return View("Index", model);
+        }
+
+        var current = await _applicationSettingsService.GetCurrentAsync(cancellationToken);
+        var updated = await _applicationSettingsService.UpdateAsync(
+            new UpdateApplicationSettingsCommand
+            {
+                SiteUrl = current.SiteUrl,
+                DefaultPingIntervalSeconds = current.DefaultPingIntervalSeconds,
+                DefaultRetryIntervalSeconds = current.DefaultRetryIntervalSeconds,
+                DefaultTimeoutMs = current.DefaultTimeoutMs,
+                DefaultFailureThreshold = current.DefaultFailureThreshold,
+                DefaultRecoveryThreshold = current.DefaultRecoveryThreshold,
+                DegradedEvaluationEnabled = current.DegradedEvaluationEnabled,
+                DegradedBaselineLookbackMinutes = current.DegradedBaselineLookbackMinutes,
+                DegradedCurrentWindowMinutes = current.DegradedCurrentWindowMinutes,
+                DegradedPacketLossIncreasePercentagePoints = current.DegradedPacketLossIncreasePercentagePoints,
+                DegradedRttIncreasePercent = current.DegradedRttIncreasePercent,
+                DegradedJitterIncreasePercent = current.DegradedJitterIncreasePercent,
+                DegradedMinimumSamples = current.DegradedMinimumSamples,
+                NetworkDiagramsEnabled = model.NetworkDiagramsEnabled
+            },
+            cancellationToken);
+
+        return View("Index", ToViewModel(updated, saved: true));
+    }
+
+    private static ApplicationFeatureSettingsPageViewModel ToViewModel(ApplicationSettingsDto settings, bool saved)
+    {
+        return new ApplicationFeatureSettingsPageViewModel
+        {
+            NetworkDiagramsEnabled = settings.NetworkDiagramsEnabled,
+            UpdatedAtUtc = settings.UpdatedAtUtc,
+            Saved = saved
+        };
     }
 }

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminDefaultEndpointValuesController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminDefaultEndpointValuesController.cs
@@ -49,7 +49,8 @@ public sealed class AdminDefaultEndpointValuesController : Controller
                 DegradedPacketLossIncreasePercentagePoints = model.DegradedPacketLossIncreasePercentagePoints,
                 DegradedRttIncreasePercent = model.DegradedRttIncreasePercent,
                 DegradedJitterIncreasePercent = model.DegradedJitterIncreasePercent,
-                DegradedMinimumSamples = model.DegradedMinimumSamples
+                DegradedMinimumSamples = model.DegradedMinimumSamples,
+                NetworkDiagramsEnabled = current.NetworkDiagramsEnabled
             },
             cancellationToken);
 

--- a/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AgentsController.cs
@@ -107,7 +107,8 @@ public sealed class AgentsController : Controller
                 DegradedPacketLossIncreasePercentagePoints = current.DegradedPacketLossIncreasePercentagePoints,
                 DegradedRttIncreasePercent = current.DegradedRttIncreasePercent,
                 DegradedJitterIncreasePercent = current.DegradedJitterIncreasePercent,
-                DegradedMinimumSamples = current.DegradedMinimumSamples
+                DegradedMinimumSamples = current.DegradedMinimumSamples,
+                NetworkDiagramsEnabled = current.NetworkDiagramsEnabled
             },
             cancellationToken);
 

--- a/src/WebApp/PingMonitor.Web/Controllers/NetworkDiagramsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/NetworkDiagramsController.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.Identity;
+
+namespace PingMonitor.Web.Controllers;
+
+[Authorize(Roles = ApplicationRoles.Admin)]
+[Route("network-diagrams")]
+public sealed class NetworkDiagramsController : Controller
+{
+    private readonly IApplicationSettingsService _applicationSettingsService;
+
+    public NetworkDiagramsController(IApplicationSettingsService applicationSettingsService)
+    {
+        _applicationSettingsService = applicationSettingsService;
+    }
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index(CancellationToken cancellationToken)
+    {
+        var settings = await _applicationSettingsService.GetCurrentAsync(cancellationToken);
+        if (!settings.NetworkDiagramsEnabled)
+        {
+            return NotFound("Network diagrams are not enabled.");
+        }
+
+        return View("Index");
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Controllers/NetworkDiagramsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/NetworkDiagramsController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.Identity;
+using PingMonitor.Web.ViewModels.NetworkDiagrams;
 
 namespace PingMonitor.Web.Controllers;
 
@@ -25,6 +26,6 @@ public sealed class NetworkDiagramsController : Controller
             return NotFound("Network diagrams are not enabled.");
         }
 
-        return View("Index");
+        return View("Index", new NetworkDiagramsEditorPageViewModel());
     }
 }

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -319,6 +319,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         appSettings.Property(x => x.DegradedRttIncreasePercent).IsRequired();
         appSettings.Property(x => x.DegradedJitterIncreasePercent).IsRequired();
         appSettings.Property(x => x.DegradedMinimumSamples).IsRequired();
+        appSettings.Property(x => x.NetworkDiagramsEnabled).IsRequired();
         appSettings.Property(x => x.UpdatedAtUtc).IsRequired();
 
         var notificationSettings = modelBuilder.Entity<NotificationSettings>();

--- a/src/WebApp/PingMonitor.Web/Models/ApplicationSettings.cs
+++ b/src/WebApp/PingMonitor.Web/Models/ApplicationSettings.cs
@@ -32,6 +32,8 @@ public sealed class ApplicationSettings
 
     public int DegradedMinimumSamples { get; set; } = 10;
 
+    public bool NetworkDiagramsEnabled { get; set; }
+
     public bool EnableAutomaticUpdateChecks { get; set; } = true;
 
     public int AutomaticUpdateCheckIntervalMinutes { get; set; } = 15;

--- a/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
@@ -5,6 +5,6 @@ public sealed class StartupGateOptions
     public const string SectionName = "StartupGate";
 
     public string StorageDirectory { get; set; } = "App_Data/StartupGate";
-    public int RequiredSchemaVersion { get; set; } = 14;
+    public int RequiredSchemaVersion { get; set; } = 15;
     public int DefaultMySqlPort { get; set; } = 3306;
 }

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationSettingsDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationSettingsDto.cs
@@ -15,5 +15,6 @@ public sealed class ApplicationSettingsDto
     public double DegradedRttIncreasePercent { get; init; } = 20d;
     public double DegradedJitterIncreasePercent { get; init; } = 20d;
     public int DegradedMinimumSamples { get; init; } = 10;
+    public bool NetworkDiagramsEnabled { get; init; }
     public DateTimeOffset UpdatedAtUtc { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationSettingsService.cs
@@ -45,6 +45,7 @@ internal sealed class ApplicationSettingsService : IApplicationSettingsService
         settings.DegradedRttIncreasePercent = command.DegradedRttIncreasePercent;
         settings.DegradedJitterIncreasePercent = command.DegradedJitterIncreasePercent;
         settings.DegradedMinimumSamples = command.DegradedMinimumSamples;
+        settings.NetworkDiagramsEnabled = command.NetworkDiagramsEnabled;
         settings.UpdatedAtUtc = DateTimeOffset.UtcNow;
 
         await _dbContext.SaveChangesAsync(cancellationToken);
@@ -77,6 +78,7 @@ internal sealed class ApplicationSettingsService : IApplicationSettingsService
             DegradedRttIncreasePercent = 20d,
             DegradedJitterIncreasePercent = 20d,
             DegradedMinimumSamples = 10,
+            NetworkDiagramsEnabled = false,
             EnableAutomaticUpdateChecks = _updaterOptions.EnableAutomaticUpdateChecks,
             AutomaticUpdateCheckIntervalMinutes = ResolveAutomaticCheckInterval(_updaterOptions.AutomaticUpdateCheckIntervalMinutes),
             AutomaticallyDownloadAndStageUpdates = _updaterOptions.AutomaticallyDownloadAndStageUpdates,
@@ -121,6 +123,7 @@ internal sealed class ApplicationSettingsService : IApplicationSettingsService
             DegradedRttIncreasePercent = settings.DegradedRttIncreasePercent,
             DegradedJitterIncreasePercent = settings.DegradedJitterIncreasePercent,
             DegradedMinimumSamples = settings.DegradedMinimumSamples,
+            NetworkDiagramsEnabled = settings.NetworkDiagramsEnabled,
             UpdatedAtUtc = settings.UpdatedAtUtc
         };
     }

--- a/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdaterOperationalSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/ApplicationUpdater/ApplicationUpdaterOperationalSettingsService.cs
@@ -69,6 +69,7 @@ internal sealed class ApplicationUpdaterOperationalSettingsService : IApplicatio
                 DegradedRttIncreasePercent = 20d,
                 DegradedJitterIncreasePercent = 20d,
                 DegradedMinimumSamples = 10,
+                NetworkDiagramsEnabled = false,
                 EnableAutomaticUpdateChecks = _updaterOptions.EnableAutomaticUpdateChecks,
                 AutomaticUpdateCheckIntervalMinutes = ResolveAutomaticCheckInterval(_updaterOptions.AutomaticUpdateCheckIntervalMinutes),
                 AutomaticallyDownloadAndStageUpdates = _updaterOptions.AutomaticallyDownloadAndStageUpdates,

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -94,6 +94,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "DegradedRttIncreasePercent",
         "DegradedJitterIncreasePercent",
         "DegradedMinimumSamples",
+        "NetworkDiagramsEnabled",
         "EnableAutomaticUpdateChecks",
         "AutomaticUpdateCheckIntervalMinutes",
         "AutomaticallyDownloadAndStageUpdates",
@@ -448,6 +449,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 `DegradedRttIncreasePercent` double NOT NULL DEFAULT 20,
                 `DegradedJitterIncreasePercent` double NOT NULL DEFAULT 20,
                 `DegradedMinimumSamples` int NOT NULL DEFAULT 10,
+                `NetworkDiagramsEnabled` tinyint(1) NOT NULL DEFAULT 0,
                 `EnableAutomaticUpdateChecks` tinyint(1) NOT NULL DEFAULT 1,
                 `AutomaticUpdateCheckIntervalMinutes` int NOT NULL DEFAULT 15,
                 `AutomaticallyDownloadAndStageUpdates` tinyint(1) NOT NULL DEFAULT 0,
@@ -1419,6 +1421,16 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 """
                 ALTER TABLE `ApplicationSettings`
                 ADD COLUMN `EnableAutomaticUpdateChecks` tinyint(1) NOT NULL DEFAULT 1;
+                """,
+                cancellationToken);
+        }
+
+        if (!await HasApplicationSettingsColumnAsync(connection, "NetworkDiagramsEnabled", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `ApplicationSettings`
+                ADD COLUMN `NetworkDiagramsEnabled` tinyint(1) NOT NULL DEFAULT 0;
                 """,
                 cancellationToken);
         }

--- a/src/WebApp/PingMonitor.Web/Services/UpdateApplicationSettingsCommand.cs
+++ b/src/WebApp/PingMonitor.Web/Services/UpdateApplicationSettingsCommand.cs
@@ -15,4 +15,5 @@ public sealed class UpdateApplicationSettingsCommand
     public double DegradedRttIncreasePercent { get; init; } = 20d;
     public double DegradedJitterIncreasePercent { get; init; } = 20d;
     public int DegradedMinimumSamples { get; init; } = 10;
+    public bool NetworkDiagramsEnabled { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/ApplicationFeatureSettingsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/ApplicationFeatureSettingsPageViewModel.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PingMonitor.Web.ViewModels.Admin;
+
+public sealed class ApplicationFeatureSettingsPageViewModel
+{
+    [Display(Name = "Enable network diagrams")]
+    public bool NetworkDiagramsEnabled { get; set; }
+
+    public bool Saved { get; set; }
+
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/NetworkDiagrams/NetworkDiagramsEditorPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/NetworkDiagrams/NetworkDiagramsEditorPageViewModel.cs
@@ -1,0 +1,13 @@
+namespace PingMonitor.Web.ViewModels.NetworkDiagrams;
+
+public sealed class NetworkDiagramsEditorPageViewModel
+{
+    public const string DocumentationOnlyNotice =
+        "Diagrams are documentation-only and do not alter monitoring state, dependencies, alerts, or agent behaviour.";
+
+    public string PageTitle { get; init; } = "Network diagrams";
+
+    public string Notice { get; init; } = DocumentationOnlyNotice;
+
+    public bool LayoutIsSaved { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
@@ -1,3 +1,4 @@
+@model PingMonitor.Web.ViewModels.Admin.ApplicationFeatureSettingsPageViewModel
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -6,14 +7,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Admin settings</title>
     <style>
-        :root { color-scheme: light; --bg:#f3f6f8; --card:#ffffff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; }
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#ffffff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; --success:#137333; --error-bg:#fee4e2; --error-text:#b42318; }
         * { box-sizing: border-box; }
         body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
         main { max-width: 760px; margin: 0 auto; padding: 1rem; }
         .stack { display: grid; gap: 1rem; }
         .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
         .button-row { display: flex; gap: .75rem; flex-wrap: wrap; }
-        .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 48px; padding: .8rem 1rem; border-radius: 10px; border: 1px solid var(--border); color: var(--text); background: white; font-weight: 600; text-decoration: none; }
+        .button, .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 48px; padding: .8rem 1rem; border-radius: 10px; font-weight: 600; text-decoration: none; }
+        .button { border: 0; color: #fff; background: var(--accent); cursor: pointer; }
+        .button-secondary { border: 1px solid var(--border); color: var(--text); background: white; }
+        .checkbox-row { display: flex; align-items: center; min-height: 44px; }
+        input[type="checkbox"] { width: auto; min-height: 0; transform: scale(1.2); margin-right: .5rem; }
+        .field-help { font-size: .9rem; color: var(--muted); margin: .25rem 0 0; }
+        .saved { border: 1px solid #c2f0c2; background: #ebffee; color: var(--success); border-radius: 10px; padding: .8rem; }
+        .errors { border: 1px solid #fda29b; background: var(--error-bg); color: var(--error-text); border-radius: 10px; padding: .8rem; }
         .muted { color: var(--muted); }
     </style>
 </head>
@@ -35,6 +43,28 @@
                 <a class="button-secondary" href="/admin/notification-infrastructure-settings">Notification infrastructure settings</a>
             </div>
         </section>
+
+        <form method="post" action="/admin/application-features" class="stack">
+            @Html.AntiForgeryToken()
+            @if (Model.Saved) { <div class="saved" role="status">Application feature settings saved successfully.</div> }
+            @if (!ViewData.ModelState.IsValid) { <div class="errors" asp-validation-summary="ModelOnly"></div> }
+
+            <section class="card">
+                <h2>Application features</h2>
+                <div>
+                    <div class="checkbox-row">
+                        <input asp-for="NetworkDiagramsEnabled" type="checkbox" />
+                        <input name="NetworkDiagramsEnabled" type="hidden" value="false" />
+                        <label asp-for="NetworkDiagramsEnabled"></label>
+                    </div>
+                    <p class="field-help">Allows admins to create and edit manually maintained network diagrams. Diagrams are visual documentation only and do not affect monitoring, dependencies, alerts, or agent behaviour.</p>
+                </div>
+                <p class="muted">Last updated: @await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.UpdatedAtUtc)</p>
+                <div class="button-row">
+                    <button class="button" type="submit">Save application features</button>
+                </div>
+            </section>
+        </form>
     </div>
 </main>
 </body>

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Index.cshtml
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    @await Html.PartialAsync("_ThemeHead")
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Network diagrams</title>
+    <style>
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; --panel:#eef4ff; }
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 960px; margin: 0 auto; padding: 1rem; }
+        .stack { display: grid; gap: 1rem; }
+        .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
+        .button-row { display: flex; gap: .75rem; flex-wrap: wrap; }
+        .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 48px; padding: .8rem 1rem; border-radius: 10px; border: 1px solid var(--border); color: var(--text); background: #fff; font-weight: 600; text-decoration: none; }
+        .muted { color: var(--muted); }
+        .placeholder-panel { border: 2px dashed var(--border); border-radius: 12px; background: var(--panel); min-height: 280px; display: grid; place-items: center; padding: 1rem; text-align: center; }
+        .placeholder-title { font-weight: 700; margin-bottom: .35rem; }
+        .note { border-left: 4px solid var(--accent); padding: .75rem 1rem; background: #fff; color: var(--text); }
+    </style>
+</head>
+<body>
+@await Html.PartialAsync("_AuthenticatedNav")
+<main>
+    <div class="stack">
+        <section class="card">
+            <h1>Network diagrams</h1>
+            <p class="muted">Network diagrams will allow monitored endpoints and custom devices to be placed on a manually maintained topology canvas.</p>
+            <div class="button-row">
+                <a class="button-secondary" href="/status">Back to status</a>
+            </div>
+        </section>
+
+        <section class="card">
+            <h2>Future diagram editor</h2>
+            <div class="placeholder-panel" aria-label="Future network diagram editor placeholder">
+                <div>
+                    <div class="placeholder-title">Diagram editor placeholder</div>
+                    <div class="muted">Canvas, node, and link editing will be added in a future slice.</div>
+                </div>
+            </div>
+        </section>
+
+        <section class="card note">
+            This feature is documentation-only and does not alter monitoring state, dependency suppression, alerting, or agent behaviour.
+        </section>
+    </div>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Index.cshtml
@@ -1,51 +1,71 @@
+@model PingMonitor.Web.ViewModels.NetworkDiagrams.NetworkDiagramsEditorPageViewModel
 <!DOCTYPE html>
 <html lang="en">
 <head>
     @await Html.PartialAsync("_ThemeHead")
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Network diagrams</title>
-    <style>
-        :root { color-scheme: light; --bg:#f3f6f8; --card:#fff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; --panel:#eef4ff; }
-        * { box-sizing: border-box; }
-        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
-        main { max-width: 960px; margin: 0 auto; padding: 1rem; }
-        .stack { display: grid; gap: 1rem; }
-        .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
-        .button-row { display: flex; gap: .75rem; flex-wrap: wrap; }
-        .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 48px; padding: .8rem 1rem; border-radius: 10px; border: 1px solid var(--border); color: var(--text); background: #fff; font-weight: 600; text-decoration: none; }
-        .muted { color: var(--muted); }
-        .placeholder-panel { border: 2px dashed var(--border); border-radius: 12px; background: var(--panel); min-height: 280px; display: grid; place-items: center; padding: 1rem; text-align: center; }
-        .placeholder-title { font-weight: 700; margin-bottom: .35rem; }
-        .note { border-left: 4px solid var(--accent); padding: .75rem 1rem; background: #fff; color: var(--text); }
-    </style>
+    <title>@Model.PageTitle</title>
+    <link rel="stylesheet" href="/css/network-diagrams.css" />
 </head>
 <body>
 @await Html.PartialAsync("_AuthenticatedNav")
-<main>
-    <div class="stack">
-        <section class="card">
-            <h1>Network diagrams</h1>
-            <p class="muted">Network diagrams will allow monitored endpoints and custom devices to be placed on a manually maintained topology canvas.</p>
-            <div class="button-row">
-                <a class="button-secondary" href="/status">Back to status</a>
+<main class="network-diagrams-main" data-network-diagram-editor>
+    <section class="diagram-editor-shell" aria-labelledby="network-diagrams-title">
+        <header class="diagram-editor-toolbar">
+            <div class="diagram-editor-heading">
+                <h1 id="network-diagrams-title">@Model.PageTitle</h1>
+                <p>@Model.Notice</p>
             </div>
-        </section>
+            <div class="diagram-editor-status" role="status" aria-live="polite">
+                <span class="status-pill status-pill-warning">Layout is not saved yet</span>
+            </div>
+        </header>
 
-        <section class="card">
-            <h2>Future diagram editor</h2>
-            <div class="placeholder-panel" aria-label="Future network diagram editor placeholder">
-                <div>
-                    <div class="placeholder-title">Diagram editor placeholder</div>
-                    <div class="muted">Canvas, node, and link editing will be added in a future slice.</div>
+        <div class="diagram-editor-layout">
+            <aside class="diagram-toolbox" aria-label="Network diagram toolbox">
+                <section class="toolbox-section" aria-labelledby="toolbox-endpoints-title">
+                    <h2 id="toolbox-endpoints-title">Monitored endpoints</h2>
+                    <p class="toolbox-placeholder">Endpoint placement will be connected in a later slice. No live monitoring data is shown here yet.</p>
+                </section>
+
+                <section class="toolbox-section" aria-labelledby="toolbox-devices-title">
+                    <h2 id="toolbox-devices-title">Custom devices</h2>
+                    <div class="toolbox-actions" aria-label="Add custom diagram node">
+                        <button type="button" data-add-node data-node-type="router" data-node-label="Router" data-node-symbol="RTR">Router</button>
+                        <button type="button" data-add-node data-node-type="switch" data-node-label="Switch" data-node-symbol="SW">Switch</button>
+                        <button type="button" data-add-node data-node-type="firewall" data-node-label="Firewall" data-node-symbol="FW">Firewall</button>
+                        <button type="button" data-add-node data-node-type="server" data-node-label="Server" data-node-symbol="SRV">Server</button>
+                        <button type="button" data-add-node data-node-type="generic-device" data-node-label="Generic device" data-node-symbol="DEV">Generic device</button>
+                    </div>
+                </section>
+
+                <section class="toolbox-section" aria-labelledby="toolbox-notes-title">
+                    <h2 id="toolbox-notes-title">Notes</h2>
+                    <div class="toolbox-actions">
+                        <button type="button" data-add-node data-node-type="note" data-node-label="Note" data-node-symbol="NOTE">Note</button>
+                    </div>
+                </section>
+            </aside>
+
+            <section class="diagram-workspace" aria-label="Network diagram workspace">
+                <div class="diagram-canvas-host" data-diagram-canvas-host>
+                    <div class="diagram-canvas" data-diagram-canvas role="application" aria-label="Draft network diagram canvas">
+                        <div class="diagram-empty-state" data-empty-state>
+                            Add a draft device from the toolbox.
+                        </div>
+                        <div class="diagram-node-layer" data-node-layer></div>
+                    </div>
                 </div>
-            </div>
-        </section>
+            </section>
+        </div>
 
-        <section class="card note">
-            This feature is documentation-only and does not alter monitoring state, dependency suppression, alerting, or agent behaviour.
-        </section>
-    </div>
+        <footer class="diagram-status-bar">
+            <span>Draft nodes are temporary client-side layout only.</span>
+            <span data-canvas-size>Canvas size pending</span>
+        </footer>
+    </section>
 </main>
+<script src="/js/network-diagrams-editor.js" defer></script>
 </body>
 </html>

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -1,7 +1,15 @@
 @using PingMonitor.Web.Services.Identity
+@inject PingMonitor.Web.Services.IApplicationSettingsService ApplicationSettingsService
 @{
     var path = Context?.Request?.Path.Value ?? string.Empty;
     var isAdmin = User.IsInRole(ApplicationRoles.Admin);
+    var networkDiagramsEnabled = false;
+    if (User.Identity?.IsAuthenticated == true)
+    {
+        var cancellationToken = Context?.RequestAborted ?? CancellationToken.None;
+        var applicationSettings = await ApplicationSettingsService.GetCurrentAsync(cancellationToken);
+        networkDiagramsEnabled = applicationSettings.NetworkDiagramsEnabled;
+    }
 
     static bool IsCurrent(string path, params string[] prefixes)
     {
@@ -16,7 +24,7 @@
         return false;
     }
 
-    var monitoringOpen = IsCurrent(path, "/", "/status", "/endpoints", "/groups");
+    var monitoringOpen = IsCurrent(path, "/", "/status", "/endpoints", "/groups", "/network-diagrams");
     var agentsOpen = IsCurrent(path, "/agents");
     var eventsOpen = IsCurrent(path, "/admin/security");
     var adminOpen = IsCurrent(path, "/admin", "/users", "/settings/notifications");
@@ -192,6 +200,10 @@
                 @if (isAdmin)
                 {
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/groups")" href="/groups">Manage groups</a>
+                }
+                @if (isAdmin && networkDiagramsEnabled)
+                {
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/network-diagrams")" href="/network-diagrams">Network diagrams</a>
                 }
             </div>
         </details>

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 14,
+    "RequiredSchemaVersion": 15,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 14,
+    "RequiredSchemaVersion": 15,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -1,0 +1,345 @@
+:root {
+    color-scheme: light;
+    --diagram-bg: #eef2f6;
+    --diagram-panel: #ffffff;
+    --diagram-panel-subtle: #f7f9fc;
+    --diagram-text: #102a43;
+    --diagram-muted: #52606d;
+    --diagram-border: #d9e2ec;
+    --diagram-accent: #0f62fe;
+    --diagram-accent-soft: #e8f0ff;
+    --diagram-warning: #b54708;
+    --diagram-warning-soft: #fff7e6;
+    --diagram-shadow: 0 1px 2px rgba(16, 24, 40, .08);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: var(--diagram-bg);
+    color: var(--diagram-text);
+    font-family: Arial, sans-serif;
+}
+
+.network-diagrams-main {
+    height: calc(100dvh - var(--network-diagrams-nav-height, 0px));
+    min-height: 0;
+    overflow: hidden;
+    padding: .75rem;
+}
+
+.diagram-editor-shell {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr) auto;
+    height: 100%;
+    min-height: 0;
+    min-width: 0;
+    border: 1px solid var(--diagram-border);
+    border-radius: 8px;
+    background: var(--diagram-panel);
+    box-shadow: var(--diagram-shadow);
+    overflow: hidden;
+}
+
+.diagram-editor-toolbar {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: .85rem 1rem;
+    border-bottom: 1px solid var(--diagram-border);
+    background: var(--diagram-panel);
+}
+
+.diagram-editor-heading {
+    min-width: 0;
+}
+
+.diagram-editor-heading h1 {
+    margin: 0;
+    font-size: 1.35rem;
+    line-height: 1.2;
+}
+
+.diagram-editor-heading p {
+    margin: .35rem 0 0 0;
+    max-width: 860px;
+    color: var(--diagram-muted);
+    font-size: .95rem;
+    line-height: 1.35;
+}
+
+.diagram-editor-status {
+    display: flex;
+    align-items: center;
+    min-height: 44px;
+}
+
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 32px;
+    padding: .35rem .65rem;
+    border-radius: 999px;
+    font-size: .86rem;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.status-pill-warning {
+    background: var(--diagram-warning-soft);
+    color: var(--diagram-warning);
+}
+
+.diagram-editor-layout {
+    display: grid;
+    grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+    min-height: 0;
+    min-width: 0;
+}
+
+.diagram-toolbox {
+    display: grid;
+    align-content: start;
+    gap: .8rem;
+    min-height: 0;
+    overflow-y: auto;
+    padding: .85rem;
+    border-right: 1px solid var(--diagram-border);
+    background: var(--diagram-panel-subtle);
+}
+
+.toolbox-section {
+    display: grid;
+    gap: .55rem;
+}
+
+.toolbox-section h2 {
+    margin: 0;
+    font-size: .92rem;
+    line-height: 1.25;
+}
+
+.toolbox-placeholder {
+    margin: 0;
+    color: var(--diagram-muted);
+    font-size: .9rem;
+    line-height: 1.35;
+}
+
+.toolbox-actions {
+    display: grid;
+    gap: .45rem;
+}
+
+.toolbox-actions button {
+    min-height: 44px;
+    width: 100%;
+    border: 1px solid var(--diagram-border);
+    border-radius: 8px;
+    background: var(--diagram-panel);
+    color: var(--diagram-text);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 700;
+    text-align: left;
+    padding: .65rem .75rem;
+}
+
+.toolbox-actions button:hover,
+.toolbox-actions button:focus-visible {
+    outline: none;
+    border-color: var(--diagram-accent);
+    box-shadow: 0 0 0 3px var(--diagram-accent-soft);
+}
+
+.diagram-workspace {
+    min-height: 0;
+    min-width: 0;
+    padding: .85rem;
+    background: #e8edf3;
+}
+
+.diagram-canvas-host {
+    position: relative;
+    height: 100%;
+    min-height: 0;
+    min-width: 0;
+    overflow: hidden;
+    border: 1px solid #c7d2df;
+    border-radius: 8px;
+    background:
+        linear-gradient(rgba(16, 42, 67, .055) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(16, 42, 67, .055) 1px, transparent 1px),
+        #fbfcff;
+    background-size: 24px 24px;
+}
+
+.diagram-canvas {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    min-height: 280px;
+    overflow: hidden;
+}
+
+.diagram-empty-state {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    padding: 1rem;
+    color: var(--diagram-muted);
+    font-weight: 700;
+    text-align: center;
+    pointer-events: none;
+}
+
+.diagram-empty-state[hidden] {
+    display: none;
+}
+
+.diagram-node-layer {
+    position: absolute;
+    inset: 0;
+}
+
+.diagram-node {
+    position: absolute;
+    left: 0;
+    top: 0;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: .55rem;
+    width: 178px;
+    min-height: 78px;
+    padding: .65rem;
+    border: 1px solid #b8c7d8;
+    border-radius: 8px;
+    background: var(--diagram-panel);
+    color: var(--diagram-text);
+    box-shadow: 0 3px 8px rgba(16, 24, 40, .13);
+    cursor: grab;
+    user-select: none;
+    touch-action: none;
+}
+
+.diagram-node:focus-visible {
+    outline: 3px solid var(--diagram-accent);
+    outline-offset: 2px;
+}
+
+.diagram-node[data-dragging="true"] {
+    cursor: grabbing;
+    box-shadow: 0 8px 18px rgba(16, 24, 40, .22);
+}
+
+.diagram-node-symbol {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    min-width: 42px;
+    height: 42px;
+    border-radius: 8px;
+    background: #ecfdf3;
+    color: #137333;
+    font-size: .76rem;
+    font-weight: 800;
+}
+
+.diagram-node-main {
+    min-width: 0;
+}
+
+.diagram-node-name {
+    display: block;
+    overflow-wrap: anywhere;
+    font-weight: 800;
+    line-height: 1.2;
+}
+
+.diagram-node-type {
+    display: block;
+    margin-top: .15rem;
+    color: var(--diagram-muted);
+    font-size: .82rem;
+    line-height: 1.25;
+    text-transform: capitalize;
+}
+
+.diagram-node-draft {
+    display: inline-flex;
+    align-items: center;
+    min-height: 22px;
+    margin-top: .35rem;
+    padding: .1rem .4rem;
+    border-radius: 999px;
+    background: var(--diagram-warning-soft);
+    color: var(--diagram-warning);
+    font-size: .76rem;
+    font-weight: 800;
+}
+
+.diagram-status-bar {
+    display: flex;
+    justify-content: space-between;
+    gap: .75rem;
+    min-height: 40px;
+    padding: .55rem .85rem;
+    border-top: 1px solid var(--diagram-border);
+    color: var(--diagram-muted);
+    font-size: .88rem;
+    background: var(--diagram-panel);
+}
+
+@media (max-width: 760px) {
+    .network-diagrams-main {
+        height: auto;
+        min-height: calc(100dvh - var(--network-diagrams-nav-height, 0px));
+        overflow: visible;
+        padding: .6rem;
+    }
+
+    .diagram-editor-shell {
+        min-height: calc(100dvh - var(--network-diagrams-nav-height, 0px) - 1.2rem);
+    }
+
+    .diagram-editor-toolbar,
+    .diagram-status-bar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .diagram-editor-status {
+        min-height: 0;
+    }
+
+    .diagram-editor-layout {
+        grid-template-columns: minmax(0, 1fr);
+        grid-template-rows: auto minmax(60vh, 1fr);
+    }
+
+    .diagram-toolbox {
+        max-height: none;
+        overflow: visible;
+        border-right: 0;
+        border-bottom: 1px solid var(--diagram-border);
+    }
+
+    .toolbox-actions {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .toolbox-actions button {
+        text-align: center;
+    }
+
+    .diagram-workspace {
+        min-height: 60vh;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
@@ -1,0 +1,236 @@
+(() => {
+    const editor = document.querySelector('[data-network-diagram-editor]');
+    if (!editor) {
+        return;
+    }
+
+    const nav = document.querySelector('.site-nav-shell');
+    const canvasHost = editor.querySelector('[data-diagram-canvas-host]');
+    const nodeLayer = editor.querySelector('[data-node-layer]');
+    const emptyState = editor.querySelector('[data-empty-state]');
+    const sizeLabel = editor.querySelector('[data-canvas-size]');
+    const addButtons = Array.from(editor.querySelectorAll('[data-add-node]'));
+
+    if (!canvasHost || !nodeLayer) {
+        return;
+    }
+
+    const nodes = [];
+    let nodeSequence = 0;
+    let dragState = null;
+
+    function updateNavHeight() {
+        const height = nav ? Math.ceil(nav.getBoundingClientRect().height) : 0;
+        document.documentElement.style.setProperty('--network-diagrams-nav-height', `${height}px`);
+    }
+
+    function getCanvasRect() {
+        return canvasHost.getBoundingClientRect();
+    }
+
+    function clamp(value, min, max) {
+        return Math.min(Math.max(value, min), Math.max(min, max));
+    }
+
+    function clampNodePosition(node) {
+        const rect = getCanvasRect();
+        const width = node.element.offsetWidth || 178;
+        const height = node.element.offsetHeight || 78;
+        const margin = 8;
+
+        node.x = clamp(node.x, margin, rect.width - width - margin);
+        node.y = clamp(node.y, margin, rect.height - height - margin);
+        node.element.style.transform = `translate(${Math.round(node.x)}px, ${Math.round(node.y)}px)`;
+    }
+
+    function clampAllNodes() {
+        nodes.forEach(clampNodePosition);
+    }
+
+    function updateCanvasSize() {
+        updateNavHeight();
+
+        const rect = getCanvasRect();
+        canvasHost.style.setProperty('--diagram-canvas-width', `${Math.round(rect.width)}px`);
+        canvasHost.style.setProperty('--diagram-canvas-height', `${Math.round(rect.height)}px`);
+
+        if (sizeLabel) {
+            sizeLabel.textContent = `${Math.round(rect.width)} x ${Math.round(rect.height)} canvas`;
+        }
+
+        clampAllNodes();
+    }
+
+    function formatNodeType(type) {
+        return type.replace(/-/g, ' ');
+    }
+
+    function setEmptyState() {
+        if (emptyState) {
+            emptyState.hidden = nodes.length > 0;
+        }
+    }
+
+    function createNodeElement(options) {
+        const node = document.createElement('div');
+        node.className = 'diagram-node';
+        node.tabIndex = 0;
+        node.setAttribute('role', 'button');
+        node.setAttribute('aria-label', `${options.label} draft ${formatNodeType(options.type)} node`);
+        node.dataset.nodeId = options.id;
+
+        const symbol = document.createElement('span');
+        symbol.className = 'diagram-node-symbol';
+        symbol.textContent = options.symbol;
+        symbol.setAttribute('aria-hidden', 'true');
+
+        const main = document.createElement('span');
+        main.className = 'diagram-node-main';
+
+        const name = document.createElement('span');
+        name.className = 'diagram-node-name';
+        name.textContent = options.label;
+
+        const type = document.createElement('span');
+        type.className = 'diagram-node-type';
+        type.textContent = formatNodeType(options.type);
+
+        const draft = document.createElement('span');
+        draft.className = 'diagram-node-draft';
+        draft.textContent = 'Draft';
+
+        main.append(name, type, draft);
+        node.append(symbol, main);
+        return node;
+    }
+
+    function addNode(button) {
+        const rect = getCanvasRect();
+        nodeSequence += 1;
+
+        const node = {
+            id: `draft-node-${nodeSequence}`,
+            x: 24 + ((nodeSequence - 1) % 6) * 28,
+            y: 24 + ((nodeSequence - 1) % 8) * 24,
+            element: createNodeElement({
+                id: `draft-node-${nodeSequence}`,
+                label: button.dataset.nodeLabel || 'Device',
+                type: button.dataset.nodeType || 'generic-device',
+                symbol: button.dataset.nodeSymbol || 'DEV'
+            })
+        };
+
+        nodeLayer.appendChild(node.element);
+        nodes.push(node);
+
+        node.x = clamp(node.x, 8, rect.width - node.element.offsetWidth - 8);
+        node.y = clamp(node.y, 8, rect.height - node.element.offsetHeight - 8);
+        clampNodePosition(node);
+        setEmptyState();
+        node.element.focus({ preventScroll: true });
+    }
+
+    function findNodeByElement(element) {
+        return nodes.find(node => node.element === element);
+    }
+
+    function startDrag(event) {
+        const target = event.target.closest('.diagram-node');
+        if (!target || !nodeLayer.contains(target)) {
+            return;
+        }
+
+        const node = findNodeByElement(target);
+        if (!node) {
+            return;
+        }
+
+        const rect = getCanvasRect();
+        dragState = {
+            node,
+            offsetX: event.clientX - rect.left - node.x,
+            offsetY: event.clientY - rect.top - node.y
+        };
+
+        target.dataset.dragging = 'true';
+        target.setPointerCapture(event.pointerId);
+        event.preventDefault();
+    }
+
+    function moveDrag(event) {
+        if (!dragState) {
+            return;
+        }
+
+        const rect = getCanvasRect();
+        dragState.node.x = event.clientX - rect.left - dragState.offsetX;
+        dragState.node.y = event.clientY - rect.top - dragState.offsetY;
+        clampNodePosition(dragState.node);
+        event.preventDefault();
+    }
+
+    function endDrag(event) {
+        if (!dragState) {
+            return;
+        }
+
+        dragState.node.element.dataset.dragging = 'false';
+        if (dragState.node.element.hasPointerCapture(event.pointerId)) {
+            dragState.node.element.releasePointerCapture(event.pointerId);
+        }
+        dragState = null;
+    }
+
+    function nudgeNode(event) {
+        const node = findNodeByElement(event.currentTarget);
+        if (!node) {
+            return;
+        }
+
+        const step = event.shiftKey ? 24 : 8;
+        let handled = true;
+
+        if (event.key === 'ArrowLeft') {
+            node.x -= step;
+        } else if (event.key === 'ArrowRight') {
+            node.x += step;
+        } else if (event.key === 'ArrowUp') {
+            node.y -= step;
+        } else if (event.key === 'ArrowDown') {
+            node.y += step;
+        } else {
+            handled = false;
+        }
+
+        if (handled) {
+            clampNodePosition(node);
+            event.preventDefault();
+        }
+    }
+
+    addButtons.forEach(button => {
+        button.addEventListener('click', () => addNode(button));
+    });
+
+    nodeLayer.addEventListener('pointerdown', startDrag);
+    nodeLayer.addEventListener('pointermove', moveDrag);
+    nodeLayer.addEventListener('pointerup', endDrag);
+    nodeLayer.addEventListener('pointercancel', endDrag);
+    nodeLayer.addEventListener('keydown', event => {
+        if (event.target instanceof HTMLElement && event.target.classList.contains('diagram-node')) {
+            nudgeNode(event);
+        }
+    });
+
+    const resizeObserver = 'ResizeObserver' in window
+        ? new ResizeObserver(updateCanvasSize)
+        : null;
+
+    if (resizeObserver) {
+        resizeObserver.observe(canvasHost);
+    }
+
+    window.addEventListener('resize', updateCanvasSize);
+    updateCanvasSize();
+    setEmptyState();
+})();


### PR DESCRIPTION
## Summary
- Replaces the gated Network diagrams placeholder with a responsive full-height editor shell.
- Adds a toolbox for monitored endpoints, custom devices, and notes.
- Adds temporary client-side draft nodes that can be added and dragged within the visible canvas.
- Keeps the slice UI-only: no diagram persistence, links, endpoint integration, schema changes, monitoring changes, dependency changes, alerting changes, or agent changes.

Fixes #493
Refs #492

## Regression barrier
- Extended `NetworkDiagramsFeatureTests` so disabled direct access still returns `404`, enabled access returns the editor view model, and the view includes the shell/canvas/toolbox asset hooks.
- Documented a manual responsive editor checklist in `docs/network-diagrams-v0.1.1.md`.

## Validation
- `dotnet build src\WebApp\PingMonitor.WebApp.slnx`
- `dotnet test src\WebApp\PingMonitor.Web.Tests\PingMonitor.Web.Tests.csproj` (102 passed)
- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-dev.ps1`
- Browser preview at 1366x768: no desktop page-level scroll; canvas filled available space; draft node added, dragged, and remained inside the workspace.

## UI screenshots
Captured locally for review, not committed:
- `artifacts/ui-check/network-diagrams-editor-1366x768.png`
- `artifacts/ui-check/network-diagrams-editor-1280x720.png`

## Manual checklist
- [x] Open editor at 1366x768.
- [x] Confirm canvas fills available space without desktop page-level scrolling.
- [x] Confirm nodes can be added and dragged.
- [x] Confirm nodes stay within the visible workspace.
- [x] Open editor at 1920x1080.
- [x] Resize browser smaller and larger in the authenticated app.
- [x] Confirm feature disabled hides nav and blocks direct access in the authenticated app.