### PR TITLE
Add A-series network diagram canvas and PDF export

### DIFF
--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -76,7 +76,7 @@ This slice upgrades the client-side draft editor from a viewport-sized placement
 
 Included in this slice:
 
-- A 4000 x 2500 diagram-unit virtual canvas rendered inside the existing visible editor area.
+- A 4000 x 2828 A-series landscape diagram-unit virtual canvas rendered inside the existing visible editor area.
 - Draft nodes and draft links use diagram/world coordinates rather than raw browser viewport coordinates.
 - Empty canvas space can be dragged with pointer events to pan the visible workspace.
 - Mouse wheel zooms the canvas around the mouse pointer.
@@ -210,3 +210,29 @@ Backup/restore follow-up:
 
 - Network diagrams are configuration, not operational monitoring history.
 - Configuration backup/restore inclusion for `NetworkDiagrams`, `NetworkDiagramNodes`, and `NetworkDiagramLinks` remains a required follow-up before publishing V0.1.1 if it is not completed in the release branch.
+
+## A-series canvas sizing and PDF export slice
+
+This slice adds paper-ratio canvas handling and saved-diagram PDF export without changing monitoring behaviour.
+
+- New diagrams use an ISO 216 A-series landscape virtual canvas by default (`4000 × 2828` world units, approximately `1.414:1`). A4 and A3 use the same ratio, so the editor canvas maps predictably to paper export.
+- Existing diagrams continue to load with their saved `CanvasWidth` and `CanvasHeight`. Legacy arbitrary-ratio diagrams are not silently normalised; the editor shows a warning and lets an admin choose an A-series canvas size when it is safe.
+- The editor provides controlled landscape canvas size presets: Small, Medium, Large, and Extra large. Changing presets preserves node/link world coordinates.
+- Shrinking or normalising to a smaller preset is blocked when any existing node would fall outside the target canvas, preventing accidental cropping.
+- PDF export is server-side, authenticated, admin-only through the existing Network Diagrams controller, and still respects `NetworkDiagramsEnabled`.
+- PDF export renders from the last saved diagram data in the database, not unsaved browser state. The editor warns before exporting when unsaved changes exist.
+- PDF export supports A4 landscape and A3 landscape and scales the saved diagram content to fit the page with padding. The export includes the diagram title, UTC export timestamp, nodes, visual links, link labels/ports where present, node labels, practical notes, and the documentation-only footer.
+- Diagram links remain visual documentation only and do not create monitoring dependencies.
+- This slice does not change endpoint monitoring, dependency suppression, alerting, agent runtime behaviour, topology discovery, SNMP, or automatic endpoint/dependency creation.
+
+Manual regression checklist for this slice:
+
+1. Create a new diagram and confirm the default world canvas reads `4000 × 2828` and is shown as A-series landscape.
+2. Add monitored endpoint nodes and custom nodes, then draw visual links.
+3. Save, expand the canvas to a larger preset, and confirm existing nodes keep their world positions.
+4. Confirm pan, zoom, node dragging, link drawing, and Fit content still work after canvas size changes.
+5. Attempt to shrink below existing node bounds and confirm the editor blocks the change with a clear message.
+6. Export A4 and A3 PDFs and confirm the diagram title, timestamp, nodes, links behind nodes, readable labels, and documentation-only footer appear without editor UI/sidebar/toolbars.
+7. Try exporting with unsaved changes and confirm the editor warns that export uses the last saved diagram.
+8. Disable `NetworkDiagramsEnabled` and confirm the export route is blocked.
+9. Confirm no endpoint dependency, alerting, state-evaluation, or agent data is created or changed.

--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -222,6 +222,8 @@ This slice adds paper-ratio canvas handling and saved-diagram PDF export without
 - PDF export is server-side, authenticated, admin-only through the existing Network Diagrams controller, and still respects `NetworkDiagramsEnabled`.
 - PDF export renders from the last saved diagram data in the database, not unsaved browser state. The editor warns before exporting when unsaved changes exist.
 - PDF export supports A4 landscape and A3 landscape and scales the saved diagram content to fit the page with padding. The export includes the diagram title, UTC export timestamp, nodes, visual links, link labels/ports where present, node labels, practical notes, and the documentation-only footer.
+- PDF export wraps, shrinks, and truncates node labels and secondary node text so exported text remains inside device boxes. Clipping is also applied to each exported node as a final safety guard.
+- Very dense diagrams may require A3 export or larger canvas spacing for best readability; export does not silently change saved diagram geometry.
 - Diagram links remain visual documentation only and do not create monitoring dependencies.
 - This slice does not change endpoint monitoring, dependency suppression, alerting, agent runtime behaviour, topology discovery, SNMP, or automatic endpoint/dependency creation.
 
@@ -233,6 +235,7 @@ Manual regression checklist for this slice:
 4. Confirm pan, zoom, node dragging, link drawing, and Fit content still work after canvas size changes.
 5. Attempt to shrink below existing node bounds and confirm the editor blocks the change with a clear message.
 6. Export A4 and A3 PDFs and confirm the diagram title, timestamp, nodes, links behind nodes, readable labels, and documentation-only footer appear without editor UI/sidebar/toolbars.
-7. Try exporting with unsaved changes and confirm the editor warns that export uses the last saved diagram.
-8. Disable `NetworkDiagramsEnabled` and confirm the export route is blocked.
-9. Confirm no endpoint dependency, alerting, state-evaluation, or agent data is created or changed.
+7. Confirm long labels such as “Summerhouse Access Point”, “Living Room Access Point”, and dense Trading VM labels stay inside node boxes and do not overlap adjacent nodes.
+8. Try exporting with unsaved changes and confirm the editor warns that export uses the last saved diagram.
+9. Disable `NetworkDiagramsEnabled` and confirm the export route is blocked.
+10. Confirm no endpoint dependency, alerting, state-evaluation, or agent data is created or changed.

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -5,6 +5,7 @@ using PingMonitor.Web.ViewModels.Endpoints;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.NetworkDiagrams;
 using PingMonitor.Web.Services.Endpoints;
+using PingMonitor.Web.Services.Identity;
 using PingMonitor.Web.ViewModels.Admin;
 using PingMonitor.Web.ViewModels.NetworkDiagrams;
 using Xunit;
@@ -63,7 +64,8 @@ public sealed class NetworkDiagramsFeatureTests
         var controller = new NetworkDiagramsController(
             new FakeApplicationSettingsService(new ApplicationSettingsDto { NetworkDiagramsEnabled = false }),
             new FakeEndpointManagementQueryService(),
-            new FakeNetworkDiagramService());
+            new FakeNetworkDiagramService(),
+            new FakeNetworkDiagramPdfExportService());
 
         var result = await controller.Index(CancellationToken.None);
 
@@ -85,7 +87,8 @@ public sealed class NetworkDiagramsFeatureTests
                 IconKey = "router",
                 CurrentState = EndpointStateKind.Up
             }),
-            new FakeNetworkDiagramService(new NetworkDiagram { DiagramId = "diagram-1", Name = "Core", UpdatedAtUtc = DateTimeOffset.UtcNow }));
+            new FakeNetworkDiagramService(new NetworkDiagram { DiagramId = "diagram-1", Name = "Core", UpdatedAtUtc = DateTimeOffset.UtcNow }),
+            new FakeNetworkDiagramPdfExportService());
 
         var result = await controller.Index(CancellationToken.None);
 
@@ -141,6 +144,135 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("data-save-status", viewMarkup);
         Assert.Contains("/js/network-diagrams-editor.js", viewMarkup);
         Assert.Contains("/css/network-diagrams.css", viewMarkup);
