### PR TITLE
Add VLAN metadata to network diagram links

### DIFF
--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -323,3 +323,25 @@ Media subtype options are dependent on media type:
 Link speed is documented with common presets: 10 Mbps, 100 Mbps, 1 Gbps, 2.5 Gbps, 5 Gbps, 10 Gbps, 25 Gbps, 40 Gbps, and 100 Gbps. Selecting Other exposes custom speed value and unit fields. Saved custom speed values must be positive and use a supported unit. For LACP links, the speed is per physical member link; labels and PDF export use summaries such as `LACP 2 × 10 Gbps` or `LACP 4 × 1 Gbps`.
 
 Link visual summaries include useful media, subtype, non-standard link type, speed, LACP member count, labels, ports, and notes where space allows. PDF export uses the same documentation metadata while keeping wireless links dashed, fibre and copper visually distinct, LACP emphasized, and parallel links separated.
+
+## Visual link VLAN metadata
+
+Network diagram links can include optional VLAN metadata for documentation. Each visual link may have zero or more VLAN entries with:
+
+- VLAN ID from 1 through 4094.
+- Optional name or label.
+- Mode: Tagged, Untagged, Native, Management, or Other.
+- Optional notes.
+
+VLAN metadata is documentation-only. It does not configure switches, routers, wireless equipment, VLAN interfaces, or any other network device. It does not create, update, or delete endpoint monitoring dependencies, and it does not affect state evaluation, dependency suppression, alerts, or agents.
+
+When VLAN entries are present, a compact VLAN summary is shown on the canvas link label and included in PDF export where space allows. Examples include `T:10 LAN,20 CCTV`, `U:5 Management`, and `Native:1`.
+
+Schema note:
+
+- This adds schema version 18 with the `NetworkDiagramLinkVlans` table.
+- VLAN rows cascade with their parent visual diagram link/diagram data only.
+
+Backup/restore follow-up:
+
+- Configuration backup/restore inclusion for network diagrams remains a required follow-up before publishing V0.1.1 if it is not completed in the release branch; that follow-up must include `NetworkDiagramLinkVlans` alongside `NetworkDiagrams`, `NetworkDiagramNodes`, and `NetworkDiagramLinks`.

--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -337,6 +337,8 @@ VLAN metadata is documentation-only. It does not configure switches, routers, wi
 
 When VLAN entries are present, a compact VLAN summary is shown on the canvas link label and included in PDF export where space allows. Examples include `T:10 LAN,20 CCTV`, `U:5 Management`, and `Native:1`.
 
+In the editor Properties panel, selecting a visual link exposes an **Add VLAN** action. Add VLAN inserts a new editable VLAN metadata row immediately for that selected visual link, with blank VLAN ID/name/notes and `Tagged` mode selected by default. Operators can edit VLAN ID, name/label, mode, and notes, remove individual VLAN rows, save the diagram, and reload the saved VLAN metadata later. Blank rows may be used while editing; saved rows must have a valid VLAN ID from 1 through 4094.
+
 Schema note:
 
 - This adds schema version 18 with the `NetworkDiagramLinkVlans` table.

--- a/docs/network_diagrams_v_0_1_1_design_notes.md
+++ b/docs/network_diagrams_v_0_1_1_design_notes.md
@@ -474,3 +474,7 @@ This remains a client-side draft-only slice. No saved diagram layout, database p
 Network diagram links now support documentation-only media/type metadata for Copper, Fibre, Wireless, LACP, VPN, Logical, and Other. The selected type controls editor and PDF styling only; wireless uses a dashed line, fibre is visually distinct from copper, and LACP/VPN/logical links use pattern/weight differences so the styling is not colour-only.
 
 Link labels and notes are drawn on-canvas near the link midpoint, and multiple links between the same unordered node pair are grouped and offset deterministically so A → B and B → A links do not overlap after save/reload. These visual links remain separate from monitoring dependencies: creating, editing, deleting, saving, or exporting links must not alter endpoint monitoring, dependency suppression, state evaluation, alerting, agents, or Startup Gate behaviour.
+
+## Link VLAN metadata addendum
+
+Visual links may carry structured VLAN documentation metadata. VLAN entries support an ID, optional label, mode (Tagged, Untagged, Native, Management, Other), optional notes, and deterministic ordering. This metadata is intentionally scoped to the diagram link as documentation only: it must not configure network devices, infer topology, create endpoints, create dependencies, or influence monitoring state, suppression, or alerting.

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -147,6 +147,9 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("data-zoom-label", viewMarkup);
         Assert.Contains("Diagram links are visual documentation only and do not create monitoring dependencies.", viewMarkup);
         Assert.Contains("data-link-properties", viewMarkup);
+        Assert.Contains("data-link-vlan-section", viewMarkup);
+        Assert.Contains("data-add-link-vlan", viewMarkup);
+        Assert.Contains("VLANs are documentation metadata for this visual link only", viewMarkup);
         Assert.Contains("data-save-status", viewMarkup);
         Assert.Contains("/js/network-diagrams-editor.js", viewMarkup);
         Assert.Contains("/css/network-diagrams.css", viewMarkup);
@@ -234,8 +237,39 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("pointer-events: none", styles);
         Assert.Contains("pointer-events: auto", styles);
         Assert.Contains(@"data-media-type=""fibre""", styles);
+        Assert.Contains("buildVlanSummary", script);
+        Assert.Contains("normalizeVlans", script);
+        Assert.Contains("data-link-vlan-list", script);
+        Assert.Contains("link-vlan-card", styles);
     }
 
+
+
+    [Fact]
+    public void NetworkDiagramVlanModes_ValidateAllowedValues()
+    {
+        Assert.Equal(NetworkDiagramVlanModes.Tagged, NetworkDiagramVlanModes.Normalize("tagged"));
+        Assert.True(NetworkDiagramVlanModes.IsAllowed("Untagged"));
+        Assert.True(NetworkDiagramVlanModes.IsAllowed("Native"));
+        Assert.True(NetworkDiagramVlanModes.IsAllowed("Management"));
+        Assert.True(NetworkDiagramVlanModes.IsAllowed("Other"));
+        Assert.False(NetworkDiagramVlanModes.IsAllowed("Invalid"));
+    }
+
+    [Fact]
+    public void NetworkDiagramService_SourceContainsVlanValidationAndPersistenceGuards()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var serviceSource = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "Services", "NetworkDiagrams", "NetworkDiagramService.cs"));
+        var schemaSource = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "Services", "StartupGate", "StartupSchemaService.cs"));
+
+        Assert.Contains("VLAN ID must be between 1 and 4094.", serviceSource);
+        Assert.Contains("This link already contains VLAN", serviceSource);
+        Assert.Contains("Select a VLAN mode.", serviceSource);
+        Assert.Contains("NetworkDiagramLinkVlan", serviceSource);
+        Assert.Contains("NetworkDiagramLinkVlans", schemaSource);
+        Assert.Contains("ON DELETE CASCADE", schemaSource);
+    }
 
     [Theory]
     [InlineData(NetworkDiagramLinkMediaTypes.Copper, "Cat5e")]
