### PR TITLE
Separate MediaType from LinkType; add fibre/speed/LACP metadata and fix link selection/edit/delete

### DIFF
--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -276,3 +276,22 @@ Manual regression checklist for this slice:
 13. Export to PDF and confirm link styles/labels/parallel links are represented.
 14. Confirm no endpoint dependencies are created or modified.
 15. Disable `NetworkDiagramsEnabled` and confirm navigation/direct access remain blocked.
+
+## Link media/type metadata refinement
+
+Network diagram links model visual documentation only. Editing, drawing, or deleting a diagram link does not create, update, or delete monitoring dependencies and does not affect endpoint state evaluation, dependency suppression, alerting, or agents.
+
+Link metadata separates:
+
+- **Media type**: the physical or transport medium (`Copper`, `Fibre`, `Wireless`, `DAC`, `VPN`, `Virtual`, `Other`).
+- **Link type**: the operational or logical role (`Standard`, `Trunk`, `Access`, `LACP`, `PointToPoint`, `Backhaul`, `WAN`, `Management`, `Logical`, `Other`).
+
+This means an LACP bundle can be documented as copper or fibre independently, and wireless links can be documented as point-to-point or backhaul links without treating those roles as physical media.
+
+Fibre links may optionally record a fibre subtype (`OM1`, `OM2`, `OM3`, `OM4`, `OM5`, `OS1`, `OS2`, `Other`). The fibre subtype is only valid when the media type is `Fibre`.
+
+Links may record structured speed metadata as a numeric value plus unit (`Mbps`, `Gbps`, or `Tbps`). For non-LACP links, the speed describes the visual link. For LACP links, the speed describes each physical member rather than an aggregate bundle speed. Example summaries include `10 Gbps fibre OM4`, `LACP 4 x 1 Gbps copper`, and `LACP 2 x 10 Gbps fibre OM4`.
+
+When the link type is `LACP`, diagrams may record a member count from 1 through 16 and per-member source/target port labels. Member port details are stored as structured JSON metadata on the diagram link so they remain documentation-only and cascade with the saved diagram link. Non-LACP links continue to use the simple source and target port label fields.
+
+Multiple visual links may exist between the same two devices. Parallel links are offset visually on the editor canvas and PDF export so each link can be selected, edited, deleted, saved, reloaded, and exported independently.

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -131,7 +131,7 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains(@"data-node-field=""label""", viewMarkup);
         Assert.Contains(@"data-node-field=""notes""", viewMarkup);
         Assert.Contains("data-multi-node-properties", viewMarkup);
-        Assert.Contains("Link type controls diagram styling only. Links do not create monitoring dependencies.", viewMarkup);
+        Assert.Contains("Media type describes the physical/transport medium.", viewMarkup);
         Assert.Contains("data-draw-link-type", viewMarkup);
         Assert.Contains(@"data-link-field=""linkType""", viewMarkup);
         Assert.Contains("Wireless", viewMarkup);
@@ -181,10 +181,12 @@ public sealed class NetworkDiagramsFeatureTests
     [Fact]
     public void NetworkDiagramLinkTypes_NormalizesOldAndMissingValuesToCopper()
     {
-        Assert.Equal(NetworkDiagramLinkTypes.Copper, NetworkDiagramLinkTypes.Normalize(null));
-        Assert.Equal(NetworkDiagramLinkTypes.Copper, NetworkDiagramLinkTypes.Normalize("default"));
-        Assert.Equal(NetworkDiagramLinkTypes.Fibre, NetworkDiagramLinkTypes.Normalize("fibre"));
-        Assert.True(NetworkDiagramLinkTypes.IsAllowed("Wireless"));
+        Assert.Equal(NetworkDiagramLinkMediaTypes.Copper, NetworkDiagramLinkMediaTypes.Normalize(null));
+        Assert.Equal(NetworkDiagramLinkMediaTypes.Copper, NetworkDiagramLinkMediaTypes.Normalize("default"));
+        Assert.Equal(NetworkDiagramLinkMediaTypes.Fibre, NetworkDiagramLinkMediaTypes.Normalize("fibre"));
+        Assert.True(NetworkDiagramLinkMediaTypes.IsAllowed("Wireless"));
+        Assert.Equal(NetworkDiagramLinkTypes.Standard, NetworkDiagramLinkTypes.Normalize(null));
+        Assert.Equal(NetworkDiagramLinkTypes.Lacp, NetworkDiagramLinkTypes.Normalize("lacp"));
         Assert.False(NetworkDiagramLinkTypes.IsAllowed("unsupported"));
     }
 
@@ -195,8 +197,8 @@ public sealed class NetworkDiagramsFeatureTests
         var serviceSource = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "Services", "NetworkDiagrams", "NetworkDiagramService.cs"));
 
         Assert.Contains("Unsupported link type", serviceSource);
-        Assert.Contains("NetworkDiagramLinkTypes.Normalize(TrimOptional(linkRequest.LinkType, 64))", serviceSource);
-        Assert.Contains("LinkType = NetworkDiagramLinkTypes.Normalize(x.LinkType)", serviceSource);
+        Assert.Contains("ResolveMediaType(linkRequest.MediaType, linkRequest.LinkType)", serviceSource);
+        Assert.Contains("ResolveLinkType(linkRequest.LinkType)", serviceSource);
         Assert.DoesNotContain("same two", serviceSource, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -210,9 +212,9 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.DoesNotContain("linkExists(sourceNodeId, targetNodeId)", script);
         Assert.Contains("getParallelOffsetIndexes", script);
         Assert.Contains("buildVisibleLinkLabel", script);
-        Assert.Contains(@"data-link-type=""wireless""", styles);
+        Assert.Contains(@"data-media-type=""wireless""", styles);
         Assert.Contains("stroke-dasharray: 12 8", styles);
-        Assert.Contains(@"data-link-type=""fibre""", styles);
+        Assert.Contains(@"data-media-type=""fibre""", styles);
     }
 
     [Fact]
@@ -261,9 +263,9 @@ public sealed class NetworkDiagramsFeatureTests
             ],
             Links =
             [
-                new NetworkDiagramLinkDto { LinkId = "link-1", SourceNodeId = "node-1", TargetNodeId = "node-2", Label = "uplink", SourcePortLabel = "Gi1/0/1", TargetPortLabel = "eth0", LinkType = NetworkDiagramLinkTypes.Copper },
-                new NetworkDiagramLinkDto { LinkId = "link-2", SourceNodeId = "node-2", TargetNodeId = "node-1", Label = "backup", Notes = "wireless failover", LinkType = NetworkDiagramLinkTypes.Wireless },
-                new NetworkDiagramLinkDto { LinkId = "link-3", SourceNodeId = "node-1", TargetNodeId = "node-2", Label = "storage", Notes = "10Gb fibre", LinkType = NetworkDiagramLinkTypes.Fibre }
+                new NetworkDiagramLinkDto { LinkId = "link-1", SourceNodeId = "node-1", TargetNodeId = "node-2", Label = "uplink", SourcePortLabel = "Gi1/0/1", TargetPortLabel = "eth0", MediaType = NetworkDiagramLinkMediaTypes.Copper, LinkType = NetworkDiagramLinkTypes.Standard },
+                new NetworkDiagramLinkDto { LinkId = "link-2", SourceNodeId = "node-2", TargetNodeId = "node-1", Label = "backup", Notes = "wireless failover", MediaType = NetworkDiagramLinkMediaTypes.Wireless, LinkType = NetworkDiagramLinkTypes.PointToPoint },
+                new NetworkDiagramLinkDto { LinkId = "link-3", SourceNodeId = "node-1", TargetNodeId = "node-2", Label = "storage", Notes = "10Gb fibre", MediaType = NetworkDiagramLinkMediaTypes.Fibre, LinkType = NetworkDiagramLinkTypes.Standard }
             ]
         };
 

