### PR TITLE
Wire Add VLAN button in Network Diagrams editor and implement VLAN add/edit/save

### DIFF
--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -337,6 +337,8 @@ VLAN metadata is documentation-only. It does not configure switches, routers, wi
 
 When VLAN entries are present, a compact VLAN summary is shown on the canvas link label and included in PDF export where space allows. Examples include `T:10 LAN,20 CCTV`, `U:5 Management`, and `Native:1`.
 
+In the editor Properties panel, selecting a visual link exposes an **Add VLAN** action. Add VLAN inserts a new editable VLAN metadata row immediately for that selected visual link, with blank VLAN ID/name/notes and `Tagged` mode selected by default. Operators can edit VLAN ID, name/label, mode, and notes, remove individual VLAN rows, save the diagram, and reload the saved VLAN metadata later. Blank rows may be used while editing; saved rows must have a valid VLAN ID from 1 through 4094.
+
 Schema note:
 
 - This adds schema version 18 with the `NetworkDiagramLinkVlans` table.

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -243,6 +243,31 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("link-vlan-card", styles);
     }
 
+    [Fact]
+    public void NetworkDiagramEditor_WiresAddVlanAndPersistsVlanPayload()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var script = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "wwwroot", "js", "network-diagrams-editor.js"));
+
+        Assert.Contains("addLinkVlanButton.addEventListener('click', addLinkVlan)", script);
+        Assert.Contains("function addLinkVlan(event)", script);
+        Assert.Contains("event?.preventDefault();", script);
+        Assert.Contains("state.selectedLinkId ? findLinkById(state.selectedLinkId) : null", script);
+        Assert.Contains("selectedLink.vlans = normalizeVlans(selectedLink.vlans);", script);
+        Assert.Contains("clientId: createVlanClientId()", script);
+        Assert.Contains("mode: 'Tagged'", script);
+        Assert.Contains("sortOrder: nextSortOrder", script);
+        Assert.Contains("markDirty();", script);
+        Assert.Contains("data-vlan-field=\"vlanId\"", script);
+        Assert.Contains("data-vlan-field=\"name\"", script);
+        Assert.Contains("data-vlan-field=\"mode\"", script);
+        Assert.Contains("data-vlan-field=\"notes\"", script);
+        Assert.Contains("validateVlanForSave", script);
+        Assert.Contains("VLAN ID must be between 1 and 4094.", script);
+        Assert.Contains("vlans: normalizeVlans(link.vlans).map", script);
+        Assert.Contains("vlanId,", script);
+        Assert.Contains("sortOrder: index", script);
+    }
 
 
     [Fact]

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
@@ -126,6 +126,7 @@
     let dragState = null;
     let panState = null;
     let pendingLinkSourceId = null;
+    let vlanSequence = 0;
 
     function updateNavHeight() {
         const height = nav ? nav.getBoundingClientRect().height : 0;
@@ -843,6 +844,11 @@
     }
 
 
+    function createVlanClientId() {
+        vlanSequence += 1;
+        return `vlan-${Date.now().toString(36)}-${vlanSequence.toString(36)}`;
+    }
+
     function normalizeVlanMode(value) {
         const requested = (value || '').trim();
         return vlanModes.find(mode => mode.toLowerCase() === requested.toLowerCase()) || 'Tagged';
@@ -853,12 +859,35 @@
             return [];
         }
 
