### PR TITLE
Enhance network diagram links: media types, labels, and parallel offsets

### DIFF
--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -239,3 +239,40 @@ Manual regression checklist for this slice:
 8. Try exporting with unsaved changes and confirm the editor warns that export uses the last saved diagram.
 9. Disable `NetworkDiagramsEnabled` and confirm the export route is blocked.
 10. Confirm no endpoint dependency, alerting, state-evaluation, or agent data is created or changed.
+
+## Link Styling, Labels, and Parallel Links Slice
+
+This slice enhances saved Network Diagram links while preserving the architectural boundary that links are documentation/status-overlay data only.
+
+Added capabilities:
+
+- Link media/type can be selected while drawing and edited later from the Properties panel.
+- Supported visual/documentation link types are Copper, Fibre, Wireless, LACP, VPN, Logical, and Other.
+- Copper, fibre, wireless, LACP, VPN, logical, and other links use distinct editor/PDF styles; wireless links are dashed.
+- Link labels and notes are visible on the canvas near the link midpoint, with link notes included when present.
+- Multiple separate links between the same two devices are allowed and are rendered with deterministic parallel offsets so they do not exactly overlap after save/reload.
+- Link type, label, source port, target port, notes, and multiple same-pair links round-trip through persistence and PDF export.
+
+Safety boundary:
+
+- Diagram links remain documentation-only.
+- Drawing, editing, deleting, styling, or exporting diagram links does not create, update, or delete endpoint monitoring dependencies.
+- Link media/type is visual/documentation metadata only and does not affect endpoint monitoring, state evaluation, dependency suppression, alerting, agents, or Startup Gate behaviour.
+
+Manual regression checklist for this slice:
+
+1. Enable `NetworkDiagramsEnabled`.
+2. Create/open a diagram.
+3. Draw a copper link.
+4. Draw a fibre link.
+5. Draw a wireless link and confirm it is dashed.
+6. Draw two or more links between the same two devices and confirm they are visually separated.
+7. Select each parallel link individually.
+8. Edit link type from the Properties panel and confirm the style updates immediately.
+9. Add notes to a link and confirm they appear on the link.
+10. Add label/source port/target port and confirm the on-canvas display is readable.
+11. Move connected nodes and confirm all parallel links and labels follow.
+12. Save, refresh, and confirm link types/notes/parallel links reload correctly.
+13. Export to PDF and confirm link styles/labels/parallel links are represented.
+14. Confirm no endpoint dependencies are created or modified.
+15. Disable `NetworkDiagramsEnabled` and confirm navigation/direct access remain blocked.

--- a/docs/network_diagrams_v_0_1_1_design_notes.md
+++ b/docs/network_diagrams_v_0_1_1_design_notes.md
@@ -468,3 +468,9 @@ The Properties panel supports draft-only edits for exactly one selected node: di
 The link Properties panel supports draft-only edits for label, source port, target port, and notes, and repeats that visual links do not create or modify monitoring dependencies. Deleting a selected link removes only the draft visual link. Deleting selected node(s) removes only draft diagram nodes and attached draft visual links; it does not delete endpoints, assignments, monitoring data, dependencies, alerts, or agent state.
 
 This remains a client-side draft-only slice. No saved diagram layout, database persistence, monitoring state evaluation, dependency suppression, alerting, Startup Gate, or agent behavior is changed. Marquee selection remains future work to avoid risking pan/zoom regressions.
+
+## Link Styling/Label Enhancement Notes
+
+Network diagram links now support documentation-only media/type metadata for Copper, Fibre, Wireless, LACP, VPN, Logical, and Other. The selected type controls editor and PDF styling only; wireless uses a dashed line, fibre is visually distinct from copper, and LACP/VPN/logical links use pattern/weight differences so the styling is not colour-only.
+
+Link labels and notes are drawn on-canvas near the link midpoint, and multiple links between the same unordered node pair are grouped and offset deterministically so A → B and B → A links do not overlap after save/reload. These visual links remain separate from monitoring dependencies: creating, editing, deleting, saving, or exporting links must not alter endpoint monitoring, dependency suppression, state evaluation, alerting, agents, or Startup Gate behaviour.

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -131,7 +131,10 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains(@"data-node-field=""label""", viewMarkup);
         Assert.Contains(@"data-node-field=""notes""", viewMarkup);
         Assert.Contains("data-multi-node-properties", viewMarkup);
