### PR TITLE
Fix startup schema provider cast

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/StartupSchemaServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/StartupSchemaServiceTests.cs
@@ -1,0 +1,55 @@
+using System.Data.Common;
+using System.Reflection;
+using PingMonitor.Web.Services.StartupGate;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class StartupSchemaServiceTests
+{
+    [Fact]
+    public void GetMissingColumns_UsesProviderNeutralConnection()
+    {
+        var method = typeof(StartupSchemaService)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(candidate => candidate.Name == "GetMissingColumnsAsync");
+
+        var connectionParameter = method.GetParameters().First();
+
+        Assert.Equal(typeof(DbConnection), connectionParameter.ParameterType);
+    }
+
+    [Fact]
+    public void NetworkDiagramMetadataMigration_DoesNotCastEfConnectionToMySqlConnectorConnection()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var sourcePath = Path.Combine(
+            repoRoot,
+            "src",
+            "WebApp",
+            "PingMonitor.Web",
+            "Services",
+            "StartupGate",
+            "StartupSchemaService.cs");
+
+        var source = File.ReadAllText(sourcePath);
+
+        Assert.DoesNotContain("GetMissingColumnsAsync((MySqlConnection)connection", source);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "global.json")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root.");
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -956,7 +956,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             await connection.OpenAsync(cancellationToken);
         }
 
-        var missingColumns = await GetMissingColumnsAsync((MySqlConnection)connection, "NetworkDiagramLinks", RequiredNetworkDiagramLinkColumns, cancellationToken);
+        var missingColumns = await GetMissingColumnsAsync(connection, "NetworkDiagramLinks", RequiredNetworkDiagramLinkColumns, cancellationToken);
         foreach (var column in missingColumns)
         {
             var alterSql = column switch
@@ -1139,7 +1139,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
     }
 
 
-    private static async Task<string[]> GetMissingColumnsAsync(MySqlConnection connection, string tableName, IReadOnlyCollection<string> requiredColumns, CancellationToken cancellationToken)
+    private static async Task<string[]> GetMissingColumnsAsync(System.Data.Common.DbConnection connection, string tableName, IReadOnlyCollection<string> requiredColumns, CancellationToken cancellationToken)
     {
         var existingColumns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         await using var command = connection.CreateCommand();
@@ -1149,7 +1149,11 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             WHERE table_schema = DATABASE()
               AND table_name = @tableName;
             """;
-        command.Parameters.AddWithValue("@tableName", tableName);
+
+        var tableNameParameter = command.CreateParameter();
+        tableNameParameter.ParameterName = "@tableName";
+        tableNameParameter.Value = tableName;
+        command.Parameters.Add(tableNameParameter);
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))


### PR DESCRIPTION
### Motivation
- Startup gate schema apply failed with an `InvalidCastException` when code cast EF/EFCore-provided `DbConnection` to `MySqlConnector.MySqlConnection` during the NetworkDiagram link metadata migration.
- The change ensures schema migration code is provider-neutral so EF-owned connections (for example `MySql.Data.MySqlClient.MySqlConnection`) are not incorrectly cast to a different provider type.

### Description
- Removed the explicit cast to `MySqlConnector.MySqlConnection` in `EnsureNetworkDiagramLinkMetadataColumnsAsync` and call the helper with the provider-neutral connection instead. 
- Changed `GetMissingColumnsAsync` to accept `System.Data.Common.DbConnection` and to create the table-name parameter via `command.CreateParameter()` rather than `AddWithValue`, keeping parameter creation provider-neutral. 
- Added `StartupSchemaServiceTests` with two assertions: one that the helper signature uses `DbConnection`, and another that the source does not contain the invalid cast. 
- This PR links the fix to the related issue: `Fixes #508`.

### Testing
- Ran the focused tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj --filter StartupSchemaServiceTests --no-restore` and the two new tests passed.
- Ran the full test assembly with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj --no-restore` and all tests passed (118 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ea6cf06c0832a91024288917ea843)