--- a/src/WebApp/PingMonitor.Web.Tests/StartupSchemaServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/StartupSchemaServiceTests.cs
@@ -1,0 +1,55 @@
+using System.Data.Common;
+using System.Reflection;
+using PingMonitor.Web.Services.StartupGate;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class StartupSchemaServiceTests
+{
+    [Fact]
+    public void GetMissingColumns_UsesProviderNeutralConnection()
+    {
+        var method = typeof(StartupSchemaService)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(candidate => candidate.Name == "GetMissingColumnsAsync");
+
+        var connectionParameter = method.GetParameters().First();
+
+        Assert.Equal(typeof(DbConnection), connectionParameter.ParameterType);
+    }
+
+    [Fact]
+    public void NetworkDiagramMetadataMigration_DoesNotCastEfConnectionToMySqlConnectorConnection()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var sourcePath = Path.Combine(
+            repoRoot,
+            "src",
+            "WebApp",
+            "PingMonitor.Web",
+            "Services",
+            "StartupGate",
+            "StartupSchemaService.cs");
+
+        var source = File.ReadAllText(sourcePath);
+
+        Assert.DoesNotContain("GetMissingColumnsAsync((MySqlConnection)connection", source);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "global.json")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root.");
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -471,7 +471,12 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         networkDiagramLink.Property(x => x.SourcePortLabel).HasMaxLength(128);
         networkDiagramLink.Property(x => x.TargetPortLabel).HasMaxLength(128);
         networkDiagramLink.Property(x => x.Notes).HasMaxLength(4096);
-        networkDiagramLink.Property(x => x.LinkType).HasMaxLength(64).IsRequired().HasDefaultValue("default");
+        networkDiagramLink.Property(x => x.MediaType).HasMaxLength(64).IsRequired().HasDefaultValue("Copper");
+        networkDiagramLink.Property(x => x.FibreSubtype).HasMaxLength(64);
+        networkDiagramLink.Property(x => x.LinkType).HasMaxLength(64).IsRequired().HasDefaultValue("Standard");
+        networkDiagramLink.Property(x => x.LinkSpeedValue).HasPrecision(10, 3);
+        networkDiagramLink.Property(x => x.LinkSpeedUnit).HasMaxLength(16);
+        networkDiagramLink.Property(x => x.LacpMemberPortsJson).HasColumnType("longtext");
         networkDiagramLink.Property(x => x.MetadataJson).HasColumnType("longtext");
         networkDiagramLink.Property(x => x.CreatedAtUtc).IsRequired();
         networkDiagramLink.Property(x => x.UpdatedAtUtc).IsRequired();

--- a/src/WebApp/PingMonitor.Web/Models/NetworkDiagramLink.cs
+++ b/src/WebApp/PingMonitor.Web/Models/NetworkDiagramLink.cs
@@ -10,7 +10,13 @@ public sealed class NetworkDiagramLink
     public string? SourcePortLabel { get; set; }
     public string? TargetPortLabel { get; set; }
     public string? Notes { get; set; }
-    public string LinkType { get; set; } = "Copper";
+    public string MediaType { get; set; } = "Copper";
+    public string? FibreSubtype { get; set; }
+    public string LinkType { get; set; } = "Standard";
+    public decimal? LinkSpeedValue { get; set; }
+    public string? LinkSpeedUnit { get; set; }
+    public int? LacpMemberCount { get; set; }
+    public string? LacpMemberPortsJson { get; set; }
     public string? MetadataJson { get; set; }
     public DateTimeOffset CreatedAtUtc { get; set; }
     public DateTimeOffset UpdatedAtUtc { get; set; }

--- a/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
@@ -5,6 +5,6 @@ public sealed class StartupGateOptions
     public const string SectionName = "StartupGate";
 
     public string StorageDirectory { get; set; } = "App_Data/StartupGate";
-    public int RequiredSchemaVersion { get; set; } = 16;
+    public int RequiredSchemaVersion { get; set; } = 17;
     public int DefaultMySqlPort { get; set; } = 3306;
 }

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramModels.cs
@@ -2,14 +2,14 @@ using PingMonitor.Web.Models;
 
 namespace PingMonitor.Web.Services.NetworkDiagrams;
 
-public static class NetworkDiagramLinkTypes
+public static class NetworkDiagramLinkMediaTypes
 {
     public const string Copper = "Copper";
     public const string Fibre = "Fibre";
     public const string Wireless = "Wireless";
-    public const string Lacp = "LACP";
+    public const string Dac = "DAC";
     public const string Vpn = "VPN";
-    public const string Logical = "Logical";
+    public const string Virtual = "Virtual";
     public const string Other = "Other";
 
     public static readonly IReadOnlySet<string> Allowed = new HashSet<string>(StringComparer.Ordinal)
@@ -17,9 +17,9 @@ public static class NetworkDiagramLinkTypes
         Copper,
         Fibre,
         Wireless,
-        Lacp,
+        Dac,
         Vpn,
-        Logical,
+        Virtual,
         Other
     };
 
@@ -35,6 +35,119 @@ public static class NetworkDiagramLinkTypes
     }
 
     public static bool IsAllowed(string? value) => Allowed.Contains(Normalize(value));
+}
+
+public static class NetworkDiagramLinkTypes
+{
+    public const string Standard = "Standard";
+    public const string Trunk = "Trunk";
+    public const string Access = "Access";
+    public const string Lacp = "LACP";
+    public const string PointToPoint = "PointToPoint";
+    public const string Backhaul = "Backhaul";
+    public const string Wan = "WAN";
+    public const string Management = "Management";
+    public const string Logical = "Logical";
+    public const string Other = "Other";
+
+    public static readonly IReadOnlySet<string> Allowed = new HashSet<string>(StringComparer.Ordinal)
+    {
+        Standard,
+        Trunk,
+        Access,
+        Lacp,
+        PointToPoint,
+        Backhaul,
+        Wan,
+        Management,
+        Logical,
+        Other
+    };
+
+    public static string Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || string.Equals(value.Trim(), "default", StringComparison.OrdinalIgnoreCase))
+        {
+            return Standard;
+        }
+
+        var trimmed = value.Trim();
+        return Allowed.FirstOrDefault(allowed => string.Equals(allowed, trimmed, StringComparison.OrdinalIgnoreCase)) ?? trimmed;
+    }
+
+    public static bool IsAllowed(string? value) => Allowed.Contains(Normalize(value));
+}
+
+public static class NetworkDiagramFibreSubtypes
+{
+    public const string OM1 = "OM1";
+    public const string OM2 = "OM2";
+    public const string OM3 = "OM3";
+    public const string OM4 = "OM4";
+    public const string OM5 = "OM5";
+    public const string OS1 = "OS1";
+    public const string OS2 = "OS2";
+    public const string Other = "Other";
+
+    public static readonly IReadOnlySet<string> Allowed = new HashSet<string>(StringComparer.Ordinal)
+    {
+        OM1,
+        OM2,
+        OM3,
+        OM4,
+        OM5,
+        OS1,
+        OS2,
+        Other
+    };
+
+    public static string? Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        return Allowed.FirstOrDefault(allowed => string.Equals(allowed, trimmed, StringComparison.OrdinalIgnoreCase)) ?? trimmed;
+    }
+
+    public static bool IsAllowed(string? value)
+    {
+        var normalized = Normalize(value);
+        return normalized is null || Allowed.Contains(normalized);
+    }
+}
+
+public static class NetworkDiagramLinkSpeedUnits
+{
+    public const string Mbps = "Mbps";
+    public const string Gbps = "Gbps";
+    public const string Tbps = "Tbps";
+
+    public static readonly IReadOnlySet<string> Allowed = new HashSet<string>(StringComparer.Ordinal)
+    {
+        Mbps,
+        Gbps,
+        Tbps
+    };
+
+    public static string? Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        return Allowed.FirstOrDefault(allowed => string.Equals(allowed, trimmed, StringComparison.OrdinalIgnoreCase)) ?? trimmed;
+    }
+
+    public static bool IsAllowed(string? value)
+    {
+        var normalized = Normalize(value);
+        return normalized is null || Allowed.Contains(normalized);
+    }
 }
 
 public sealed class NetworkDiagramSaveRequest
@@ -74,7 +187,13 @@ public sealed class NetworkDiagramLinkSaveRequest
     public string? SourcePortLabel { get; init; }
     public string? TargetPortLabel { get; init; }
     public string? Notes { get; init; }
+    public string? MediaType { get; init; }
+    public string? FibreSubtype { get; init; }
     public string? LinkType { get; init; }
+    public decimal? LinkSpeedValue { get; init; }
+    public string? LinkSpeedUnit { get; init; }
+    public int? LacpMemberCount { get; init; }
+    public string? LacpMemberPortsJson { get; init; }
     public string? MetadataJson { get; init; }
 }
 
