### PR TITLE
Network diagrams editor: add monitored endpoint toolbox and client-side draft links

### DIFF
--- a/docs/network_diagrams_v_0_1_1_design_notes.md
+++ b/docs/network_diagrams_v_0_1_1_design_notes.md
@@ -411,3 +411,48 @@ V0.1.1 introduces optional manually managed network diagrams. Admins can enable 
 - Should endpoint state summary be endpoint-wide or assignment-selected per node?
 - Should link styling be simple text-only initially, or include selectable link types such as fibre, copper, wireless, trunk, and LAG?
 
+
+## Current editor slice: monitored endpoint placement and draft links
+
+This V0.1.1 editor slice keeps the current diagram editor client-side draft-only. It does not add diagram, node, or link persistence and it intentionally keeps the visible “Layout is not saved yet” messaging.
+
+Implemented in this slice:
+
+- The editor toolbox lists monitored endpoints visible through the existing endpoint query path.
+- Endpoint toolbox entries can be added to the draft canvas as monitored endpoint visual nodes.
+- Adding the same monitored endpoint more than once is allowed; each placement is a separate visual draft instance and does not create or update an endpoint.
+- Custom draft devices remain available and draggable.
+- Draw link mode lets users create basic client-side links between non-note nodes.
+- Draft links can be selected, deleted, and edited with basic label, source port, target port, and notes metadata.
+- Link labels and port text are rendered on the SVG link overlay when provided.
+- Links are documentation/status-overlay objects only.
+
+Still not implemented in this slice:
+
+- Saved diagrams or persisted layouts.
+- Automatic topology discovery.
+- SNMP discovery.
+- Automatic endpoint creation.
+- Automatic monitoring dependency creation.
+- Physical link-state detection.
+- Monitoring, dependency suppression, alerting, or agent behaviour changes.
+
+Diagram links must not be interpreted as monitoring dependencies or real physical link state. Deleting a diagram link removes only the draft visual link and must not alter endpoint dependencies, monitoring history, alerting, or agent configuration.
+
+### Manual regression checklist for endpoint placement and draft links
+
+1. Enable `NetworkDiagramsEnabled`.
+2. Open the editor at 1920x1080.
+3. Open the editor at 1366x768.
+4. Confirm monitored endpoints appear in the toolbox.
+5. Add a monitored endpoint to the canvas.
+6. Add a custom device to the canvas.
+7. Drag both nodes and confirm they remain within the visible canvas.
+8. Switch to Draw link mode.
+9. Draw a link between the monitored endpoint node and the custom device node.
+10. Drag nodes after creating the link and confirm the line follows the node positions.
+11. Select the link and edit label, source port, target port, and notes text.
+12. Confirm the link label and port text display on or near the line.
+13. Delete the selected link and confirm both nodes remain on the canvas.
+14. Confirm deleting the visual link does not alter endpoint dependencies.
+15. Disable `NetworkDiagramsEnabled` and confirm navigation, linked access, and direct page access are blocked.

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -1,7 +1,9 @@
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Controllers;
 using PingMonitor.Web.Models;
+using PingMonitor.Web.ViewModels.Endpoints;
 using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.Endpoints;
 using PingMonitor.Web.ViewModels.Admin;
 using PingMonitor.Web.ViewModels.NetworkDiagrams;
 using Xunit;
@@ -57,8 +59,9 @@ public sealed class NetworkDiagramsFeatureTests
     [Fact]
     public async Task NetworkDiagramsIndex_ReturnsNotFound_WhenFeatureDisabled()
     {
-        var controller = new NetworkDiagramsController(new FakeApplicationSettingsService(
-            new ApplicationSettingsDto { NetworkDiagramsEnabled = false }));
+        var controller = new NetworkDiagramsController(
+            new FakeApplicationSettingsService(new ApplicationSettingsDto { NetworkDiagramsEnabled = false }),
+            new FakeEndpointManagementQueryService());
 
         var result = await controller.Index(CancellationToken.None);
 
@@ -69,8 +72,17 @@ public sealed class NetworkDiagramsFeatureTests
     [Fact]
     public async Task NetworkDiagramsIndex_ReturnsEditorShellView_WhenFeatureEnabled()
     {
-        var controller = new NetworkDiagramsController(new FakeApplicationSettingsService(
-            new ApplicationSettingsDto { NetworkDiagramsEnabled = true }));
+        var controller = new NetworkDiagramsController(
+            new FakeApplicationSettingsService(new ApplicationSettingsDto { NetworkDiagramsEnabled = true }),
+            new FakeEndpointManagementQueryService(new ManageEndpointRowViewModel
+            {
+                AssignmentId = "assignment-1",
+                EndpointId = "endpoint-1",
+                EndpointName = "Core router",
+                Target = "192.0.2.1",
+                IconKey = "router",
+                CurrentState = EndpointStateKind.Up
+            }));
 
         var result = await controller.Index(CancellationToken.None);
 
@@ -80,6 +92,12 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Equal("Network diagrams", model.PageTitle);
         Assert.Equal(NetworkDiagramsEditorPageViewModel.DocumentationOnlyNotice, model.Notice);
         Assert.False(model.LayoutIsSaved);
+        var endpoint = Assert.Single(model.MonitoredEndpoints);
+        Assert.Equal("endpoint-1", endpoint.EndpointId);
+        Assert.Equal("Core router", endpoint.Name);
+        Assert.Equal("192.0.2.1", endpoint.Target);
+        Assert.Equal("router", endpoint.IconKey);
+        Assert.Equal(EndpointStateKind.Up, endpoint.SummaryState);
     }
 
     [Fact]
@@ -100,6 +118,11 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("data-network-diagram-editor", viewMarkup);
         Assert.Contains("data-diagram-canvas-host", viewMarkup);
         Assert.Contains("Network diagram toolbox", viewMarkup);
+        Assert.Contains("Monitored endpoints", viewMarkup);
+        Assert.Contains("data-add-endpoint-node", viewMarkup);
+        Assert.Contains("Draw link", viewMarkup);
+        Assert.Contains("Diagram links are visual documentation only and do not create monitoring dependencies.", viewMarkup);
+        Assert.Contains("data-link-properties", viewMarkup);
         Assert.Contains("Layout is not saved yet", viewMarkup);
         Assert.Contains("/js/network-diagrams-editor.js", viewMarkup);
         Assert.Contains("/css/network-diagrams.css", viewMarkup);
@@ -121,6 +144,31 @@ public sealed class NetworkDiagramsFeatureTests
         }
 
         throw new InvalidOperationException("Could not locate repository root.");