+    }
+
+
+    [Fact]
+    public void NetworkDiagram_DefaultCanvasUsesASeriesLandscapeRatio()
+    {
+        var diagram = new NetworkDiagram();
+
+        Assert.Equal(4000, diagram.CanvasWidth);
+        Assert.Equal(2828, diagram.CanvasHeight);
+        Assert.True(NetworkDiagramPaper.IsApproximatelyASeriesLandscape(diagram.CanvasWidth, diagram.CanvasHeight));
+    }
+
+    [Fact]
+    public void NetworkDiagramEditor_IncludesCanvasPresetAndPdfExportControls()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var viewMarkup = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "Views", "NetworkDiagrams", "Edit.cshtml"));
+        var script = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "wwwroot", "js", "network-diagrams-editor.js"));
+
+        Assert.Contains("data-export-pdf-url", viewMarkup);
+        Assert.Contains("data-canvas-size-preset", viewMarkup);
+        Assert.Contains("Small (4000 × 2828)", viewMarkup);
+        Assert.Contains("data-export-pdf", viewMarkup);
+        Assert.Contains("A4 landscape", viewMarkup);
+        Assert.Contains("A3 landscape", viewMarkup);
+        Assert.Contains("Canvas cannot shrink", script);
+        Assert.Contains("1.41421356237", script);
+        Assert.Contains("Export uses the last saved diagram", script);
+    }
+
+
+    [Fact]
+    public void NetworkDiagramPdfExportService_RendersSavedNodesAndLinksToPdf()
+    {
+        var service = new NetworkDiagramPdfExportService();
+        var diagram = new NetworkDiagramDto
+        {
+            DiagramId = "diagram-1",
+            Name = "Core",
+            CanvasWidth = 4000,
+            CanvasHeight = 2828,
+            Nodes =
+            [
+                new NetworkDiagramNodeDto { NodeId = "node-1", NodeType = "CustomDevice", DisplayLabel = "Router", X = 100, Y = 100, Width = 178, Height = 78 },
+                new NetworkDiagramNodeDto { NodeId = "node-2", NodeType = "MonitoredEndpoint", DisplayLabel = "Web server", X = 600, Y = 300, Width = 178, Height = 78 }
+            ],
+            Links =
+            [
+                new NetworkDiagramLinkDto { LinkId = "link-1", SourceNodeId = "node-1", TargetNodeId = "node-2", Label = "uplink", SourcePortLabel = "Gi1/0/1", TargetPortLabel = "eth0" }
+            ]
+        };
+
+        var export = service.Export(diagram, new NetworkDiagramPdfExportOptions("A4", new DateTimeOffset(2026, 6, 1, 17, 0, 0, TimeSpan.Zero)));
+        var pdfText = System.Text.Encoding.ASCII.GetString(export.Content);
+
+        Assert.Equal("application/pdf", export.ContentType);
+        Assert.StartsWith("%PDF-1.4", pdfText);
+        Assert.Contains("Core", pdfText);
+        Assert.Contains("Router", pdfText);
+        Assert.Contains("Web server", pdfText);
+        Assert.Contains("uplink", pdfText);
+        Assert.Contains("Diagram links are visual documentation only", pdfText);
+    }
+
+    [Fact]
+    public void NetworkDiagramsController_RequiresAdminAuthorizationForExport()
+    {
+        var authorize = typeof(NetworkDiagramsController)
+            .GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AuthorizeAttribute), inherit: true)
+            .Cast<Microsoft.AspNetCore.Authorization.AuthorizeAttribute>()
+            .Single();
+
+        Assert.Equal(ApplicationRoles.Admin, authorize.Roles);
+    }
+
+    [Fact]
+    public async Task NetworkDiagramsExportPdf_ReturnsNotFound_WhenFeatureDisabled()
+    {
+        var controller = new NetworkDiagramsController(
+            new FakeApplicationSettingsService(new ApplicationSettingsDto { NetworkDiagramsEnabled = false }),
+            new FakeEndpointManagementQueryService(),
+            new FakeNetworkDiagramService(),
+            new FakeNetworkDiagramPdfExportService());
+
+        var result = await controller.ExportPdf("missing", "A4", CancellationToken.None);
+
+        var notFound = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal("Network diagrams are not enabled.", notFound.Value);
+    }
+
+    [Fact]
+    public async Task NetworkDiagramsExportPdf_ReturnsNotFound_WhenDiagramMissing()
+    {
+        var controller = new NetworkDiagramsController(
+            new FakeApplicationSettingsService(new ApplicationSettingsDto { NetworkDiagramsEnabled = true }),
+            new FakeEndpointManagementQueryService(),
+            new FakeNetworkDiagramService(),
+            new FakeNetworkDiagramPdfExportService());
+
+        var result = await controller.ExportPdf("missing", "A4", CancellationToken.None);
+
+        var notFound = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal("Network diagram was not found.", notFound.Value);
+    }
+
+    [Fact]
+    public async Task NetworkDiagramsExportPdf_ReturnsPdfForExistingDiagram()
+    {
+        var service = new FakeNetworkDiagramService(new NetworkDiagram { DiagramId = "diagram-1", Name = "Core", UpdatedAtUtc = DateTimeOffset.UtcNow });
+        service.LoadResult = new NetworkDiagramDto
+        {
+            DiagramId = "diagram-1",
+            Name = "Core",
+            CanvasWidth = 4000,
+            CanvasHeight = 2828
+        };
+        var controller = new NetworkDiagramsController(
+            new FakeApplicationSettingsService(new ApplicationSettingsDto { NetworkDiagramsEnabled = true }),
+            new FakeEndpointManagementQueryService(),
+            service,
+            new FakeNetworkDiagramPdfExportService());
+
+        var result = await controller.ExportPdf("diagram-1", "A4", CancellationToken.None);
+
+        var file = Assert.IsType<FileContentResult>(result);
+        Assert.Equal("application/pdf", file.ContentType);
+        Assert.StartsWith("PingMonitor-NetworkDiagram-Core", file.FileDownloadName);
+        Assert.StartsWith("%PDF", System.Text.Encoding.ASCII.GetString(file.FileContents));
     }
 
     private static string FindRepositoryRoot()
@@ -220,9 +352,11 @@ public sealed class NetworkDiagramsFeatureTests
             return Task.FromResult(diagram);
         }
 
+        public NetworkDiagramDto? LoadResult { get; set; }
+
         public Task<NetworkDiagramDto?> LoadAsync(string diagramId, CancellationToken cancellationToken)
         {
-            return Task.FromResult<NetworkDiagramDto?>(null);
+            return Task.FromResult(LoadResult);
         }
 
         public Task<NetworkDiagramDto> SaveAsync(string diagramId, NetworkDiagramSaveRequest request, string? userId, CancellationToken cancellationToken)
@@ -233,6 +367,14 @@ public sealed class NetworkDiagramsFeatureTests
         public Task<bool> DeleteAsync(string diagramId, CancellationToken cancellationToken)
         {
             return Task.FromResult(_diagrams.RemoveAll(x => x.DiagramId == diagramId) > 0);
+        }
+    }
+
+    private sealed class FakeNetworkDiagramPdfExportService : INetworkDiagramPdfExportService
+    {
+        public NetworkDiagramPdfExportResult Export(NetworkDiagramDto diagram, NetworkDiagramPdfExportOptions options)
+        {
+            return new NetworkDiagramPdfExportResult(System.Text.Encoding.ASCII.GetBytes("%PDF test"), "application/pdf", $"PingMonitor-NetworkDiagram-{diagram.Name}-{options.ExportedAtUtc:yyyyMMdd-HHmm}.pdf");
         }
     }
 

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -176,6 +176,36 @@ public sealed class NetworkDiagramsFeatureTests
     }
 
 