@@ -117,6 +236,12 @@ public sealed class NetworkDiagramLinkDto
     public string? SourcePortLabel { get; init; }
     public string? TargetPortLabel { get; init; }
     public string? Notes { get; init; }
-    public string LinkType { get; init; } = NetworkDiagramLinkTypes.Copper;
+    public string MediaType { get; init; } = NetworkDiagramLinkMediaTypes.Copper;
+    public string? FibreSubtype { get; init; }
+    public string LinkType { get; init; } = NetworkDiagramLinkTypes.Standard;
+    public decimal? LinkSpeedValue { get; init; }
+    public string? LinkSpeedUnit { get; init; }
+    public int? LacpMemberCount { get; init; }
+    public string? LacpMemberPortsJson { get; init; }
     public string? MetadataJson { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramPdfExportService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramPdfExportService.cs
@@ -283,7 +283,7 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
             var ty = MapY(target.Y + target.Height / 2);
             var geometry = BuildLinkGeometry(sx, sy, tx, ty, offsetIndexes.GetValueOrDefault(link.LinkId));
             stream.AppendLine("q");
-            ApplyLinkStyle(stream, link.LinkType);
+            ApplyLinkStyle(stream, link);
             stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.##} {1:0.##} m {2:0.##} {3:0.##} l S\n", geometry.StartX, geometry.StartY, geometry.EndX, geometry.EndY);
             stream.AppendLine("Q");
 
@@ -375,38 +375,40 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
         return new LinkGeometry(startX, startY, endX, endY, (startX + endX) / 2, (startY + endY) / 2 + (offset == 0 ? 6 : Math.Sign(offset) * 6));
     }
 
-    private static void ApplyLinkStyle(StringBuilder stream, string? linkType)
+    private static void ApplyLinkStyle(StringBuilder stream, NetworkDiagramLinkDto link)
     {
-        switch (NetworkDiagramLinkTypes.Normalize(linkType))
+        var width = NetworkDiagramLinkTypes.Normalize(link.LinkType) == NetworkDiagramLinkTypes.Lacp ? 2.6d : 1.5d;
+        switch (NetworkDiagramLinkMediaTypes.Normalize(link.MediaType))
         {
-            case NetworkDiagramLinkTypes.Fibre:
+            case NetworkDiagramLinkMediaTypes.Fibre:
                 stream.AppendLine("0.49 0.23 0.93 RG");
-                stream.AppendLine("1.8 w");
+                stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.#} w\n", Math.Max(width, 1.8d));
                 stream.AppendLine("[] 0 d");
                 break;
-            case NetworkDiagramLinkTypes.Wireless:
+            case NetworkDiagramLinkMediaTypes.Copper:
+                stream.AppendLine("0.60 0.40 0 RG");
+                stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.#} w\n", width);
+                stream.AppendLine("[] 0 d");
+                break;
+            case NetworkDiagramLinkMediaTypes.Wireless:
                 stream.AppendLine("0.28 0.32 0.38 RG");
-                stream.AppendLine("1.5 w");
+                stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.#} w\n", width);
                 stream.AppendLine("[8 5] 0 d");
                 break;
-            case NetworkDiagramLinkTypes.Lacp:
+            case NetworkDiagramLinkMediaTypes.Vpn:
+            case NetworkDiagramLinkMediaTypes.Virtual:
                 stream.AppendLine("0.28 0.32 0.38 RG");
-                stream.AppendLine("2.4 w");
-                stream.AppendLine("[] 0 d");
-                break;
-            case NetworkDiagramLinkTypes.Vpn:
-                stream.AppendLine("0.28 0.32 0.38 RG");
-                stream.AppendLine("1.5 w");
+                stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.#} w\n", width);
                 stream.AppendLine("[9 4 2 4] 0 d");
                 break;
-            case NetworkDiagramLinkTypes.Logical:
-                stream.AppendLine("0.48 0.55 0.64 RG");
-                stream.AppendLine("1.2 w");
-                stream.AppendLine("[4 4] 0 d");
+            case NetworkDiagramLinkMediaTypes.Dac:
+                stream.AppendLine("0.06 0.46 0.43 RG");
+                stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.#} w\n", Math.Max(width, 1.8d));
+                stream.AppendLine("[] 0 d");
                 break;
             default:
                 stream.AppendLine("0.28 0.32 0.38 RG");
-                stream.AppendLine("1.5 w");
+                stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.#} w\n", width);
                 stream.AppendLine("[] 0 d");
                 break;
         }
@@ -434,11 +436,22 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
 
     private static string BuildLinkLabel(NetworkDiagramLinkDto link)
     {
-        var ports = !string.IsNullOrWhiteSpace(link.SourcePortLabel) || !string.IsNullOrWhiteSpace(link.TargetPortLabel)
+        var linkType = NetworkDiagramLinkTypes.Normalize(link.LinkType);
+        var mediaType = NetworkDiagramLinkMediaTypes.Normalize(link.MediaType).ToLowerInvariant();
+        var fibreSubtype = string.Equals(NetworkDiagramLinkMediaTypes.Normalize(link.MediaType), NetworkDiagramLinkMediaTypes.Fibre, StringComparison.Ordinal)
+            ? NetworkDiagramFibreSubtypes.Normalize(link.FibreSubtype)
+            : null;
+        var speed = link.LinkSpeedValue is null || string.IsNullOrWhiteSpace(link.LinkSpeedUnit)
+            ? null
+            : $"{link.LinkSpeedValue:0.###} {NetworkDiagramLinkSpeedUnits.Normalize(link.LinkSpeedUnit)}";
+        var summary = linkType == NetworkDiagramLinkTypes.Lacp
+            ? string.Join(" ", new[] { "LACP", $"{link.LacpMemberCount ?? 2} x", speed, mediaType, fibreSubtype }.Where(x => !string.IsNullOrWhiteSpace(x)))
+            : string.Join(" ", new[] { linkType == NetworkDiagramLinkTypes.Standard ? null : linkType, speed, mediaType, fibreSubtype }.Where(x => !string.IsNullOrWhiteSpace(x)));
+        var ports = linkType != NetworkDiagramLinkTypes.Lacp && (!string.IsNullOrWhiteSpace(link.SourcePortLabel) || !string.IsNullOrWhiteSpace(link.TargetPortLabel))
             ? $"{link.SourcePortLabel ?? "?"} <-> {link.TargetPortLabel ?? "?"}"
             : null;
         var labelAndNotes = string.Join(" -- ", new[] { link.Label, link.Notes }.Where(x => !string.IsNullOrWhiteSpace(x)));
-        var parts = new[] { NetworkDiagramLinkTypes.Normalize(link.LinkType), ports, labelAndNotes }
+        var parts = new[] { summary, ports, labelAndNotes }
             .Where(x => !string.IsNullOrWhiteSpace(x));
         return string.Join(" • ", parts);
     }

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
@@ -153,7 +154,13 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
                 SourcePortLabel = TrimOptional(linkRequest.SourcePortLabel, 128),
                 TargetPortLabel = TrimOptional(linkRequest.TargetPortLabel, 128),
                 Notes = TrimOptional(linkRequest.Notes, 4096),
-                LinkType = NetworkDiagramLinkTypes.Normalize(TrimOptional(linkRequest.LinkType, 64)),
+                MediaType = ResolveMediaType(linkRequest.MediaType, linkRequest.LinkType),
+                FibreSubtype = ResolveFibreSubtype(linkRequest.MediaType, linkRequest.FibreSubtype),
+                LinkType = ResolveLinkType(linkRequest.LinkType),
+                LinkSpeedValue = NormalizeLinkSpeedValue(linkRequest.LinkSpeedValue),
+                LinkSpeedUnit = ResolveLinkSpeedUnit(linkRequest.LinkSpeedValue, linkRequest.LinkSpeedUnit),
+                LacpMemberCount = ResolveLacpMemberCount(linkRequest.LinkType, linkRequest.LacpMemberCount),
+                LacpMemberPortsJson = NormalizeLacpMemberPortsJson(linkRequest.LinkType, linkRequest.LacpMemberPortsJson),
                 MetadataJson = TrimOptional(linkRequest.MetadataJson, 65535),
                 CreatedAtUtc = now,
                 UpdatedAtUtc = now
@@ -234,11 +241,7 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
                 throw new NetworkDiagramValidationException("Diagram links must reference nodes in the same diagram payload.");
             }
 