-        Assert.Contains("This visual link does not create or modify monitoring dependencies.", viewMarkup);
+        Assert.Contains("Link type controls diagram styling only. Links do not create monitoring dependencies.", viewMarkup);
+        Assert.Contains("data-draw-link-type", viewMarkup);
+        Assert.Contains(@"data-link-field=""linkType""", viewMarkup);
+        Assert.Contains("Wireless", viewMarkup);
         Assert.Contains("Zoom in", viewMarkup);
         Assert.Contains("Zoom out", viewMarkup);
         Assert.Contains("Reset view", viewMarkup);
@@ -175,7 +178,42 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("Export uses the last saved diagram", script);
     }
 
+    [Fact]
+    public void NetworkDiagramLinkTypes_NormalizesOldAndMissingValuesToCopper()
+    {
+        Assert.Equal(NetworkDiagramLinkTypes.Copper, NetworkDiagramLinkTypes.Normalize(null));
+        Assert.Equal(NetworkDiagramLinkTypes.Copper, NetworkDiagramLinkTypes.Normalize("default"));
+        Assert.Equal(NetworkDiagramLinkTypes.Fibre, NetworkDiagramLinkTypes.Normalize("fibre"));
+        Assert.True(NetworkDiagramLinkTypes.IsAllowed("Wireless"));
+        Assert.False(NetworkDiagramLinkTypes.IsAllowed("unsupported"));
+    }
 
+    [Fact]
+    public void NetworkDiagramService_ValidatesAndPersistsLinkTypeMetadata()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var serviceSource = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "Services", "NetworkDiagrams", "NetworkDiagramService.cs"));
+
+        Assert.Contains("Unsupported link type", serviceSource);
+        Assert.Contains("NetworkDiagramLinkTypes.Normalize(TrimOptional(linkRequest.LinkType, 64))", serviceSource);
+        Assert.Contains("LinkType = NetworkDiagramLinkTypes.Normalize(x.LinkType)", serviceSource);
+        Assert.DoesNotContain("same two", serviceSource, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void NetworkDiagramEditor_AllowsParallelLinksAndRendersLabelsByType()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var script = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "wwwroot", "js", "network-diagrams-editor.js"));
+        var styles = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "wwwroot", "css", "network-diagrams.css"));
+
+        Assert.DoesNotContain("linkExists(sourceNodeId, targetNodeId)", script);
+        Assert.Contains("getParallelOffsetIndexes", script);
+        Assert.Contains("buildVisibleLinkLabel", script);
+        Assert.Contains(@"data-link-type=""wireless""", styles);
+        Assert.Contains("stroke-dasharray: 12 8", styles);
+        Assert.Contains(@"data-link-type=""fibre""", styles);
+    }
 
     [Fact]
     public void NetworkDiagramPdfTextFitter_WrapsShortMultiWordLabels()
@@ -223,7 +261,9 @@ public sealed class NetworkDiagramsFeatureTests
             ],
             Links =
             [
-                new NetworkDiagramLinkDto { LinkId = "link-1", SourceNodeId = "node-1", TargetNodeId = "node-2", Label = "uplink", SourcePortLabel = "Gi1/0/1", TargetPortLabel = "eth0" }
+                new NetworkDiagramLinkDto { LinkId = "link-1", SourceNodeId = "node-1", TargetNodeId = "node-2", Label = "uplink", SourcePortLabel = "Gi1/0/1", TargetPortLabel = "eth0", LinkType = NetworkDiagramLinkTypes.Copper },
+                new NetworkDiagramLinkDto { LinkId = "link-2", SourceNodeId = "node-2", TargetNodeId = "node-1", Label = "backup", Notes = "wireless failover", LinkType = NetworkDiagramLinkTypes.Wireless },
+                new NetworkDiagramLinkDto { LinkId = "link-3", SourceNodeId = "node-1", TargetNodeId = "node-2", Label = "storage", Notes = "10Gb fibre", LinkType = NetworkDiagramLinkTypes.Fibre }
             ]
         };
 
@@ -236,6 +276,10 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("Router", pdfText);
         Assert.Contains("Web server", pdfText);
         Assert.Contains("uplink", pdfText);
+        Assert.Contains("wireless failover", pdfText);
+        Assert.Contains("10Gb fibre", pdfText);
+        Assert.Contains("[8 5] 0 d", pdfText);
+        Assert.Contains("0.49 0.23 0.93 RG", pdfText);
         Assert.Contains("Diagram links are visual documentation only", pdfText);
     }
 

--- a/src/WebApp/PingMonitor.Web/Models/NetworkDiagramLink.cs
+++ b/src/WebApp/PingMonitor.Web/Models/NetworkDiagramLink.cs
@@ -10,7 +10,7 @@ public sealed class NetworkDiagramLink
     public string? SourcePortLabel { get; set; }
     public string? TargetPortLabel { get; set; }
     public string? Notes { get; set; }