@@ -308,7 +342,7 @@ public sealed class NetworkDiagramsFeatureTests
             ],
             Links =
             [
-                new NetworkDiagramLinkDto { LinkId = "link-1", SourceNodeId = "node-1", TargetNodeId = "node-2", Label = "uplink", SourcePortLabel = "Gi1/0/1", TargetPortLabel = "eth0", MediaType = NetworkDiagramLinkMediaTypes.Copper, MediaSubtype = "Cat6", LinkType = NetworkDiagramLinkTypes.Standard, LinkSpeedValue = 1, LinkSpeedUnit = NetworkDiagramLinkSpeedUnits.Gbps },
+                new NetworkDiagramLinkDto { LinkId = "link-1", SourceNodeId = "node-1", TargetNodeId = "node-2", Label = "uplink", SourcePortLabel = "Gi1/0/1", TargetPortLabel = "eth0", MediaType = NetworkDiagramLinkMediaTypes.Copper, MediaSubtype = "Cat6", LinkType = NetworkDiagramLinkTypes.Standard, LinkSpeedValue = 1, LinkSpeedUnit = NetworkDiagramLinkSpeedUnits.Gbps, Vlans = [new NetworkDiagramLinkVlanDto { VlanId = 10, Name = "LAN", Mode = NetworkDiagramVlanModes.Tagged }, new NetworkDiagramLinkVlanDto { VlanId = 5, Name = "Mgmt", Mode = NetworkDiagramVlanModes.Untagged }] },
                 new NetworkDiagramLinkDto { LinkId = "link-2", SourceNodeId = "node-2", TargetNodeId = "node-1", Label = "backup", Notes = "wireless failover", MediaType = NetworkDiagramLinkMediaTypes.Wireless, MediaSubtype = "802.11ac / Wi-Fi 5", LinkType = NetworkDiagramLinkTypes.PointToPoint },
                 new NetworkDiagramLinkDto { LinkId = "link-3", SourceNodeId = "node-1", TargetNodeId = "node-2", Label = "storage", Notes = "10Gb fibre", MediaType = NetworkDiagramLinkMediaTypes.Fibre, MediaSubtype = "OM4", LinkType = NetworkDiagramLinkTypes.Lacp, LinkSpeedValue = 10, LinkSpeedUnit = NetworkDiagramLinkSpeedUnits.Gbps, LacpMemberCount = 2 }
             ]
@@ -326,6 +360,8 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("backup", pdfText);
         Assert.Contains("10Gb fibre", pdfText);
         Assert.Contains("Cat6", pdfText);
+        Assert.Contains("T:10 LAN", pdfText);
+        Assert.Contains("U:5", pdfText);
         Assert.Contains("LACP", pdfText);
         Assert.Contains("[8 5] 0 d", pdfText);
         Assert.Contains("0.49 0.23 0.93 RG", pdfText);

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -243,6 +243,31 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("link-vlan-card", styles);
     }
 
+    [Fact]
+    public void NetworkDiagramEditor_WiresAddVlanAndPersistsVlanPayload()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var script = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "wwwroot", "js", "network-diagrams-editor.js"));
+
+        Assert.Contains("addLinkVlanButton.addEventListener('click', addLinkVlan)", script);
+        Assert.Contains("function addLinkVlan(event)", script);
+        Assert.Contains("event?.preventDefault();", script);
+        Assert.Contains("state.selectedLinkId ? findLinkById(state.selectedLinkId) : null", script);
+        Assert.Contains("selectedLink.vlans = normalizeVlans(selectedLink.vlans);", script);
+        Assert.Contains("clientId: createVlanClientId()", script);
+        Assert.Contains("mode: 'Tagged'", script);
+        Assert.Contains("sortOrder: nextSortOrder", script);
+        Assert.Contains("markDirty();", script);
+        Assert.Contains("data-vlan-field=\"vlanId\"", script);
+        Assert.Contains("data-vlan-field=\"name\"", script);
+        Assert.Contains("data-vlan-field=\"mode\"", script);
+        Assert.Contains("data-vlan-field=\"notes\"", script);
+        Assert.Contains("validateVlanForSave", script);
+        Assert.Contains("VLAN ID must be between 1 and 4094.", script);
+        Assert.Contains("vlans: normalizeVlans(link.vlans).map", script);
+        Assert.Contains("vlanId,", script);
+        Assert.Contains("sortOrder: index", script);
+    }
 
 
     [Fact]

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -45,6 +45,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
     public DbSet<NetworkDiagram> NetworkDiagrams => Set<NetworkDiagram>();
     public DbSet<NetworkDiagramNode> NetworkDiagramNodes => Set<NetworkDiagramNode>();
     public DbSet<NetworkDiagramLink> NetworkDiagramLinks => Set<NetworkDiagramLink>();