-            var linkType = TrimOptional(link.LinkType, 64);
-            if (!NetworkDiagramLinkTypes.IsAllowed(linkType))
-            {
-                throw new NetworkDiagramValidationException($"Unsupported link type '{linkType}'.");
-            }
+            ValidateLinkMetadata(link);
 
             _ = TrimOptional(link.Label, 255);
             _ = TrimOptional(link.SourcePortLabel, 128);
@@ -283,10 +286,201 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
                 SourcePortLabel = x.SourcePortLabel,
                 TargetPortLabel = x.TargetPortLabel,
                 Notes = x.Notes,
-                LinkType = NetworkDiagramLinkTypes.Normalize(x.LinkType),
+                MediaType = ResolveMediaType(x.MediaType, x.LinkType),
+                FibreSubtype = string.Equals(ResolveMediaType(x.MediaType, x.LinkType), NetworkDiagramLinkMediaTypes.Fibre, StringComparison.Ordinal)
+                    ? NetworkDiagramFibreSubtypes.Normalize(x.FibreSubtype)
+                    : null,
+                LinkType = ResolveLinkType(x.LinkType),
+                LinkSpeedValue = NormalizeLinkSpeedValue(x.LinkSpeedValue),
+                LinkSpeedUnit = NetworkDiagramLinkSpeedUnits.Normalize(x.LinkSpeedUnit),
+                LacpMemberCount = ResolveLacpMemberCount(x.LinkType, x.LacpMemberCount),
+                LacpMemberPortsJson = NormalizeLacpMemberPortsJson(x.LinkType, x.LacpMemberPortsJson),
                 MetadataJson = x.MetadataJson
             }).ToArray()
         };