-    public string LinkType { get; set; } = "default";
+    public string LinkType { get; set; } = "Copper";
     public string? MetadataJson { get; set; }
     public DateTimeOffset CreatedAtUtc { get; set; }
     public DateTimeOffset UpdatedAtUtc { get; set; }

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramModels.cs
@@ -2,6 +2,41 @@ using PingMonitor.Web.Models;
 
 namespace PingMonitor.Web.Services.NetworkDiagrams;
 
+public static class NetworkDiagramLinkTypes
+{
+    public const string Copper = "Copper";
+    public const string Fibre = "Fibre";
+    public const string Wireless = "Wireless";
+    public const string Lacp = "LACP";
+    public const string Vpn = "VPN";
+    public const string Logical = "Logical";
+    public const string Other = "Other";
+
+    public static readonly IReadOnlySet<string> Allowed = new HashSet<string>(StringComparer.Ordinal)
+    {
+        Copper,
+        Fibre,
+        Wireless,
+        Lacp,
+        Vpn,
+        Logical,
+        Other
+    };
+
+    public static string Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || string.Equals(value.Trim(), "default", StringComparison.OrdinalIgnoreCase))
+        {
+            return Copper;
+        }
+
+        var trimmed = value.Trim();
+        return Allowed.FirstOrDefault(allowed => string.Equals(allowed, trimmed, StringComparison.OrdinalIgnoreCase)) ?? trimmed;
+    }
+
+    public static bool IsAllowed(string? value) => Allowed.Contains(Normalize(value));
+}
+
 public sealed class NetworkDiagramSaveRequest
 {
     public string Name { get; init; } = string.Empty;
@@ -82,6 +117,6 @@ public sealed class NetworkDiagramLinkDto
     public string? SourcePortLabel { get; init; }
     public string? TargetPortLabel { get; init; }
     public string? Notes { get; init; }
-    public string LinkType { get; init; } = "default";
+    public string LinkType { get; init; } = NetworkDiagramLinkTypes.Copper;
     public string? MetadataJson { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramPdfExportService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramPdfExportService.cs
@@ -269,6 +269,7 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
         double MapHeight(double worldHeight) => worldHeight * scale;
 
         var nodeLookup = diagram.Nodes.ToDictionary(x => x.NodeId, StringComparer.Ordinal);
+        var offsetIndexes = GetParallelOffsetIndexes(diagram.Links);
         foreach (var link in diagram.Links)
         {
             if (!nodeLookup.TryGetValue(link.SourceNodeId, out var source) || !nodeLookup.TryGetValue(link.TargetNodeId, out var target))
@@ -280,17 +281,17 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
             var sy = MapY(source.Y + source.Height / 2);
             var tx = MapX(target.X + target.Width / 2);
             var ty = MapY(target.Y + target.Height / 2);
+            var geometry = BuildLinkGeometry(sx, sy, tx, ty, offsetIndexes.GetValueOrDefault(link.LinkId));
             stream.AppendLine("q");
-            stream.AppendLine("0.28 0.32 0.38 RG");
-            stream.AppendLine("1.5 w");
-            stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.##} {1:0.##} m {2:0.##} {3:0.##} l S\n", sx, sy, tx, ty);
+            ApplyLinkStyle(stream, link.LinkType);
+            stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.##} {1:0.##} m {2:0.##} {3:0.##} l S\n", geometry.StartX, geometry.StartY, geometry.EndX, geometry.EndY);
             stream.AppendLine("Q");
 
             var label = BuildLinkLabel(link);
             if (!string.IsNullOrWhiteSpace(label))
             {
-                var fittedLabel = NetworkDiagramPdfTextFitter.Fit(label, maxWidth: 90, maxLines: 1, fontSize: 7, minimumFontSize: 5, useEllipsis: true);
-                AddFittedText(stream, (sx + tx) / 2 - 45, (sy + ty) / 2 + 5, fittedLabel, bold: false);
+                var fittedLabel = NetworkDiagramPdfTextFitter.Fit(label, maxWidth: 132, maxLines: 1, fontSize: 7, minimumFontSize: 5, useEllipsis: true);
+                AddFittedText(stream, geometry.LabelX - 66, geometry.LabelY + 5, fittedLabel, bold: false);
             }
         }
 
@@ -334,6 +335,83 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
         return stream.ToString();
     }
 
+
+    private static Dictionary<string, double> GetParallelOffsetIndexes(IReadOnlyList<NetworkDiagramLinkDto> links)
+    {
+        var result = new Dictionary<string, double>(StringComparer.Ordinal);
+        foreach (var group in links.GroupBy(link => string.CompareOrdinal(link.SourceNodeId, link.TargetNodeId) <= 0
+            ? $"{link.SourceNodeId}::{link.TargetNodeId}"
+            : $"{link.TargetNodeId}::{link.SourceNodeId}"))
+        {
+            var ordered = group.OrderBy(link => link.LinkId, StringComparer.Ordinal).ToArray();
+            var center = (ordered.Length - 1) / 2d;
+            for (var i = 0; i < ordered.Length; i++)
+            {
+                result[ordered[i].LinkId] = i - center;
+            }
+        }
+
+        return result;
+    }
+
+    private static LinkGeometry BuildLinkGeometry(double sx, double sy, double tx, double ty, double offsetIndex)
+    {
+        var dx = tx - sx;
+        var dy = ty - sy;
+        var length = Math.Sqrt(dx * dx + dy * dy);
+        if (length <= 0.01d)
+        {
+            length = 1d;
+        }
+
+        var px = -dy / length;
+        var py = dx / length;
+        var offset = offsetIndex * 9d;
+        var startX = sx + px * offset;
+        var startY = sy + py * offset;
+        var endX = tx + px * offset;
+        var endY = ty + py * offset;
+
+        return new LinkGeometry(startX, startY, endX, endY, (startX + endX) / 2, (startY + endY) / 2 + (offset == 0 ? 6 : Math.Sign(offset) * 6));
+    }
+
+    private static void ApplyLinkStyle(StringBuilder stream, string? linkType)
+    {
+        switch (NetworkDiagramLinkTypes.Normalize(linkType))
+        {
+            case NetworkDiagramLinkTypes.Fibre:
+                stream.AppendLine("0.49 0.23 0.93 RG");
+                stream.AppendLine("1.8 w");
+                stream.AppendLine("[] 0 d");
+                break;
+            case NetworkDiagramLinkTypes.Wireless:
+                stream.AppendLine("0.28 0.32 0.38 RG");
+                stream.AppendLine("1.5 w");
+                stream.AppendLine("[8 5] 0 d");
+                break;
+            case NetworkDiagramLinkTypes.Lacp:
+                stream.AppendLine("0.28 0.32 0.38 RG");
+                stream.AppendLine("2.4 w");
+                stream.AppendLine("[] 0 d");
+                break;
+            case NetworkDiagramLinkTypes.Vpn:
+                stream.AppendLine("0.28 0.32 0.38 RG");
+                stream.AppendLine("1.5 w");
+                stream.AppendLine("[9 4 2 4] 0 d");
+                break;
+            case NetworkDiagramLinkTypes.Logical:
+                stream.AppendLine("0.48 0.55 0.64 RG");
+                stream.AppendLine("1.2 w");
+                stream.AppendLine("[4 4] 0 d");
+                break;
+            default:
+                stream.AppendLine("0.28 0.32 0.38 RG");
+                stream.AppendLine("1.5 w");
+                stream.AppendLine("[] 0 d");
+                break;
+        }
+    }
+
     private static DiagramBounds GetExportBounds(NetworkDiagramDto diagram)
     {
         if (diagram.Nodes.Count == 0)
@@ -356,7 +434,11 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
 
     private static string BuildLinkLabel(NetworkDiagramLinkDto link)
     {
-        var parts = new[] { link.SourcePortLabel, link.Label, link.TargetPortLabel }
+        var ports = !string.IsNullOrWhiteSpace(link.SourcePortLabel) || !string.IsNullOrWhiteSpace(link.TargetPortLabel)
+            ? $"{link.SourcePortLabel ?? "?"} <-> {link.TargetPortLabel ?? "?"}"
+            : null;
+        var labelAndNotes = string.Join(" -- ", new[] { link.Label, link.Notes }.Where(x => !string.IsNullOrWhiteSpace(x)));
+        var parts = new[] { NetworkDiagramLinkTypes.Normalize(link.LinkType), ports, labelAndNotes }
             .Where(x => !string.IsNullOrWhiteSpace(x));
         return string.Join(" • ", parts);
     }
@@ -469,6 +551,7 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
     }
 
     private sealed record PdfPaper(string Name, double WidthPoints, double HeightPoints);
+    private sealed record LinkGeometry(double StartX, double StartY, double EndX, double EndY, double LabelX, double LabelY);
     private sealed record DiagramBounds(double MinX, double MinY, double MaxX, double MaxY)
     {
         public double Width => Math.Max(1, MaxX - MinX);

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramService.cs
@@ -153,7 +153,7 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
                 SourcePortLabel = TrimOptional(linkRequest.SourcePortLabel, 128),
                 TargetPortLabel = TrimOptional(linkRequest.TargetPortLabel, 128),
                 Notes = TrimOptional(linkRequest.Notes, 4096),
-                LinkType = TrimOptional(linkRequest.LinkType, 64) ?? "default",
+                LinkType = NetworkDiagramLinkTypes.Normalize(TrimOptional(linkRequest.LinkType, 64)),
                 MetadataJson = TrimOptional(linkRequest.MetadataJson, 65535),
                 CreatedAtUtc = now,
                 UpdatedAtUtc = now
@@ -233,6 +233,17 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
             {
                 throw new NetworkDiagramValidationException("Diagram links must reference nodes in the same diagram payload.");
             }
+
+            var linkType = TrimOptional(link.LinkType, 64);
+            if (!NetworkDiagramLinkTypes.IsAllowed(linkType))
+            {
+                throw new NetworkDiagramValidationException($"Unsupported link type '{linkType}'.");
+            }
+
+            _ = TrimOptional(link.Label, 255);
+            _ = TrimOptional(link.SourcePortLabel, 128);
+            _ = TrimOptional(link.TargetPortLabel, 128);
+            _ = TrimOptional(link.Notes, 4096);
         }
     }
 