+
+    [Fact]
+    public void NetworkDiagramPdfTextFitter_WrapsShortMultiWordLabels()
+    {
+        var fit = NetworkDiagramPdfTextFitter.Fit("Living Room Access Point", maxWidth: 46, maxLines: 2, fontSize: 8, minimumFontSize: 5.5, useEllipsis: true);
+
+        Assert.True(fit.Lines.Count >= 2);
+        Assert.True(fit.Lines.Count <= 2);
+        Assert.All(fit.Lines, line => Assert.True(NetworkDiagramPdfTextFitter.MeasureWidth(line, fit.FontSize) <= 46.01));
+    }
+
+    [Fact]
+    public void NetworkDiagramPdfTextFitter_TruncatesVeryLongLabelsWithEllipsis()
+    {
+        var fit = NetworkDiagramPdfTextFitter.Fit("TradingVmNodeWithAnExtremelyLongUnbrokenHostnameThatCannotFit", maxWidth: 38, maxLines: 1, fontSize: 8, minimumFontSize: 5, useEllipsis: true);
+
+        var line = Assert.Single(fit.Lines);
+        Assert.EndsWith("...", line);
+        Assert.True(NetworkDiagramPdfTextFitter.MeasureWidth(line, fit.FontSize) <= 38.01);
+    }
+
+    [Fact]
+    public void NetworkDiagramPdfTextFitter_NeverReturnsLinesWiderThanMaxWidth()
+    {
+        var fit = NetworkDiagramPdfTextFitter.Fit("Summerhouse Access Point monitored endpoint secondary text", maxWidth: 58, maxLines: 2, fontSize: 8, minimumFontSize: 5, useEllipsis: true);
+
+        Assert.InRange(fit.Lines.Count, 1, 2);
+        Assert.All(fit.Lines, line => Assert.True(NetworkDiagramPdfTextFitter.MeasureWidth(line, fit.FontSize) <= 58.01));
+    }
+
     [Fact]
     public void NetworkDiagramPdfExportService_RendersSavedNodesAndLinksToPdf()
     {
@@ -207,6 +237,53 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("Web server", pdfText);
         Assert.Contains("uplink", pdfText);
         Assert.Contains("Diagram links are visual documentation only", pdfText);
+    }
+
+
+    [Fact]
+    public void NetworkDiagramPdfExportService_ExportsLongAndDenseNodeLabelsToPdf()
+    {
+        var service = new NetworkDiagramPdfExportService();
+        var nodes = new List<NetworkDiagramNodeDto>();
+        for (var i = 0; i < 12; i++)
+        {
+            nodes.Add(new NetworkDiagramNodeDto
+            {
+                NodeId = $"node-{i}",
+                NodeType = "MonitoredEndpoint",
+                DisplayLabel = i % 2 == 0 ? $"Trading VM {i} With Very Long Endpoint Label" : $"Summerhouse Access Point {i}",
+                X = 120 + i * 90,
+                Y = 400 + (i % 3) * 90,
+                Width = 178,
+                Height = 78,
+                Notes = "operator note that should only render when there is enough room"
+            });
+        }
+
+        var diagram = new NetworkDiagramDto
+        {
+            DiagramId = "dense",
+            Name = "Dense Home",
+            CanvasWidth = 4000,
+            CanvasHeight = 2828,
+            Nodes = nodes,
+            Links = nodes.Skip(1).Select((node, index) => new NetworkDiagramLinkDto
+            {
+                LinkId = $"link-{index}",
+                SourceNodeId = nodes[index].NodeId,
+                TargetNodeId = node.NodeId,
+                Label = "very long access uplink label that should not overflow"
+            }).ToArray()
+        };
+
+        var export = service.Export(diagram, new NetworkDiagramPdfExportOptions("A3", new DateTimeOffset(2026, 6, 1, 17, 0, 0, TimeSpan.Zero)));
+        var pdfText = System.Text.Encoding.ASCII.GetString(export.Content);
+
+        Assert.Equal("application/pdf", export.ContentType);
+        Assert.StartsWith("%PDF-1.4", pdfText);
+        Assert.Contains("Dense Home", pdfText);
+        Assert.Contains("re W n", pdfText);
+        Assert.Contains("Trading VM", pdfText);
     }
 
     [Fact]

--- a/src/WebApp/PingMonitor.Web/Controllers/NetworkDiagramsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/NetworkDiagramsController.cs
@@ -17,15 +17,18 @@ public sealed class NetworkDiagramsController : Controller
     private readonly IApplicationSettingsService _applicationSettingsService;
     private readonly IEndpointManagementQueryService _endpointManagementQueryService;
     private readonly INetworkDiagramService _networkDiagramService;
+    private readonly INetworkDiagramPdfExportService _pdfExportService;
 
     public NetworkDiagramsController(
         IApplicationSettingsService applicationSettingsService,
         IEndpointManagementQueryService endpointManagementQueryService,
-        INetworkDiagramService networkDiagramService)
+        INetworkDiagramService networkDiagramService,
+        INetworkDiagramPdfExportService pdfExportService)
     {
         _applicationSettingsService = applicationSettingsService;
         _endpointManagementQueryService = endpointManagementQueryService;
         _networkDiagramService = networkDiagramService;
+        _pdfExportService = pdfExportService;
     }
 
     [HttpGet("")]
@@ -106,6 +109,7 @@ public sealed class NetworkDiagramsController : Controller
             DiagramDescription = diagram.Description,
             LoadUrl = Url.Action(nameof(Load), new { diagramId = diagram.DiagramId }) ?? string.Empty,
             SaveUrl = Url.Action(nameof(Save), new { diagramId = diagram.DiagramId }) ?? string.Empty,
+            ExportPdfUrl = Url.Action(nameof(ExportPdf), new { diagramId = diagram.DiagramId }) ?? string.Empty,
             MonitoredEndpoints = BuildEndpointToolbox(endpoints.Rows)
         });
     }
@@ -140,6 +144,25 @@ public sealed class NetworkDiagramsController : Controller
         {
             return BadRequest(new { error = ex.Message });
         }
+    }
+
+
+    [HttpGet("{diagramId}/export/pdf")]
+    public async Task<IActionResult> ExportPdf(string diagramId, [FromQuery] string paper = "A4", CancellationToken cancellationToken = default)
+    {
+        if (!await NetworkDiagramsEnabledAsync(cancellationToken))
+        {
+            return NotFound("Network diagrams are not enabled.");
+        }
+
+        var diagram = await _networkDiagramService.LoadAsync(diagramId, cancellationToken);
+        if (diagram is null)
+        {
+            return NotFound("Network diagram was not found.");
+        }
+
+        var export = _pdfExportService.Export(diagram, new NetworkDiagramPdfExportOptions(paper, DateTimeOffset.UtcNow));
+        return File(export.Content, export.ContentType, export.FileName);
     }
 
     [HttpPost("{diagramId}/delete")]

--- a/src/WebApp/PingMonitor.Web/Models/NetworkDiagram.cs
+++ b/src/WebApp/PingMonitor.Web/Models/NetworkDiagram.cs
@@ -6,7 +6,7 @@ public sealed class NetworkDiagram
     public string Name { get; set; } = string.Empty;
     public string? Description { get; set; }
     public double CanvasWidth { get; set; } = 4000;
-    public double CanvasHeight { get; set; } = 2500;
+    public double CanvasHeight { get; set; } = 2828;
     public double ViewportPanX { get; set; }
     public double ViewportPanY { get; set; }
     public double ViewportZoom { get; set; } = 1;

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -230,6 +230,7 @@ builder.Services.AddScoped<ITelegramNotificationSender, TelegramNotificationSend
 builder.Services.AddScoped<IEndpointCreationQueryService, EndpointCreationQueryService>();
 builder.Services.AddScoped<IEndpointManagementQueryService, EndpointManagementQueryService>();
 builder.Services.AddScoped<PingMonitor.Web.Services.NetworkDiagrams.INetworkDiagramService, PingMonitor.Web.Services.NetworkDiagrams.NetworkDiagramService>();