+    }
+
+    private static void ValidateLinkMetadata(NetworkDiagramLinkSaveRequest link)
+    {
+        var mediaType = ResolveMediaType(link.MediaType, link.LinkType);
+        if (!NetworkDiagramLinkMediaTypes.IsAllowed(mediaType))
+        {
+            throw new NetworkDiagramValidationException($"Unsupported media type '{mediaType}'.");
+        }
+
+        var linkType = ResolveLinkType(link.LinkType);
+        if (!NetworkDiagramLinkTypes.IsAllowed(linkType))
+        {
+            throw new NetworkDiagramValidationException($"Unsupported link type '{linkType}'.");
+        }
+
+        var fibreSubtype = NetworkDiagramFibreSubtypes.Normalize(link.FibreSubtype);
+        if (!NetworkDiagramFibreSubtypes.IsAllowed(fibreSubtype))
+        {
+            throw new NetworkDiagramValidationException($"Unsupported fibre subtype '{fibreSubtype}'.");
+        }
+
+        if (!string.Equals(mediaType, NetworkDiagramLinkMediaTypes.Fibre, StringComparison.Ordinal) && fibreSubtype is not null)
+        {
+            throw new NetworkDiagramValidationException("Fibre subtype can only be set when media type is Fibre.");
+        }
+
+        var speedValue = NormalizeLinkSpeedValue(link.LinkSpeedValue);
+        var speedUnit = NetworkDiagramLinkSpeedUnits.Normalize(link.LinkSpeedUnit);
+        if (!NetworkDiagramLinkSpeedUnits.IsAllowed(speedUnit))
+        {
+            throw new NetworkDiagramValidationException($"Unsupported link speed unit '{speedUnit}'.");
+        }
+
+        if (speedValue is not null && speedUnit is null)
+        {
+            throw new NetworkDiagramValidationException("Link speed unit is required when link speed value is set.");
+        }
+
+        if (speedUnit is not null && speedValue is null)
+        {
+            throw new NetworkDiagramValidationException("Link speed value is required when link speed unit is set.");
+        }
+
+        var memberCount = ResolveLacpMemberCount(link.LinkType, link.LacpMemberCount);
+        if (!string.Equals(linkType, NetworkDiagramLinkTypes.Lacp, StringComparison.Ordinal) && (link.LacpMemberCount is not null || !string.IsNullOrWhiteSpace(link.LacpMemberPortsJson)))
+        {
+            throw new NetworkDiagramValidationException("LACP member metadata can only be set when link type is LACP.");
+        }
+
+        _ = memberCount;
+        _ = NormalizeLacpMemberPortsJson(link.LinkType, link.LacpMemberPortsJson);
+    }
+
+    private static string ResolveMediaType(string? mediaType, string? legacyLinkType)
+    {
+        var normalized = NetworkDiagramLinkMediaTypes.Normalize(mediaType);
+        if (!string.IsNullOrWhiteSpace(mediaType))
+        {
+            return normalized;
+        }
+
+        return NetworkDiagramLinkTypes.Normalize(legacyLinkType) switch
+        {
+            NetworkDiagramLinkTypes.Lacp => NetworkDiagramLinkMediaTypes.Other,
+            NetworkDiagramLinkTypes.Logical => NetworkDiagramLinkMediaTypes.Virtual,
+            _ => NetworkDiagramLinkMediaTypes.Allowed.Contains(NetworkDiagramLinkMediaTypes.Normalize(legacyLinkType))
+                ? NetworkDiagramLinkMediaTypes.Normalize(legacyLinkType)
+                : NetworkDiagramLinkMediaTypes.Copper
+        };
+    }
+
+    private static string ResolveLinkType(string? linkType)
+    {
+        var normalized = NetworkDiagramLinkTypes.Normalize(linkType);
+        if (NetworkDiagramLinkTypes.Allowed.Contains(normalized))
+        {
+            return normalized;
+        }
+
+        var legacyMedia = NetworkDiagramLinkMediaTypes.Normalize(linkType);
+        return NetworkDiagramLinkMediaTypes.Allowed.Contains(legacyMedia) ? NetworkDiagramLinkTypes.Standard : normalized;
+    }
+
+    private static string? ResolveFibreSubtype(string? mediaType, string? fibreSubtype)
+    {
+        return string.Equals(NetworkDiagramLinkMediaTypes.Normalize(mediaType), NetworkDiagramLinkMediaTypes.Fibre, StringComparison.Ordinal)
+            ? NetworkDiagramFibreSubtypes.Normalize(fibreSubtype)
+            : null;
+    }
+
+    private static decimal? NormalizeLinkSpeedValue(decimal? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        if (value < 0 || value > 1000000)
+        {
+            throw new NetworkDiagramValidationException("Link speed value must be between 0 and 1,000,000.");
+        }
+
+        return Math.Round(value.Value, 3);
+    }
+
+    private static string? ResolveLinkSpeedUnit(decimal? speedValue, string? speedUnit)
+    {
+        var normalized = NetworkDiagramLinkSpeedUnits.Normalize(speedUnit);
+        return speedValue is null ? null : normalized;
+    }
+
+    private static int? ResolveLacpMemberCount(string? linkType, int? count)
+    {
+        if (!string.Equals(ResolveLinkType(linkType), NetworkDiagramLinkTypes.Lacp, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var resolved = count ?? 2;
+        if (resolved < 1 || resolved > 16)
+        {
+            throw new NetworkDiagramValidationException("LACP member count must be between 1 and 16.");
+        }
+
+        return resolved;
+    }
+
+    private static string? NormalizeLacpMemberPortsJson(string? linkType, string? json)
+    {
+        if (!string.Equals(ResolveLinkType(linkType), NetworkDiagramLinkTypes.Lacp, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        if (json.Length > 65535)
+        {
+            throw new NetworkDiagramValidationException("LACP member port metadata is too large.");
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            if (document.RootElement.ValueKind != JsonValueKind.Array || document.RootElement.GetArrayLength() > 16)
+            {
+                throw new NetworkDiagramValidationException("LACP member port metadata must be an array with at most 16 members.");
+            }
+
+            foreach (var member in document.RootElement.EnumerateArray())
+            {
+                if (member.ValueKind != JsonValueKind.Object)
+                {
+                    throw new NetworkDiagramValidationException("Each LACP member port entry must be an object.");
+                }
+
+                ValidateOptionalMemberPort(member, "sourcePort");
+                ValidateOptionalMemberPort(member, "targetPort");
+            }
+        }
+        catch (JsonException ex)
+        {
+            throw new NetworkDiagramValidationException($"LACP member port metadata must be valid JSON: {ex.Message}");
+        }
+
+        return json;
+    }
+
+    private static void ValidateOptionalMemberPort(JsonElement member, string propertyName)
+    {
+        if (!member.TryGetProperty(propertyName, out var value) || value.ValueKind == JsonValueKind.Null)
+        {
+            return;
+        }
+
+        if (value.ValueKind != JsonValueKind.String || value.GetString() is { Length: > 128 })
+        {
+            throw new NetworkDiagramValidationException("LACP member port labels must be strings of 128 characters or fewer.");
+        }
     }
 
     private static string TrimRequired(string value, int maxLength, string fieldName)

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -956,7 +956,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             await connection.OpenAsync(cancellationToken);
         }
 
-        var missingColumns = await GetMissingColumnsAsync((MySqlConnection)connection, "NetworkDiagramLinks", RequiredNetworkDiagramLinkColumns, cancellationToken);
+        var missingColumns = await GetMissingColumnsAsync(connection, "NetworkDiagramLinks", RequiredNetworkDiagramLinkColumns, cancellationToken);
         foreach (var column in missingColumns)
         {
             var alterSql = column switch
@@ -1139,7 +1139,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
     }
 
 
-    private static async Task<string[]> GetMissingColumnsAsync(MySqlConnection connection, string tableName, IReadOnlyCollection<string> requiredColumns, CancellationToken cancellationToken)
+    private static async Task<string[]> GetMissingColumnsAsync(System.Data.Common.DbConnection connection, string tableName, IReadOnlyCollection<string> requiredColumns, CancellationToken cancellationToken)
     {
         var existingColumns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         await using var command = connection.CreateCommand();
@@ -1149,7 +1149,11 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             WHERE table_schema = DATABASE()
               AND table_name = @tableName;
             """;
-        command.Parameters.AddWithValue("@tableName", tableName);
+
+        var tableNameParameter = command.CreateParameter();
+        tableNameParameter.ParameterName = "@tableName";
+        tableNameParameter.Value = tableName;
+        command.Parameters.Add(tableNameParameter);
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -92,7 +92,13 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "SourcePortLabel",
         "TargetPortLabel",
         "Notes",
+        "MediaType",
+        "FibreSubtype",
         "LinkType",
+        "LinkSpeedValue",
+        "LinkSpeedUnit",
+        "LacpMemberCount",
+        "LacpMemberPortsJson",
         "MetadataJson",
         "CreatedAtUtc",
         "UpdatedAtUtc"
@@ -885,7 +891,13 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 `SourcePortLabel` varchar(128) NULL,
                 `TargetPortLabel` varchar(128) NULL,
                 `Notes` varchar(4096) NULL,
-                `LinkType` varchar(64) NOT NULL DEFAULT 'default',
+                `MediaType` varchar(64) NOT NULL DEFAULT 'Copper',
+                `FibreSubtype` varchar(64) NULL,
+                `LinkType` varchar(64) NOT NULL DEFAULT 'Standard',
+                `LinkSpeedValue` decimal(10,3) NULL,
+                `LinkSpeedUnit` varchar(16) NULL,
+                `LacpMemberCount` int NULL,
+                `LacpMemberPortsJson` longtext NULL,
                 `MetadataJson` longtext NULL,
                 `CreatedAtUtc` datetime(6) NOT NULL,
                 `UpdatedAtUtc` datetime(6) NOT NULL,
@@ -930,8 +942,61 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await EnsureAspNetUsersColumnsAsync(dbContext, cancellationToken);
         await EnsureCheckResultsNormalizedSchemaAsync(dbContext, cancellationToken);
         await EnsureRttPrecisionSchemaAsync(dbContext, cancellationToken);
+        await EnsureNetworkDiagramLinkMetadataColumnsAsync(dbContext, cancellationToken);
         await EnsureMetricsIndexesAsync(dbContext, cancellationToken);
         await MigrateLegacyEndpointDependenciesAsync(dbContext, cancellationToken);
+    }
+
+
+    private static async Task EnsureNetworkDiagramLinkMetadataColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
+    {
+        await using var connection = dbContext.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        var missingColumns = await GetMissingColumnsAsync((MySqlConnection)connection, "NetworkDiagramLinks", RequiredNetworkDiagramLinkColumns, cancellationToken);
+        foreach (var column in missingColumns)
+        {
+            var alterSql = column switch
+            {
+                "MediaType" => "ALTER TABLE `NetworkDiagramLinks` ADD COLUMN `MediaType` varchar(64) NOT NULL DEFAULT 'Copper';",
+                "FibreSubtype" => "ALTER TABLE `NetworkDiagramLinks` ADD COLUMN `FibreSubtype` varchar(64) NULL;",
+                "LinkSpeedValue" => "ALTER TABLE `NetworkDiagramLinks` ADD COLUMN `LinkSpeedValue` decimal(10,3) NULL;",
+                "LinkSpeedUnit" => "ALTER TABLE `NetworkDiagramLinks` ADD COLUMN `LinkSpeedUnit` varchar(16) NULL;",
+                "LacpMemberCount" => "ALTER TABLE `NetworkDiagramLinks` ADD COLUMN `LacpMemberCount` int NULL;",
+                "LacpMemberPortsJson" => "ALTER TABLE `NetworkDiagramLinks` ADD COLUMN `LacpMemberPortsJson` longtext NULL;",
+                _ => null
+            };
+
+            if (alterSql is not null)
+            {
+                await dbContext.Database.ExecuteSqlRawAsync(alterSql, cancellationToken);
+            }
+        }
+
+        await dbContext.Database.ExecuteSqlRawAsync("""
+            UPDATE `NetworkDiagramLinks`
+            SET
+                `MediaType` = CASE
+                    WHEN LOWER(`LinkType`) IN ('copper', 'default') THEN 'Copper'
+                    WHEN LOWER(`LinkType`) = 'fibre' THEN 'Fibre'
+                    WHEN LOWER(`LinkType`) = 'wireless' THEN 'Wireless'
+                    WHEN LOWER(`LinkType`) = 'vpn' THEN 'VPN'
+                    WHEN LOWER(`LinkType`) = 'logical' THEN 'Virtual'
+                    WHEN LOWER(`LinkType`) = 'lacp' THEN 'Other'
+                    ELSE `MediaType`
+                END,
+                `LinkType` = CASE
+                    WHEN LOWER(`LinkType`) IN ('copper', 'fibre', 'wireless', 'vpn', 'default') THEN 'Standard'
+                    WHEN LOWER(`LinkType`) = 'logical' THEN 'Logical'
+                    WHEN LOWER(`LinkType`) = 'lacp' THEN 'LACP'
+                    ELSE `LinkType`
+                END
+            WHERE `MediaType` = 'Copper'
+              AND LOWER(`LinkType`) IN ('copper', 'fibre', 'wireless', 'vpn', 'logical', 'lacp', 'default');
+            """, cancellationToken);
     }
 
     private static async Task EnsureMetricsIndexesAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
@@ -89,13 +89,28 @@
                     <button type="button" class="diagram-tool-button" data-tool-button="select" aria-pressed="true">Select / move</button>
                     <button type="button" class="diagram-tool-button" data-tool-button="draw-link" aria-pressed="false">Draw link</button>
                     <label class="diagram-toolbar-select-label diagram-link-type-toolbar">
-                        Link type
-                        <select data-draw-link-type aria-label="Link type for newly drawn links">
+                        Media
+                        <select data-draw-media-type aria-label="Media type for newly drawn links">
                             <option value="Copper">Copper</option>
                             <option value="Fibre">Fibre</option>
                             <option value="Wireless">Wireless</option>
-                            <option value="LACP">LACP</option>
+                            <option value="DAC">DAC</option>
                             <option value="VPN">VPN</option>
+                            <option value="Virtual">Virtual</option>
+                            <option value="Other">Other</option>
+                        </select>
+                    </label>
+                    <label class="diagram-toolbar-select-label diagram-link-type-toolbar">
+                        Link
+                        <select data-draw-link-type aria-label="Link type for newly drawn links">
+                            <option value="Standard">Standard</option>
+                            <option value="Trunk">Trunk</option>
+                            <option value="Access">Access</option>
+                            <option value="LACP">LACP</option>
+                            <option value="PointToPoint">Point-to-point</option>
+                            <option value="Backhaul">Backhaul</option>
+                            <option value="WAN">WAN</option>
+                            <option value="Management">Management</option>
                             <option value="Logical">Logical</option>
                             <option value="Other">Other</option>
                         </select>
@@ -139,7 +154,7 @@
                             Add a monitored endpoint or custom device from the toolbox. Drag empty space to pan. Use mouse wheel to zoom.
                         </div>
                         <div class="diagram-world" data-diagram-world>
-                            <svg class="diagram-link-layer" data-link-layer aria-hidden="true"></svg>
+                            <svg class="diagram-link-layer" data-link-layer></svg>
                             <div class="diagram-node-layer" data-node-layer></div>
                         </div>
                     </div>
@@ -183,19 +198,70 @@
                     <button type="button" class="danger-button" data-delete-selection>Delete selected nodes</button>
                 </div>
                 <form class="link-properties" data-link-properties hidden>
-                    <p class="toolbox-help">Link type controls diagram styling only. Links do not create monitoring dependencies.</p>
+                    <p class="toolbox-help">Media type describes the physical/transport medium. Link type describes the operational role. These fields are documentation only and do not create monitoring dependencies.</p>
                     <label>
-                        Link type / media
-                        <select data-link-field="linkType">
+                        Media type
+                        <select data-link-field="mediaType">
                             <option value="Copper">Copper</option>
                             <option value="Fibre">Fibre</option>
                             <option value="Wireless">Wireless</option>
-                            <option value="LACP">LACP</option>
+                            <option value="DAC">DAC</option>
                             <option value="VPN">VPN</option>
+                            <option value="Virtual">Virtual</option>
+                            <option value="Other">Other</option>
+                        </select>
+                    </label>
+                    <label data-fibre-subtype-field hidden>
+                        Fibre subtype
+                        <select data-link-field="fibreSubtype">
+                            <option value="">None</option>
+                            <option value="OM1">OM1</option>
+                            <option value="OM2">OM2</option>
+                            <option value="OM3">OM3</option>
+                            <option value="OM4">OM4</option>
+                            <option value="OM5">OM5</option>
+                            <option value="OS1">OS1</option>
+                            <option value="OS2">OS2</option>
+                            <option value="Other">Other</option>
+                        </select>
+                    </label>
+                    <label>
+                        Link type
+                        <select data-link-field="linkType">
+                            <option value="Standard">Standard</option>
+                            <option value="Trunk">Trunk</option>
+                            <option value="Access">Access</option>
+                            <option value="LACP">LACP</option>
+                            <option value="PointToPoint">Point-to-point</option>
+                            <option value="Backhaul">Backhaul</option>
+                            <option value="WAN">WAN</option>
+                            <option value="Management">Management</option>
                             <option value="Logical">Logical</option>
                             <option value="Other">Other</option>
                         </select>
                     </label>
+                    <div class="link-speed-fields">
+                        <label>
+                            Speed
+                            <input type="number" data-link-field="linkSpeedValue" min="0" max="1000000" step="0.001" />
+                        </label>
+                        <label>
+                            Unit
+                            <select data-link-field="linkSpeedUnit">
+                                <option value="">None</option>
+                                <option value="Mbps">Mbps</option>
+                                <option value="Gbps">Gbps</option>
+                                <option value="Tbps">Tbps</option>
+                            </select>
+                        </label>
+                    </div>
+                    <div data-lacp-fields hidden>
+                        <label>
+                            LACP member count
+                            <input type="number" data-link-field="lacpMemberCount" min="1" max="16" step="1" />
+                        </label>
+                        <div class="lacp-member-ports" data-lacp-member-ports></div>
+                    </div>
                     <label>
                         Link label
                         <input type="text" data-link-field="label" maxlength="80" />

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 16,
+    "RequiredSchemaVersion": 17,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 16,
+    "RequiredSchemaVersion": 17,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -531,7 +531,7 @@ body {
     width: 100%;
     height: 100%;
     overflow: visible;
-    pointer-events: none;
+    pointer-events: auto;
     z-index: 1;
 }
 
@@ -556,12 +556,12 @@ body {
     stroke-linejoin: round;
 }
 
-.diagram-link-group[data-link-type="fibre"] .diagram-link-line {
+.diagram-link-group[data-media-type="fibre"] .diagram-link-line {
     stroke: #7c3aed;
     stroke-width: 3.4;
 }
 
-.diagram-link-group[data-link-type="wireless"] .diagram-link-line {
+.diagram-link-group[data-media-type="wireless"] .diagram-link-line {
     stroke-dasharray: 12 8;
 }
 
@@ -569,7 +569,23 @@ body {
     stroke-width: 5;
 }
 
-.diagram-link-group[data-link-type="vpn"] .diagram-link-line {
+.diagram-link-group[data-media-type="copper"] .diagram-link-line {
+    stroke: #9a6700;
+}
+
+.diagram-link-group[data-media-type="dac"] .diagram-link-line {
+    stroke: #0f766e;
+    stroke-width: 4;
+}
+
+.diagram-link-group[data-link-type="trunk"] .diagram-link-line,
+.diagram-link-group[data-link-type="wan"] .diagram-link-line,
+.diagram-link-group[data-link-type="backhaul"] .diagram-link-line {
+    stroke-width: 4;
+}
+
+.diagram-link-group[data-media-type="vpn"] .diagram-link-line,
+.diagram-link-group[data-media-type="virtual"] .diagram-link-line {
     stroke-dasharray: 14 6 3 6;
 }
 
@@ -578,7 +594,7 @@ body {
     stroke-dasharray: 5 7;
 }
 
-.diagram-link-group[data-link-type="other"] .diagram-link-line {
+.diagram-link-group[data-media-type="other"] .diagram-link-line {
     stroke: #667085;
 }
 
@@ -676,7 +692,8 @@ body {
 .node-properties input,
 .node-properties textarea,
 .link-properties input,
-.link-properties textarea {
+.link-properties textarea,
+.link-properties select {
     width: 100%;
     border: 1px solid var(--diagram-border);
     border-radius: 8px;
@@ -767,11 +784,11 @@ html[data-theme="dark"] .diagram-link-line {
     stroke: #cbd5e1;
 }
 
-html[data-theme="dark"] .diagram-link-group[data-link-type="fibre"] .diagram-link-line {
+html[data-theme="dark"] .diagram-link-group[data-media-type="fibre"] .diagram-link-line {
     stroke: #c4b5fd;
 }
 
-html[data-theme="dark"] .diagram-link-group[data-link-type="other"] .diagram-link-line {
+html[data-theme="dark"] .diagram-link-group[data-media-type="other"] .diagram-link-line {
     stroke: #94a3b8;
 }
 
@@ -904,4 +921,29 @@ html[data-theme="dark"] .diagram-link-port-label {
 
 .diagram-canvas-ratio-warning[hidden] {
     display: none;
+}
+
+
+.link-speed-fields {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(88px, .45fr);
+    gap: .5rem;
+}
+
+.lacp-member-ports {
+    display: grid;
+    gap: .4rem;
+}
+
+.lacp-member-port-row {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr);
+    gap: .35rem;
+    align-items: center;
+}
+
+.lacp-member-port-row span {
+    color: var(--diagram-muted);
+    font-size: .78rem;
+    font-weight: 800;
 }

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
@@ -42,7 +42,11 @@
     const exportPaperSelect = editor.querySelector('[data-export-paper]');
     const canvasSizePresetSelect = editor.querySelector('[data-canvas-size-preset]');
     const canvasRatioWarning = editor.querySelector('[data-canvas-ratio-warning]');
+    const drawMediaTypeSelect = editor.querySelector('[data-draw-media-type]');
     const drawLinkTypeSelect = editor.querySelector('[data-draw-link-type]');
+    const fibreSubtypeField = editor.querySelector('[data-fibre-subtype-field]');
+    const lacpFields = editor.querySelector('[data-lacp-fields]');
+    const lacpMemberPorts = editor.querySelector('[data-lacp-member-ports]');
     const saveStatus = editor.querySelector('[data-save-status]');
     const antiforgeryToken = editor.querySelector('input[name="__RequestVerificationToken"]')?.value || '';
     const loadUrl = editor.dataset.loadUrl || '';
@@ -58,7 +62,10 @@
     const zoomStep = 1.1;
     const nodeMargin = 8;
     const aSeriesLandscapeRatio = 1.41421356237;
-    const linkTypes = ['Copper', 'Fibre', 'Wireless', 'LACP', 'VPN', 'Logical', 'Other'];
+    const mediaTypes = ['Copper', 'Fibre', 'Wireless', 'DAC', 'VPN', 'Virtual', 'Other'];
+    const linkTypes = ['Standard', 'Trunk', 'Access', 'LACP', 'PointToPoint', 'Backhaul', 'WAN', 'Management', 'Logical', 'Other'];
+    const fibreSubtypes = ['OM1', 'OM2', 'OM3', 'OM4', 'OM5', 'OS1', 'OS2', 'Other'];
+    const linkSpeedUnits = ['Mbps', 'Gbps', 'Tbps'];
     const parallelLinkOffsetStep = 34;
     const canvasPresets = [
         { value: 'small', label: 'Small', width: 4000, height: 2828 },
@@ -83,7 +90,8 @@
         description: '',
         dirty: false,
         loading: true,
-        selectedDrawLinkType: 'Copper'
+        selectedDrawMediaType: 'Copper',
+        selectedDrawLinkType: 'Standard'
     };
 
     let nodeSequence = 0;
@@ -478,13 +486,60 @@
         return node && node.nodeType !== 'note';
     }
 
+    function normalizeMediaType(value, legacyLinkType) {
+        const requested = (value || '').trim();
+        if (requested) {
+            return mediaTypes.find(type => type.toLowerCase() === requested.toLowerCase()) || 'Other';
+        }
+
+        const legacy = (legacyLinkType || '').trim().toLowerCase();
+        if (!legacy || legacy === 'default') {
+            return 'Copper';
+        }
+        if (legacy === 'fibre') { return 'Fibre'; }
+        if (legacy === 'wireless') { return 'Wireless'; }
+        if (legacy === 'vpn') { return 'VPN'; }
+        if (legacy === 'logical') { return 'Virtual'; }
+        if (legacy === 'lacp') { return 'Other'; }
+        return mediaTypes.find(type => type.toLowerCase() === legacy) || 'Copper';
+    }
+
     function normalizeLinkType(value) {
         const requested = (value || '').trim();
         if (!requested || requested.toLowerCase() === 'default') {
-            return 'Copper';
+            return 'Standard';
         }
 
-        return linkTypes.find(type => type.toLowerCase() === requested.toLowerCase()) || 'Other';
+        const normalized = linkTypes.find(type => type.toLowerCase() === requested.toLowerCase());
+        if (normalized) {
+            return normalized;
+        }
+
+        const legacyMedia = mediaTypes.find(type => type.toLowerCase() === requested.toLowerCase());
+        return legacyMedia ? 'Standard' : 'Other';
+    }
+
+    function normalizeFibreSubtype(value, mediaType) {
+        if (normalizeMediaType(mediaType) !== 'Fibre') {
+            return '';
+        }
+
+        const requested = (value || '').trim();
+        return fibreSubtypes.find(type => type.toLowerCase() === requested.toLowerCase()) || '';
+    }
+
+    function normalizeSpeedUnit(value) {
+        const requested = (value || '').trim();
+        return linkSpeedUnits.find(unit => unit.toLowerCase() === requested.toLowerCase()) || '';
+    }
+
+    function normalizeLacpMemberCount(value, linkType) {
+        if (normalizeLinkType(linkType) !== 'LACP') {
+            return '';
+        }
+
+        const parsed = Number.parseInt(value, 10);
+        return String(clamp(Number.isFinite(parsed) ? parsed : 2, 1, 16));
     }
 
     function createLink(sourceNodeId, targetNodeId) {
@@ -501,7 +556,13 @@
             sourcePort: '',
             targetPort: '',
             notes: '',
-            linkType: normalizeLinkType(state.selectedDrawLinkType)
+            mediaType: normalizeMediaType(state.selectedDrawMediaType),
+            fibreSubtype: '',
+            linkType: normalizeLinkType(state.selectedDrawLinkType),
+            linkSpeedValue: '',
+            linkSpeedUnit: 'Gbps',
+            lacpMemberCount: normalizeLinkType(state.selectedDrawLinkType) === 'LACP' ? '2' : '',
+            lacpMemberPorts: []
         };
 
         state.links.push(link);
@@ -747,9 +808,31 @@
         return normalized.length <= maxLength ? normalized : `${normalized.slice(0, Math.max(0, maxLength - 1))}…`;
     }
 
+    function formatSpeed(value, unit) {
+        const speed = (value || '').toString().trim();
+        const normalizedUnit = normalizeSpeedUnit(unit);
+        return speed && normalizedUnit ? `${speed} ${normalizedUnit}` : '';
+    }
+
+    function buildLinkSummary(link) {
+        const media = normalizeMediaType(link.mediaType, link.linkType);
+        const type = normalizeLinkType(link.linkType);
+        const speed = formatSpeed(link.linkSpeedValue, link.linkSpeedUnit);
+        const fibre = normalizeFibreSubtype(link.fibreSubtype, media);
+        const mediaLabel = [media.toLowerCase(), fibre].filter(Boolean).join(' ');
+        if (type === 'LACP') {
+            const count = normalizeLacpMemberCount(link.lacpMemberCount, type) || '2';
+            return ['LACP', `${count} ×`, speed, mediaLabel].filter(Boolean).join(' ');
+        }
+
+        const typeLabel = type === 'Standard' ? '' : type;
+        return [typeLabel, speed, mediaLabel].filter(Boolean).join(' ');
+    }
+
     function buildVisibleLinkLabel(link) {
-        const main = [link.label, link.notes].filter(value => value && value.trim()).join(' — ');
-        const ports = link.sourcePort || link.targetPort
+        const summary = buildLinkSummary(link);
+        const main = [summary, link.label, link.notes].filter(value => value && value.trim()).join(' — ');
+        const ports = normalizeLinkType(link.linkType) !== 'LACP' && (link.sourcePort || link.targetPort)
             ? [link.sourcePort || '?', link.targetPort || '?'].join(' ↔ ')
             : '';
         return truncateLinkText([main, ports].filter(Boolean).join(' • '), 96);
@@ -771,6 +854,7 @@
             group.classList.add('diagram-link-group');
             group.dataset.linkId = link.id;
             group.dataset.selected = state.selectedLinkId === link.id ? 'true' : 'false';
+            group.dataset.mediaType = normalizeMediaType(link.mediaType, link.linkType).toLowerCase();
             group.dataset.linkType = normalizeLinkType(link.linkType).toLowerCase();
 
             const hit = createSvgElement('path');
@@ -870,6 +954,16 @@
             const propertyName = field.dataset.linkField;
             field.value = selectedLink && propertyName ? selectedLink[propertyName] || '' : '';
         });
+
+        const selectedMediaType = selectedLink ? normalizeMediaType(selectedLink.mediaType, selectedLink.linkType) : '';
+        const selectedLinkType = selectedLink ? normalizeLinkType(selectedLink.linkType) : '';
+        if (fibreSubtypeField) {
+            fibreSubtypeField.hidden = selectedMediaType !== 'Fibre';
+        }
+        if (lacpFields) {
+            lacpFields.hidden = selectedLinkType !== 'LACP';
+        }
+        renderLacpMemberPortFields(selectedLink);
     }
 
     function updateSelectedNodeField(event) {
@@ -890,6 +984,60 @@
         markDirty();
     }
 
+
+    function parseLacpMemberPorts(json) {
+        if (!json) {
+            return [];
+        }
+        try {
+            const parsed = JSON.parse(json);
+            return Array.isArray(parsed) ? parsed.slice(0, 16).map(member => ({
+                sourcePort: String(member?.sourcePort || '').slice(0, 128),
+                targetPort: String(member?.targetPort || '').slice(0, 128)
+            })) : [];
+        } catch {
+            return [];
+        }
+    }
+
+    function syncLacpMemberPortCount(link) {
+        if (!link || normalizeLinkType(link.linkType) !== 'LACP') {
+            return;
+        }
+
+        const count = Number.parseInt(normalizeLacpMemberCount(link.lacpMemberCount, link.linkType), 10);
+        link.lacpMemberPorts = Array.isArray(link.lacpMemberPorts) ? link.lacpMemberPorts.slice(0, count) : [];
+        while (link.lacpMemberPorts.length < count) {
+            link.lacpMemberPorts.push({ sourcePort: '', targetPort: '' });
+        }
+    }
+
+    function renderLacpMemberPortFields(link) {
+        if (!lacpMemberPorts) {
+            return;
+        }
+
+        lacpMemberPorts.replaceChildren();
+        if (!link || normalizeLinkType(link.linkType) !== 'LACP') {
+            return;
+        }
+
+        syncLacpMemberPortCount(link);
+        link.lacpMemberPorts.forEach((member, index) => {
+            const row = document.createElement('div');
+            row.className = 'lacp-member-port-row';
+            row.innerHTML = `<span>Member ${index + 1}</span><input type="text" maxlength="80" aria-label="LACP member ${index + 1} source port" placeholder="Source port" value="${escapeHtml(member.sourcePort || '')}"><input type="text" maxlength="80" aria-label="LACP member ${index + 1} target port" placeholder="Target port" value="${escapeHtml(member.targetPort || '')}">`;
+            const inputs = row.querySelectorAll('input');
+            inputs[0].addEventListener('input', event => { member.sourcePort = event.currentTarget.value; renderLinks(); markDirty(); });
+            inputs[1].addEventListener('input', event => { member.targetPort = event.currentTarget.value; renderLinks(); markDirty(); });
+            lacpMemberPorts.appendChild(row);
+        });
+    }
+
+    function escapeHtml(value) {
+        return String(value).replace(/[&<>"]/g, char => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[char]);
+    }
+
     function updateSelectedLinkField(event) {
         const selectedLink = state.selectedLinkId ? findLinkById(state.selectedLinkId) : null;
         const field = event.currentTarget;
@@ -898,8 +1046,25 @@
             return;
         }
 
-        selectedLink[propertyName] = field.value;
+        if (propertyName === 'mediaType') {
+            selectedLink.mediaType = normalizeMediaType(field.value);
+            selectedLink.fibreSubtype = normalizeFibreSubtype(selectedLink.fibreSubtype, selectedLink.mediaType);
+        } else if (propertyName === 'fibreSubtype') {
+            selectedLink.fibreSubtype = normalizeFibreSubtype(field.value, selectedLink.mediaType);
+        } else if (propertyName === 'linkType') {
+            selectedLink.linkType = normalizeLinkType(field.value);
+            selectedLink.lacpMemberCount = normalizeLacpMemberCount(selectedLink.lacpMemberCount, selectedLink.linkType);
+            syncLacpMemberPortCount(selectedLink);
+        } else if (propertyName === 'linkSpeedUnit') {
+            selectedLink.linkSpeedUnit = normalizeSpeedUnit(field.value);
+        } else if (propertyName === 'lacpMemberCount') {
+            selectedLink.lacpMemberCount = normalizeLacpMemberCount(field.value, selectedLink.linkType);
+            syncLacpMemberPortCount(selectedLink);
+        } else {
+            selectedLink[propertyName] = field.value;
+        }
         renderLinks();
+        updatePropertiesPanel();
         markDirty();
     }
 
@@ -1188,7 +1353,13 @@
             sourcePort: link.sourcePortLabel || '',
             targetPort: link.targetPortLabel || '',
             notes: link.notes || '',
-            linkType: normalizeLinkType(link.linkType)
+            mediaType: normalizeMediaType(link.mediaType, link.linkType),
+            fibreSubtype: normalizeFibreSubtype(link.fibreSubtype, link.mediaType),
+            linkType: normalizeLinkType(link.linkType),
+            linkSpeedValue: link.linkSpeedValue == null ? '' : String(link.linkSpeedValue),
+            linkSpeedUnit: normalizeSpeedUnit(link.linkSpeedUnit),
+            lacpMemberCount: normalizeLacpMemberCount(link.lacpMemberCount, link.linkType),
+            lacpMemberPorts: parseLacpMemberPorts(link.lacpMemberPortsJson)
         }));
         state.loading = false;
         state.dirty = false;
@@ -1240,7 +1411,13 @@
                 sourcePortLabel: link.sourcePort || null,
                 targetPortLabel: link.targetPort || null,
                 notes: link.notes || null,
+                mediaType: normalizeMediaType(link.mediaType, link.linkType),
+                fibreSubtype: normalizeMediaType(link.mediaType, link.linkType) === 'Fibre' ? normalizeFibreSubtype(link.fibreSubtype, link.mediaType) || null : null,
                 linkType: normalizeLinkType(link.linkType),
+                linkSpeedValue: link.linkSpeedValue === '' || link.linkSpeedValue == null ? null : Number(link.linkSpeedValue),
+                linkSpeedUnit: link.linkSpeedValue === '' || link.linkSpeedValue == null ? null : normalizeSpeedUnit(link.linkSpeedUnit) || null,
+                lacpMemberCount: normalizeLinkType(link.linkType) === 'LACP' ? Number(normalizeLacpMemberCount(link.lacpMemberCount, link.linkType)) : null,
+                lacpMemberPortsJson: normalizeLinkType(link.linkType) === 'LACP' ? JSON.stringify(link.lacpMemberPorts || []) : null,
                 metadataJson: null
             }))
         };
@@ -1305,6 +1482,13 @@
     toolButtons.forEach(button => {
         button.addEventListener('click', () => setTool(button.dataset.toolButton || 'select'));
     });
+
+    if (drawMediaTypeSelect) {
+        drawMediaTypeSelect.addEventListener('change', () => {
+            state.selectedDrawMediaType = normalizeMediaType(drawMediaTypeSelect.value);
+            drawMediaTypeSelect.value = state.selectedDrawMediaType;
+        });
+    }
 
     if (drawLinkTypeSelect) {
         drawLinkTypeSelect.addEventListener('change', () => {


### PR DESCRIPTION
### Motivation
- The editor incorrectly merged physical media and operational link role into one field and link editing/select/delete was unreliable; this change separates those concerns and restores robust selection/interaction.  Fixes #508. 
- Links must be rich documentation-only objects (media subtype, speed, LACP members) without affecting monitoring, so the model, validation, UI, and PDF export needed coordinated updates.

### Description
- Data model and persistence: added `MediaType`, `FibreSubtype`, `LinkSpeedValue`, `LinkSpeedUnit`, `LacpMemberCount`, and `LacpMemberPortsJson` to `NetworkDiagramLink`, updated EF model and Startup Gate SQL creation, and added safe migration/ALTER logic and legacy-value mapping; bumped required schema version to `17`.
- Server validation and DTOs: extended `NetworkDiagramSaveRequest`/`NetworkDiagramLinkDto` and added server-side validation/resolvers for media vs legacy values, fibre-subtype rules, speed unit/value consistency, and LACP member JSON shape/limits; old merged link values are mapped conservatively on load/save.
- Editor UI/JS/CSS: split the draw-toolbar into media and link-type selectors, added fibre-subtype, speed inputs, LACP member count and per-member port rows, ensured fibre-subtype and LACP UI are conditional, and serialized the richer metadata in save payloads; added JSON parsing/normalization helpers and LACP port field rendering in the editor.
- Selection/hit-testing fix: enabled pointer events on the SVG link layer and rendered a wide transparent SVG hit path (`.diagram-link-hit`) that reliably receives pointer events so links (including parallel links and links with labels) can be selected, edited, and deleted without node interference.
- Styling and PDF export: updated canvas CSS and PDF renderer to style links using both `MediaType` (primary line style / pattern) and `LinkType` (secondary emphasis such as LACP thickness), and to include media/subtype/speed/LACP summaries in PDF labels.
- Documentation and tests: updated network diagrams docs with the media vs link-type distinction and LACP guidance, and adjusted/added unit assertions in existing feature tests to cover normalization, editor markup expectations, parallel-link rendering hints, and PDF export content.

### Testing
- `dotnet build` of the web project succeeded (`PATH=/tmp/dotnet:$PATH dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`).
- Unit/integration tests passed: `PATH=/tmp/dotnet:$PATH dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` (all tests passed).
- Editor script static check succeeded: `node --check src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js`.
- The change includes a manual regression checklist in the docs and test updates asserting editor/view expectations and PDF export strings; automated tests and script checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e9fa04adc832a977062d71e326662)