@@ -272,7 +283,7 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
                 SourcePortLabel = x.SourcePortLabel,
                 TargetPortLabel = x.TargetPortLabel,
                 Notes = x.Notes,
-                LinkType = x.LinkType,
+                LinkType = NetworkDiagramLinkTypes.Normalize(x.LinkType),
                 MetadataJson = x.MetadataJson
             }).ToArray()
         };

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
@@ -88,6 +88,18 @@
                 <div class="diagram-workspace-toolbar" aria-label="Network diagram tools">
                     <button type="button" class="diagram-tool-button" data-tool-button="select" aria-pressed="true">Select / move</button>
                     <button type="button" class="diagram-tool-button" data-tool-button="draw-link" aria-pressed="false">Draw link</button>
+                    <label class="diagram-toolbar-select-label diagram-link-type-toolbar">
+                        Link type
+                        <select data-draw-link-type aria-label="Link type for newly drawn links">
+                            <option value="Copper">Copper</option>
+                            <option value="Fibre">Fibre</option>
+                            <option value="Wireless">Wireless</option>
+                            <option value="LACP">LACP</option>
+                            <option value="VPN">VPN</option>
+                            <option value="Logical">Logical</option>
+                            <option value="Other">Other</option>
+                        </select>
+                    </label>
                     <span class="diagram-toolbar-divider" aria-hidden="true"></span>
                     <button type="button" class="diagram-tool-button" data-select-all>Select all nodes</button>
                     <button type="button" class="diagram-tool-button" data-clear-selection disabled>Clear selection</button>