+    }
+
+    private sealed class FakeEndpointManagementQueryService : IEndpointManagementQueryService
+    {
+        private readonly IReadOnlyList<ManageEndpointRowViewModel> _rows;
+
+        public FakeEndpointManagementQueryService(params ManageEndpointRowViewModel[] rows)
+        {
+            _rows = rows;
+        }
+
+        public Task<ManageEndpointsPageViewModel> GetManagePageAsync(string? groupId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new ManageEndpointsPageViewModel { Rows = _rows });
+        }
+
+        public Task<EditEndpointOptionsViewModel> GetEditOptionsAsync(string assignmentId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new EditEndpointOptionsViewModel());
+        }
+
+        public Task<RemoveEndpointDetails?> GetRemoveDetailsAsync(string assignmentId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<RemoveEndpointDetails?>(null);
+        }
     }
 
     private sealed class FakeApplicationSettingsService : IApplicationSettingsService

--- a/src/WebApp/PingMonitor.Web/Controllers/NetworkDiagramsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/NetworkDiagramsController.cs
@@ -1,7 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Models;
 using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.Endpoints;
 using PingMonitor.Web.Services.Identity;
+using PingMonitor.Web.ViewModels.Endpoints;
 using PingMonitor.Web.ViewModels.NetworkDiagrams;
 
 namespace PingMonitor.Web.Controllers;
@@ -11,10 +14,14 @@ namespace PingMonitor.Web.Controllers;
 public sealed class NetworkDiagramsController : Controller
 {
     private readonly IApplicationSettingsService _applicationSettingsService;
+    private readonly IEndpointManagementQueryService _endpointManagementQueryService;
 
-    public NetworkDiagramsController(IApplicationSettingsService applicationSettingsService)
+    public NetworkDiagramsController(
+        IApplicationSettingsService applicationSettingsService,
+        IEndpointManagementQueryService endpointManagementQueryService)
     {
         _applicationSettingsService = applicationSettingsService;
+        _endpointManagementQueryService = endpointManagementQueryService;
     }
 
     [HttpGet("")]
@@ -26,6 +33,67 @@ public sealed class NetworkDiagramsController : Controller
             return NotFound("Network diagrams are not enabled.");
         }
 