+    public DbSet<NetworkDiagramLinkVlan> NetworkDiagramLinkVlans => Set<NetworkDiagramLinkVlan>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -485,6 +486,27 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         networkDiagramLink.HasOne(x => x.Diagram)
             .WithMany(x => x.Links)
             .HasForeignKey(x => x.DiagramId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+
+        var networkDiagramLinkVlan = modelBuilder.Entity<NetworkDiagramLinkVlan>();
+        networkDiagramLinkVlan.ToTable("NetworkDiagramLinkVlans");
+        networkDiagramLinkVlan.HasKey(x => x.LinkVlanId);
+        networkDiagramLinkVlan.Property(x => x.LinkVlanId).HasMaxLength(64);
+        networkDiagramLinkVlan.Property(x => x.LinkId).HasMaxLength(64).IsRequired();
+        networkDiagramLinkVlan.Property(x => x.DiagramId).HasMaxLength(64).IsRequired();
+        networkDiagramLinkVlan.Property(x => x.VlanId).IsRequired();
+        networkDiagramLinkVlan.Property(x => x.Name).HasMaxLength(128);
+        networkDiagramLinkVlan.Property(x => x.Mode).HasMaxLength(32).IsRequired();
+        networkDiagramLinkVlan.Property(x => x.Notes).HasMaxLength(512);
+        networkDiagramLinkVlan.Property(x => x.SortOrder).IsRequired();
+        networkDiagramLinkVlan.Property(x => x.CreatedAtUtc).IsRequired();
+        networkDiagramLinkVlan.Property(x => x.UpdatedAtUtc).IsRequired();
+        networkDiagramLinkVlan.HasIndex(x => x.DiagramId);
+        networkDiagramLinkVlan.HasIndex(x => new { x.LinkId, x.VlanId }).IsUnique();
+        networkDiagramLinkVlan.HasOne(x => x.Link)
+            .WithMany(x => x.Vlans)
+            .HasForeignKey(x => x.LinkId)
             .OnDelete(DeleteBehavior.Cascade);
         var securitySettings = modelBuilder.Entity<SecuritySettings>();
         securitySettings.ToTable("SecuritySettings");

--- a/src/WebApp/PingMonitor.Web/Models/NetworkDiagramLink.cs
+++ b/src/WebApp/PingMonitor.Web/Models/NetworkDiagramLink.cs
@@ -21,4 +21,5 @@ public sealed class NetworkDiagramLink
     public DateTimeOffset CreatedAtUtc { get; set; }
     public DateTimeOffset UpdatedAtUtc { get; set; }
     public NetworkDiagram? Diagram { get; set; }
+    public List<NetworkDiagramLinkVlan> Vlans { get; set; } = [];
 }

--- a/src/WebApp/PingMonitor.Web/Models/NetworkDiagramLinkVlan.cs
+++ b/src/WebApp/PingMonitor.Web/Models/NetworkDiagramLinkVlan.cs
@@ -1,0 +1,16 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class NetworkDiagramLinkVlan
+{
+    public string LinkVlanId { get; set; } = Guid.NewGuid().ToString("N");
+    public string LinkId { get; set; } = string.Empty;
+    public string DiagramId { get; set; } = string.Empty;
+    public int VlanId { get; set; }
+    public string? Name { get; set; }
+    public string Mode { get; set; } = "Tagged";
+    public string? Notes { get; set; }
+    public int SortOrder { get; set; }
+    public DateTimeOffset CreatedAtUtc { get; set; }
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+    public NetworkDiagramLink? Link { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
@@ -5,6 +5,6 @@ public sealed class StartupGateOptions
     public const string SectionName = "StartupGate";
 
     public string StorageDirectory { get; set; } = "App_Data/StartupGate";
-    public int RequiredSchemaVersion { get; set; } = 17;
+    public int RequiredSchemaVersion { get; set; } = 18;
     public int DefaultMySqlPort { get; set; } = 3306;
 }

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramModels.cs
@@ -78,6 +78,38 @@ public static class NetworkDiagramLinkTypes
     public static bool IsAllowed(string? value) => Allowed.Contains(Normalize(value));
 }
 
+
+public static class NetworkDiagramVlanModes
+{
+    public const string Tagged = "Tagged";
+    public const string Untagged = "Untagged";
+    public const string Native = "Native";
+    public const string Management = "Management";
+    public const string Other = "Other";
+
+    public static readonly IReadOnlySet<string> Allowed = new HashSet<string>(StringComparer.Ordinal)
+    {
+        Tagged,
+        Untagged,
+        Native,
+        Management,
+        Other
+    };
+
+    public static string Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var trimmed = value.Trim();
+        return Allowed.FirstOrDefault(allowed => string.Equals(allowed, trimmed, StringComparison.OrdinalIgnoreCase)) ?? trimmed;
+    }
+
+    public static bool IsAllowed(string? value) => Allowed.Contains(Normalize(value));
+}
+
 public static class NetworkDiagramMediaSubtypes
 {
     public const string None = "None";
@@ -221,6 +253,15 @@ public sealed class NetworkDiagramLinkSaveRequest
     public int? LacpMemberCount { get; init; }
     public string? LacpMemberPortsJson { get; init; }
     public string? MetadataJson { get; init; }
+    public IReadOnlyList<NetworkDiagramLinkVlanSaveRequest> Vlans { get; init; } = [];
+}
+
+public sealed class NetworkDiagramLinkVlanSaveRequest
+{
+    public int? VlanId { get; init; }
+    public string? Name { get; init; }
+    public string? Mode { get; init; }
+    public string? Notes { get; init; }
 }
 
 public sealed class NetworkDiagramDto
@@ -271,4 +312,14 @@ public sealed class NetworkDiagramLinkDto
     public int? LacpMemberCount { get; init; }
     public string? LacpMemberPortsJson { get; init; }
     public string? MetadataJson { get; init; }
