### PR TITLE
Fix network diagram PDF label fitting

### DIFF
--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -222,6 +222,8 @@ This slice adds paper-ratio canvas handling and saved-diagram PDF export without
 - PDF export is server-side, authenticated, admin-only through the existing Network Diagrams controller, and still respects `NetworkDiagramsEnabled`.
 - PDF export renders from the last saved diagram data in the database, not unsaved browser state. The editor warns before exporting when unsaved changes exist.
 - PDF export supports A4 landscape and A3 landscape and scales the saved diagram content to fit the page with padding. The export includes the diagram title, UTC export timestamp, nodes, visual links, link labels/ports where present, node labels, practical notes, and the documentation-only footer.
+- PDF export wraps, shrinks, and truncates node labels and secondary node text so exported text remains inside device boxes. Clipping is also applied to each exported node as a final safety guard.
+- Very dense diagrams may require A3 export or larger canvas spacing for best readability; export does not silently change saved diagram geometry.
 - Diagram links remain visual documentation only and do not create monitoring dependencies.
 - This slice does not change endpoint monitoring, dependency suppression, alerting, agent runtime behaviour, topology discovery, SNMP, or automatic endpoint/dependency creation.
 
@@ -233,6 +235,7 @@ Manual regression checklist for this slice:
 4. Confirm pan, zoom, node dragging, link drawing, and Fit content still work after canvas size changes.
 5. Attempt to shrink below existing node bounds and confirm the editor blocks the change with a clear message.
 6. Export A4 and A3 PDFs and confirm the diagram title, timestamp, nodes, links behind nodes, readable labels, and documentation-only footer appear without editor UI/sidebar/toolbars.
-7. Try exporting with unsaved changes and confirm the editor warns that export uses the last saved diagram.
-8. Disable `NetworkDiagramsEnabled` and confirm the export route is blocked.
-9. Confirm no endpoint dependency, alerting, state-evaluation, or agent data is created or changed.
+7. Confirm long labels such as “Summerhouse Access Point”, “Living Room Access Point”, and dense Trading VM labels stay inside node boxes and do not overlap adjacent nodes.
+8. Try exporting with unsaved changes and confirm the editor warns that export uses the last saved diagram.
+9. Disable `NetworkDiagramsEnabled` and confirm the export route is blocked.
+10. Confirm no endpoint dependency, alerting, state-evaluation, or agent data is created or changed.

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -176,6 +176,36 @@ public sealed class NetworkDiagramsFeatureTests
     }
 
 