-        return View("Index", new NetworkDiagramsEditorPageViewModel());
+        var endpoints = await _endpointManagementQueryService.GetManagePageAsync(groupId: null, cancellationToken);
+
+        return View("Index", new NetworkDiagramsEditorPageViewModel
+        {
+            MonitoredEndpoints = BuildEndpointToolbox(endpoints.Rows)
+        });
+    }
+
+    private static IReadOnlyList<NetworkDiagramEndpointToolboxItemViewModel> BuildEndpointToolbox(
+        IReadOnlyList<ManageEndpointRowViewModel> rows)
+    {
+        return rows
+            .GroupBy(row => row.EndpointId, StringComparer.Ordinal)
+            .Select(group =>
+            {
+                var first = group.OrderBy(row => row.EndpointName, StringComparer.OrdinalIgnoreCase)
+                    .ThenBy(row => row.Target, StringComparer.OrdinalIgnoreCase)
+                    .First();
+
+                return new NetworkDiagramEndpointToolboxItemViewModel
+                {
+                    EndpointId = first.EndpointId,
+                    Name = first.EndpointName,
+                    Target = first.Target,
+                    IconKey = first.IconKey,
+                    SummaryState = SelectSummaryState(group.Select(row => row.CurrentState))
+                };
+            })
+            .OrderBy(item => item.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(item => item.Target, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static EndpointStateKind SelectSummaryState(IEnumerable<EndpointStateKind> states)
+    {
+        var summary = EndpointStateKind.Unknown;
+        var priority = -1;
+
+        foreach (var state in states)
+        {
+            var statePriority = GetSummaryPriority(state);
+            if (statePriority > priority)
+            {
+                summary = state;
+                priority = statePriority;
+            }
+        }
+
+        return summary;
+    }
+
+    private static int GetSummaryPriority(EndpointStateKind state)
+    {
+        return state switch
+        {
+            EndpointStateKind.Down => 4,
+            EndpointStateKind.Suppressed => 3,
+            EndpointStateKind.Degraded => 2,
+            EndpointStateKind.Unknown => 1,
+            EndpointStateKind.Up => 0,
+            _ => 1
+        };
     }
 }

--- a/src/WebApp/PingMonitor.Web/ViewModels/NetworkDiagrams/NetworkDiagramsEditorPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/NetworkDiagrams/NetworkDiagramsEditorPageViewModel.cs
@@ -1,3 +1,5 @@
+using PingMonitor.Web.Models;
+
 namespace PingMonitor.Web.ViewModels.NetworkDiagrams;
 
 public sealed class NetworkDiagramsEditorPageViewModel
@@ -10,4 +12,19 @@ public sealed class NetworkDiagramsEditorPageViewModel
     public string Notice { get; init; } = DocumentationOnlyNotice;
 
     public bool LayoutIsSaved { get; init; }
+
+    public IReadOnlyList<NetworkDiagramEndpointToolboxItemViewModel> MonitoredEndpoints { get; init; } = [];
+}
+
+public sealed class NetworkDiagramEndpointToolboxItemViewModel
+{
+    public string EndpointId { get; init; } = string.Empty;
+
+    public string Name { get; init; } = string.Empty;
+
+    public string Target { get; init; } = string.Empty;
+
+    public string IconKey { get; init; } = "generic";
+
+    public EndpointStateKind SummaryState { get; init; } = EndpointStateKind.Unknown;
 }

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Index.cshtml
@@ -16,6 +16,7 @@
             <div class="diagram-editor-heading">
                 <h1 id="network-diagrams-title">@Model.PageTitle</h1>
                 <p>@Model.Notice</p>
+                <p class="diagram-documentation-note">Diagram links are visual documentation only and do not create monitoring dependencies.</p>
             </div>
             <div class="diagram-editor-status" role="status" aria-live="polite">
                 <span class="status-pill status-pill-warning">Layout is not saved yet</span>
@@ -26,7 +27,41 @@
             <aside class="diagram-toolbox" aria-label="Network diagram toolbox">
                 <section class="toolbox-section" aria-labelledby="toolbox-endpoints-title">
                     <h2 id="toolbox-endpoints-title">Monitored endpoints</h2>
-                    <p class="toolbox-placeholder">Endpoint placement will be connected in a later slice. No live monitoring data is shown here yet.</p>
+                    @if (Model.MonitoredEndpoints.Count == 0)
+                    {
+                        <p class="toolbox-placeholder">No monitored endpoints are available to place on this draft canvas.</p>
+                    }
+                    else
+                    {
+                        <p class="toolbox-help">Use Add to place another visual instance of an endpoint on the draft canvas.</p>
+                        <div class="endpoint-toolbox-list" data-endpoint-toolbox-list>
+                            @foreach (var endpoint in Model.MonitoredEndpoints)
+                            {
+                                <article class="endpoint-toolbox-item">
+                                    <div class="endpoint-toolbox-main">
+                                        <span class="endpoint-toolbox-icon" aria-hidden="true">@endpoint.IconKey</span>
+                                        <span class="endpoint-toolbox-text">
+                                            <strong>@endpoint.Name</strong>
+                                            @if (!string.IsNullOrWhiteSpace(endpoint.Target))
+                                            {
+                                                <span>@endpoint.Target</span>
+                                            }
+                                            <span class="endpoint-toolbox-state">State: @endpoint.SummaryState</span>
+                                        </span>
+                                    </div>
+                                    <button type="button"
+                                            data-add-endpoint-node
+                                            data-endpoint-id="@endpoint.EndpointId"
+                                            data-endpoint-name="@endpoint.Name"
+                                            data-endpoint-target="@endpoint.Target"
+                                            data-endpoint-icon="@endpoint.IconKey"
+                                            data-endpoint-state="@endpoint.SummaryState">
+                                        Add
+                                    </button>
+                                </article>
+                            }
+                        </div>
+                    }
                 </section>
 
                 <section class="toolbox-section" aria-labelledby="toolbox-devices-title">
@@ -49,19 +84,52 @@
             </aside>
 
             <section class="diagram-workspace" aria-label="Network diagram workspace">
+                <div class="diagram-workspace-toolbar" aria-label="Network diagram tools">
+                    <button type="button" class="diagram-tool-button" data-tool-button="select" aria-pressed="true">Select / move</button>
+                    <button type="button" class="diagram-tool-button" data-tool-button="draw-link" aria-pressed="false">Draw link</button>
+                    <span class="diagram-tool-hint" data-tool-hint>Select nodes to move them. Draw link mode creates documentation-only links.</span>
+                </div>
                 <div class="diagram-canvas-host" data-diagram-canvas-host>
                     <div class="diagram-canvas" data-diagram-canvas role="application" aria-label="Draft network diagram canvas">
                         <div class="diagram-empty-state" data-empty-state>
-                            Add a draft device from the toolbox.
+                            Add a monitored endpoint or draft device from the toolbox.
                         </div>
+                        <svg class="diagram-link-layer" data-link-layer aria-hidden="true"></svg>
                         <div class="diagram-node-layer" data-node-layer></div>
                     </div>
                 </div>
             </section>
+
+            <aside class="diagram-properties" aria-label="Diagram selection properties">
+                <h2>Properties</h2>
+                <div data-no-selection-panel>
+                    <p>Select a visual link to edit its draft label, ports, or notes.</p>
+                </div>
+                <form class="link-properties" data-link-properties hidden>
+                    <p class="toolbox-help">Selected link metadata is client-side draft documentation only.</p>
+                    <label>
+                        Link label
+                        <input type="text" data-link-field="label" maxlength="80" />
+                    </label>
+                    <label>
+                        Source port
+                        <input type="text" data-link-field="sourcePort" maxlength="80" />
+                    </label>
+                    <label>
+                        Target port
+                        <input type="text" data-link-field="targetPort" maxlength="80" />
+                    </label>
+                    <label>
+                        Notes
+                        <textarea data-link-field="notes" rows="4" maxlength="400"></textarea>
+                    </label>
+                    <button type="button" class="danger-button" data-delete-link>Delete selected link</button>
+                </form>
+            </aside>
         </div>
 
         <footer class="diagram-status-bar">
-            <span>Draft nodes are temporary client-side layout only.</span>
+            <span>Draft nodes and links are temporary client-side layout only.</span>
             <span data-canvas-size>Canvas size pending</span>
         </footer>
     </section>

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -343,3 +343,315 @@ body {
         min-height: 60vh;
     }
 }