+    public IReadOnlyList<NetworkDiagramLinkVlanDto> Vlans { get; init; } = [];
+}
+
+public sealed class NetworkDiagramLinkVlanDto
+{
+    public int VlanId { get; init; }
+    public string? Name { get; init; }
+    public string Mode { get; init; } = NetworkDiagramVlanModes.Tagged;
+    public string? Notes { get; init; }
+    public int SortOrder { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramPdfExportService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramPdfExportService.cs
@@ -453,9 +453,43 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
             ? $"{link.SourcePortLabel ?? "?"} <-> {link.TargetPortLabel ?? "?"}"
             : null;
         var labelAndNotes = string.Join(" -- ", new[] { link.Label, link.Notes }.Where(x => !string.IsNullOrWhiteSpace(x)));
-        var parts = new[] { summary, ports, labelAndNotes }
+        var vlanSummary = BuildVlanSummary(link);
+        var parts = new[] { summary, ports, labelAndNotes, vlanSummary }
             .Where(x => !string.IsNullOrWhiteSpace(x));
         return string.Join(" • ", parts);
+    }
+
+
+    private static string? BuildVlanSummary(NetworkDiagramLinkDto link)
+    {
+        if (link.Vlans.Count == 0)
+        {
+            return null;
+        }
+
+        var labels = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [NetworkDiagramVlanModes.Tagged] = "T",
+            [NetworkDiagramVlanModes.Untagged] = "U",
+            [NetworkDiagramVlanModes.Native] = "Native",
+            [NetworkDiagramVlanModes.Management] = "Mgmt",
+            [NetworkDiagramVlanModes.Other] = "Other"
+        };
+
+        var parts = NetworkDiagramVlanModes.Allowed
+            .Select(mode =>
+            {
+                var values = link.Vlans
+                    .Where(vlan => string.Equals(NetworkDiagramVlanModes.Normalize(vlan.Mode), mode, StringComparison.Ordinal))
+                    .OrderBy(vlan => vlan.SortOrder)
+                    .ThenBy(vlan => vlan.VlanId)
+                    .Select(vlan => string.IsNullOrWhiteSpace(vlan.Name) ? vlan.VlanId.ToString(CultureInfo.InvariantCulture) : $"{vlan.VlanId} {vlan.Name}")
+                    .ToArray();
+                return values.Length == 0 ? null : $"{labels[mode]}:{string.Join(",", values)}";
+            })
+            .Where(x => !string.IsNullOrWhiteSpace(x));
+
+        return Truncate(string.Join(" · ", parts), 80);
     }
 
     private static string FormatNodeType(string nodeType)

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramService.cs
@@ -90,6 +90,7 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
             .AsNoTracking()
             .Include(x => x.Nodes)
             .Include(x => x.Links)
+                .ThenInclude(x => x.Vlans)
             .FirstOrDefaultAsync(x => x.DiagramId == diagramId, cancellationToken);
 
         return diagram is null ? null : ToDto(diagram);
@@ -100,6 +101,7 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
         var diagram = await _dbContext.NetworkDiagrams
             .Include(x => x.Nodes)
             .Include(x => x.Links)
+                .ThenInclude(x => x.Vlans)
             .FirstOrDefaultAsync(x => x.DiagramId == diagramId, cancellationToken)
             ?? throw new NetworkDiagramValidationException("Diagram does not exist.");
 
@@ -144,7 +146,7 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
 
         foreach (var linkRequest in request.Links)
         {
-            diagram.Links.Add(new NetworkDiagramLink
+            var link = new NetworkDiagramLink
             {
                 LinkId = TrimRequired(linkRequest.LinkId, 64, "Link ID"),
                 DiagramId = diagram.DiagramId,
@@ -164,7 +166,26 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
                 MetadataJson = TrimOptional(linkRequest.MetadataJson, 65535),
                 CreatedAtUtc = now,
                 UpdatedAtUtc = now
-            });
+            };
+
+            foreach (var vlan in NormalizeVlans(linkRequest.Vlans))
+            {
+                link.Vlans.Add(new NetworkDiagramLinkVlan
+                {
+                    LinkVlanId = Guid.NewGuid().ToString("N"),
+                    LinkId = link.LinkId,
+                    DiagramId = diagram.DiagramId,
+                    VlanId = vlan.VlanId,
+                    Name = vlan.Name,
+                    Mode = vlan.Mode,
+                    Notes = vlan.Notes,
+                    SortOrder = vlan.SortOrder,
+                    CreatedAtUtc = now,
+                    UpdatedAtUtc = now
+                });
+            }
+
+            diagram.Links.Add(link);
         }
 
         await _dbContext.SaveChangesAsync(cancellationToken);
@@ -242,6 +263,7 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
             }
 
             ValidateLinkMetadata(link);
+            _ = NormalizeVlans(link.Vlans);
 
             _ = TrimOptional(link.Label, 255);
             _ = TrimOptional(link.SourcePortLabel, 128);
@@ -296,7 +318,15 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
                 LinkSpeedUnit = NetworkDiagramLinkSpeedUnits.Normalize(x.LinkSpeedUnit),
                 LacpMemberCount = ResolveLacpMemberCount(x.LinkType, x.LacpMemberCount),
                 LacpMemberPortsJson = NormalizeLacpMemberPortsJson(x.LinkType, x.LacpMemberPortsJson),
-                MetadataJson = x.MetadataJson
+                MetadataJson = x.MetadataJson,
+                Vlans = x.Vlans.OrderBy(v => v.SortOrder).ThenBy(v => v.VlanId).Select(v => new NetworkDiagramLinkVlanDto
+                {
+                    VlanId = v.VlanId,
+                    Name = v.Name,
+                    Mode = NetworkDiagramVlanModes.Normalize(v.Mode),
+                    Notes = v.Notes,
+                    SortOrder = v.SortOrder
+                }).ToArray()
             }).ToArray()
         };
     }
@@ -346,6 +376,53 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
 
         _ = memberCount;
         _ = NormalizeLacpMemberPortsJson(link.LinkType, link.LacpMemberPortsJson);
+    }
+
+
+    private static IReadOnlyList<NetworkDiagramLinkVlanDto> NormalizeVlans(IReadOnlyList<NetworkDiagramLinkVlanSaveRequest>? vlans)
+    {
+        if (vlans is null || vlans.Count == 0)
+        {
+            return [];
+        }
+
+        var result = new List<NetworkDiagramLinkVlanDto>();
+        var seenVlanIds = new HashSet<int>();
+        var sortOrder = 0;
+        foreach (var vlan in vlans)
+        {
+            if (vlan.VlanId is null && string.IsNullOrWhiteSpace(vlan.Name) && string.IsNullOrWhiteSpace(vlan.Mode) && string.IsNullOrWhiteSpace(vlan.Notes))
+            {
+                continue;
+            }
+
+            if (vlan.VlanId is null or < 1 or > 4094)
+            {
+                throw new NetworkDiagramValidationException("VLAN ID must be between 1 and 4094.");
+            }
+
+            if (!seenVlanIds.Add(vlan.VlanId.Value))
+            {
+                throw new NetworkDiagramValidationException($"This link already contains VLAN {vlan.VlanId.Value}.");
+            }
+
+            var mode = NetworkDiagramVlanModes.Normalize(vlan.Mode);
+            if (!NetworkDiagramVlanModes.IsAllowed(mode))
+            {
+                throw new NetworkDiagramValidationException("Select a VLAN mode.");
+            }
+
+            result.Add(new NetworkDiagramLinkVlanDto
+            {
+                VlanId = vlan.VlanId.Value,
+                Name = TrimOptional(vlan.Name, 128),
+                Mode = mode,
+                Notes = TrimOptional(vlan.Notes, 512),
+                SortOrder = sortOrder++
+            });
+        }
+
+        return result.OrderBy(x => x.SortOrder).ToArray();
     }
 
     private static string ResolveMediaType(string? mediaType, string? legacyLinkType)

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -103,6 +103,20 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "CreatedAtUtc",
         "UpdatedAtUtc"
     ];