-        return vlans.map(vlan => ({
+        return vlans.map((vlan, index) => ({
+            clientId: String(vlan?.clientId || vlan?.linkVlanId || createVlanClientId()),
             vlanId: vlan?.vlanId == null || vlan.vlanId === '' ? '' : String(vlan.vlanId).slice(0, 4),
             name: String(vlan?.name || '').slice(0, 128),
             mode: normalizeVlanMode(vlan?.mode),
-            notes: String(vlan?.notes || '').slice(0, 512)
-        }));
+            notes: String(vlan?.notes || '').slice(0, 512),
+            sortOrder: Number.isFinite(Number(vlan?.sortOrder)) ? Number(vlan.sortOrder) : index
+        })).sort((left, right) => left.sortOrder - right.sortOrder);
+    }
+
+    function isBlankVlan(vlan) {
+        return !vlan.vlanId && !vlan.name && !vlan.notes;
+    }
+
+    function validateVlanForSave(vlan) {
+        if (isBlankVlan(vlan)) {
+            return null;
+        }
+
+        const vlanId = Number(vlan.vlanId);
+        if (!Number.isInteger(vlanId) || vlanId < 1 || vlanId > 4094) {
+            throw new Error('VLAN ID must be between 1 and 4094.');
+        }
+
+        if (!vlanModes.includes(normalizeVlanMode(vlan.mode))) {
+            throw new Error('Select a VLAN mode.');
+        }
+
+        return vlanId;
     }
 
     function buildVlanSummary(link, maxLength = 72) {
@@ -1082,17 +1111,30 @@
         renderVlanFields(selectedLink);
     }
 