+
+.diagram-documentation-note {
+    color: var(--diagram-warning) !important;
+    font-weight: 700;
+}
+
+.diagram-editor-layout {
+    grid-template-columns: minmax(230px, 300px) minmax(0, 1fr) minmax(220px, 280px);
+}
+
+.toolbox-help {
+    margin: 0;
+    color: var(--diagram-muted);
+    font-size: .84rem;
+    line-height: 1.35;
+}
+
+.endpoint-toolbox-list {
+    display: grid;
+    gap: .55rem;
+}
+
+.endpoint-toolbox-item {
+    display: grid;
+    gap: .55rem;
+    padding: .65rem;
+    border: 1px solid var(--diagram-border);
+    border-radius: 8px;
+    background: var(--diagram-panel);
+}
+
+.endpoint-toolbox-main {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: .55rem;
+    align-items: start;
+}
+
+.endpoint-toolbox-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    min-width: 40px;
+    height: 40px;
+    border-radius: 8px;
+    background: #e8f0ff;
+    color: #0f62fe;
+    font-size: .68rem;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.endpoint-toolbox-text {
+    display: grid;
+    gap: .15rem;
+    min-width: 0;
+    color: var(--diagram-muted);
+    font-size: .82rem;
+    line-height: 1.25;
+}
+
+.endpoint-toolbox-text strong {
+    color: var(--diagram-text);
+    overflow-wrap: anywhere;
+}
+
+.endpoint-toolbox-state {
+    font-weight: 700;
+}
+
+.endpoint-toolbox-item button,
+.diagram-tool-button,
+.link-properties button,
+.danger-button {
+    min-height: 44px;
+    border: 1px solid var(--diagram-border);
+    border-radius: 8px;
+    background: var(--diagram-panel);
+    color: var(--diagram-text);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 700;
+    padding: .55rem .7rem;
+}
+
+.endpoint-toolbox-item button:hover,
+.endpoint-toolbox-item button:focus-visible,
+.diagram-tool-button:hover,
+.diagram-tool-button:focus-visible,
+.link-properties button:hover,
+.link-properties button:focus-visible {
+    outline: none;
+    border-color: var(--diagram-accent);
+    box-shadow: 0 0 0 3px var(--diagram-accent-soft);
+}
+
+.diagram-workspace {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    gap: .65rem;
+}
+
+.diagram-workspace-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: .5rem;
+}
+
+.diagram-tool-button[aria-pressed="true"] {
+    border-color: var(--diagram-accent);
+    background: var(--diagram-accent-soft);
+    color: var(--diagram-accent);
+}
+
+.diagram-tool-hint {
+    color: var(--diagram-muted);
+    font-size: .85rem;
+    line-height: 1.35;
+}
+
+.diagram-link-layer {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    overflow: visible;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.diagram-node-layer {
+    z-index: 2;
+}
+
+.diagram-link-hit {
+    pointer-events: stroke;
+    stroke: transparent;
+    stroke-width: 18;
+    cursor: pointer;
+}
+
+.diagram-link-line {
+    pointer-events: none;
+    stroke: #475467;
+    stroke-width: 3;
+    stroke-linecap: round;
+}
+
+.diagram-link-group[data-selected="true"] .diagram-link-line {
+    stroke: var(--diagram-accent);
+    stroke-width: 4;
+}
+
+.diagram-link-label,
+.diagram-link-port-label {
+    pointer-events: none;
+    fill: var(--diagram-text);
+    paint-order: stroke;
+    stroke: var(--diagram-panel);
+    stroke-width: 4px;
+    stroke-linejoin: round;
+    font-size: 12px;
+    font-weight: 800;
+}
+
+.diagram-link-port-label {
+    fill: var(--diagram-muted);
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.diagram-node[data-node-kind="monitored-endpoint"] {
+    border-color: #7aa7ff;
+    background: linear-gradient(180deg, #ffffff 0%, #f4f8ff 100%);
+}
+
+.diagram-node[data-selected="true"] {
+    border-color: var(--diagram-accent);
+    box-shadow: 0 0 0 3px var(--diagram-accent-soft), 0 3px 8px rgba(16, 24, 40, .13);
+}
+
+.diagram-node[data-link-pending="true"] {
+    outline: 3px solid var(--diagram-warning);
+    outline-offset: 2px;
+}
+
+.diagram-node-target {
+    display: block;
+    margin-top: .15rem;
+    color: var(--diagram-muted);
+    font-size: .78rem;
+    line-height: 1.25;
+    overflow-wrap: anywhere;
+}
+
+.diagram-properties {
+    min-height: 0;
+    overflow-y: auto;
+    padding: .85rem;
+    border-left: 1px solid var(--diagram-border);
+    background: var(--diagram-panel-subtle);
+}
+
+.diagram-properties h2 {
+    margin: 0 0 .65rem 0;
+    font-size: .92rem;
+}
+
+.diagram-properties p {
+    margin: 0;
+    color: var(--diagram-muted);
+    font-size: .9rem;
+    line-height: 1.35;
+}
+
+.link-properties {
+    display: grid;
+    gap: .65rem;
+}
+
+.link-properties[hidden] {
+    display: none;
+}
+
+.link-properties label {
+    display: grid;
+    gap: .25rem;
+    color: var(--diagram-muted);
+    font-size: .84rem;
+    font-weight: 700;
+}
+
+.link-properties input,
+.link-properties textarea {
+    width: 100%;
+    border: 1px solid var(--diagram-border);
+    border-radius: 8px;
+    background: var(--diagram-panel);
+    color: var(--diagram-text);
+    font: inherit;
+    padding: .55rem .6rem;
+}
+
+.danger-button {
+    border-color: #f3b3b3;
+    background: #fff5f5;
+    color: #b42318;
+}
+
+html[data-theme="dark"] {
+    color-scheme: dark;
+    --diagram-bg: #111827;
+    --diagram-panel: #1f2937;
+    --diagram-panel-subtle: #172033;
+    --diagram-text: #f9fafb;
+    --diagram-muted: #cbd5e1;
+    --diagram-border: #374151;
+    --diagram-accent: #8ab4ff;
+    --diagram-accent-soft: rgba(138, 180, 255, .18);
+    --diagram-warning: #fbbf24;
+    --diagram-warning-soft: rgba(251, 191, 36, .16);
+    --diagram-shadow: none;
+}
+
+html[data-theme="dark"] .diagram-workspace {
+    background: #111827;
+}
+
+html[data-theme="dark"] .diagram-canvas-host {
+    border-color: #374151;
+    background:
+        linear-gradient(rgba(203, 213, 225, .08) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(203, 213, 225, .08) 1px, transparent 1px),
+        #0f172a;
+    background-size: 24px 24px;
+}
+
+html[data-theme="dark"] .diagram-node[data-node-kind="monitored-endpoint"] {
+    background: linear-gradient(180deg, #1f2937 0%, #172554 100%);
+}
+
+html[data-theme="dark"] .diagram-link-line {
+    stroke: #cbd5e1;
+}
+
+html[data-theme="dark"] .diagram-link-label,
+html[data-theme="dark"] .diagram-link-port-label {
+    stroke: #1f2937;
+}
+
+@media (max-width: 980px) {
+    .diagram-editor-layout {
+        grid-template-columns: minmax(0, 1fr);
+        grid-template-rows: auto minmax(60vh, 1fr) auto;
+    }
+
+    .diagram-toolbox,
+    .diagram-properties {
+        max-height: none;
+        overflow: visible;
+        border-right: 0;
+        border-left: 0;
+        border-bottom: 1px solid var(--diagram-border);
+    }
+
+    .diagram-properties {
+        border-top: 1px solid var(--diagram-border);
+        border-bottom: 0;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
@@ -4,32 +4,54 @@
         return;
     }
 
-    const nav = document.querySelector('.site-nav-shell');
+    const nav = document.querySelector('.site-nav');
     const canvasHost = editor.querySelector('[data-diagram-canvas-host]');
+    const canvas = editor.querySelector('[data-diagram-canvas]');
     const nodeLayer = editor.querySelector('[data-node-layer]');
+    const linkLayer = editor.querySelector('[data-link-layer]');
     const emptyState = editor.querySelector('[data-empty-state]');
     const sizeLabel = editor.querySelector('[data-canvas-size]');
     const addButtons = Array.from(editor.querySelectorAll('[data-add-node]'));
+    const addEndpointButtons = Array.from(editor.querySelectorAll('[data-add-endpoint-node]'));
+    const toolButtons = Array.from(editor.querySelectorAll('[data-tool-button]'));
+    const toolHint = editor.querySelector('[data-tool-hint]');
+    const linkProperties = editor.querySelector('[data-link-properties]');
+    const noSelectionPanel = editor.querySelector('[data-no-selection-panel]');
+    const deleteLinkButton = editor.querySelector('[data-delete-link]');
+    const linkFields = Array.from(editor.querySelectorAll('[data-link-field]'));
 
-    if (!canvasHost || !nodeLayer) {
+    if (!canvasHost || !canvas || !nodeLayer || !linkLayer) {
         return;
     }
 
-    const nodes = [];
+    const state = {
+        nodes: [],
+        links: [],
+        selectedNodeId: null,
+        selectedLinkId: null,
+        currentTool: 'select'
+    };
+
     let nodeSequence = 0;
+    let linkSequence = 0;
     let dragState = null;
+    let pendingLinkSourceId = null;
 
     function updateNavHeight() {
-        const height = nav ? Math.ceil(nav.getBoundingClientRect().height) : 0;
+        const height = nav ? nav.getBoundingClientRect().height : 0;
         document.documentElement.style.setProperty('--network-diagrams-nav-height', `${height}px`);
     }
 
     function getCanvasRect() {
-        return canvasHost.getBoundingClientRect();
+        return canvas.getBoundingClientRect();
     }
 
     function clamp(value, min, max) {
-        return Math.min(Math.max(value, min), Math.max(min, max));
+        if (max < min) {
+            return min;
+        }
+
+        return Math.min(Math.max(value, min), max);
     }
 
     function clampNodePosition(node) {
@@ -41,10 +63,11 @@
         node.x = clamp(node.x, margin, rect.width - width - margin);
         node.y = clamp(node.y, margin, rect.height - height - margin);
         node.element.style.transform = `translate(${Math.round(node.x)}px, ${Math.round(node.y)}px)`;
+        renderLinks();
     }
 
     function clampAllNodes() {
-        nodes.forEach(clampNodePosition);
+        state.nodes.forEach(clampNodePosition);
     }
 
     function updateCanvasSize() {
@@ -53,12 +76,14 @@
         const rect = getCanvasRect();
         canvasHost.style.setProperty('--diagram-canvas-width', `${Math.round(rect.width)}px`);
         canvasHost.style.setProperty('--diagram-canvas-height', `${Math.round(rect.height)}px`);
+        linkLayer.setAttribute('viewBox', `0 0 ${Math.max(1, Math.round(rect.width))} ${Math.max(1, Math.round(rect.height))}`);
 
         if (sizeLabel) {
             sizeLabel.textContent = `${Math.round(rect.width)} x ${Math.round(rect.height)} canvas`;
         }
 
         clampAllNodes();
+        renderLinks();
     }
 
     function formatNodeType(type) {
@@ -67,7 +92,7 @@
 
     function setEmptyState() {
         if (emptyState) {
-            emptyState.hidden = nodes.length > 0;
+            emptyState.hidden = state.nodes.length > 0;
         }
     }
 
@@ -78,6 +103,7 @@
         node.setAttribute('role', 'button');
         node.setAttribute('aria-label', `${options.label} draft ${formatNodeType(options.type)} node`);
         node.dataset.nodeId = options.id;
+        node.dataset.nodeKind = options.kind;
 
         const symbol = document.createElement('span');
         symbol.className = 'diagram-node-symbol';
@@ -93,48 +119,177 @@
 
         const type = document.createElement('span');
         type.className = 'diagram-node-type';
-        type.textContent = formatNodeType(options.type);
+        type.textContent = options.kind === 'monitored-endpoint' ? 'monitored endpoint' : formatNodeType(options.type);
+
+        main.append(name, type);
+
+        if (options.target) {
+            const target = document.createElement('span');
+            target.className = 'diagram-node-target';
+            target.textContent = options.target;
+            main.appendChild(target);
+        }
 
         const draft = document.createElement('span');
         draft.className = 'diagram-node-draft';
-        draft.textContent = 'Draft';
+        draft.textContent = options.kind === 'monitored-endpoint' ? 'Draft visual instance' : 'Draft';
+        main.appendChild(draft);
 
-        main.append(name, type, draft);
         node.append(symbol, main);
         return node;
     }
 
-    function addNode(button) {
-        const rect = getCanvasRect();
+    function getNextNodePosition() {
         nodeSequence += 1;
-
-        const node = {
+        return {
             id: `draft-node-${nodeSequence}`,
             x: 24 + ((nodeSequence - 1) % 6) * 28,
-            y: 24 + ((nodeSequence - 1) % 8) * 24,
+            y: 24 + ((nodeSequence - 1) % 8) * 24
+        };
+    }
+
+    function addNodeFromOptions(options) {
+        const rect = getCanvasRect();
+        const position = getNextNodePosition();
+        const node = {
+            id: position.id,
+            nodeType: options.type,
+            nodeKind: options.kind,
+            endpointId: options.endpointId || '',
+            label: options.label,
+            target: options.target || '',
+            iconKey: options.iconKey || options.symbol || '',
+            x: position.x,
+            y: position.y,
             element: createNodeElement({
-                id: `draft-node-${nodeSequence}`,
-                label: button.dataset.nodeLabel || 'Device',
-                type: button.dataset.nodeType || 'generic-device',
-                symbol: button.dataset.nodeSymbol || 'DEV'
+                id: position.id,
+                label: options.label,
+                target: options.target || '',
+                type: options.type,
+                kind: options.kind,
+                symbol: options.symbol
             })
         };
 
         nodeLayer.appendChild(node.element);
-        nodes.push(node);
+        state.nodes.push(node);
 
         node.x = clamp(node.x, 8, rect.width - node.element.offsetWidth - 8);
         node.y = clamp(node.y, 8, rect.height - node.element.offsetHeight - 8);
         clampNodePosition(node);
         setEmptyState();
+        selectNode(node.id);
         node.element.focus({ preventScroll: true });
     }
 
-    function findNodeByElement(element) {
-        return nodes.find(node => node.element === element);
+    function addCustomNode(button) {
+        addNodeFromOptions({
+            type: button.dataset.nodeType || 'generic-device',
+            kind: 'custom-device',
+            label: button.dataset.nodeLabel || 'Device',
+            symbol: button.dataset.nodeSymbol || 'DEV'
+        });
     }
 
-    function startDrag(event) {
+    function addEndpointNode(button) {
+        addNodeFromOptions({
+            type: 'monitored-endpoint',
+            kind: 'monitored-endpoint',
+            endpointId: button.dataset.endpointId || '',
+            label: button.dataset.endpointName || 'Monitored endpoint',
+            target: button.dataset.endpointTarget || '',
+            iconKey: button.dataset.endpointIcon || 'generic',
+            symbol: button.dataset.endpointIcon || 'END'
+        });
+    }
+
+    function findNodeByElement(element) {
+        return state.nodes.find(node => node.element === element);
+    }
+
+    function findNodeById(nodeId) {
+        return state.nodes.find(node => node.id === nodeId) || null;
+    }
+
+    function findLinkById(linkId) {
+        return state.links.find(link => link.id === linkId) || null;
+    }
+
+    function setTool(tool) {
+        state.currentTool = tool;
+        if (tool !== 'draw-link') {
+            setPendingLinkSource(null);
+        }
+
+        toolButtons.forEach(button => {
+            button.setAttribute('aria-pressed', button.dataset.toolButton === tool ? 'true' : 'false');
+        });
+
+        if (toolHint) {
+            toolHint.textContent = tool === 'draw-link'
+                ? 'Draw link mode: select a source node, then select a different target node.'
+                : 'Select nodes to move them. Draw link mode creates documentation-only links.';
+        }
+    }
+
+    function selectNode(nodeId) {
+        state.selectedNodeId = nodeId;
+        state.selectedLinkId = null;
+        state.nodes.forEach(node => {
+            node.element.dataset.selected = node.id === nodeId ? 'true' : 'false';
+        });
+        renderLinks();
+        updatePropertiesPanel();
+    }
+
+    function selectLink(linkId) {
+        state.selectedLinkId = linkId;
+        state.selectedNodeId = null;
+        state.nodes.forEach(node => {
+            node.element.dataset.selected = 'false';
+        });
+        renderLinks();
+        updatePropertiesPanel();
+    }
+
+    function setPendingLinkSource(nodeId) {
+        pendingLinkSourceId = nodeId;
+        state.nodes.forEach(node => {
+            node.element.dataset.linkPending = node.id === nodeId ? 'true' : 'false';
+        });
+    }
+
+    function canLinkToNode(node) {
+        return node && node.nodeType !== 'note';
+    }
+
+    function linkExists(sourceNodeId, targetNodeId) {
+        return state.links.some(link =>
+            (link.sourceNodeId === sourceNodeId && link.targetNodeId === targetNodeId) ||
+            (link.sourceNodeId === targetNodeId && link.targetNodeId === sourceNodeId));
+    }
+
+    function createLink(sourceNodeId, targetNodeId) {
+        if (sourceNodeId === targetNodeId || linkExists(sourceNodeId, targetNodeId)) {
+            return;
+        }
+
+        linkSequence += 1;
+        const link = {
+            id: `draft-link-${linkSequence}`,
+            sourceNodeId,
+            targetNodeId,
+            label: '',
+            sourcePort: '',
+            targetPort: '',
+            notes: ''
+        };
+
+        state.links.push(link);
+        selectLink(link.id);
+    }
+
+    function handleNodePointerDown(event) {
         const target = event.target.closest('.diagram-node');
         if (!target || !nodeLayer.contains(target)) {
             return;
@@ -145,6 +300,23 @@
             return;
         }
 
+        if (state.currentTool === 'draw-link') {
+            event.preventDefault();
+            if (!canLinkToNode(node)) {
+                return;
+            }
+
+            if (!pendingLinkSourceId) {
+                setPendingLinkSource(node.id);
+                selectNode(node.id);
+                return;
+            }
+
+            createLink(pendingLinkSourceId, node.id);
+            setPendingLinkSource(null);
+            return;
+        }
+
         const rect = getCanvasRect();
         dragState = {
             node,
@@ -152,6 +324,7 @@
             offsetY: event.clientY - rect.top - node.y
         };
 
+        selectNode(node.id);
         target.dataset.dragging = 'true';
         target.setPointerCapture(event.pointerId);
         event.preventDefault();
@@ -183,7 +356,7 @@
 
     function nudgeNode(event) {
         const node = findNodeByElement(event.currentTarget);
-        if (!node) {
+        if (!node || state.currentTool !== 'select') {
             return;
         }
 
@@ -203,22 +376,173 @@
         }
 
         if (handled) {
+            selectNode(node.id);
             clampNodePosition(node);
             event.preventDefault();
         }
     }
 
+    function getNodeCenter(node) {
+        return {
+            x: node.x + (node.element.offsetWidth || 178) / 2,
+            y: node.y + (node.element.offsetHeight || 78) / 2
+        };
+    }
+
+    function createSvgElement(name) {
+        return document.createElementNS('http://www.w3.org/2000/svg', name);
+    }
+
+    function renderLinks() {
+        linkLayer.replaceChildren();
+
+        state.links.forEach(link => {
+            const source = findNodeById(link.sourceNodeId);
+            const target = findNodeById(link.targetNodeId);
+            if (!source || !target) {
+                return;
+            }
+
+            const start = getNodeCenter(source);
+            const end = getNodeCenter(target);
+            const group = createSvgElement('g');
+            group.classList.add('diagram-link-group');
+            group.dataset.linkId = link.id;
+            group.dataset.selected = state.selectedLinkId === link.id ? 'true' : 'false';
+
+            const hit = createSvgElement('line');
+            hit.classList.add('diagram-link-hit');
+            setLineCoordinates(hit, start, end);
+            hit.addEventListener('pointerdown', event => {
+                selectLink(link.id);
+                event.preventDefault();
+                event.stopPropagation();
+            });
+
+            const line = createSvgElement('line');
+            line.classList.add('diagram-link-line');
+            setLineCoordinates(line, start, end);
+
+            group.append(hit, line);
+
+            if (link.label) {
+                const label = createSvgElement('text');
+                label.classList.add('diagram-link-label');
+                label.setAttribute('x', String((start.x + end.x) / 2));
+                label.setAttribute('y', String((start.y + end.y) / 2 - 8));
+                label.setAttribute('text-anchor', 'middle');
+                label.textContent = link.label;
+                group.appendChild(label);
+            }
+
+            if (link.sourcePort) {
+                const sourcePort = createSvgElement('text');
+                sourcePort.classList.add('diagram-link-port-label');
+                sourcePort.setAttribute('x', String(start.x + (end.x - start.x) * 0.18));
+                sourcePort.setAttribute('y', String(start.y + (end.y - start.y) * 0.18 - 6));
+                sourcePort.setAttribute('text-anchor', 'middle');
+                sourcePort.textContent = link.sourcePort;
+                group.appendChild(sourcePort);
+            }
+
+            if (link.targetPort) {
+                const targetPort = createSvgElement('text');
+                targetPort.classList.add('diagram-link-port-label');
+                targetPort.setAttribute('x', String(start.x + (end.x - start.x) * 0.82));
+                targetPort.setAttribute('y', String(start.y + (end.y - start.y) * 0.82 - 6));
+                targetPort.setAttribute('text-anchor', 'middle');
+                targetPort.textContent = link.targetPort;
+                group.appendChild(targetPort);
+            }
+
+            linkLayer.appendChild(group);
+        });
+    }
+
+    function setLineCoordinates(line, start, end) {
+        line.setAttribute('x1', String(start.x));
+        line.setAttribute('y1', String(start.y));
+        line.setAttribute('x2', String(end.x));
+        line.setAttribute('y2', String(end.y));
+    }
+
+    function updatePropertiesPanel() {
+        const selectedLink = state.selectedLinkId ? findLinkById(state.selectedLinkId) : null;
+        if (linkProperties) {
+            linkProperties.hidden = !selectedLink;
+        }
+        if (noSelectionPanel) {
+            noSelectionPanel.hidden = Boolean(selectedLink);
+        }
+
+        linkFields.forEach(field => {
+            const propertyName = field.dataset.linkField;
+            field.value = selectedLink && propertyName ? selectedLink[propertyName] || '' : '';
+        });
+    }
+
+    function updateSelectedLinkField(event) {
+        const selectedLink = state.selectedLinkId ? findLinkById(state.selectedLinkId) : null;
+        const field = event.currentTarget;
+        const propertyName = field.dataset.linkField;
+        if (!selectedLink || !propertyName) {
+            return;
+        }
+
+        selectedLink[propertyName] = field.value;
+        renderLinks();
+    }
+
+    function deleteSelectedLink() {
+        if (!state.selectedLinkId) {
+            return;
+        }
+
+        state.links = state.links.filter(link => link.id !== state.selectedLinkId);
+        state.selectedLinkId = null;
+        renderLinks();
+        updatePropertiesPanel();
+    }
+
     addButtons.forEach(button => {
-        button.addEventListener('click', () => addNode(button));
+        button.addEventListener('click', () => addCustomNode(button));
     });
 
-    nodeLayer.addEventListener('pointerdown', startDrag);
+    addEndpointButtons.forEach(button => {
+        button.addEventListener('click', () => addEndpointNode(button));
+    });
+
+    toolButtons.forEach(button => {
+        button.addEventListener('click', () => setTool(button.dataset.toolButton || 'select'));
+    });
+
+    linkFields.forEach(field => {
+        field.addEventListener('input', updateSelectedLinkField);
+    });
+
+    if (deleteLinkButton) {
+        deleteLinkButton.addEventListener('click', deleteSelectedLink);
+    }
+
+    nodeLayer.addEventListener('pointerdown', handleNodePointerDown);
     nodeLayer.addEventListener('pointermove', moveDrag);
     nodeLayer.addEventListener('pointerup', endDrag);
     nodeLayer.addEventListener('pointercancel', endDrag);
     nodeLayer.addEventListener('keydown', event => {
         if (event.target instanceof HTMLElement && event.target.classList.contains('diagram-node')) {
             nudgeNode(event);
+        }
+    });
+
+    canvas.addEventListener('pointerdown', event => {
+        if (event.target === canvas || event.target === linkLayer) {
+            state.selectedNodeId = null;
+            state.selectedLinkId = null;
+            state.nodes.forEach(node => {
+                node.element.dataset.selected = 'false';
+            });
+            renderLinks();
+            updatePropertiesPanel();
         }
     });
 
@@ -232,5 +556,7 @@
 
     window.addEventListener('resize', updateCanvasSize);
     updateCanvasSize();
+    setTool('select');
     setEmptyState();
+    updatePropertiesPanel();
 })();


### PR DESCRIPTION
### Motivation

- Provide V0.1.1 editor functionality so monitored endpoints can be placed onto the draft canvas and simple documentation-only links can be drawn between nodes while keeping diagrams client-side draft-only.  
- Preserve platform safety and visibility rules: do not create/update endpoints, dependencies, alerts, agents, or backend schema from diagram actions.  
- Keep behavior explicit and discoverable for operators (warning text and unchanged "Layout is not saved yet").

### Description

- Populate the editor toolbox from existing endpoint query paths by adding `IEndpointManagementQueryService` usage in `NetworkDiagramsController` and a small endpoint toolbox view model (`NetworkDiagramEndpointToolboxItemViewModel`).  
- Replace the placeholder toolbox with a real monitored endpoint list showing name, target, icon, and a per-item `Add` button that places a distinct draft visual instance on the canvas (duplicates allowed as separate visual instances).  
- Add a simple draw-link mode, an SVG link overlay behind nodes, and a link properties panel that supports editing link label, source port, target port, and notes; selecting and deleting draft links affects only client-side state.  
- Implement an explicit, small client-side editor state model in `wwwroot/js/network-diagrams-editor.js` tracking `nodes`, `links`, `selectedNodeId`, `selectedLinkId`, and `currentTool`, plus node dragging and live link rendering that follows node movement.  
- Update CSS (`network-diagrams.css`) and the editor view (`Index.cshtml`) to add UI controls, warnings, and responsive layout changes; add documentation note reminding that diagram links are documentation-only.  
- Add/adjust unit tests to verify feature-gate behavior, toolbox population, and presence of new editor UI/markup.  
- Update V0.1.1 design notes to document this slice, the draft-only nature, and a manual regression checklist.  
- This change is intentionally draft-only and does not add diagram/node/link persistence or database schema changes.  
- Fixes #495.

### Testing

- Ran `dotnet build src/WebApp/PingMonitor.WebApp.slnx` and the web project build succeeded.  
- Ran unit tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` (test run succeeded; existing test suite passed: 102 passed).  
- Ran full solution tests with `dotnet test src/WebApp/PingMonitor.WebApp.slnx` and the test run completed successfully.  
- Performed packaging smoke check with `pwsh -NoProfile -File scripts/build.ps1 -Version V0.1.1 -Runtime linux-x64` which completed and produced the release artifacts (packaging step succeeded).  
- Relevant automated checks in tests include feature-disabled access blocking and verification that the editor view includes monitored endpoint toolbox and the new draw-link UI elements (all test assertions passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d764d64b8832a89c89fc0aef4613a)