@@ -171,7 +183,19 @@
                     <button type="button" class="danger-button" data-delete-selection>Delete selected nodes</button>
                 </div>
                 <form class="link-properties" data-link-properties hidden>
-                    <p class="toolbox-help">This visual link does not create or modify monitoring dependencies. Link metadata is saved diagram documentation only.</p>
+                    <p class="toolbox-help">Link type controls diagram styling only. Links do not create monitoring dependencies.</p>
+                    <label>
+                        Link type / media
+                        <select data-link-field="linkType">
+                            <option value="Copper">Copper</option>
+                            <option value="Fibre">Fibre</option>
+                            <option value="Wireless">Wireless</option>
+                            <option value="LACP">LACP</option>
+                            <option value="VPN">VPN</option>
+                            <option value="Logical">Logical</option>
+                            <option value="Other">Other</option>
+                        </select>
+                    </label>
                     <label>
                         Link label
                         <input type="text" data-link-field="label" maxlength="80" />

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -540,22 +540,53 @@ body {
 }
 
 .diagram-link-hit {
+    fill: none;
     pointer-events: stroke;
     stroke: transparent;
-    stroke-width: 18;
+    stroke-width: 22;
     cursor: pointer;
 }
 
 .diagram-link-line {
     pointer-events: none;
+    fill: none;
     stroke: #475467;
     stroke-width: 3;
     stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.diagram-link-group[data-link-type="fibre"] .diagram-link-line {
+    stroke: #7c3aed;
+    stroke-width: 3.4;
+}
+
+.diagram-link-group[data-link-type="wireless"] .diagram-link-line {
+    stroke-dasharray: 12 8;
+}
+
+.diagram-link-group[data-link-type="lacp"] .diagram-link-line {
+    stroke-width: 5;
+}
+
+.diagram-link-group[data-link-type="vpn"] .diagram-link-line {
+    stroke-dasharray: 14 6 3 6;
+}
+
+.diagram-link-group[data-link-type="logical"] .diagram-link-line {
+    opacity: .72;
+    stroke-dasharray: 5 7;
+}
+
+.diagram-link-group[data-link-type="other"] .diagram-link-line {
+    stroke: #667085;
 }
 
 .diagram-link-group[data-selected="true"] .diagram-link-line {
     stroke: var(--diagram-accent);
-    stroke-width: 4;
+    stroke-width: 5;
+    opacity: 1;
+    filter: drop-shadow(0 0 2px var(--diagram-accent-soft));
 }
 
 .diagram-link-label,
@@ -734,6 +765,14 @@ html[data-theme="dark"] .diagram-node[data-node-kind="monitored-endpoint"] {
 
 html[data-theme="dark"] .diagram-link-line {
     stroke: #cbd5e1;
+}
+
+html[data-theme="dark"] .diagram-link-group[data-link-type="fibre"] .diagram-link-line {
+    stroke: #c4b5fd;
+}
+
+html[data-theme="dark"] .diagram-link-group[data-link-type="other"] .diagram-link-line {
+    stroke: #94a3b8;
 }
 
 html[data-theme="dark"] .diagram-link-label,

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
@@ -42,6 +42,7 @@
     const exportPaperSelect = editor.querySelector('[data-export-paper]');
     const canvasSizePresetSelect = editor.querySelector('[data-canvas-size-preset]');
     const canvasRatioWarning = editor.querySelector('[data-canvas-ratio-warning]');
+    const drawLinkTypeSelect = editor.querySelector('[data-draw-link-type]');
     const saveStatus = editor.querySelector('[data-save-status]');
     const antiforgeryToken = editor.querySelector('input[name="__RequestVerificationToken"]')?.value || '';
     const loadUrl = editor.dataset.loadUrl || '';
@@ -57,6 +58,8 @@
     const zoomStep = 1.1;
     const nodeMargin = 8;
     const aSeriesLandscapeRatio = 1.41421356237;
+    const linkTypes = ['Copper', 'Fibre', 'Wireless', 'LACP', 'VPN', 'Logical', 'Other'];
+    const parallelLinkOffsetStep = 34;
     const canvasPresets = [
         { value: 'small', label: 'Small', width: 4000, height: 2828 },
         { value: 'medium', label: 'Medium', width: 5656, height: 4000 },
@@ -79,7 +82,8 @@
         name: '',
         description: '',
         dirty: false,
-        loading: true
+        loading: true,
+        selectedDrawLinkType: 'Copper'
     };
 
     let nodeSequence = 0;
@@ -474,14 +478,17 @@
         return node && node.nodeType !== 'note';
     }
 
-    function linkExists(sourceNodeId, targetNodeId) {
-        return state.links.some(link =>
-            (link.sourceNodeId === sourceNodeId && link.targetNodeId === targetNodeId) ||
-            (link.sourceNodeId === targetNodeId && link.targetNodeId === sourceNodeId));
+    function normalizeLinkType(value) {
+        const requested = (value || '').trim();
+        if (!requested || requested.toLowerCase() === 'default') {
+            return 'Copper';
+        }
+
+        return linkTypes.find(type => type.toLowerCase() === requested.toLowerCase()) || 'Other';
     }
 
     function createLink(sourceNodeId, targetNodeId) {
-        if (sourceNodeId === targetNodeId || linkExists(sourceNodeId, targetNodeId)) {
+        if (sourceNodeId === targetNodeId) {
             return;
         }
 
@@ -493,7 +500,8 @@
             label: '',
             sourcePort: '',
             targetPort: '',
-            notes: ''
+            notes: '',
+            linkType: normalizeLinkType(state.selectedDrawLinkType)
         };
 
         state.links.push(link);
@@ -678,8 +686,78 @@
         return document.createElementNS('http://www.w3.org/2000/svg', name);
     }
 
+    function getUnorderedLinkPairKey(link) {
+        return [link.sourceNodeId, link.targetNodeId].sort().join('::');
+    }
+
+    function getParallelOffsetIndexes() {
+        const groups = new Map();
+        state.links.forEach(link => {
+            const key = getUnorderedLinkPairKey(link);
+            const group = groups.get(key) || [];
+            group.push(link);
+            groups.set(key, group);
+        });
+
+        const offsets = new Map();
+        groups.forEach(group => {
+            const ordered = [...group].sort((left, right) => String(left.id).localeCompare(String(right.id)));
+            const center = (ordered.length - 1) / 2;
+            ordered.forEach((link, index) => offsets.set(link.id, index - center));
+        });
+
+        return offsets;
+    }
+
+    function buildLinkGeometry(source, target, offsetIndex) {
+        const start = getNodeCenter(source);
+        const end = getNodeCenter(target);
+        const dx = end.x - start.x;
+        const dy = end.y - start.y;
+        const length = Math.hypot(dx, dy) || 1;
+        const perpendicularX = -dy / length;
+        const perpendicularY = dx / length;
+        const offset = offsetIndex * parallelLinkOffsetStep;
+        const control = {
+            x: (start.x + end.x) / 2 + perpendicularX * offset,
+            y: (start.y + end.y) / 2 + perpendicularY * offset
+        };
+        const midpoint = {
+            x: start.x * 0.25 + control.x * 0.5 + end.x * 0.25,
+            y: start.y * 0.25 + control.y * 0.5 + end.y * 0.25
+        };
+        const labelNormal = offset === 0 ? -14 : Math.sign(offset) * 14;
+        const label = {
+            x: midpoint.x + perpendicularX * labelNormal,
+            y: midpoint.y + perpendicularY * labelNormal - 4
+        };
+
+        return {
+            start,
+            end,
+            control,
+            midpoint,
+            label,
+            path: `M ${start.x} ${start.y} Q ${control.x} ${control.y} ${end.x} ${end.y}`
+        };
+    }
+
+    function truncateLinkText(value, maxLength) {
+        const normalized = (value || '').replace(/\s+/g, ' ').trim();
+        return normalized.length <= maxLength ? normalized : `${normalized.slice(0, Math.max(0, maxLength - 1))}…`;
+    }
+
+    function buildVisibleLinkLabel(link) {
+        const main = [link.label, link.notes].filter(value => value && value.trim()).join(' — ');
+        const ports = link.sourcePort || link.targetPort
+            ? [link.sourcePort || '?', link.targetPort || '?'].join(' ↔ ')
+            : '';
+        return truncateLinkText([main, ports].filter(Boolean).join(' • '), 96);
+    }
+
     function renderLinks() {
         linkLayer.replaceChildren();
+        const offsetIndexes = getParallelOffsetIndexes();
 
         state.links.forEach(link => {
             const source = findNodeById(link.sourceNodeId);
@@ -688,67 +766,41 @@
                 return;
             }
 
-            const start = getNodeCenter(source);
-            const end = getNodeCenter(target);
+            const geometry = buildLinkGeometry(source, target, offsetIndexes.get(link.id) || 0);
             const group = createSvgElement('g');
             group.classList.add('diagram-link-group');
             group.dataset.linkId = link.id;
             group.dataset.selected = state.selectedLinkId === link.id ? 'true' : 'false';
+            group.dataset.linkType = normalizeLinkType(link.linkType).toLowerCase();
 
-            const hit = createSvgElement('line');
+            const hit = createSvgElement('path');
             hit.classList.add('diagram-link-hit');
-            setLineCoordinates(hit, start, end);
+            hit.setAttribute('d', geometry.path);
             hit.addEventListener('pointerdown', event => {
                 selectLink(link.id);
                 event.preventDefault();
                 event.stopPropagation();
             });
 
-            const line = createSvgElement('line');
+            const line = createSvgElement('path');
             line.classList.add('diagram-link-line');
-            setLineCoordinates(line, start, end);
+            line.setAttribute('d', geometry.path);
 
             group.append(hit, line);
 
-            if (link.label) {
+            const visibleLabel = buildVisibleLinkLabel(link);
+            if (visibleLabel) {
                 const label = createSvgElement('text');
                 label.classList.add('diagram-link-label');
-                label.setAttribute('x', String((start.x + end.x) / 2));
-                label.setAttribute('y', String((start.y + end.y) / 2 - 8));
+                label.setAttribute('x', String(geometry.label.x));
+                label.setAttribute('y', String(geometry.label.y));
                 label.setAttribute('text-anchor', 'middle');
-                label.textContent = link.label;
+                label.textContent = visibleLabel;
                 group.appendChild(label);
-            }
-
-            if (link.sourcePort) {
-                const sourcePort = createSvgElement('text');
-                sourcePort.classList.add('diagram-link-port-label');
-                sourcePort.setAttribute('x', String(start.x + (end.x - start.x) * 0.18));
-                sourcePort.setAttribute('y', String(start.y + (end.y - start.y) * 0.18 - 6));
-                sourcePort.setAttribute('text-anchor', 'middle');
-                sourcePort.textContent = link.sourcePort;
-                group.appendChild(sourcePort);
-            }
-
-            if (link.targetPort) {
-                const targetPort = createSvgElement('text');
-                targetPort.classList.add('diagram-link-port-label');
-                targetPort.setAttribute('x', String(start.x + (end.x - start.x) * 0.82));
-                targetPort.setAttribute('y', String(start.y + (end.y - start.y) * 0.82 - 6));
-                targetPort.setAttribute('text-anchor', 'middle');
-                targetPort.textContent = link.targetPort;
-                group.appendChild(targetPort);
             }
 
             linkLayer.appendChild(group);
         });
-    }
-
-    function setLineCoordinates(line, start, end) {
-        line.setAttribute('x1', String(start.x));
-        line.setAttribute('y1', String(start.y));
-        line.setAttribute('x2', String(end.x));
-        line.setAttribute('y2', String(end.y));
     }
 
     function updatePropertiesPanel() {
@@ -1135,7 +1187,8 @@
             label: link.label || '',
             sourcePort: link.sourcePortLabel || '',
             targetPort: link.targetPortLabel || '',
-            notes: link.notes || ''
+            notes: link.notes || '',
+            linkType: normalizeLinkType(link.linkType)
         }));
         state.loading = false;
         state.dirty = false;