+
+    private static readonly string[] RequiredNetworkDiagramLinkVlanColumns =
+    [
+        "LinkVlanId",
+        "LinkId",
+        "DiagramId",
+        "VlanId",
+        "Name",
+        "Mode",
+        "Notes",
+        "SortOrder",
+        "CreatedAtUtc",
+        "UpdatedAtUtc"
+    ];
     private static readonly string[] RequiredEndpointDependencyColumns =
     [
         "EndpointDependencyId",
@@ -418,6 +432,15 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         {
             var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
             status.Diagnostics.Add($"NetworkDiagramLinks table is missing required columns: {string.Join(", ", missingNetworkDiagramLinkColumns)}.");
+            return status;
+        }
+
+
+        var missingNetworkDiagramLinkVlanColumns = await GetMissingColumnsAsync(connection, "NetworkDiagramLinkVlans", RequiredNetworkDiagramLinkVlanColumns, cancellationToken);
+        if (missingNetworkDiagramLinkVlanColumns.Length > 0)
+        {
+            var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
+            status.Diagnostics.Add($"NetworkDiagramLinkVlans table is missing required columns: {string.Join(", ", missingNetworkDiagramLinkVlanColumns)}.");
             return status;
         }
 
@@ -908,6 +931,27 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             );
             """;
 
+
+
+        const string createNetworkDiagramLinkVlansSql = """
+            CREATE TABLE IF NOT EXISTS `NetworkDiagramLinkVlans` (
+                `LinkVlanId` varchar(64) NOT NULL,
+                `LinkId` varchar(64) NOT NULL,
+                `DiagramId` varchar(64) NOT NULL,
+                `VlanId` int NOT NULL,
+                `Name` varchar(128) NULL,
+                `Mode` varchar(32) NOT NULL,
+                `Notes` varchar(512) NULL,
+                `SortOrder` int NOT NULL DEFAULT 0,
+                `CreatedAtUtc` datetime(6) NOT NULL,
+                `UpdatedAtUtc` datetime(6) NOT NULL,
+                PRIMARY KEY (`LinkVlanId`),
+                UNIQUE KEY `IX_NetworkDiagramLinkVlans_LinkId_VlanId` (`LinkId`, `VlanId`),
+                KEY `IX_NetworkDiagramLinkVlans_DiagramId` (`DiagramId`),
+                CONSTRAINT `FK_NetworkDiagramLinkVlans_NetworkDiagramLinks_LinkId` FOREIGN KEY (`LinkId`) REFERENCES `NetworkDiagramLinks` (`LinkId`) ON DELETE CASCADE
+            );
+            """;
+
         await dbContext.Database.ExecuteSqlRawAsync(createEndpointStatesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createStateTransitionsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createAssignmentMetrics24hSql, cancellationToken);
@@ -931,6 +975,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await dbContext.Database.ExecuteSqlRawAsync(createNetworkDiagramsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createNetworkDiagramNodesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createNetworkDiagramLinksSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createNetworkDiagramLinkVlansSql, cancellationToken);
         await EnsureEndpointDependenciesColumnsAsync(dbContext, cancellationToken);
         await EnsureEndpointColumnsAsync(dbContext, cancellationToken);
         await EnsureSecuritySettingsColumnsAsync(dbContext, cancellationToken);
@@ -943,10 +988,34 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await EnsureCheckResultsNormalizedSchemaAsync(dbContext, cancellationToken);
         await EnsureRttPrecisionSchemaAsync(dbContext, cancellationToken);
         await EnsureNetworkDiagramLinkMetadataColumnsAsync(dbContext, cancellationToken);
+        await EnsureNetworkDiagramLinkVlanTableAsync(dbContext, cancellationToken);
         await EnsureMetricsIndexesAsync(dbContext, cancellationToken);
         await MigrateLegacyEndpointDependenciesAsync(dbContext, cancellationToken);
     }
 
+
+
+    private static async Task EnsureNetworkDiagramLinkVlanTableAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
+    {
+        await dbContext.Database.ExecuteSqlRawAsync("""
+            CREATE TABLE IF NOT EXISTS `NetworkDiagramLinkVlans` (
+                `LinkVlanId` varchar(64) NOT NULL,
+                `LinkId` varchar(64) NOT NULL,
+                `DiagramId` varchar(64) NOT NULL,
+                `VlanId` int NOT NULL,
+                `Name` varchar(128) NULL,
+                `Mode` varchar(32) NOT NULL,
+                `Notes` varchar(512) NULL,
+                `SortOrder` int NOT NULL DEFAULT 0,
+                `CreatedAtUtc` datetime(6) NOT NULL,
+                `UpdatedAtUtc` datetime(6) NOT NULL,
+                PRIMARY KEY (`LinkVlanId`),
+                UNIQUE KEY `IX_NetworkDiagramLinkVlans_LinkId_VlanId` (`LinkId`, `VlanId`),
+                KEY `IX_NetworkDiagramLinkVlans_DiagramId` (`DiagramId`),
+                CONSTRAINT `FK_NetworkDiagramLinkVlans_NetworkDiagramLinks_LinkId` FOREIGN KEY (`LinkId`) REFERENCES `NetworkDiagramLinks` (`LinkId`) ON DELETE CASCADE
+            );
+            """, cancellationToken);
+    }
 
     private static async Task EnsureNetworkDiagramLinkMetadataColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
     {

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
@@ -285,6 +285,14 @@
                         Notes
                         <textarea data-link-field="notes" rows="4" maxlength="400"></textarea>
                     </label>
+                    <section class="link-vlan-section" data-link-vlan-section aria-label="Link VLAN metadata">
+                        <div class="link-vlan-section-header">
+                            <h3>VLANs</h3>
+                            <button type="button" data-add-link-vlan>Add VLAN</button>
+                        </div>
+                        <p class="toolbox-help">VLANs are documentation metadata for this visual link only. They do not configure switches or affect monitoring dependencies.</p>
+                        <div class="link-vlan-list" data-link-vlan-list></div>
+                    </section>
                     <button type="button" class="danger-button" data-delete-selection>Delete selected link</button>
                 </form>
             </aside>

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 17,
+    "RequiredSchemaVersion": 18,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -951,3 +951,57 @@ html[data-theme="dark"] .diagram-link-port-label {
     font-size: .78rem;
     font-weight: 800;
 }
+
+.link-vlan-section {
+    display: grid;
+    gap: .5rem;
+    padding: .6rem;
+    border: 1px solid var(--diagram-border);
+    border-radius: 8px;
+    background: var(--diagram-panel);
+}
+
+.link-vlan-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .5rem;
+}
+
+.link-vlan-section-header h3 {
+    margin: 0;
+    font-size: .88rem;
+}
+
+.link-vlan-list {
+    display: grid;
+    gap: .5rem;
+    max-height: 340px;
+    overflow-y: auto;
+}
+
+.link-vlan-card {
+    display: grid;
+    gap: .45rem;
+    padding: .5rem;
+    border: 1px solid var(--diagram-border);
+    border-radius: 8px;
+    background: var(--diagram-panel-subtle);
+}
+
+.link-vlan-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .5rem;
+}
+
+.link-vlan-card-header strong {
+    font-size: .82rem;
+}
+
+.link-vlan-card-header button,
+.link-vlan-section-header button {
+    min-height: 36px;
+    padding: .35rem .55rem;
+}

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
@@ -50,6 +50,8 @@
     const customSpeedFields = editor.querySelector('[data-custom-speed-fields]');
     const lacpFields = editor.querySelector('[data-lacp-fields]');
     const lacpMemberPorts = editor.querySelector('[data-lacp-member-ports]');
+    const linkVlanList = editor.querySelector('[data-link-vlan-list]');
+    const addLinkVlanButton = editor.querySelector('[data-add-link-vlan]');
     const saveStatus = editor.querySelector('[data-save-status]');
     const antiforgeryToken = editor.querySelector('input[name="__RequestVerificationToken"]')?.value || '';
     const loadUrl = editor.dataset.loadUrl || '';
@@ -90,6 +92,7 @@
         { value: 'Other', label: 'Other', speedValue: '', unit: 'Gbps' }
     ];
     const linkSpeedUnits = ['Mbps', 'Gbps', 'Tbps'];
+    const vlanModes = ['Tagged', 'Untagged', 'Native', 'Management', 'Other'];
     const parallelLinkOffsetStep = 34;
     const canvasPresets = [
         { value: 'small', label: 'Small', width: 4000, height: 2828 },
@@ -839,6 +842,42 @@
         return normalized.length <= maxLength ? normalized : `${normalized.slice(0, Math.max(0, maxLength - 1))}…`;
     }
 
+
+    function normalizeVlanMode(value) {
+        const requested = (value || '').trim();
+        return vlanModes.find(mode => mode.toLowerCase() === requested.toLowerCase()) || 'Tagged';
+    }
+
+    function normalizeVlans(vlans) {
+        if (!Array.isArray(vlans)) {
+            return [];
+        }
+
+        return vlans.map(vlan => ({
+            vlanId: vlan?.vlanId == null || vlan.vlanId === '' ? '' : String(vlan.vlanId).slice(0, 4),
+            name: String(vlan?.name || '').slice(0, 128),
+            mode: normalizeVlanMode(vlan?.mode),
+            notes: String(vlan?.notes || '').slice(0, 512)
+        }));
+    }
+
+    function buildVlanSummary(link, maxLength = 72) {
+        const vlans = normalizeVlans(link?.vlans);
+        if (vlans.length === 0) {
+            return '';
+        }
+
+        const labels = { Tagged: 'T', Untagged: 'U', Native: 'Native', Management: 'Mgmt', Other: 'Other' };
+        const parts = vlanModes.map(mode => {
+            const values = vlans
+                .filter(vlan => vlan.mode === mode && vlan.vlanId)
+                .map(vlan => vlan.name ? `${vlan.vlanId} ${vlan.name}` : vlan.vlanId);
+            return values.length > 0 ? `${labels[mode]}:${values.join(',')}` : '';
+        }).filter(Boolean);
+
+        return truncateLinkText(parts.join(' · '), maxLength);
+    }
+
     function formatSpeed(value, unit) {
         const speed = (value || '').toString().trim();
         const normalizedUnit = normalizeSpeedUnit(unit);
@@ -876,7 +915,7 @@
         const ports = normalizeLinkType(link.linkType) !== 'LACP' && (link.sourcePort || link.targetPort)
             ? [link.sourcePort || '?', link.targetPort || '?'].join(' ↔ ')
             : '';
-        return truncateLinkText([main, ports].filter(Boolean).join(' • '), 96);
+        return truncateLinkText([main, ports, buildVlanSummary(link)].filter(Boolean).join(' • '), 116);
     }
 
     function renderLinks() {
@@ -1040,6 +1079,59 @@
             lacpFields.hidden = selectedLinkType !== 'LACP';
         }
         renderLacpMemberPortFields(selectedLink);
+        renderVlanFields(selectedLink);
+    }
+
+    function addLinkVlan() {
+        const selectedLink = state.selectedLinkId ? findLinkById(state.selectedLinkId) : null;
+        if (!selectedLink) {
+            return;
+        }
+
+        selectedLink.vlans = normalizeVlans(selectedLink.vlans);
+        selectedLink.vlans.push({ vlanId: '', name: '', mode: 'Tagged', notes: '' });
+        renderVlanFields(selectedLink);
+        renderLinks();
+        markDirty();
+    }
+
+    function renderVlanFields(link) {
+        if (!linkVlanList) {
+            return;
+        }
+
+        linkVlanList.replaceChildren();
+        if (!link) {
+            return;
+        }
+
+        link.vlans = normalizeVlans(link.vlans);
+        if (link.vlans.length === 0) {
+            const empty = document.createElement('p');
+            empty.className = 'toolbox-help';
+            empty.textContent = 'No VLAN metadata has been added to this visual link.';
+            linkVlanList.appendChild(empty);
+            return;
+        }
+
+        link.vlans.forEach((vlan, index) => {
+            const card = document.createElement('div');
+            card.className = 'link-vlan-card';
+            card.innerHTML = `<div class="link-vlan-card-header"><strong>VLAN ${index + 1}</strong><button type="button" aria-label="Remove VLAN ${index + 1}">Remove</button></div><label>ID<input type="number" min="1" max="4094" step="1" value="${escapeHtml(vlan.vlanId)}" placeholder="10"></label><label>Name<input type="text" maxlength="128" value="${escapeHtml(vlan.name)}" placeholder="LAN"></label><label>Mode<select>${vlanModes.map(mode => `<option value="${mode}"${mode === vlan.mode ? ' selected' : ''}>${mode}</option>`).join('')}</select></label><label>Notes<textarea rows="2" maxlength="512">${escapeHtml(vlan.notes)}</textarea></label>`;
+            const remove = card.querySelector('button');
+            const inputs = card.querySelectorAll('input, select, textarea');
+            remove.addEventListener('click', () => {
+                link.vlans.splice(index, 1);
+                renderVlanFields(link);
+                renderLinks();
+                markDirty();
+            });
+            inputs[0].addEventListener('input', event => { vlan.vlanId = event.currentTarget.value; renderLinks(); markDirty(); });
+            inputs[1].addEventListener('input', event => { vlan.name = event.currentTarget.value; renderLinks(); markDirty(); });
+            inputs[2].addEventListener('change', event => { vlan.mode = normalizeVlanMode(event.currentTarget.value); renderLinks(); markDirty(); });
+            inputs[3].addEventListener('input', event => { vlan.notes = event.currentTarget.value; markDirty(); });
+            linkVlanList.appendChild(card);
+        });
     }
 
     function updateSelectedNodeField(event) {
@@ -1453,7 +1545,8 @@
             linkSpeedUnit: normalizeSpeedUnit(link.linkSpeedUnit),
             linkSpeedPreset: getSpeedPreset(link.linkSpeedValue == null ? '' : String(link.linkSpeedValue), link.linkSpeedUnit),
             lacpMemberCount: normalizeLacpMemberCount(link.lacpMemberCount, link.linkType),
-            lacpMemberPorts: parseLacpMemberPorts(link.lacpMemberPortsJson)
+            lacpMemberPorts: parseLacpMemberPorts(link.lacpMemberPortsJson),
+            vlans: normalizeVlans(link.vlans)
         }));
         state.loading = false;
         state.dirty = false;
@@ -1513,7 +1606,14 @@
                 linkSpeedUnit: link.linkSpeedValue === '' || link.linkSpeedValue == null ? null : normalizeSpeedUnit(link.linkSpeedUnit) || null,
                 lacpMemberCount: normalizeLinkType(link.linkType) === 'LACP' ? Number(normalizeLacpMemberCount(link.lacpMemberCount, link.linkType)) : null,
                 lacpMemberPortsJson: normalizeLinkType(link.linkType) === 'LACP' ? JSON.stringify(link.lacpMemberPorts || []) : null,
-                metadataJson: null
+                metadataJson: null,
+                vlans: normalizeVlans(link.vlans).filter(vlan => vlan.vlanId || vlan.name || vlan.notes).map((vlan, index) => ({
+                    vlanId: vlan.vlanId === '' ? null : Number(vlan.vlanId),
+                    name: vlan.name || null,
+                    mode: normalizeVlanMode(vlan.mode),
+                    notes: vlan.notes || null,
+                    sortOrder: index
+                }))
             }))
         };
     }

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
@@ -126,6 +126,7 @@
     let dragState = null;
     let panState = null;
     let pendingLinkSourceId = null;
+    let vlanSequence = 0;
 
     function updateNavHeight() {
         const height = nav ? nav.getBoundingClientRect().height : 0;
@@ -843,6 +844,11 @@
     }
 
 
+    function createVlanClientId() {
+        vlanSequence += 1;
+        return `vlan-${Date.now().toString(36)}-${vlanSequence.toString(36)}`;
+    }
+
     function normalizeVlanMode(value) {
         const requested = (value || '').trim();
         return vlanModes.find(mode => mode.toLowerCase() === requested.toLowerCase()) || 'Tagged';
@@ -853,12 +859,35 @@
             return [];
         }
 
-        return vlans.map(vlan => ({
+        return vlans.map((vlan, index) => ({
+            clientId: String(vlan?.clientId || vlan?.linkVlanId || createVlanClientId()),
             vlanId: vlan?.vlanId == null || vlan.vlanId === '' ? '' : String(vlan.vlanId).slice(0, 4),
             name: String(vlan?.name || '').slice(0, 128),
             mode: normalizeVlanMode(vlan?.mode),
-            notes: String(vlan?.notes || '').slice(0, 512)
-        }));
+            notes: String(vlan?.notes || '').slice(0, 512),
+            sortOrder: Number.isFinite(Number(vlan?.sortOrder)) ? Number(vlan.sortOrder) : index
+        })).sort((left, right) => left.sortOrder - right.sortOrder);
+    }
+
+    function isBlankVlan(vlan) {
+        return !vlan.vlanId && !vlan.name && !vlan.notes;
+    }
+
+    function validateVlanForSave(vlan) {
+        if (isBlankVlan(vlan)) {
+            return null;
+        }
+
+        const vlanId = Number(vlan.vlanId);
+        if (!Number.isInteger(vlanId) || vlanId < 1 || vlanId > 4094) {
+            throw new Error('VLAN ID must be between 1 and 4094.');
+        }
+
+        if (!vlanModes.includes(normalizeVlanMode(vlan.mode))) {
+            throw new Error('Select a VLAN mode.');
+        }
+
+        return vlanId;
     }
 
     function buildVlanSummary(link, maxLength = 72) {
@@ -1082,17 +1111,30 @@
         renderVlanFields(selectedLink);
     }
 
-    function addLinkVlan() {
+    function addLinkVlan(event) {
+        event?.preventDefault();
         const selectedLink = state.selectedLinkId ? findLinkById(state.selectedLinkId) : null;
         if (!selectedLink) {
             return;
         }
 
         selectedLink.vlans = normalizeVlans(selectedLink.vlans);
-        selectedLink.vlans.push({ vlanId: '', name: '', mode: 'Tagged', notes: '' });
+        const nextSortOrder = selectedLink.vlans.length === 0
+            ? 0
+            : Math.max(...selectedLink.vlans.map(vlan => vlan.sortOrder || 0)) + 1;
+        const newVlan = {
+            clientId: createVlanClientId(),
+            vlanId: '',
+            name: '',
+            mode: 'Tagged',
+            notes: '',
+            sortOrder: nextSortOrder
+        };
+        selectedLink.vlans.push(newVlan);
         renderVlanFields(selectedLink);
         renderLinks();
         markDirty();
+        linkVlanList?.querySelector(`[data-vlan-client-id="${CSS.escape(newVlan.clientId)}"] [data-vlan-field="vlanId"]`)?.focus();
     }
 
     function renderVlanFields(link) {
@@ -1117,11 +1159,16 @@
         link.vlans.forEach((vlan, index) => {
             const card = document.createElement('div');
             card.className = 'link-vlan-card';
-            card.innerHTML = `<div class="link-vlan-card-header"><strong>VLAN ${index + 1}</strong><button type="button" aria-label="Remove VLAN ${index + 1}">Remove</button></div><label>ID<input type="number" min="1" max="4094" step="1" value="${escapeHtml(vlan.vlanId)}" placeholder="10"></label><label>Name<input type="text" maxlength="128" value="${escapeHtml(vlan.name)}" placeholder="LAN"></label><label>Mode<select>${vlanModes.map(mode => `<option value="${mode}"${mode === vlan.mode ? ' selected' : ''}>${mode}</option>`).join('')}</select></label><label>Notes<textarea rows="2" maxlength="512">${escapeHtml(vlan.notes)}</textarea></label>`;
+            card.dataset.vlanClientId = vlan.clientId;
+            card.innerHTML = `<div class="link-vlan-card-header"><strong>VLAN ${index + 1}</strong><button type="button" aria-label="Remove VLAN ${index + 1}">Remove</button></div><label>ID<input type="number" data-vlan-field="vlanId" min="1" max="4094" step="1" value="${escapeHtml(vlan.vlanId)}" placeholder="10"></label><label>Name<input type="text" data-vlan-field="name" maxlength="128" value="${escapeHtml(vlan.name)}" placeholder="LAN"></label><label>Mode<select data-vlan-field="mode">${vlanModes.map(mode => `<option value="${mode}"${mode === vlan.mode ? ' selected' : ''}>${mode}</option>`).join('')}</select></label><label>Notes<textarea data-vlan-field="notes" rows="2" maxlength="512">${escapeHtml(vlan.notes)}</textarea></label>`;
             const remove = card.querySelector('button');
             const inputs = card.querySelectorAll('input, select, textarea');
-            remove.addEventListener('click', () => {
-                link.vlans.splice(index, 1);
+            remove.addEventListener('click', event => {
+                event.preventDefault();
+                const currentIndex = link.vlans.findIndex(entry => entry.clientId === vlan.clientId);
+                if (currentIndex >= 0) {
+                    link.vlans.splice(currentIndex, 1);
+                }
                 renderVlanFields(link);
                 renderLinks();
                 markDirty();
@@ -1607,13 +1654,16 @@
                 lacpMemberCount: normalizeLinkType(link.linkType) === 'LACP' ? Number(normalizeLacpMemberCount(link.lacpMemberCount, link.linkType)) : null,
                 lacpMemberPortsJson: normalizeLinkType(link.linkType) === 'LACP' ? JSON.stringify(link.lacpMemberPorts || []) : null,
                 metadataJson: null,
-                vlans: normalizeVlans(link.vlans).filter(vlan => vlan.vlanId || vlan.name || vlan.notes).map((vlan, index) => ({
-                    vlanId: vlan.vlanId === '' ? null : Number(vlan.vlanId),
-                    name: vlan.name || null,
-                    mode: normalizeVlanMode(vlan.mode),
-                    notes: vlan.notes || null,
-                    sortOrder: index
-                }))
+                vlans: normalizeVlans(link.vlans).map((vlan, index) => {
+                    const vlanId = validateVlanForSave(vlan);
+                    return vlanId === null ? null : {
+                        vlanId,
+                        name: vlan.name || null,
+                        mode: normalizeVlanMode(vlan.mode),
+                        notes: vlan.notes || null,
+                        sortOrder: index
+                    };
+                }).filter(Boolean)
             }))
         };
     }
@@ -1734,6 +1784,10 @@
 
     if (exportPdfButton) {
         exportPdfButton.addEventListener('click', exportPdf);
+    }
+
+    if (addLinkVlanButton) {
+        addLinkVlanButton.addEventListener('click', addLinkVlan);
     }
 
     if (saveButton) {


### PR DESCRIPTION
### Motivation

- Provide structured, persistent VLAN documentation on visual network diagram links while keeping diagrams strictly documentation-only. 
- Preserve startup gate/schema rules by declaring and creating the new table and bumping the required schema version. 
- Surface VLAN summaries on the canvas and in PDF export so operators can document VLANs without affecting monitoring logic.

### Description

- Data model: added `NetworkDiagramLinkVlan` entity and `NetworkDiagramLink.Vlans` collection, EF mapping, unique (`LinkId`,`VlanId`) index, and cascade delete; added DTOs and save/load DTO fields. 
- Validation & service: server-side save/load validation of VLAN entries (VLAN ID range 1–4094, allowed modes, length limits, duplicate ID rejection, deterministic SortOrder) and normalization helpers in `NetworkDiagramService`. 
- Startup Gate / schema: created SQL to ensure `NetworkDiagramLinkVlans` table in `StartupSchemaService` and incremented `StartupGate.RequiredSchemaVersion` to `18`. 
- UI: added a compact VLAN section to the link Properties panel (`Edit.cshtml` + CSS) with add/remove/edit VLAN card UI and client-side helpers in `network-diagrams-editor.js` to edit, normalize, and serialize VLANs. 
- Canvas & PDF: link canvas label generation includes a compact VLAN summary; `NetworkDiagramPdfExportService` now includes VLAN summaries (truncated/safe) in exported PDFs. 
- Docs & tests: updated design/docs to describe VLAN metadata as documentation-only and added unit/source assertions and feature tests referencing the new model and PDF output; created issue #515 to track work.

### Testing

- `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` succeeded. 
- `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` ran all tests and passed (132 total tests). 
- JavaScript syntax validation: `node --check src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js` returned no errors. 
- Verified no agent files changed via `git diff -- src/Agent src/WebApp/Agent`. 
- Manual smoke checks: built web project and exercised editor save/load/PDF code paths in tests that assert VLAN summary presence in PDF export.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ebe4fa104832a941b696ace46eaa0)