### PR TITLE
Network Diagrams: make existing visual links selectable, editable, and deletable

### DIFF
--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -300,7 +300,9 @@ Multiple visual links may exist between the same two devices. Parallel links are
 
 Diagram links are documentation/status-overlay objects only. Selecting, editing, saving, deleting, or exporting a diagram link must not create, update, or remove endpoint monitoring dependencies, suppression relationships, alert rules, agent assignments, or automatically discovered topology.
 
-In the editor, each visual link is selectable from the canvas. The rendered link includes a visible path plus a wider transparent hit-test path following the same geometry so thin, dashed, dotted, curved, and parallel/offset links remain selectable at different zoom and pan positions. Link labels and notes are non-blocking; clicking the label area should not prevent the underlying visual link from being selected. Selecting a link clears node selection, shows the link properties panel, and delete selected removes only that visual link.
+In the editor, each visual link is selectable from the canvas. The rendered link includes a visible path plus a wider transparent hit-test path following the same geometry so thin, dashed, dotted, curved, and parallel/offset links remain selectable at different zoom and pan positions. The node overlay layer must not intercept empty-space SVG clicks; only actual node cards should receive node pointer events. Link labels and notes are non-blocking; clicking the label area should not prevent the underlying visual link from being selected. Selecting a link clears node selection, shows the link properties panel, and delete selected removes only that visual link.
+
+Deleting a visual link changes only the saved diagram documentation. It does not delete nodes and does not create, remove, or update endpoint dependencies, monitoring state, dependency suppression, alerting, agent assignments, or discovered topology.
 
 Link metadata uses separate concepts:
 

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -217,11 +217,22 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("buildVisibleLinkLabel", script);
         Assert.Contains("diagram-link-hit", script);
         Assert.Contains("group.dataset.linkId = link.id", script);
+        Assert.Contains("hit.dataset.linkId = link.id", script);
+        Assert.Contains("line.dataset.linkId = link.id", script);
+        Assert.Contains("const selectRenderedLink = event =>", script);
+        Assert.Contains("label.addEventListener('pointerdown', selectRenderedLink)", script);
         Assert.Contains("selectLink(link.id)", script);
+        Assert.Contains("event.stopPropagation();", script);
+        Assert.Contains("group.append(line, hit)", script);
         Assert.Contains(@"data-media-type=""wireless""", styles);
         Assert.Contains("stroke-dasharray: 12 8", styles);
-        Assert.Contains("stroke-width: 28", styles);
+        Assert.Contains("stroke-width: 18", styles);
+        Assert.Contains("vector-effect: non-scaling-stroke", styles);
         Assert.Contains("pointer-events: all", styles);
+        Assert.Contains("pointer-events: stroke", styles);
+        Assert.Contains(".diagram-node-layer", styles);
+        Assert.Contains("pointer-events: none", styles);
+        Assert.Contains("pointer-events: auto", styles);
         Assert.Contains(@"data-media-type=""fibre""", styles);
     }
 

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -224,11 +224,14 @@ body {
 .diagram-node-layer {
     position: absolute;
     inset: 0;
+    /* Keep the full-size node overlay from blocking SVG link hit targets underneath. */
+    pointer-events: none;
 }
 
 .diagram-node {
     position: absolute;
     left: 0;
+    pointer-events: auto;
     top: 0;
     display: grid;
     grid-template-columns: auto minmax(0, 1fr);
@@ -543,12 +546,13 @@ body {
     fill: none;
     pointer-events: all;
     stroke: rgba(0, 0, 0, .001);
-    stroke-width: 28;
+    stroke-width: 18;
+    vector-effect: non-scaling-stroke;
     cursor: pointer;
 }
 
 .diagram-link-line {
-    pointer-events: none;
+    pointer-events: stroke;
     fill: none;
     stroke: #475467;
     stroke-width: 3;
@@ -600,9 +604,9 @@ body {
 
 .diagram-link-group[data-selected="true"] .diagram-link-line {
     stroke: var(--diagram-accent);
-    stroke-width: 5;
+    stroke-width: 7;
     opacity: 1;
-    filter: drop-shadow(0 0 2px var(--diagram-accent-soft));
+    filter: drop-shadow(0 0 3px var(--diagram-accent)) drop-shadow(0 0 7px var(--diagram-accent-soft));
 }
 
 .diagram-link-label,

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
@@ -898,20 +898,30 @@
             group.dataset.mediaType = normalizeMediaType(link.mediaType, link.linkType).toLowerCase();
             group.dataset.linkType = normalizeLinkType(link.linkType).toLowerCase();
 
-            const hit = createSvgElement('path');
-            hit.classList.add('diagram-link-hit');
-            hit.setAttribute('d', geometry.path);
-            hit.addEventListener('pointerdown', event => {
+            const selectRenderedLink = event => {
+                if (state.currentTool !== 'select') {
+                    return;
+                }
+
                 selectLink(link.id);
+                canvas.focus({ preventScroll: true });
                 event.preventDefault();
                 event.stopPropagation();
-            });
+            };
 
             const line = createSvgElement('path');
             line.classList.add('diagram-link-line');
+            line.dataset.linkId = link.id;
             line.setAttribute('d', geometry.path);
+            line.addEventListener('pointerdown', selectRenderedLink);
 
-            group.append(hit, line);
+            const hit = createSvgElement('path');
+            hit.classList.add('diagram-link-hit');
+            hit.dataset.linkId = link.id;
+            hit.setAttribute('d', geometry.path);
+            hit.addEventListener('pointerdown', selectRenderedLink);
+
+            group.append(line, hit);
 
             const visibleLabel = buildVisibleLinkLabel(link);
             if (visibleLabel) {
@@ -921,11 +931,7 @@
                 label.setAttribute('y', String(geometry.label.y));
                 label.setAttribute('text-anchor', 'middle');
                 label.textContent = visibleLabel;
-                label.addEventListener('pointerdown', event => {
-                    selectLink(link.id);
-                    event.preventDefault();
-                    event.stopPropagation();
-                });
+                label.addEventListener('pointerdown', selectRenderedLink);
                 group.appendChild(label);
             }
 


### PR DESCRIPTION
### Motivation
- Fixes #513: users could not select, edit, or delete existing visual links because link pointer events were being blocked by the node overlay layer.  
- The change ensures diagram links are purely documentation objects and selection/edit/delete remain decoupled from monitoring/dependency state.  
- Root cause: the `.diagram-node-layer` overlay intercepted pointer events before SVG link hit paths could receive them, so `selectedLinkId` was never set when clicking rendered links.

### Description
- Allow SVG link hit targets to receive pointer events by setting `.diagram-node-layer { pointer-events: none; }` while keeping individual `.diagram-node { pointer-events: auto; }`.  
- Render each link as a visible path plus a wider transparent, non-scaling hit-test path and wire both (and link labels) to a single `selectRenderedLink` handler that stops propagation and focuses the canvas.  
- Make visible link paths respond to pointer events (`pointer-events: stroke`) and improve hit reliability with `stroke-width: 18` and `vector-effect: non-scaling-stroke`, and strengthen selected-link highlighting styling.  
- Update docs and tests assertions to reflect selection semantics and that deleting a visual link is documentation-only and does not alter endpoint dependencies.

### Testing
- Ran `node --check src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js` which succeeded.  
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which succeeded.  
- Ran unit tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` which passed (130 passed, 0 failed).  
- Executed the repository dev packaging smoke `pwsh -NoLogo -NoProfile -File scripts/build-dev.ps1 -Runtime linux-x64` which completed successfully and `git diff --check` showed no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eb2ef10c8832a857af2fb3b29b3ef)