### PR TITLE
Network diagrams editor: selection, edit/delete, multi-select & group move

### DIFF
--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -113,3 +113,60 @@ Architecture boundary:
 - Confirm reset view works.
 - Confirm feature disabled hides nav and blocks direct access.
 - Confirm no endpoint dependencies are created or changed.
+
+## Draft Editor Selection, Edit/Delete, and Group Move Slice
+
+Issue: #499
+
+This slice extends the client-side draft editor interactions without adding persistence. The visible “Layout is not saved yet” messaging remains accurate: node and link edits affect only the current browser draft diagram state.
+
+Included in this slice:
+
+- Draft node selection with visible selected-node highlighting.
+- Draft visual link selection with visible selected-link highlighting.
+- Shift/Ctrl/Cmd-click multi-selection for draft nodes.
+- Select all nodes and clear selection toolbar actions.
+- Group movement: dragging any selected node moves all selected draft nodes together in virtual canvas/world coordinates.
+- Group movement remains bounded so selected draft nodes stay recoverable inside the virtual canvas.
+- Single-node Properties panel editing for diagram display label and notes.
+- Monitored endpoint node details in the Properties panel, with clear messaging that editing the diagram label does not rename the monitored endpoint.
+- Link Properties panel editing for link label, source port, target port, and notes.
+- Safe delete actions for selected draft nodes and selected draft visual links.
+- Keyboard support for Ctrl/Cmd+A select all, Escape clear selection, and Delete/Backspace delete selection while focus is inside the editor and not inside a text field.
+
+Draft-only safety boundary:
+
+- Deleting a diagram node removes only the draft diagram node and any attached draft visual links.
+- Deleting a monitored endpoint visual node does not delete the endpoint, monitoring data, assignments, dependencies, alerts, or agent state.
+- Deleting a visual link does not delete or modify monitoring dependencies.
+- Visual links remain documentation-only and do not create, change, or delete endpoint dependencies.
+- This slice does not change endpoint monitoring, monitoring state evaluation, dependency suppression, alerting, agent behavior, Startup Gate behavior, SNMP discovery, topology inference, endpoint creation, or dependency creation.
+
+Marquee selection is intentionally left as future work for this slice so it does not interfere with existing pan/zoom behavior.
+
+### Manual Regression Checklist - Selection and Group Move
+
+1. Enable `NetworkDiagramsEnabled`.
+2. Open the editor at 1920x1080.
+3. Open the editor at 1366x768.
+4. Add several monitored endpoint nodes.
+5. Add several custom nodes.
+6. Draw links between nodes.
+7. Select one node.
+8. Edit the node display label.
+9. Edit the node notes.
+10. Select one link.
+11. Edit the link label, source port, target port, and notes.
+12. Delete a link and confirm connected nodes remain.
+13. Delete a custom node and confirm attached visual links are removed.
+14. Delete a monitored endpoint node and confirm the actual endpoint remains in the app.
+15. Select multiple nodes with Shift/Ctrl-click.
+16. Use Select all nodes.
+17. Use Clear selection.
+18. Drag selected nodes as a group to the right to create space on the left.
+19. Confirm links follow moved nodes.
+20. Confirm group drag works after zooming to 0.5x and 2x.
+21. Confirm panning empty canvas still works.
+22. Confirm draw-link mode still works.
+23. Disable `NetworkDiagramsEnabled` and confirm nav/direct access are blocked.
+24. Confirm no endpoint dependencies are created, changed, or deleted.

--- a/docs/network_diagrams_v_0_1_1_design_notes.md
+++ b/docs/network_diagrams_v_0_1_1_design_notes.md
@@ -456,3 +456,15 @@ Diagram links must not be interpreted as monitoring dependencies or real physica
 13. Delete the selected link and confirm both nodes remain on the canvas.
 14. Confirm deleting the visual link does not alter endpoint dependencies.
 15. Disable `NetworkDiagramsEnabled` and confirm navigation, linked access, and direct page access are blocked.
+
+## Current editor slice: selection, edit/delete, and group move
+
+Issue: #499
+
+The draft editor now supports selecting draft nodes and documentation-only visual links. Multiple nodes can be selected with Shift/Ctrl/Cmd-click, Select all nodes selects every current draft node, and Clear selection removes both node and link selection. Dragging any selected node moves the selected group together in virtual canvas/world coordinates so links remain connected while the group moves.
+
+The Properties panel supports draft-only edits for exactly one selected node: diagram display label and notes. For monitored endpoint visual nodes, the panel shows endpoint details and states that changing the diagram label does not rename the monitored endpoint. When multiple nodes are selected, the panel shows the selected count and group delete action rather than single-node-only fields.
+
+The link Properties panel supports draft-only edits for label, source port, target port, and notes, and repeats that visual links do not create or modify monitoring dependencies. Deleting a selected link removes only the draft visual link. Deleting selected node(s) removes only draft diagram nodes and attached draft visual links; it does not delete endpoints, assignments, monitoring data, dependencies, alerts, or agent state.
+
+This remains a client-side draft-only slice. No saved diagram layout, database persistence, monitoring state evaluation, dependency suppression, alerting, Startup Gate, or agent behavior is changed. Marquee selection remains future work to avoid risking pan/zoom regressions.

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -121,6 +121,17 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("Monitored endpoints", viewMarkup);
         Assert.Contains("data-add-endpoint-node", viewMarkup);
         Assert.Contains("Draw link", viewMarkup);