-    function addLinkVlan() {
+    function addLinkVlan(event) {
+        event?.preventDefault();
         const selectedLink = state.selectedLinkId ? findLinkById(state.selectedLinkId) : null;
         if (!selectedLink) {
             return;
         }
 
         selectedLink.vlans = normalizeVlans(selectedLink.vlans);
-        selectedLink.vlans.push({ vlanId: '', name: '', mode: 'Tagged', notes: '' });
+        const nextSortOrder = selectedLink.vlans.length === 0
+            ? 0
+            : Math.max(...selectedLink.vlans.map(vlan => vlan.sortOrder || 0)) + 1;
+        const newVlan = {
+            clientId: createVlanClientId(),
+            vlanId: '',
+            name: '',
+            mode: 'Tagged',
+            notes: '',
+            sortOrder: nextSortOrder
+        };
+        selectedLink.vlans.push(newVlan);
         renderVlanFields(selectedLink);
         renderLinks();
         markDirty();
+        linkVlanList?.querySelector(`[data-vlan-client-id="${CSS.escape(newVlan.clientId)}"] [data-vlan-field="vlanId"]`)?.focus();
     }
 
     function renderVlanFields(link) {
@@ -1117,11 +1159,16 @@
         link.vlans.forEach((vlan, index) => {
             const card = document.createElement('div');
             card.className = 'link-vlan-card';
-            card.innerHTML = `<div class="link-vlan-card-header"><strong>VLAN ${index + 1}</strong><button type="button" aria-label="Remove VLAN ${index + 1}">Remove</button></div><label>ID<input type="number" min="1" max="4094" step="1" value="${escapeHtml(vlan.vlanId)}" placeholder="10"></label><label>Name<input type="text" maxlength="128" value="${escapeHtml(vlan.name)}" placeholder="LAN"></label><label>Mode<select>${vlanModes.map(mode => `<option value="${mode}"${mode === vlan.mode ? ' selected' : ''}>${mode}</option>`).join('')}</select></label><label>Notes<textarea rows="2" maxlength="512">${escapeHtml(vlan.notes)}</textarea></label>`;
+            card.dataset.vlanClientId = vlan.clientId;
+            card.innerHTML = `<div class="link-vlan-card-header"><strong>VLAN ${index + 1}</strong><button type="button" aria-label="Remove VLAN ${index + 1}">Remove</button></div><label>ID<input type="number" data-vlan-field="vlanId" min="1" max="4094" step="1" value="${escapeHtml(vlan.vlanId)}" placeholder="10"></label><label>Name<input type="text" data-vlan-field="name" maxlength="128" value="${escapeHtml(vlan.name)}" placeholder="LAN"></label><label>Mode<select data-vlan-field="mode">${vlanModes.map(mode => `<option value="${mode}"${mode === vlan.mode ? ' selected' : ''}>${mode}</option>`).join('')}</select></label><label>Notes<textarea data-vlan-field="notes" rows="2" maxlength="512">${escapeHtml(vlan.notes)}</textarea></label>`;
             const remove = card.querySelector('button');
             const inputs = card.querySelectorAll('input, select, textarea');
-            remove.addEventListener('click', () => {
-                link.vlans.splice(index, 1);
+            remove.addEventListener('click', event => {
+                event.preventDefault();
+                const currentIndex = link.vlans.findIndex(entry => entry.clientId === vlan.clientId);
+                if (currentIndex >= 0) {
+                    link.vlans.splice(currentIndex, 1);
+                }
                 renderVlanFields(link);
                 renderLinks();
                 markDirty();
@@ -1607,13 +1654,16 @@
                 lacpMemberCount: normalizeLinkType(link.linkType) === 'LACP' ? Number(normalizeLacpMemberCount(link.lacpMemberCount, link.linkType)) : null,
                 lacpMemberPortsJson: normalizeLinkType(link.linkType) === 'LACP' ? JSON.stringify(link.lacpMemberPorts || []) : null,
                 metadataJson: null,
-                vlans: normalizeVlans(link.vlans).filter(vlan => vlan.vlanId || vlan.name || vlan.notes).map((vlan, index) => ({
-                    vlanId: vlan.vlanId === '' ? null : Number(vlan.vlanId),
-                    name: vlan.name || null,
-                    mode: normalizeVlanMode(vlan.mode),
-                    notes: vlan.notes || null,
-                    sortOrder: index
-                }))
+                vlans: normalizeVlans(link.vlans).map((vlan, index) => {
+                    const vlanId = validateVlanForSave(vlan);
+                    return vlanId === null ? null : {
+                        vlanId,
+                        name: vlan.name || null,
+                        mode: normalizeVlanMode(vlan.mode),
+                        notes: vlan.notes || null,
+                        sortOrder: index
+                    };
+                }).filter(Boolean)
             }))
         };
     }
@@ -1734,6 +1784,10 @@
 
     if (exportPdfButton) {
         exportPdfButton.addEventListener('click', exportPdf);
+    }
+
+    if (addLinkVlanButton) {
+        addLinkVlanButton.addEventListener('click', addLinkVlan);
     }
 
     if (saveButton) {


### PR DESCRIPTION
### Motivation
- Fixes #515: clicking the Properties panel Add VLAN button did nothing because the button was rendered but never wired to a handler.  Root cause: missing event listener and incomplete client-side VLAN lifecycle handling.  
- Provide immediate, editable VLAN rows on the selected-link Properties panel and ensure VLAN metadata round-trips with saves while remaining documentation-only.

### Description
- Wire the Add VLAN control to the editor: attach `addLinkVlanButton.addEventListener('click', addLinkVlan)` and prevent default button behaviour in the handler.  
- Implement client-side VLAN lifecycle: add stable client IDs, maintain `sortOrder`, normalize/sort VLANs with `normalizeVlans`, expose `createVlanClientId()`, `isBlankVlan()`, and `validateVlanForSave()` helpers, and focus the new VLAN ID input after creation.  
- Update `addLinkVlan`, `renderVlanFields`, and save payload generation so new VLAN rows are shown immediately, editable (ID, name, mode, notes), marked dirty, and included in the `buildSavePayload()` mapping only when valid (blank in-progress rows ignored).  
- Keep all behavior scoped to visual-link metadata only; no monitoring, dependency, agent, or startup-gate semantics were changed.  
- Add a source-level regression test asserting the new wiring and code snippets are present and update documentation to describe the Add VLAN editor behaviour and persistence.

### Testing
- Ran `node --check src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js` with no syntax errors. (passed)
- Built web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` (passed).  
- Ran server tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and the test suite passed (133 passed, 0 failed).  
- Note: `dotnet build`/`dotnet test` at the repository root were attempted but the repo has no root solution/project file (MSBuild returned MSB1003), so project-scoped build/test commands were used instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f13540de4832a925ce5051b28e41d)