@@ -1187,7 +1240,7 @@
                 sourcePortLabel: link.sourcePort || null,
                 targetPortLabel: link.targetPort || null,
                 notes: link.notes || null,
-                linkType: 'default',
+                linkType: normalizeLinkType(link.linkType),
                 metadataJson: null
             }))
         };
@@ -1252,6 +1305,13 @@
     toolButtons.forEach(button => {
         button.addEventListener('click', () => setTool(button.dataset.toolButton || 'select'));
     });
+
+    if (drawLinkTypeSelect) {
+        drawLinkTypeSelect.addEventListener('change', () => {
+            state.selectedDrawLinkType = normalizeLinkType(drawLinkTypeSelect.value);
+            drawLinkTypeSelect.value = state.selectedDrawLinkType;
+        });
+    }
 
     nodeFields.forEach(field => {
         field.addEventListener('input', updateSelectedNodeField);


### PR DESCRIPTION
### Motivation

- Make network-diagram links richer documentation: allow selecting a media/type, show visible labels/notes/ports on the canvas, and allow multiple separate links between the same two nodes without exact overlap.  
- Preserve safety boundaries: diagram links remain documentation-only and must not affect monitoring dependencies, state evaluation, alerting, agents, or Startup Gate.  
- Provide deterministic, stable rendering and round-trip persistence (editor, DB, and PDF) so saved diagrams look identical after reload and export.

### Description

- Added a normalized link type catalog `NetworkDiagramLinkTypes` and defaulted legacy/missing/`default` values to `Copper`, with server-side validation and normalization in `NetworkDiagramService` and model adjustments to persist `LinkType`.  
- Editor UI and client logic: a draw-toolbar `Link type` selector and a selected-link `Link type` field were added to `Edit.cshtml` and `network-diagrams-editor.js`; saved/loaded `linkType` is normalized and applied immediately when drawing or editing links.  
- Visual rendering and parallel-link support: link rendering switched to SVG `path` curves with deterministic perpendicular offsets for unordered node pairs (stable ordering by link id) so multiple links between the same nodes do not overlap; on-canvas labels/notes/ports are placed near the curved midpoint and truncated for readability.  
- Styling and PDF export: editor CSS provides distinct, theme-compatible styles (dashed for Wireless, distinct Fibre/Copper, thicker LACP, VPN patterns, lighter Logical, etc.); server-side PDF export now computes parallel offsets and applies per-type drawing commands (`ApplyLinkStyle`, `BuildLinkGeometry`) and includes link labels/notes/ports in fitted text.  
- Documentation and tests: updated network-diagrams docs and design notes; added unit coverage for link-type normalization/validation, editor presence of parallel-link/label machinery, and PDF export checks for wireless/fibre/copper rendering.

### Testing

- Ran `dotnet build` and `dotnet test` for the WebApp test project; tests passed (`Passed: 116, Failed: 0`).  
- Executed the dev packaging script `pwsh -NoLogo -NoProfile -File scripts/build-dev.ps1 -Runtime linux-x64` to validate publish/publish-layout; packaging completed successfully.  
- New/updated automated tests exercised: link-type normalization/allowlist and service validation, presence of editor code paths for parallel offsets and visible labels, and PDF export assertions for wireless/fibre styling and exported label/notes; all test assertions passed locally.  

Fixes #506

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dd72a69f4832aa02cb3f40ce2e084)