+builder.Services.AddScoped<PingMonitor.Web.Services.NetworkDiagrams.INetworkDiagramPdfExportService, PingMonitor.Web.Services.NetworkDiagrams.NetworkDiagramPdfExportService>();
 builder.Services.AddScoped<IEndpointManagementService, EndpointManagementService>();
 builder.Services.AddScoped<IEndpointPerformanceQueryService, EndpointPerformanceQueryService>();
 builder.Services.AddScoped<IGroupManagementService, GroupManagementService>();

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramPaper.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramPaper.cs
@@ -1,0 +1,28 @@
+namespace PingMonitor.Web.Services.NetworkDiagrams;
+
+public static class NetworkDiagramPaper
+{
+    public const double ASeriesLandscapeRatio = 1.41421356237;
+    public const double SmallCanvasWidth = 4000;
+    public const double SmallCanvasHeight = 2828;
+
+    public static readonly IReadOnlyList<NetworkDiagramCanvasPreset> CanvasPresets =
+    [
+        new("small", "Small", SmallCanvasWidth, SmallCanvasHeight),
+        new("medium", "Medium", 5656, 4000),
+        new("large", "Large", 8000, 5657),
+        new("extra-large", "Extra large", 11314, 8000)
+    ];
+
+    public static bool IsApproximatelyASeriesLandscape(double width, double height)
+    {
+        if (width <= 0 || height <= 0)
+        {
+            return false;
+        }
+
+        return Math.Abs((width / height) - ASeriesLandscapeRatio) < 0.01;
+    }
+}
+
+public sealed record NetworkDiagramCanvasPreset(string Value, string Label, double Width, double Height);

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramPdfExportService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramPdfExportService.cs
@@ -1,0 +1,282 @@
+using System.Globalization;
+using System.Text;
+
+namespace PingMonitor.Web.Services.NetworkDiagrams;
+
+public interface INetworkDiagramPdfExportService
+{
+    NetworkDiagramPdfExportResult Export(NetworkDiagramDto diagram, NetworkDiagramPdfExportOptions options);
+}
+
+public sealed record NetworkDiagramPdfExportOptions(string PaperSize, DateTimeOffset ExportedAtUtc);
+
+public sealed record NetworkDiagramPdfExportResult(byte[] Content, string ContentType, string FileName);
+
+internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportService
+{
+    private const string DocumentationFooter = "Diagram links are visual documentation only and do not create monitoring dependencies.";
+
+    public NetworkDiagramPdfExportResult Export(NetworkDiagramDto diagram, NetworkDiagramPdfExportOptions options)
+    {
+        var paper = ResolvePaper(options.PaperSize);
+        var content = RenderContent(diagram, paper, options.ExportedAtUtc);
+        var pdf = SimplePdfDocument.Create(paper.WidthPoints, paper.HeightPoints, content);
+        var fileName = $"PingMonitor-NetworkDiagram-{MakeSafeFileName(diagram.Name)}-{options.ExportedAtUtc:yyyyMMdd-HHmm}.pdf";
+        return new NetworkDiagramPdfExportResult(pdf, "application/pdf", fileName);
+    }
+
+    private static PdfPaper ResolvePaper(string? paperSize)
+    {
+        return string.Equals(paperSize, "A3", StringComparison.OrdinalIgnoreCase)
+            ? new PdfPaper("A3", 1190.55, 841.89)
+            : new PdfPaper("A4", 841.89, 595.28);
+    }
+
+    private static string RenderContent(NetworkDiagramDto diagram, PdfPaper paper, DateTimeOffset exportedAtUtc)
+    {
+        var stream = new StringBuilder();
+        var pageMargin = 36d;
+        var headerHeight = 58d;
+        var footerHeight = 34d;
+        var drawingLeft = pageMargin;
+        var drawingBottom = pageMargin + footerHeight;
+        var drawingWidth = paper.WidthPoints - pageMargin * 2;
+        var drawingHeight = paper.HeightPoints - pageMargin * 2 - headerHeight - footerHeight;
+        var drawingTop = drawingBottom + drawingHeight;
+
+        stream.AppendLine("q");
+        stream.AppendLine("1 1 1 rg");
+        stream.AppendFormat(CultureInfo.InvariantCulture, "0 0 {0:0.##} {1:0.##} re f\n", paper.WidthPoints, paper.HeightPoints);
+        stream.AppendLine("Q");
+
+        AddText(stream, pageMargin, paper.HeightPoints - pageMargin - 6, 18, Truncate(diagram.Name, 90), bold: true);
+        AddText(stream, pageMargin, paper.HeightPoints - pageMargin - 28, 9,
+            $"Exported {exportedAtUtc:yyyy-MM-dd HH:mm} UTC • {paper.Name} landscape • saved diagram data", bold: false);
+        AddText(stream, pageMargin, pageMargin + 8, 8, DocumentationFooter, bold: false);
+
+        stream.AppendLine("q");
+        stream.AppendLine("0.96 0.98 1 rg");
+        stream.AppendLine("0.82 0.86 0.92 RG");
+        stream.AppendLine("0.75 w");
+        stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.##} {1:0.##} {2:0.##} {3:0.##} re B\n", drawingLeft, drawingBottom, drawingWidth, drawingHeight);
+        stream.AppendLine("Q");
+
+        var bounds = GetExportBounds(diagram);
+        var scaledWidth = bounds.Width * Math.Min(drawingWidth / bounds.Width, drawingHeight / bounds.Height);
+        var scaledHeight = bounds.Height * Math.Min(drawingWidth / bounds.Width, drawingHeight / bounds.Height);
+        var scale = Math.Min(drawingWidth / bounds.Width, drawingHeight / bounds.Height);
+        var offsetX = drawingLeft + (drawingWidth - scaledWidth) / 2;
+        var offsetY = drawingBottom + (drawingHeight - scaledHeight) / 2;
+
+        double MapX(double worldX) => offsetX + (worldX - bounds.MinX) * scale;
+        double MapY(double worldY) => offsetY + scaledHeight - (worldY - bounds.MinY) * scale;
+        double MapWidth(double worldWidth) => worldWidth * scale;
+        double MapHeight(double worldHeight) => worldHeight * scale;
+
+        var nodeLookup = diagram.Nodes.ToDictionary(x => x.NodeId, StringComparer.Ordinal);
+        foreach (var link in diagram.Links)
+        {
+            if (!nodeLookup.TryGetValue(link.SourceNodeId, out var source) || !nodeLookup.TryGetValue(link.TargetNodeId, out var target))
+            {
+                continue;
+            }
+
+            var sx = MapX(source.X + source.Width / 2);
+            var sy = MapY(source.Y + source.Height / 2);
+            var tx = MapX(target.X + target.Width / 2);
+            var ty = MapY(target.Y + target.Height / 2);
+            stream.AppendLine("q");
+            stream.AppendLine("0.28 0.32 0.38 RG");
+            stream.AppendLine("1.5 w");
+            stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.##} {1:0.##} m {2:0.##} {3:0.##} l S\n", sx, sy, tx, ty);
+            stream.AppendLine("Q");
+
+            var label = BuildLinkLabel(link);
+            if (!string.IsNullOrWhiteSpace(label))
+            {
+                AddText(stream, (sx + tx) / 2 - 45, (sy + ty) / 2 + 5, 7, Truncate(label, 48), bold: false);
+            }
+        }
+
+        foreach (var node in diagram.Nodes)
+        {
+            var x = MapX(node.X);
+            var height = Math.Max(22, MapHeight(node.Height));
+            var width = Math.Max(44, MapWidth(node.Width));
+            var y = MapY(node.Y + node.Height);
+            stream.AppendLine("q");
+            if (string.Equals(node.NodeType, "MonitoredEndpoint", StringComparison.OrdinalIgnoreCase))
+            {
+                stream.AppendLine("0.93 0.96 1 rg");
+                stream.AppendLine("0.29 0.48 0.82 RG");
+            }
+            else if (string.Equals(node.NodeType, "Note", StringComparison.OrdinalIgnoreCase))
+            {
+                stream.AppendLine("1 0.98 0.86 rg");
+                stream.AppendLine("0.72 0.53 0.04 RG");
+            }
+            else
+            {
+                stream.AppendLine("1 1 1 rg");
+                stream.AppendLine("0.55 0.61 0.69 RG");
+            }
+
+            stream.AppendLine("1 w");
+            stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.##} {1:0.##} {2:0.##} {3:0.##} re B\n", x, y, width, height);
+            stream.AppendLine("Q");
+
+            AddText(stream, x + 5, y + height - 12, 8, Truncate(node.DisplayLabel, 34), bold: true);
+            AddText(stream, x + 5, y + height - 23, 6.5, FormatNodeType(node.NodeType), bold: false);
+            if (!string.IsNullOrWhiteSpace(node.Notes))
+            {
+                AddText(stream, x + 5, y + 6, 6, Truncate(node.Notes, 44), bold: false);
+            }
+        }
+
+        if (diagram.Nodes.Any(x => !string.IsNullOrWhiteSpace(x.Notes)) || diagram.Links.Any(x => !string.IsNullOrWhiteSpace(x.Notes)))
+        {
+            AddText(stream, pageMargin, pageMargin + 20, 7, "Notes are included on canvas where space allows; export uses the last saved diagram.", bold: false);
+        }
+
+        return stream.ToString();
+    }
+
+    private static DiagramBounds GetExportBounds(NetworkDiagramDto diagram)
+    {
+        if (diagram.Nodes.Count == 0)
+        {
+            return new DiagramBounds(0, 0, Math.Max(1, diagram.CanvasWidth), Math.Max(1, diagram.CanvasHeight));
+        }
+
+        var padding = 160d;
+        var minX = Math.Max(0, diagram.Nodes.Min(x => x.X) - padding);
+        var minY = Math.Max(0, diagram.Nodes.Min(x => x.Y) - padding);
+        var maxX = Math.Min(Math.Max(diagram.CanvasWidth, 1), diagram.Nodes.Max(x => x.X + x.Width) + padding);
+        var maxY = Math.Min(Math.Max(diagram.CanvasHeight, 1), diagram.Nodes.Max(x => x.Y + x.Height) + padding);
+        if (maxX <= minX || maxY <= minY)
+        {
+            return new DiagramBounds(0, 0, Math.Max(1, diagram.CanvasWidth), Math.Max(1, diagram.CanvasHeight));
+        }
+
+        return new DiagramBounds(minX, minY, maxX, maxY);
+    }
+
+    private static string BuildLinkLabel(NetworkDiagramLinkDto link)
+    {
+        var parts = new[] { link.SourcePortLabel, link.Label, link.TargetPortLabel }
+            .Where(x => !string.IsNullOrWhiteSpace(x));
+        return string.Join(" • ", parts);
+    }
+
+    private static string FormatNodeType(string nodeType)
+    {
+        return nodeType switch
+        {
+            "MonitoredEndpoint" => "monitored endpoint",
+            "CustomDevice" => "custom diagram node",
+            "Note" => "note",
+            _ => "diagram node"
+        };
+    }
+
+    private static string MakeSafeFileName(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var safe = new string(value.Select(ch => invalid.Contains(ch) || char.IsWhiteSpace(ch) ? '-' : ch).ToArray()).Trim('-');
+        return string.IsNullOrWhiteSpace(safe) ? "Diagram" : Truncate(safe, 80);
+    }
+
+    private static string Truncate(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var singleLine = value.Replace("\r", " ").Replace("\n", " ").Trim();
+        return singleLine.Length <= maxLength ? singleLine : singleLine[..Math.Max(0, maxLength - 1)] + "…";
+    }
+
+    private static void AddText(StringBuilder stream, double x, double y, double size, string text, bool bold)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+
+        stream.AppendLine("BT");
+        stream.AppendFormat(CultureInfo.InvariantCulture, "/{0} {1:0.##} Tf\n", bold ? "F2" : "F1", size);
+        stream.AppendLine("0 0 0 rg");
+        stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.##} {1:0.##} Td\n", x, y);
+        stream.AppendFormat("({0}) Tj\n", EscapePdfText(text));
+        stream.AppendLine("ET");
+    }
+
+    private static string EscapePdfText(string text)
+    {
+        var normalized = text.Replace("…", "...");
+        var builder = new StringBuilder(normalized.Length);
+        foreach (var ch in normalized)
+        {
+            builder.Append(ch switch
+            {
+                '(' => "\\(",
+                ')' => "\\)",
+                '\\' => "\\\\",
+                >= ' ' and <= '~' => ch,
+                _ => '?'
+            });
+        }
+
+        return builder.ToString();
+    }
+
+    private sealed record PdfPaper(string Name, double WidthPoints, double HeightPoints);
+    private sealed record DiagramBounds(double MinX, double MinY, double MaxX, double MaxY)
+    {
+        public double Width => Math.Max(1, MaxX - MinX);
+        public double Height => Math.Max(1, MaxY - MinY);
+    }
+
+    private static class SimplePdfDocument
+    {
+        public static byte[] Create(double widthPoints, double heightPoints, string content)
+        {
+            var objects = new List<string>
+            {
+                "<< /Type /Catalog /Pages 2 0 R >>",
+                "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+                string.Create(CultureInfo.InvariantCulture, $"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {widthPoints:0.##} {heightPoints:0.##}] /Resources << /Font << /F1 4 0 R /F2 5 0 R >> >> /Contents 6 0 R >>"),
+                "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+                "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>",
+                $"<< /Length {Encoding.ASCII.GetByteCount(content)} >>\nstream\n{content}\nendstream"
+            };
+
+            using var memory = new MemoryStream();
+            void Write(string value)
+            {
+                var bytes = Encoding.ASCII.GetBytes(value);
+                memory.Write(bytes, 0, bytes.Length);
+            }
+
+            Write("%PDF-1.4\n% PingMonitor\n");
+            var offsets = new List<long> { 0 };
+            for (var i = 0; i < objects.Count; i++)
+            {
+                offsets.Add(memory.Position);
+                Write($"{i + 1} 0 obj\n{objects[i]}\nendobj\n");
+            }
+
+            var xrefOffset = memory.Position;
+            Write($"xref\n0 {objects.Count + 1}\n");
+            Write("0000000000 65535 f \n");
+            foreach (var offset in offsets.Skip(1))
+            {
+                Write($"{offset:0000000000} 00000 n \n");
+            }
+
+            Write($"trailer\n<< /Size {objects.Count + 1} /Root 1 0 R >>\nstartxref\n{xrefOffset}\n%%EOF\n");
+            return memory.ToArray();
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramPdfExportService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramPdfExportService.cs
@@ -12,9 +12,204 @@ public sealed record NetworkDiagramPdfExportOptions(string PaperSize, DateTimeOf
 
 public sealed record NetworkDiagramPdfExportResult(byte[] Content, string ContentType, string FileName);
 
+internal sealed record NetworkDiagramPdfTextFitResult(IReadOnlyList<string> Lines, double FontSize)
+{
+    public double LineHeight => FontSize * 1.18d;
+    public double TotalHeight => Lines.Count == 0 ? 0 : FontSize + (Lines.Count - 1) * LineHeight;
+}
+
+internal static class NetworkDiagramPdfTextFitter
+{
+    private const string Ellipsis = "...";
+
+    public static NetworkDiagramPdfTextFitResult Fit(string? text, double maxWidth, int maxLines, double fontSize, double minimumFontSize, bool useEllipsis)
+    {
+        if (maxLines < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxLines), "At least one line is required.");
+        }
+
+        var normalized = Normalize(text);
+        if (string.IsNullOrEmpty(normalized) || maxWidth <= 0)
+        {
+            return new NetworkDiagramPdfTextFitResult(Array.Empty<string>(), Math.Max(minimumFontSize, Math.Min(fontSize, minimumFontSize)));
+        }
+
+        for (var size = fontSize; size >= minimumFontSize; size -= 0.5d)
+        {
+            var lines = Wrap(normalized, maxWidth, size);
+            if (lines.Count <= maxLines && lines.All(line => MeasureWidth(line, size) <= maxWidth + 0.01d))
+            {
+                return new NetworkDiagramPdfTextFitResult(lines, size);
+            }
+        }
+
+        var fittedLines = WrapToMaximumLines(normalized, maxWidth, minimumFontSize, maxLines, useEllipsis);
+        return new NetworkDiagramPdfTextFitResult(fittedLines, minimumFontSize);
+    }
+
+    public static double MeasureWidth(string text, double fontSize)
+    {
+        var width = 0d;
+        foreach (var ch in Normalize(text))
+        {
+            width += CharacterWidthFactor(ch) * fontSize;
+        }
+
+        return width;
+    }
+
+    private static IReadOnlyList<string> WrapToMaximumLines(string text, double maxWidth, double fontSize, int maxLines, bool useEllipsis)
+    {
+        var allLines = Wrap(text, maxWidth, fontSize);
+        if (allLines.Count <= maxLines)
+        {
+            return allLines;
+        }
+
+        var result = allLines.Take(maxLines).ToList();
+        if (useEllipsis && result.Count > 0)
+        {
+            result[^1] = TrimToWidth(result[^1], maxWidth, fontSize, appendEllipsis: true);
+        }
+
+        return result;
+    }
+
+    private static List<string> Wrap(string text, double maxWidth, double fontSize)
+    {
+        var lines = new List<string>();
+        var current = string.Empty;
+        foreach (var word in text.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (MeasureWidth(word, fontSize) > maxWidth)
+            {
+                if (!string.IsNullOrEmpty(current))
+                {
+                    lines.Add(current);
+                    current = string.Empty;
+                }
+
+                lines.AddRange(SplitLongWord(word, maxWidth, fontSize));
+                continue;
+            }
+
+            var candidate = string.IsNullOrEmpty(current) ? word : current + " " + word;
+            if (MeasureWidth(candidate, fontSize) <= maxWidth)
+            {
+                current = candidate;
+            }
+            else
+            {
+                if (!string.IsNullOrEmpty(current))
+                {
+                    lines.Add(current);
+                }
+
+                current = word;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(current))
+        {
+            lines.Add(current);
+        }
+
+        return lines;
+    }
+
+    private static IEnumerable<string> SplitLongWord(string word, double maxWidth, double fontSize)
+    {
+        var current = new StringBuilder();
+        foreach (var ch in word)
+        {
+            var candidate = current.ToString() + ch;
+            if (MeasureWidth(candidate, fontSize) > maxWidth)
+            {
+                if (current.Length > 0)
+                {
+                    yield return current.ToString();
+                    current.Clear();
+                }
+                else
+                {
+                    var singleCharacter = TrimToWidth(ch.ToString(), maxWidth, fontSize, appendEllipsis: false);
+                    if (!string.IsNullOrEmpty(singleCharacter))
+                    {
+                        yield return singleCharacter;
+                    }
+
+                    continue;
+                }
+            }
+
+            current.Append(ch);
+        }
+
+        if (current.Length > 0)
+        {
+            yield return current.ToString();
+        }
+    }
+
+    private static string TrimToWidth(string text, double maxWidth, double fontSize, bool appendEllipsis)
+    {
+        var suffix = appendEllipsis ? TrimSuffixToWidth(Ellipsis, maxWidth, fontSize) : string.Empty;
+        var availableWidth = Math.Max(0, maxWidth - MeasureWidth(suffix, fontSize));
+        var builder = new StringBuilder();
+        foreach (var ch in Normalize(text))
+        {
+            var candidate = builder.ToString() + ch;
+            if (MeasureWidth(candidate, fontSize) > availableWidth)
+            {
+                break;
+            }
+
+            builder.Append(ch);
+        }
+
+        return builder.ToString().TrimEnd() + suffix;
+    }
+
+    private static string TrimSuffixToWidth(string suffix, double maxWidth, double fontSize)
+    {
+        var candidate = suffix;
+        while (candidate.Length > 0 && MeasureWidth(candidate, fontSize) > maxWidth)
+        {
+            candidate = candidate[..^1];
+        }
+
+        return candidate;
+    }
+
+    private static string Normalize(string? text)
+    {
+        return string.IsNullOrWhiteSpace(text)
+            ? string.Empty
+            : text.Replace("\r", " ").Replace("\n", " ").Replace("…", Ellipsis).Trim();
+    }
+
+    private static double CharacterWidthFactor(char ch)
+    {
+        return ch switch
+        {
+            ' ' => 0.28d,
+            '.' or ',' or ':' or ';' or '!' or '|' => 0.25d,
+            'i' or 'l' or 'I' or '1' => 0.28d,
+            'm' or 'w' or 'M' or 'W' => 0.86d,
+            >= 'A' and <= 'Z' => 0.68d,
+            >= '0' and <= '9' => 0.56d,
+            _ => 0.52d
+        };
+    }
+}
+
 internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportService
 {
     private const string DocumentationFooter = "Diagram links are visual documentation only and do not create monitoring dependencies.";
+    private const double MinimumExportNodeWidth = 92d;
+    private const double MinimumExportNodeHeight = 48d;
+    private const double NodePadding = 6d;
 
     public NetworkDiagramPdfExportResult Export(NetworkDiagramDto diagram, NetworkDiagramPdfExportOptions options)
     {
@@ -94,16 +289,19 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
             var label = BuildLinkLabel(link);
             if (!string.IsNullOrWhiteSpace(label))
             {
-                AddText(stream, (sx + tx) / 2 - 45, (sy + ty) / 2 + 5, 7, Truncate(label, 48), bold: false);
+                var fittedLabel = NetworkDiagramPdfTextFitter.Fit(label, maxWidth: 90, maxLines: 1, fontSize: 7, minimumFontSize: 5, useEllipsis: true);
+                AddFittedText(stream, (sx + tx) / 2 - 45, (sy + ty) / 2 + 5, fittedLabel, bold: false);
             }
         }
 
         foreach (var node in diagram.Nodes)
         {
-            var x = MapX(node.X);
-            var height = Math.Max(22, MapHeight(node.Height));
-            var width = Math.Max(44, MapWidth(node.Width));
-            var y = MapY(node.Y + node.Height);
+            var rawWidth = Math.Max(1, MapWidth(node.Width));
+            var rawHeight = Math.Max(1, MapHeight(node.Height));
+            var width = Math.Max(MinimumExportNodeWidth, rawWidth);
+            var height = Math.Max(MinimumExportNodeHeight, rawHeight);
+            var x = MapX(node.X) - (width - rawWidth) / 2;
+            var y = MapY(node.Y + node.Height) - (height - rawHeight) / 2;
             stream.AppendLine("q");
             if (string.Equals(node.NodeType, "MonitoredEndpoint", StringComparison.OrdinalIgnoreCase))
             {
@@ -125,12 +323,7 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
             stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.##} {1:0.##} {2:0.##} {3:0.##} re B\n", x, y, width, height);
             stream.AppendLine("Q");
 
-            AddText(stream, x + 5, y + height - 12, 8, Truncate(node.DisplayLabel, 34), bold: true);
-            AddText(stream, x + 5, y + height - 23, 6.5, FormatNodeType(node.NodeType), bold: false);
-            if (!string.IsNullOrWhiteSpace(node.Notes))
-            {
-                AddText(stream, x + 5, y + 6, 6, Truncate(node.Notes, 44), bold: false);
-            }
+            AddNodeText(stream, node, x, y, width, height);
         }
 
         if (diagram.Nodes.Any(x => !string.IsNullOrWhiteSpace(x.Notes)) || diagram.Links.Any(x => !string.IsNullOrWhiteSpace(x.Notes)))
@@ -195,6 +388,50 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
 
         var singleLine = value.Replace("\r", " ").Replace("\n", " ").Trim();
         return singleLine.Length <= maxLength ? singleLine : singleLine[..Math.Max(0, maxLength - 1)] + "…";
+    }
+
+    private static void AddNodeText(StringBuilder stream, NetworkDiagramNodeDto node, double x, double y, double width, double height)
+    {
+        var contentX = x + NodePadding;
+        var contentTop = y + height - NodePadding;
+        var contentWidth = Math.Max(1, width - NodePadding * 2);
+        var contentHeight = Math.Max(1, height - NodePadding * 2);
+        var currentTop = contentTop;
+
+        stream.AppendLine("q");
+        stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.##} {1:0.##} {2:0.##} {3:0.##} re W n\n", x + 1, y + 1, Math.Max(1, width - 2), Math.Max(1, height - 2));
+
+        var label = NetworkDiagramPdfTextFitter.Fit(node.DisplayLabel, contentWidth, maxLines: 2, fontSize: 8, minimumFontSize: 5.5, useEllipsis: true);
+        AddFittedTextFromTop(stream, contentX, currentTop, label, bold: true);
+        currentTop -= label.TotalHeight + 3;
+
+        if (currentTop - y > 9)
+        {
+            var type = NetworkDiagramPdfTextFitter.Fit(FormatNodeType(node.NodeType), contentWidth, maxLines: 1, fontSize: 6.5, minimumFontSize: 5, useEllipsis: true);
+            AddFittedTextFromTop(stream, contentX, currentTop, type, bold: false);
+            currentTop -= type.TotalHeight + 3;
+        }
+
+        if (!string.IsNullOrWhiteSpace(node.Notes) && currentTop - y > 12 && contentHeight >= 42)
+        {
+            var notes = NetworkDiagramPdfTextFitter.Fit(node.Notes, contentWidth, maxLines: 1, fontSize: 5.5, minimumFontSize: 5, useEllipsis: true);
+            AddFittedText(stream, contentX, y + NodePadding, notes, bold: false);
+        }
+
+        stream.AppendLine("Q");
+    }
+
+    private static void AddFittedTextFromTop(StringBuilder stream, double x, double topY, NetworkDiagramPdfTextFitResult text, bool bold)
+    {
+        AddFittedText(stream, x, topY - text.FontSize, text, bold);
+    }
+
+    private static void AddFittedText(StringBuilder stream, double x, double baselineY, NetworkDiagramPdfTextFitResult text, bool bold)
+    {
+        for (var i = 0; i < text.Lines.Count; i++)
+        {
+            AddText(stream, x, baselineY - i * text.LineHeight, text.FontSize, text.Lines[i], bold);
+        }
     }
 
     private static void AddText(StringBuilder stream, double x, double y, double size, string text, bool bold)

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramService.cs
@@ -31,8 +31,6 @@ public sealed class NetworkDiagramValidationException : InvalidOperationExceptio
 
 internal sealed class NetworkDiagramService : INetworkDiagramService
 {
-    private const double DefaultCanvasWidth = 4000;
-    private const double DefaultCanvasHeight = 2500;
     private readonly PingMonitorDbContext _dbContext;
 
     public NetworkDiagramService(PingMonitorDbContext dbContext)
@@ -71,8 +69,8 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
             DiagramId = Guid.NewGuid().ToString("N"),
             Name = trimmedName,
             Description = TrimOptional(description, 2048),
-            CanvasWidth = DefaultCanvasWidth,
-            CanvasHeight = DefaultCanvasHeight,
+            CanvasWidth = NetworkDiagramPaper.SmallCanvasWidth,
+            CanvasHeight = NetworkDiagramPaper.SmallCanvasHeight,
             ViewportZoom = 1,
             CreatedAtUtc = now,
             UpdatedAtUtc = now,

--- a/src/WebApp/PingMonitor.Web/ViewModels/NetworkDiagrams/NetworkDiagramPersistenceViewModels.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/NetworkDiagrams/NetworkDiagramPersistenceViewModels.cs
@@ -49,6 +49,8 @@ public sealed class NetworkDiagramEditorPageViewModel
 
     public string SaveUrl { get; init; } = string.Empty;
 
+    public string ExportPdfUrl { get; init; } = string.Empty;
+
     public IReadOnlyList<NetworkDiagramEndpointToolboxItemViewModel> MonitoredEndpoints { get; init; } = [];
 }
 

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
@@ -10,7 +10,7 @@
 </head>
 <body>
 @await Html.PartialAsync("_AuthenticatedNav")
-<main class="network-diagrams-main" data-network-diagram-editor data-diagram-id="@Model.DiagramId" data-load-url="@Model.LoadUrl" data-save-url="@Model.SaveUrl">
+<main class="network-diagrams-main" data-network-diagram-editor data-diagram-id="@Model.DiagramId" data-load-url="@Model.LoadUrl" data-save-url="@Model.SaveUrl" data-export-pdf-url="@Model.ExportPdfUrl">
     @Html.AntiForgeryToken()
     <section class="diagram-editor-shell" aria-labelledby="network-diagrams-title">
         <header class="diagram-editor-toolbar">
@@ -98,6 +98,26 @@
                     <button type="button" class="diagram-tool-button" data-reset-view>Reset view</button>
                     <button type="button" class="diagram-tool-button" data-fit-content>Fit content</button>
                     <span class="diagram-zoom-label" data-zoom-label aria-live="polite">100%</span>
+                    <span class="diagram-toolbar-divider" aria-hidden="true"></span>
+                    <label class="diagram-toolbar-select-label">
+                        Canvas size
+                        <select data-canvas-size-preset aria-label="Canvas size preset">
+                            <option value="small">Small (4000 × 2828)</option>
+                            <option value="medium">Medium (5656 × 4000)</option>
+                            <option value="large">Large (8000 × 5657)</option>
+                            <option value="extra-large">Extra large (11314 × 8000)</option>
+                        </select>
+                    </label>
+                    <span class="diagram-canvas-ratio-warning" data-canvas-ratio-warning hidden>Legacy canvas ratio loaded. Choose a canvas size to normalise safely.</span>
+                    <span class="diagram-toolbar-divider" aria-hidden="true"></span>
+                    <label class="diagram-toolbar-select-label">
+                        PDF paper
+                        <select data-export-paper aria-label="PDF paper size">
+                            <option value="A4">A4 landscape</option>
+                            <option value="A3">A3 landscape</option>
+                        </select>
+                    </label>
+                    <button type="button" class="diagram-tool-button" data-export-pdf>Export PDF</button>
                     <button type="button" class="diagram-tool-button" data-save-diagram>Save</button>
                     <span class="diagram-tool-hint" data-tool-hint>Select nodes to move them. Draw link mode creates documentation-only links. Drag empty space to pan. Use mouse wheel to zoom.</span>
                 </div>

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -194,7 +194,7 @@ body {
     left: 0;
     top: 0;
     width: var(--diagram-world-width, 4000px);
-    height: var(--diagram-world-height, 2500px);
+    height: var(--diagram-world-height, 2828px);
     transform-origin: 0 0;
     background:
         linear-gradient(rgba(16, 42, 67, .055) 1px, transparent 1px),
@@ -824,4 +824,45 @@ html[data-theme="dark"] .diagram-link-port-label {
     .diagram-list-card {
         grid-template-columns: 1fr;
     }
+}
+
+.diagram-toolbar-select-label {
+    display: inline-grid;
+    gap: .15rem;
+    color: var(--diagram-muted);
+    font-size: .76rem;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.diagram-toolbar-select-label select {
+    min-height: 44px;
+    border: 1px solid var(--diagram-border);
+    border-radius: 8px;
+    background: var(--diagram-panel);
+    color: var(--diagram-text);
+    font: inherit;
+    font-size: .86rem;
+    font-weight: 700;
+    padding: .45rem .55rem;
+    text-transform: none;
+}
+
+.diagram-canvas-ratio-warning {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    max-width: 260px;
+    padding: .35rem .55rem;
+    border: 1px solid var(--diagram-warning);
+    border-radius: 8px;
+    background: var(--diagram-warning-soft);
+    color: var(--diagram-warning);
+    font-size: .8rem;
+    font-weight: 800;
+    line-height: 1.25;
+}
+
+.diagram-canvas-ratio-warning[hidden] {
+    display: none;
 }

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
@@ -38,10 +38,15 @@
     const selectedNodeHelp = editor.querySelector('[data-selected-node-help]');
     const selectedNodeCount = editor.querySelector('[data-selected-node-count]');
     const saveButton = editor.querySelector('[data-save-diagram]');
+    const exportPdfButton = editor.querySelector('[data-export-pdf]');
+    const exportPaperSelect = editor.querySelector('[data-export-paper]');
+    const canvasSizePresetSelect = editor.querySelector('[data-canvas-size-preset]');
+    const canvasRatioWarning = editor.querySelector('[data-canvas-ratio-warning]');
     const saveStatus = editor.querySelector('[data-save-status]');
     const antiforgeryToken = editor.querySelector('input[name="__RequestVerificationToken"]')?.value || '';
     const loadUrl = editor.dataset.loadUrl || '';
     const saveUrl = editor.dataset.saveUrl || '';
+    const exportPdfUrl = editor.dataset.exportPdfUrl || '';
 
     if (!canvasHost || !canvas || !world || !nodeLayer || !linkLayer) {
         return;
@@ -51,6 +56,13 @@
     const maximumZoom = 3;
     const zoomStep = 1.1;
     const nodeMargin = 8;
+    const aSeriesLandscapeRatio = 1.41421356237;
+    const canvasPresets = [
+        { value: 'small', label: 'Small', width: 4000, height: 2828 },
+        { value: 'medium', label: 'Medium', width: 5656, height: 4000 },
+        { value: 'large', label: 'Large', width: 8000, height: 5657 },
+        { value: 'extra-large', label: 'Extra large', width: 11314, height: 8000 }
+    ];
 
     const state = {
         nodes: [],
@@ -63,7 +75,7 @@
         panX: 0,
         panY: 0,
         virtualCanvasWidth: 4000,
-        virtualCanvasHeight: 2500,
+        virtualCanvasHeight: 2828,
         name: '',
         description: '',
         dirty: false,
@@ -143,13 +155,60 @@
         canvasHost.style.setProperty('--diagram-canvas-width', `${Math.round(rect.width)}px`);
         canvasHost.style.setProperty('--diagram-canvas-height', `${Math.round(rect.height)}px`);
 
+        const orientation = state.virtualCanvasWidth >= state.virtualCanvasHeight ? 'landscape' : 'portrait';
+        const aSeries = isASeriesLandscapeCanvas() ? 'A-series' : 'legacy ratio';
         if (sizeLabel) {
-            sizeLabel.textContent = `${Math.round(rect.width)} x ${Math.round(rect.height)} visible • ${state.virtualCanvasWidth} x ${state.virtualCanvasHeight} world • ${Math.round(state.zoom * 100)}% zoom`;
+            sizeLabel.textContent = `${Math.round(rect.width)} x ${Math.round(rect.height)} visible • ${state.virtualCanvasWidth} x ${state.virtualCanvasHeight} world • ${orientation} ${aSeries} • ${Math.round(state.zoom * 100)}% zoom`;
         }
 
+        if (canvasRatioWarning) {
+            canvasRatioWarning.hidden = isASeriesLandscapeCanvas();
+        }
+
+        syncCanvasPresetSelector();
         applyViewTransform();
         clampAllNodes();
         renderLinks();
+    }
+
+    function isASeriesLandscapeCanvas() {
+        if (state.virtualCanvasWidth <= 0 || state.virtualCanvasHeight <= 0) {
+            return false;
+        }
+
+        return Math.abs((state.virtualCanvasWidth / state.virtualCanvasHeight) - aSeriesLandscapeRatio) < 0.01;
+    }
+
+    function syncCanvasPresetSelector() {
+        if (!canvasSizePresetSelect) {
+            return;
+        }
+
+        const preset = canvasPresets.find(item => item.width === state.virtualCanvasWidth && item.height === state.virtualCanvasHeight);
+        canvasSizePresetSelect.value = preset ? preset.value : '';
+    }
+
+    function canFitNodesWithin(width, height) {
+        return state.nodes.every(node => node.x + getNodeWidth(node) + nodeMargin <= width && node.y + getNodeHeight(node) + nodeMargin <= height);
+    }
+
+    function applyCanvasPreset(value) {
+        const preset = canvasPresets.find(item => item.value === value);
+        if (!preset) {
+            return;
+        }
+
+        if (!canFitNodesWithin(preset.width, preset.height)) {
+            setSaveStatus(`Canvas cannot shrink to ${preset.label}; one or more nodes would be outside the A-series canvas. Move nodes inward or choose a larger size.`, { error: true });
+            syncCanvasPresetSelector();
+            return;
+        }
+
+        state.virtualCanvasWidth = preset.width;
+        state.virtualCanvasHeight = preset.height;
+        updateCanvasSize();
+        markDirty();
+        setSaveStatus(`${preset.label} A-series landscape canvas selected. Save to persist this canvas size.`, { dirty: true });
     }
 
     function formatNodeType(type) {
@@ -1134,6 +1193,23 @@
         };
     }
 
+    function exportPdf() {
+        if (!exportPdfUrl) {
+            return;
+        }
+
+        if (state.dirty) {
+            const confirmed = window.confirm('Export uses the last saved diagram. Save your changes before exporting if you want them in the PDF. Continue exporting the saved version?');
+            if (!confirmed) {
+                return;
+            }
+        }
+
+        const paper = exportPaperSelect ? exportPaperSelect.value : 'A4';
+        const separator = exportPdfUrl.includes('?') ? '&' : '?';
+        window.location.href = `${exportPdfUrl}${separator}paper=${encodeURIComponent(paper)}`;
+    }
+
     async function saveDiagram() {
         if (!saveUrl || !saveButton) {
             return;
@@ -1211,6 +1287,14 @@
 
     if (fitContentButton) {
         fitContentButton.addEventListener('click', fitContent);
+    }
+
+    if (canvasSizePresetSelect) {
+        canvasSizePresetSelect.addEventListener('change', event => applyCanvasPreset(event.currentTarget.value));
+    }
+
+    if (exportPdfButton) {
+        exportPdfButton.addEventListener('click', exportPdf);
     }
 
     if (saveButton) {


### PR DESCRIPTION
### Motivation

- Provide predictable A-series paper-ratio canvases for saved network diagrams so editor world coordinates map to printable paper sizes (A4/A3) without changing monitoring behavior.  
- Offer a safe, server-side PDF export of saved diagrams that renders nodes/links for operator documentation while preserving the documentation-only boundary of diagram links.  

### Description

- Default diagram canvas now uses an ISO 216 A-series landscape ratio and a default world size of `4000 × 2828`, with centralized presets exposed in `NetworkDiagramPaper` and new editor presets (Small/Medium/Large/Extra large).  
- Editor UI added canvas-size presets, a legacy-ratio warning, shrink-blocking logic that prevents cropping existing nodes, an A4/A3 paper selector, and an `Export PDF` button wired to the saved-diagram export endpoint.  
- Server-side PDF export service `INetworkDiagramPdfExportService` was implemented to render saved `NetworkDiagramDto` content to a printable PDF (A4/A3 landscape), produce a safe filename, and include a documentation-only footer; controller route `GET /network-diagrams/{diagramId}/export/pdf` enforces `NetworkDiagramsEnabled` and admin auth.  
- No database schema changes were introduced; existing `CanvasWidth`/`CanvasHeight` fields are reused and the Startup Gate/schema metadata was not changed.  

### Testing

- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which succeeded.  
- Ran `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and all tests passed (109 tests).  
- Executed the repository dev packaging script `pwsh -NoLogo -NoProfile -File scripts/build-dev.ps1` to validate publish/publish layout which completed successfully and confirmed no `src/Agent` files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dc16f45b0832abe4803c62e6a6b5a)