+        Assert.Contains("Select all nodes", viewMarkup);
+        Assert.Contains("Clear selection", viewMarkup);
+        Assert.Contains("Delete selected", viewMarkup);
+        Assert.Contains("data-select-all", viewMarkup);
+        Assert.Contains("data-clear-selection", viewMarkup);
+        Assert.Contains("data-delete-selection", viewMarkup);
+        Assert.Contains("data-node-properties", viewMarkup);
+        Assert.Contains(@"data-node-field=""label""", viewMarkup);
+        Assert.Contains(@"data-node-field=""notes""", viewMarkup);
+        Assert.Contains("data-multi-node-properties", viewMarkup);
+        Assert.Contains("This visual link does not create or modify monitoring dependencies.", viewMarkup);
         Assert.Contains("Zoom in", viewMarkup);
         Assert.Contains("Zoom out", viewMarkup);
         Assert.Contains("Reset view", viewMarkup);

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Index.cshtml
@@ -88,6 +88,10 @@
                     <button type="button" class="diagram-tool-button" data-tool-button="select" aria-pressed="true">Select / move</button>
                     <button type="button" class="diagram-tool-button" data-tool-button="draw-link" aria-pressed="false">Draw link</button>
                     <span class="diagram-toolbar-divider" aria-hidden="true"></span>
+                    <button type="button" class="diagram-tool-button" data-select-all>Select all nodes</button>
+                    <button type="button" class="diagram-tool-button" data-clear-selection disabled>Clear selection</button>
+                    <button type="button" class="diagram-tool-button danger-button" data-delete-selection disabled>Delete selected</button>
+                    <span class="diagram-toolbar-divider" aria-hidden="true"></span>
                     <button type="button" class="diagram-tool-button" data-zoom-out aria-label="Zoom out">Zoom out</button>
                     <button type="button" class="diagram-tool-button" data-zoom-in aria-label="Zoom in">Zoom in</button>
                     <button type="button" class="diagram-tool-button" data-reset-view>Reset view</button>
@@ -96,7 +100,7 @@
                     <span class="diagram-tool-hint" data-tool-hint>Select nodes to move them. Draw link mode creates documentation-only links. Drag empty space to pan. Use mouse wheel to zoom.</span>
                 </div>
                 <div class="diagram-canvas-host" data-diagram-canvas-host>
-                    <div class="diagram-canvas" data-diagram-canvas role="application" aria-label="Draft network diagram canvas">
+                    <div class="diagram-canvas" data-diagram-canvas role="application" aria-label="Draft network diagram canvas" tabindex="0">
                         <div class="diagram-empty-state" data-empty-state>
                             Add a monitored endpoint or draft device from the toolbox. Drag empty space to pan. Use mouse wheel to zoom.
                         </div>
@@ -111,10 +115,41 @@
             <aside class="diagram-properties" aria-label="Diagram selection properties">
                 <h2>Properties</h2>
                 <div data-no-selection-panel>
-                    <p>Select a visual link to edit its draft label, ports, or notes.</p>
+                    <p>Select a node or visual link to edit draft-only diagram properties. Shift/Ctrl-click nodes to multi-select and move them as a group.</p>
+                </div>
+                <form class="node-properties" data-node-properties hidden>
+                    <p class="toolbox-help" data-selected-node-kind>Selected draft node</p>
+                    <p class="toolbox-help" data-selected-node-help>Node edits affect only this client-side draft diagram.</p>
+                    <dl class="diagram-property-summary">
+                        <div>
+                            <dt>Node type</dt>
+                            <dd data-selected-node-type>Draft node</dd>
+                        </div>
+                        <div data-selected-node-endpoint-details hidden>
+                            <dt>Monitored endpoint</dt>
+                            <dd>
+                                <span data-selected-node-endpoint-name></span>
+                                <span data-selected-node-endpoint-target></span>
+                            </dd>
+                        </div>
+                    </dl>
+                    <label>
+                        Diagram display label
+                        <input type="text" data-node-field="label" maxlength="80" />
+                    </label>
+                    <label>
+                        Notes
+                        <textarea data-node-field="notes" rows="4" maxlength="400"></textarea>
+                    </label>
+                    <button type="button" class="danger-button" data-delete-selection>Delete selected node</button>
+                </form>
+                <div class="multi-node-properties" data-multi-node-properties hidden>
+                    <p><strong><span data-selected-node-count>0</span> nodes selected.</strong></p>
+                    <p class="toolbox-help">Drag any selected node to move the selected draft nodes together. Bulk editing is not enabled for this slice.</p>
+                    <button type="button" class="danger-button" data-delete-selection>Delete selected nodes</button>
                 </div>
                 <form class="link-properties" data-link-properties hidden>