+
+    [Fact]
+    public void NetworkDiagramPdfTextFitter_WrapsShortMultiWordLabels()
+    {
+        var fit = NetworkDiagramPdfTextFitter.Fit("Living Room Access Point", maxWidth: 46, maxLines: 2, fontSize: 8, minimumFontSize: 5.5, useEllipsis: true);
+
+        Assert.True(fit.Lines.Count >= 2);
+        Assert.True(fit.Lines.Count <= 2);
+        Assert.All(fit.Lines, line => Assert.True(NetworkDiagramPdfTextFitter.MeasureWidth(line, fit.FontSize) <= 46.01));
+    }
+
+    [Fact]
+    public void NetworkDiagramPdfTextFitter_TruncatesVeryLongLabelsWithEllipsis()
+    {
+        var fit = NetworkDiagramPdfTextFitter.Fit("TradingVmNodeWithAnExtremelyLongUnbrokenHostnameThatCannotFit", maxWidth: 38, maxLines: 1, fontSize: 8, minimumFontSize: 5, useEllipsis: true);
+
+        var line = Assert.Single(fit.Lines);
+        Assert.EndsWith("...", line);
+        Assert.True(NetworkDiagramPdfTextFitter.MeasureWidth(line, fit.FontSize) <= 38.01);
+    }
+
+    [Fact]
+    public void NetworkDiagramPdfTextFitter_NeverReturnsLinesWiderThanMaxWidth()
+    {
+        var fit = NetworkDiagramPdfTextFitter.Fit("Summerhouse Access Point monitored endpoint secondary text", maxWidth: 58, maxLines: 2, fontSize: 8, minimumFontSize: 5, useEllipsis: true);
+
+        Assert.InRange(fit.Lines.Count, 1, 2);
+        Assert.All(fit.Lines, line => Assert.True(NetworkDiagramPdfTextFitter.MeasureWidth(line, fit.FontSize) <= 58.01));
+    }
+
     [Fact]
     public void NetworkDiagramPdfExportService_RendersSavedNodesAndLinksToPdf()
     {
@@ -207,6 +237,53 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("Web server", pdfText);
         Assert.Contains("uplink", pdfText);
         Assert.Contains("Diagram links are visual documentation only", pdfText);
+    }
+
+
+    [Fact]
+    public void NetworkDiagramPdfExportService_ExportsLongAndDenseNodeLabelsToPdf()
+    {
+        var service = new NetworkDiagramPdfExportService();
+        var nodes = new List<NetworkDiagramNodeDto>();
+        for (var i = 0; i < 12; i++)
+        {
+            nodes.Add(new NetworkDiagramNodeDto
+            {
+                NodeId = $"node-{i}",
+                NodeType = "MonitoredEndpoint",
+                DisplayLabel = i % 2 == 0 ? $"Trading VM {i} With Very Long Endpoint Label" : $"Summerhouse Access Point {i}",
+                X = 120 + i * 90,
+                Y = 400 + (i % 3) * 90,
+                Width = 178,
+                Height = 78,
+                Notes = "operator note that should only render when there is enough room"
+            });
+        }
+
+        var diagram = new NetworkDiagramDto
+        {
+            DiagramId = "dense",
+            Name = "Dense Home",
+            CanvasWidth = 4000,
+            CanvasHeight = 2828,
+            Nodes = nodes,
+            Links = nodes.Skip(1).Select((node, index) => new NetworkDiagramLinkDto
+            {
+                LinkId = $"link-{index}",
+                SourceNodeId = nodes[index].NodeId,
+                TargetNodeId = node.NodeId,
+                Label = "very long access uplink label that should not overflow"
+            }).ToArray()
+        };
+
+        var export = service.Export(diagram, new NetworkDiagramPdfExportOptions("A3", new DateTimeOffset(2026, 6, 1, 17, 0, 0, TimeSpan.Zero)));
+        var pdfText = System.Text.Encoding.ASCII.GetString(export.Content);
+
+        Assert.Equal("application/pdf", export.ContentType);
+        Assert.StartsWith("%PDF-1.4", pdfText);
+        Assert.Contains("Dense Home", pdfText);
+        Assert.Contains("re W n", pdfText);
+        Assert.Contains("Trading VM", pdfText);
     }
 
     [Fact]

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramPdfExportService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramPdfExportService.cs
@@ -12,9 +12,204 @@ public sealed record NetworkDiagramPdfExportOptions(string PaperSize, DateTimeOf
 
 public sealed record NetworkDiagramPdfExportResult(byte[] Content, string ContentType, string FileName);
 
+internal sealed record NetworkDiagramPdfTextFitResult(IReadOnlyList<string> Lines, double FontSize)
+{
+    public double LineHeight => FontSize * 1.18d;
+    public double TotalHeight => Lines.Count == 0 ? 0 : FontSize + (Lines.Count - 1) * LineHeight;
+}
+
+internal static class NetworkDiagramPdfTextFitter
+{
+    private const string Ellipsis = "...";
+
+    public static NetworkDiagramPdfTextFitResult Fit(string? text, double maxWidth, int maxLines, double fontSize, double minimumFontSize, bool useEllipsis)
+    {
+        if (maxLines < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxLines), "At least one line is required.");
+        }
+
+        var normalized = Normalize(text);
+        if (string.IsNullOrEmpty(normalized) || maxWidth <= 0)
+        {
+            return new NetworkDiagramPdfTextFitResult(Array.Empty<string>(), Math.Max(minimumFontSize, Math.Min(fontSize, minimumFontSize)));
+        }
+
+        for (var size = fontSize; size >= minimumFontSize; size -= 0.5d)
+        {
+            var lines = Wrap(normalized, maxWidth, size);
+            if (lines.Count <= maxLines && lines.All(line => MeasureWidth(line, size) <= maxWidth + 0.01d))
+            {
+                return new NetworkDiagramPdfTextFitResult(lines, size);
+            }
+        }
+
+        var fittedLines = WrapToMaximumLines(normalized, maxWidth, minimumFontSize, maxLines, useEllipsis);
+        return new NetworkDiagramPdfTextFitResult(fittedLines, minimumFontSize);
+    }
+
+    public static double MeasureWidth(string text, double fontSize)
+    {
+        var width = 0d;
+        foreach (var ch in Normalize(text))
+        {
+            width += CharacterWidthFactor(ch) * fontSize;
+        }
+
+        return width;
+    }
+
+    private static IReadOnlyList<string> WrapToMaximumLines(string text, double maxWidth, double fontSize, int maxLines, bool useEllipsis)
+    {
+        var allLines = Wrap(text, maxWidth, fontSize);
+        if (allLines.Count <= maxLines)
+        {
+            return allLines;
+        }
+
+        var result = allLines.Take(maxLines).ToList();
+        if (useEllipsis && result.Count > 0)
+        {
+            result[^1] = TrimToWidth(result[^1], maxWidth, fontSize, appendEllipsis: true);
+        }
+
+        return result;
+    }
+
+    private static List<string> Wrap(string text, double maxWidth, double fontSize)
+    {
+        var lines = new List<string>();
+        var current = string.Empty;
+        foreach (var word in text.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (MeasureWidth(word, fontSize) > maxWidth)
+            {
+                if (!string.IsNullOrEmpty(current))
+                {
+                    lines.Add(current);
+                    current = string.Empty;
+                }
+
+                lines.AddRange(SplitLongWord(word, maxWidth, fontSize));
+                continue;
+            }
+
+            var candidate = string.IsNullOrEmpty(current) ? word : current + " " + word;
+            if (MeasureWidth(candidate, fontSize) <= maxWidth)
+            {
+                current = candidate;
+            }
+            else
+            {
+                if (!string.IsNullOrEmpty(current))
+                {
+                    lines.Add(current);
+                }
+
+                current = word;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(current))
+        {
+            lines.Add(current);
+        }
+
+        return lines;
+    }
+
+    private static IEnumerable<string> SplitLongWord(string word, double maxWidth, double fontSize)
+    {
+        var current = new StringBuilder();
+        foreach (var ch in word)
+        {
+            var candidate = current.ToString() + ch;
+            if (MeasureWidth(candidate, fontSize) > maxWidth)
+            {
+                if (current.Length > 0)
+                {
+                    yield return current.ToString();
+                    current.Clear();
+                }
+                else
+                {
+                    var singleCharacter = TrimToWidth(ch.ToString(), maxWidth, fontSize, appendEllipsis: false);
+                    if (!string.IsNullOrEmpty(singleCharacter))
+                    {
+                        yield return singleCharacter;
+                    }
+
+                    continue;
+                }
+            }
+
+            current.Append(ch);
+        }
+
+        if (current.Length > 0)
+        {
+            yield return current.ToString();
+        }
+    }
+
+    private static string TrimToWidth(string text, double maxWidth, double fontSize, bool appendEllipsis)
+    {
+        var suffix = appendEllipsis ? TrimSuffixToWidth(Ellipsis, maxWidth, fontSize) : string.Empty;
+        var availableWidth = Math.Max(0, maxWidth - MeasureWidth(suffix, fontSize));
+        var builder = new StringBuilder();
+        foreach (var ch in Normalize(text))
+        {
+            var candidate = builder.ToString() + ch;
+            if (MeasureWidth(candidate, fontSize) > availableWidth)
+            {
+                break;
+            }
+
+            builder.Append(ch);
+        }
+
+        return builder.ToString().TrimEnd() + suffix;
+    }
+
+    private static string TrimSuffixToWidth(string suffix, double maxWidth, double fontSize)
+    {
+        var candidate = suffix;
+        while (candidate.Length > 0 && MeasureWidth(candidate, fontSize) > maxWidth)
+        {
+            candidate = candidate[..^1];
+        }
+
+        return candidate;
+    }
+
+    private static string Normalize(string? text)
+    {
+        return string.IsNullOrWhiteSpace(text)
+            ? string.Empty
+            : text.Replace("\r", " ").Replace("\n", " ").Replace("…", Ellipsis).Trim();
+    }
+
+    private static double CharacterWidthFactor(char ch)
+    {
+        return ch switch
+        {
+            ' ' => 0.28d,
+            '.' or ',' or ':' or ';' or '!' or '|' => 0.25d,
+            'i' or 'l' or 'I' or '1' => 0.28d,
+            'm' or 'w' or 'M' or 'W' => 0.86d,
+            >= 'A' and <= 'Z' => 0.68d,
+            >= '0' and <= '9' => 0.56d,
+            _ => 0.52d
+        };
+    }
+}
+
 internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportService
 {
     private const string DocumentationFooter = "Diagram links are visual documentation only and do not create monitoring dependencies.";
+    private const double MinimumExportNodeWidth = 92d;
+    private const double MinimumExportNodeHeight = 48d;
+    private const double NodePadding = 6d;
 
     public NetworkDiagramPdfExportResult Export(NetworkDiagramDto diagram, NetworkDiagramPdfExportOptions options)
     {
@@ -94,16 +289,19 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
             var label = BuildLinkLabel(link);
             if (!string.IsNullOrWhiteSpace(label))
             {
-                AddText(stream, (sx + tx) / 2 - 45, (sy + ty) / 2 + 5, 7, Truncate(label, 48), bold: false);
+                var fittedLabel = NetworkDiagramPdfTextFitter.Fit(label, maxWidth: 90, maxLines: 1, fontSize: 7, minimumFontSize: 5, useEllipsis: true);
+                AddFittedText(stream, (sx + tx) / 2 - 45, (sy + ty) / 2 + 5, fittedLabel, bold: false);
             }
         }
 
         foreach (var node in diagram.Nodes)
         {
-            var x = MapX(node.X);
-            var height = Math.Max(22, MapHeight(node.Height));
-            var width = Math.Max(44, MapWidth(node.Width));
-            var y = MapY(node.Y + node.Height);
+            var rawWidth = Math.Max(1, MapWidth(node.Width));
+            var rawHeight = Math.Max(1, MapHeight(node.Height));
+            var width = Math.Max(MinimumExportNodeWidth, rawWidth);
+            var height = Math.Max(MinimumExportNodeHeight, rawHeight);
+            var x = MapX(node.X) - (width - rawWidth) / 2;
+            var y = MapY(node.Y + node.Height) - (height - rawHeight) / 2;
             stream.AppendLine("q");
             if (string.Equals(node.NodeType, "MonitoredEndpoint", StringComparison.OrdinalIgnoreCase))
             {
@@ -125,12 +323,7 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
             stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.##} {1:0.##} {2:0.##} {3:0.##} re B\n", x, y, width, height);
             stream.AppendLine("Q");
 
-            AddText(stream, x + 5, y + height - 12, 8, Truncate(node.DisplayLabel, 34), bold: true);
-            AddText(stream, x + 5, y + height - 23, 6.5, FormatNodeType(node.NodeType), bold: false);
-            if (!string.IsNullOrWhiteSpace(node.Notes))
-            {
-                AddText(stream, x + 5, y + 6, 6, Truncate(node.Notes, 44), bold: false);
-            }
+            AddNodeText(stream, node, x, y, width, height);
         }
 
         if (diagram.Nodes.Any(x => !string.IsNullOrWhiteSpace(x.Notes)) || diagram.Links.Any(x => !string.IsNullOrWhiteSpace(x.Notes)))
@@ -195,6 +388,50 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
 
         var singleLine = value.Replace("\r", " ").Replace("\n", " ").Trim();
         return singleLine.Length <= maxLength ? singleLine : singleLine[..Math.Max(0, maxLength - 1)] + "…";
+    }
+
+    private static void AddNodeText(StringBuilder stream, NetworkDiagramNodeDto node, double x, double y, double width, double height)
+    {
+        var contentX = x + NodePadding;
+        var contentTop = y + height - NodePadding;
+        var contentWidth = Math.Max(1, width - NodePadding * 2);
+        var contentHeight = Math.Max(1, height - NodePadding * 2);
+        var currentTop = contentTop;
+
+        stream.AppendLine("q");
+        stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.##} {1:0.##} {2:0.##} {3:0.##} re W n\n", x + 1, y + 1, Math.Max(1, width - 2), Math.Max(1, height - 2));
+
+        var label = NetworkDiagramPdfTextFitter.Fit(node.DisplayLabel, contentWidth, maxLines: 2, fontSize: 8, minimumFontSize: 5.5, useEllipsis: true);
+        AddFittedTextFromTop(stream, contentX, currentTop, label, bold: true);
+        currentTop -= label.TotalHeight + 3;
+
+        if (currentTop - y > 9)
+        {
+            var type = NetworkDiagramPdfTextFitter.Fit(FormatNodeType(node.NodeType), contentWidth, maxLines: 1, fontSize: 6.5, minimumFontSize: 5, useEllipsis: true);
+            AddFittedTextFromTop(stream, contentX, currentTop, type, bold: false);
+            currentTop -= type.TotalHeight + 3;
+        }
+
+        if (!string.IsNullOrWhiteSpace(node.Notes) && currentTop - y > 12 && contentHeight >= 42)
+        {
+            var notes = NetworkDiagramPdfTextFitter.Fit(node.Notes, contentWidth, maxLines: 1, fontSize: 5.5, minimumFontSize: 5, useEllipsis: true);
+            AddFittedText(stream, contentX, y + NodePadding, notes, bold: false);
+        }
+
+        stream.AppendLine("Q");
+    }
+
+    private static void AddFittedTextFromTop(StringBuilder stream, double x, double topY, NetworkDiagramPdfTextFitResult text, bool bold)
+    {
+        AddFittedText(stream, x, topY - text.FontSize, text, bold);
+    }
+
+    private static void AddFittedText(StringBuilder stream, double x, double baselineY, NetworkDiagramPdfTextFitResult text, bool bold)
+    {
+        for (var i = 0; i < text.Lines.Count; i++)
+        {
+            AddText(stream, x, baselineY - i * text.LineHeight, text.FontSize, text.Lines[i], bold);
+        }
     }
 
     private static void AddText(StringBuilder stream, double x, double y, double size, string text, bool bold)


### PR DESCRIPTION
### Motivation
- PDF export was allowing long node and link labels to overflow device boxes and overlap adjacent nodes, making exported diagrams unreadable.
- The change implements deterministic, export-only text fitting and clipping so exported PDFs match the editor layout expectations without changing diagram data or monitoring semantics.
- Preserve A-series mapping and saved world coordinates while ensuring a minimum readable rendering size for very small scaled nodes.

### Description
- Added a reusable text-fitting helper `NetworkDiagramPdfTextFitter` that supports `maxWidth`, `maxLines`, `fontSize`, `minimumFontSize`, wrapping, long-word splitting, shrink-to-fit and optional ellipsis for overflow handling.
- Updated `NetworkDiagramPdfExportService` to use the fitter for node labels, secondary type text, link labels and notes, added `AddNodeText`/`AddFittedText` helpers, applied a per-node clipping region, and enforced deterministic minimum export node sizes while keeping node centers aligned.
- Truncated/fitted long link labels and ensured links remain drawn behind nodes; no monitoring, dependency, or agent behaviour was changed and export continues to render from saved diagram data.
- Documentation updated to note wrapping/shrinking/truncation and A3 guidance, and this PR links the existing issue with `Fixes #504`.

### Testing
- Ran unit tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and the targeted `NetworkDiagramsFeatureTests`, and all tests passed (new and existing tests included). 
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which succeeded.
- Executed the dev packaging smoke script `pwsh -NoLogo -NoProfile -File scripts/build-dev.ps1` to validate publish/publish-time checks which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dcc4f8e50832abfea5634b2ab277b)