-                    <p class="toolbox-help">Selected link metadata is client-side draft documentation only.</p>
+                    <p class="toolbox-help">This visual link does not create or modify monitoring dependencies. Link metadata is client-side draft documentation only.</p>
                     <label>
                         Link label
                         <input type="text" data-link-field="label" maxlength="80" />
@@ -131,7 +166,7 @@
                         Notes
                         <textarea data-link-field="notes" rows="4" maxlength="400"></textarea>
                     </label>
-                    <button type="button" class="danger-button" data-delete-link>Delete selected link</button>
+                    <button type="button" class="danger-button" data-delete-selection>Delete selected link</button>
                 </form>
             </aside>
         </div>

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -435,6 +435,8 @@ body {
 .endpoint-toolbox-item button,
 .diagram-tool-button,
 .link-properties button,
+.node-properties button,
+.multi-node-properties button,
 .danger-button {
     min-height: 44px;
     border: 1px solid var(--diagram-border);
@@ -447,12 +449,30 @@ body {
     padding: .55rem .7rem;
 }
 
+.diagram-tool-button:disabled,
+.link-properties button:disabled,
+.node-properties button:disabled,
+.multi-node-properties button:disabled,
+.danger-button:disabled {
+    cursor: not-allowed;
+    opacity: .55;
+}
+
+.diagram-tool-button.danger-button {
+    min-height: 38px;
+}
+
+
 .endpoint-toolbox-item button:hover,
 .endpoint-toolbox-item button:focus-visible,
 .diagram-tool-button:hover,
 .diagram-tool-button:focus-visible,
 .link-properties button:hover,
-.link-properties button:focus-visible {
+.link-properties button:focus-visible,
+.node-properties button:hover,
+.node-properties button:focus-visible,
+.multi-node-properties button:hover,
+.multi-node-properties button:focus-visible {
     outline: none;
     border-color: var(--diagram-accent);
     box-shadow: 0 0 0 3px var(--diagram-accent-soft);
@@ -600,15 +620,20 @@ body {
     line-height: 1.35;
 }
 
+.node-properties,
+.multi-node-properties,
 .link-properties {
     display: grid;
     gap: .65rem;
 }
 
+.node-properties[hidden],
+.multi-node-properties[hidden],
 .link-properties[hidden] {
     display: none;
 }
 
+.node-properties label,
 .link-properties label {
     display: grid;
     gap: .25rem;
@@ -617,6 +642,8 @@ body {
     font-weight: 700;
 }
 
+.node-properties input,
+.node-properties textarea,
 .link-properties input,
 .link-properties textarea {
     width: 100%;
@@ -626,6 +653,41 @@ body {
     color: var(--diagram-text);
     font: inherit;
     padding: .55rem .6rem;
+}
+
+.diagram-property-summary {
+    display: grid;
+    gap: .45rem;
+    margin: 0;
+    padding: .65rem;
+    border: 1px solid var(--diagram-border);
+    border-radius: 8px;
+    background: var(--diagram-panel);
+}
+
+.diagram-property-summary div {
+    display: grid;
+    gap: .15rem;
+}
+
+.diagram-property-summary div[hidden] {
+    display: none;
+}
+
+.diagram-property-summary dt {
+    color: var(--diagram-muted);
+    font-size: .76rem;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.diagram-property-summary dd {
+    display: grid;
+    gap: .1rem;
+    margin: 0;
+    color: var(--diagram-text);
+    font-size: .86rem;
+    overflow-wrap: anywhere;
 }
 
 .danger-button {

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
@@ -17,14 +17,26 @@
     const zoomOutButton = editor.querySelector('[data-zoom-out]');
     const resetViewButton = editor.querySelector('[data-reset-view]');
     const fitContentButton = editor.querySelector('[data-fit-content]');
+    const selectAllButton = editor.querySelector('[data-select-all]');
+    const clearSelectionButton = editor.querySelector('[data-clear-selection]');
+    const deleteSelectionButtons = Array.from(editor.querySelectorAll('[data-delete-selection]'));
     const addButtons = Array.from(editor.querySelectorAll('[data-add-node]'));
     const addEndpointButtons = Array.from(editor.querySelectorAll('[data-add-endpoint-node]'));
     const toolButtons = Array.from(editor.querySelectorAll('[data-tool-button]'));
     const toolHint = editor.querySelector('[data-tool-hint]');
+    const nodeProperties = editor.querySelector('[data-node-properties]');
+    const multiNodeProperties = editor.querySelector('[data-multi-node-properties]');
     const linkProperties = editor.querySelector('[data-link-properties]');
     const noSelectionPanel = editor.querySelector('[data-no-selection-panel]');
-    const deleteLinkButton = editor.querySelector('[data-delete-link]');
+    const nodeFields = Array.from(editor.querySelectorAll('[data-node-field]'));
     const linkFields = Array.from(editor.querySelectorAll('[data-link-field]'));
+    const selectedNodeKindLabel = editor.querySelector('[data-selected-node-kind]');
+    const selectedNodeEndpointDetails = editor.querySelector('[data-selected-node-endpoint-details]');
+    const selectedNodeEndpointName = editor.querySelector('[data-selected-node-endpoint-name]');
+    const selectedNodeEndpointTarget = editor.querySelector('[data-selected-node-endpoint-target]');
+    const selectedNodeTypeLabel = editor.querySelector('[data-selected-node-type]');
+    const selectedNodeHelp = editor.querySelector('[data-selected-node-help]');
+    const selectedNodeCount = editor.querySelector('[data-selected-node-count]');
 
     if (!canvasHost || !canvas || !world || !nodeLayer || !linkLayer) {
         return;
@@ -38,8 +50,9 @@
     const state = {
         nodes: [],
         links: [],
-        selectedNodeId: null,
+        selectedNodeIds: [],
         selectedLinkId: null,
+        activeSelectionType: 'none',
         currentTool: 'select',
         zoom: 1,
         panX: 0,
@@ -79,13 +92,17 @@
         return node.element.offsetHeight || 78;
     }
 
+    function applyNodePosition(node) {
+        node.element.style.transform = `translate(${Math.round(node.x)}px, ${Math.round(node.y)}px)`;
+    }
+
     function clampNodePosition(node) {
         const width = getNodeWidth(node);
         const height = getNodeHeight(node);
 
         node.x = clamp(node.x, nodeMargin, state.virtualCanvasWidth - width - nodeMargin);
         node.y = clamp(node.y, nodeMargin, state.virtualCanvasHeight - height - nodeMargin);
-        node.element.style.transform = `translate(${Math.round(node.x)}px, ${Math.round(node.y)}px)`;
+        applyNodePosition(node);
         renderLinks();
     }
 
@@ -172,6 +189,7 @@
         node.setAttribute('aria-label', `${options.label} draft ${formatNodeType(options.type)} node`);
         node.dataset.nodeId = options.id;
         node.dataset.nodeKind = options.kind;
+        node.dataset.selected = 'false';
 
         const symbol = document.createElement('span');
         symbol.className = 'diagram-node-symbol';
@@ -183,6 +201,7 @@
 
         const name = document.createElement('span');
         name.className = 'diagram-node-name';
+        name.dataset.nodeName = 'true';
         name.textContent = options.label;
 
         const type = document.createElement('span');
@@ -207,6 +226,15 @@
         return node;
     }
 
+    function updateNodeElement(node) {
+        const name = node.element.querySelector('[data-node-name]');
+        if (name) {
+            name.textContent = node.label;
+        }
+
+        node.element.setAttribute('aria-label', `${node.label} draft ${formatNodeType(node.nodeType)} node`);
+    }
+
     function addNodeFromOptions(options) {
         const position = getNextNodePosition();
         const node = {
@@ -214,9 +242,11 @@
             nodeType: options.type,
             nodeKind: options.kind,
             endpointId: options.endpointId || '',
+            endpointName: options.endpointName || options.label,
             label: options.label,
             target: options.target || '',
             iconKey: options.iconKey || options.symbol || '',
+            notes: '',
             x: position.x,
             y: position.y,
             element: createNodeElement({
@@ -234,7 +264,7 @@
 
         clampNodePosition(node);
         setEmptyState();
-        selectNode(node.id);
+        selectOnlyNode(node.id);
         node.element.focus({ preventScroll: true });
     }
 
@@ -252,6 +282,7 @@
             type: 'monitored-endpoint',
             kind: 'monitored-endpoint',
             endpointId: button.dataset.endpointId || '',
+            endpointName: button.dataset.endpointName || 'Monitored endpoint',
             label: button.dataset.endpointName || 'Monitored endpoint',
             target: button.dataset.endpointTarget || '',
             iconKey: button.dataset.endpointIcon || 'generic',
@@ -271,6 +302,23 @@
         return state.links.find(link => link.id === linkId) || null;
     }
 
+    function selectedNodes() {
+        return state.selectedNodeIds.map(findNodeById).filter(Boolean);
+    }
+
+    function hasSelection() {
+        return state.selectedNodeIds.length > 0 || Boolean(state.selectedLinkId);
+    }
+
+    function syncSelectionDom() {
+        state.nodes.forEach(node => {
+            node.element.dataset.selected = state.selectedNodeIds.includes(node.id) ? 'true' : 'false';
+        });
+        renderLinks();
+        updatePropertiesPanel();
+        updateSelectionButtons();
+    }
+
     function setTool(tool) {
         state.currentTool = tool;
         if (tool !== 'draw-link') {
@@ -284,38 +332,62 @@
         if (toolHint) {
             toolHint.textContent = tool === 'draw-link'
                 ? 'Draw link mode: select a source node, then select a different target node. Drag empty space to pan. Use mouse wheel to zoom.'
-                : 'Select nodes to move them. Draw link mode creates documentation-only links. Drag empty space to pan. Use mouse wheel to zoom.';
+                : 'Select nodes or links. Shift/Ctrl-click nodes to multi-select; drag selected nodes to move the group. Drag empty space to pan.';
         }
     }
 
-    function selectNode(nodeId) {
-        state.selectedNodeId = nodeId;
+    function selectOnlyNode(nodeId) {
+        state.selectedNodeIds = [nodeId];
         state.selectedLinkId = null;
-        state.nodes.forEach(node => {
-            node.element.dataset.selected = node.id === nodeId ? 'true' : 'false';
-        });
-        renderLinks();
-        updatePropertiesPanel();
+        state.activeSelectionType = 'nodes';
+        syncSelectionDom();
+    }
+
+    function toggleNodeSelection(nodeId) {
+        state.selectedLinkId = null;
+        if (state.selectedNodeIds.includes(nodeId)) {
+            state.selectedNodeIds = state.selectedNodeIds.filter(id => id !== nodeId);
+        } else {
+            state.selectedNodeIds = [...state.selectedNodeIds, nodeId];
+        }
+
+        state.activeSelectionType = state.selectedNodeIds.length > 0 ? 'nodes' : 'none';
+        syncSelectionDom();
+    }
+
+    function selectAllNodes() {
+        state.selectedNodeIds = state.nodes.map(node => node.id);
+        state.selectedLinkId = null;
+        state.activeSelectionType = state.selectedNodeIds.length > 0 ? 'nodes' : 'none';
+        syncSelectionDom();
     }
 
     function clearSelection() {
-        state.selectedNodeId = null;
+        state.selectedNodeIds = [];
         state.selectedLinkId = null;
-        state.nodes.forEach(node => {
-            node.element.dataset.selected = 'false';
-        });
-        renderLinks();
-        updatePropertiesPanel();
+        state.activeSelectionType = 'none';
+        syncSelectionDom();
     }
 
     function selectLink(linkId) {
         state.selectedLinkId = linkId;
-        state.selectedNodeId = null;
-        state.nodes.forEach(node => {
-            node.element.dataset.selected = 'false';
+        state.selectedNodeIds = [];
+        state.activeSelectionType = 'link';
+        syncSelectionDom();
+    }
+
+    function updateSelectionButtons() {
+        if (selectAllButton) {
+            selectAllButton.disabled = state.nodes.length === 0;
+        }
+
+        if (clearSelectionButton) {
+            clearSelectionButton.disabled = !hasSelection();
+        }
+
+        deleteSelectionButtons.forEach(button => {
+            button.disabled = !hasSelection();
         });
-        renderLinks();
-        updatePropertiesPanel();
     }
 
     function setPendingLinkSource(nodeId) {
@@ -355,6 +427,38 @@
         selectLink(link.id);
     }
 
+    function getGroupBounds(nodes) {
+        return nodes.reduce((bounds, node) => ({
+            minX: Math.min(bounds.minX, node.x),
+            minY: Math.min(bounds.minY, node.y),
+            maxX: Math.max(bounds.maxX, node.x + getNodeWidth(node)),
+            maxY: Math.max(bounds.maxY, node.y + getNodeHeight(node))
+        }), { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity });
+    }
+
+    function clampGroupDelta(nodes, requestedDeltaX, requestedDeltaY, startPositions) {
+        if (nodes.length === 0) {
+            return { deltaX: 0, deltaY: 0 };
+        }
+
+        const bounds = startPositions
+            ? nodes.reduce((currentBounds, node) => {
+                const start = startPositions.get(node.id) || { x: node.x, y: node.y };
+                return {
+                    minX: Math.min(currentBounds.minX, start.x),
+                    minY: Math.min(currentBounds.minY, start.y),
+                    maxX: Math.max(currentBounds.maxX, start.x + getNodeWidth(node)),
+                    maxY: Math.max(currentBounds.maxY, start.y + getNodeHeight(node))
+                };
+            }, { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity })
+            : getGroupBounds(nodes);
+
+        return {
+            deltaX: clamp(requestedDeltaX, nodeMargin - bounds.minX, state.virtualCanvasWidth - nodeMargin - bounds.maxX),
+            deltaY: clamp(requestedDeltaY, nodeMargin - bounds.minY, state.virtualCanvasHeight - nodeMargin - bounds.maxY)
+        };
+    }
+
     function handleNodePointerDown(event) {
         const target = event.target.closest('.diagram-node');
         if (!target || !nodeLayer.contains(target)) {
@@ -374,7 +478,7 @@
 
             if (!pendingLinkSourceId) {
                 setPendingLinkSource(node.id);
-                selectNode(node.id);
+                selectOnlyNode(node.id);
                 return;
             }
 
@@ -383,16 +487,26 @@
             return;
         }
 
-        const pointer = screenToWorld(event.clientX, event.clientY);
+        const additiveSelection = event.shiftKey || event.ctrlKey || event.metaKey;
+        if (additiveSelection) {
+            toggleNodeSelection(node.id);
+        } else if (!state.selectedNodeIds.includes(node.id)) {
+            selectOnlyNode(node.id);
+        }
+
+        const nodesForDrag = state.selectedNodeIds.includes(node.id) ? selectedNodes() : [node];
         dragState = {
-            node,
             pointerId: event.pointerId,
-            offsetX: pointer.x - node.x,
-            offsetY: pointer.y - node.y
+            startPointer: screenToWorld(event.clientX, event.clientY),
+            nodes: nodesForDrag,
+            startPositions: new Map(nodesForDrag.map(selectedNode => [selectedNode.id, { x: selectedNode.x, y: selectedNode.y }])),
+            moved: false
         };
 
-        selectNode(node.id);
-        target.dataset.dragging = 'true';
+        nodesForDrag.forEach(selectedNode => {
+            selectedNode.element.dataset.dragging = 'true';
+        });
+        target.focus({ preventScroll: true });
         target.setPointerCapture(event.pointerId);
         event.preventDefault();
         event.stopPropagation();
@@ -404,9 +518,23 @@
         }
 
         const pointer = screenToWorld(event.clientX, event.clientY);
-        dragState.node.x = pointer.x - dragState.offsetX;
-        dragState.node.y = pointer.y - dragState.offsetY;
-        clampNodePosition(dragState.node);
+        const requestedDeltaX = pointer.x - dragState.startPointer.x;
+        const requestedDeltaY = pointer.y - dragState.startPointer.y;
+        const { deltaX, deltaY } = clampGroupDelta(dragState.nodes, requestedDeltaX, requestedDeltaY, dragState.startPositions);
+        dragState.moved = dragState.moved || Math.abs(deltaX) > 1 || Math.abs(deltaY) > 1;
+
+        dragState.nodes.forEach(node => {
+            const start = dragState.startPositions.get(node.id);
+            if (!start) {
+                return;
+            }
+
+            node.x = start.x + deltaX;
+            node.y = start.y + deltaY;
+            applyNodePosition(node);
+        });
+
+        renderLinks();
         event.preventDefault();
     }
 
@@ -415,39 +543,51 @@
             return;
         }
 
-        dragState.node.element.dataset.dragging = 'false';
-        if (dragState.node.element.hasPointerCapture(event.pointerId)) {
-            dragState.node.element.releasePointerCapture(event.pointerId);
-        }
+        dragState.nodes.forEach(node => {
+            node.element.dataset.dragging = 'false';
+            if (node.element.hasPointerCapture(event.pointerId)) {
+                node.element.releasePointerCapture(event.pointerId);
+            }
+        });
         dragState = null;
+        updatePropertiesPanel();
     }
 
-    function nudgeNode(event) {
+    function nudgeSelectedNodes(event) {
         const node = findNodeByElement(event.currentTarget);
         if (!node || state.currentTool !== 'select') {
             return;
         }
 
         const step = event.shiftKey ? 24 : 8;
-        let handled = true;
+        let deltaX = 0;
+        let deltaY = 0;
 
         if (event.key === 'ArrowLeft') {
-            node.x -= step;
+            deltaX = -step;
         } else if (event.key === 'ArrowRight') {
-            node.x += step;
+            deltaX = step;
         } else if (event.key === 'ArrowUp') {
-            node.y -= step;
+            deltaY = -step;
         } else if (event.key === 'ArrowDown') {
-            node.y += step;
+            deltaY = step;
         } else {
-            handled = false;
+            return;
         }
 
-        if (handled) {
-            selectNode(node.id);
-            clampNodePosition(node);
-            event.preventDefault();
+        if (!state.selectedNodeIds.includes(node.id)) {
+            selectOnlyNode(node.id);
         }
+
+        const nodes = selectedNodes();
+        const clamped = clampGroupDelta(nodes, deltaX, deltaY);
+        nodes.forEach(selectedNode => {
+            selectedNode.x += clamped.deltaX;
+            selectedNode.y += clamped.deltaY;
+            applyNodePosition(selectedNode);
+        });
+        renderLinks();
+        event.preventDefault();
     }
 
     function getNodeCenter(node) {
@@ -536,17 +676,88 @@
 
     function updatePropertiesPanel() {
         const selectedLink = state.selectedLinkId ? findLinkById(state.selectedLinkId) : null;
+        const nodes = selectedNodes();
+        const singleNode = nodes.length === 1 ? nodes[0] : null;
+        const multipleNodes = nodes.length > 1;
+
+        if (noSelectionPanel) {
+            noSelectionPanel.hidden = Boolean(selectedLink) || Boolean(singleNode) || multipleNodes;
+        }
+
+        if (nodeProperties) {
+            nodeProperties.hidden = !singleNode;
+        }
+
+        if (multiNodeProperties) {
+            multiNodeProperties.hidden = !multipleNodes;
+        }
+
         if (linkProperties) {
             linkProperties.hidden = !selectedLink;
         }
-        if (noSelectionPanel) {
-            noSelectionPanel.hidden = Boolean(selectedLink);
+
+        if (singleNode) {
+            if (selectedNodeKindLabel) {
+                selectedNodeKindLabel.textContent = singleNode.nodeKind === 'monitored-endpoint'
+                    ? 'Selected monitored endpoint visual node'
+                    : 'Selected custom draft node';
+            }
+
+            if (selectedNodeTypeLabel) {
+                selectedNodeTypeLabel.textContent = singleNode.nodeKind === 'monitored-endpoint'
+                    ? 'Monitored endpoint'
+                    : formatNodeType(singleNode.nodeType);
+            }
+
+            if (selectedNodeHelp) {
+                selectedNodeHelp.textContent = singleNode.nodeKind === 'monitored-endpoint'
+                    ? 'Editing this diagram label does not rename the monitored endpoint. Changes remain client-side draft layout only.'
+                    : 'Editing this node changes only the current client-side draft diagram.';
+            }
+
+            if (selectedNodeEndpointDetails) {
+                selectedNodeEndpointDetails.hidden = singleNode.nodeKind !== 'monitored-endpoint';
+            }
+
+            if (selectedNodeEndpointName) {
+                selectedNodeEndpointName.textContent = singleNode.endpointName || singleNode.label;
+            }
+
+            if (selectedNodeEndpointTarget) {
+                selectedNodeEndpointTarget.textContent = singleNode.target || 'No target recorded';
+            }
         }
+
+        if (selectedNodeCount) {
+            selectedNodeCount.textContent = String(nodes.length);
+        }
+
+        nodeFields.forEach(field => {
+            const propertyName = field.dataset.nodeField;
+            field.value = singleNode && propertyName ? singleNode[propertyName] || '' : '';
+        });
 
         linkFields.forEach(field => {
             const propertyName = field.dataset.linkField;
             field.value = selectedLink && propertyName ? selectedLink[propertyName] || '' : '';
         });
+    }
+
+    function updateSelectedNodeField(event) {
+        const nodes = selectedNodes();
+        if (nodes.length !== 1) {
+            return;
+        }
+
+        const node = nodes[0];
+        const field = event.currentTarget;
+        const propertyName = field.dataset.nodeField;
+        if (!propertyName) {
+            return;
+        }
+
+        node[propertyName] = field.value;
+        updateNodeElement(node);
     }
 
     function updateSelectedLinkField(event) {
@@ -561,15 +772,43 @@
         renderLinks();
     }
 
-    function deleteSelectedLink() {
-        if (!state.selectedLinkId) {
+    function deleteSelection() {
+        if (state.selectedNodeIds.length > 0) {
+            const confirmed = window.confirm('Remove selected item(s) from this draft diagram only? Monitored endpoints and monitoring data will not be deleted.');
+            if (!confirmed) {
+                return;
+            }
+
+            const nodeIds = new Set(state.selectedNodeIds);
+            state.nodes = state.nodes.filter(node => {
+                if (!nodeIds.has(node.id)) {
+                    return true;
+                }
+
+                node.element.remove();
+                return false;
+            });
+            state.links = state.links.filter(link => !nodeIds.has(link.sourceNodeId) && !nodeIds.has(link.targetNodeId));
+            state.selectedNodeIds = [];
+            state.selectedLinkId = null;
+            state.activeSelectionType = 'none';
+            setPendingLinkSource(null);
+            setEmptyState();
+            syncSelectionDom();
             return;
         }
 
-        state.links = state.links.filter(link => link.id !== state.selectedLinkId);
-        state.selectedLinkId = null;
-        renderLinks();
-        updatePropertiesPanel();
+        if (state.selectedLinkId) {
+            const confirmed = window.confirm('Remove this visual link from the draft diagram only? Monitoring dependencies will not be changed.');
+            if (!confirmed) {
+                return;
+            }
+
+            state.links = state.links.filter(link => link.id !== state.selectedLinkId);
+            state.selectedLinkId = null;
+            state.activeSelectionType = 'none';
+            syncSelectionDom();
+        }
     }
 
     function zoomAt(clientX, clientY, requestedZoom) {
@@ -638,6 +877,7 @@
         };
         canvas.dataset.panning = 'true';
         canvas.setPointerCapture(event.pointerId);
+        canvas.focus({ preventScroll: true });
         event.preventDefault();
     }
 
@@ -672,6 +912,42 @@
         }
     }
 
+    function isEditableTarget(target) {
+        if (!(target instanceof HTMLElement)) {
+            return false;
+        }
+
+        return Boolean(target.closest('input, textarea, select, [contenteditable="true"]'));
+    }
+
+    function handleEditorKeyDown(event) {
+        if (isEditableTarget(event.target)) {
+            return;
+        }
+
+        const isCanvasFocused = canvas.contains(document.activeElement) || document.activeElement === canvas;
+        if (!isCanvasFocused) {
+            return;
+        }
+
+        if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'a') {
+            selectAllNodes();
+            event.preventDefault();
+            return;
+        }
+
+        if (event.key === 'Escape') {
+            clearSelection();
+            event.preventDefault();
+            return;
+        }
+
+        if (event.key === 'Delete' || event.key === 'Backspace') {
+            deleteSelection();
+            event.preventDefault();
+        }
+    }
+
     addButtons.forEach(button => {
         button.addEventListener('click', () => addCustomNode(button));
     });
@@ -684,12 +960,24 @@
         button.addEventListener('click', () => setTool(button.dataset.toolButton || 'select'));
     });
 
+    nodeFields.forEach(field => {
+        field.addEventListener('input', updateSelectedNodeField);
+    });
+
     linkFields.forEach(field => {
         field.addEventListener('input', updateSelectedLinkField);
     });
 
-    if (deleteLinkButton) {
-        deleteLinkButton.addEventListener('click', deleteSelectedLink);
+    deleteSelectionButtons.forEach(button => {
+        button.addEventListener('click', deleteSelection);
+    });
+
+    if (selectAllButton) {
+        selectAllButton.addEventListener('click', selectAllNodes);
+    }
+
+    if (clearSelectionButton) {
+        clearSelectionButton.addEventListener('click', clearSelection);
     }
 
     if (zoomInButton) {
@@ -714,7 +1002,7 @@
     nodeLayer.addEventListener('pointercancel', endDrag);
     nodeLayer.addEventListener('keydown', event => {
         if (event.target instanceof HTMLElement && event.target.classList.contains('diagram-node')) {
-            nudgeNode(event);
+            nudgeSelectedNodes(event);
         }
     });
 
@@ -722,6 +1010,7 @@
     canvas.addEventListener('pointermove', movePan);
     canvas.addEventListener('pointerup', endPan);
     canvas.addEventListener('pointercancel', endPan);
+    canvas.addEventListener('keydown', handleEditorKeyDown);
     canvas.addEventListener('wheel', event => {
         const factor = event.deltaY < 0 ? zoomStep : 1 / zoomStep;
         zoomAt(event.clientX, event.clientY, state.zoom * factor);
@@ -742,4 +1031,5 @@
     setTool('select');
     setEmptyState();
     updatePropertiesPanel();
+    updateSelectionButtons();
 })();


### PR DESCRIPTION
### Motivation
- Provide a usable draft editor interaction model so users can select nodes/links, edit properties, delete safely, and move multiple items together while preserving the existing draft-only safety boundary. 
- Keep all changes client-side/draft-only and explicitly avoid any changes to monitoring, dependencies, agents, or Startup Gate behavior. 

### Description
- Add a selection model and group movement to the editor by extending the client state to include `selectedNodeIds`, `selectedLinkId`, and `activeSelectionType`, and adding multi-select, toggle-select, `selectAll`, `clearSelection`, and bounded group drag logic in `wwwroot/js/network-diagrams-editor.js`. 
- Add node and multi-node property panels and wire up single-node edits (`label`, `notes`) and link edits (`label`, `sourcePort`, `targetPort`, `notes`) with clear documentation-only messaging in `Views/NetworkDiagrams/Index.cshtml` and UI wiring in the editor JS. 
- Add toolbar controls for `Select all`, `Clear selection`, and `Delete selected`, keyboard shortcuts (Ctrl/Cmd+A, Escape, Delete/Backspace in-editor), and confirm-based safe deletion that removes only draft nodes/links (no endpoints, dependencies, or monitoring data). 
- Update CSS for disabled and property UI states in `wwwroot/css/network-diagrams.css`, extend view markup to include properties/tooling, update automated view assertions in `NetworkDiagramsFeatureTests.cs`, and update documentation in `docs/network-diagrams-v0.1.1.md` and `docs/network_diagrams_v_0_1_1_design_notes.md` to describe the slice and manual regression checklist. 

### Testing
- Ran `node --check src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js` with no syntax errors reported. 
- Ran `git diff --check` and static checks with no issues. 
- Built the web app with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which succeeded. 
- Executed unit tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and all tests passed (`Passed: 102, Failed: 0`). 
- Ran the dev packaging script `pwsh -NoLogo -NoProfile -File scripts/build-dev.ps1` as a validation step and the dev package generation completed successfully.

Fixes #499

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d84f83e64832a904181e02faa6bef)