### PR TITLE
Add read-only network diagram viewer with live overlay

### DIFF
--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -347,3 +347,36 @@ Schema note:
 Backup/restore follow-up:
 
 - Configuration backup/restore inclusion for network diagrams remains a required follow-up before publishing V0.1.1 if it is not completed in the release branch; that follow-up must include `NetworkDiagramLinkVlans` alongside `NetworkDiagrams`, `NetworkDiagramNodes`, and `NetworkDiagramLinks`.
+
+## Read-only viewer and live endpoint overlay slice
+
+This slice adds a read-only Network Diagram viewer for operational display while keeping the existing editor as the admin-only edit mode.
+
+- Saved diagrams open in read-only view by default from the diagram list.
+- Admin users can navigate from the viewer to the editor when `NetworkDiagramsEnabled` is enabled.
+- The viewer preserves saved virtual canvas dimensions, pan, zoom, fit content behaviour, saved nodes, visual links, parallel link rendering, link labels, notes, ports, and VLAN summaries.
+- The viewer does not show editor-only controls such as the toolbox, Properties edit forms, Save, Delete selected, Draw link, or add-node controls.
+- Viewer node and link details are read-only.
+- Visual links remain documentation-only and do not create, update, or delete monitoring dependencies.
+
+Live endpoint overlay behaviour:
+
+- Monitored endpoint nodes display existing server-calculated monitoring data: summary state, 24-hour uptime, and last RTT.
+- The viewer does not calculate endpoint state, dependency suppression, degraded state, uptime windows, or alerting decisions independently.
+- Endpoint state remains assignment-scoped. When a diagram node references an endpoint with multiple assignments, the viewer uses a UI-only urgency summary: Down, Unknown, Suppressed, Degraded, then Up.
+- The UI-only summary does not redefine the monitoring state machine and is not fed back into monitoring, alerting, suppression, agents, endpoint configuration, or dependency configuration.
+- The live overlay endpoint batches assignment/current-state lookup for all monitored nodes on the diagram and uses existing 24-hour assignment metrics snapshots for uptime and RTT fields instead of scanning raw check results on every refresh.
+- Live data refresh uses lightweight polling every 20 seconds. If refresh fails, the existing diagram stays visible and the viewer marks the live overlay as stale.
+
+Access and feature-gate behaviour:
+
+- `NetworkDiagramsEnabled` gates the viewer page, static diagram JSON, and live overlay JSON endpoints.
+- Authenticated users can view diagrams.
+- Admin users can create, edit, save, export PDF, and delete diagrams.
+- Non-admin diagram JSON and live overlay responses are filtered through existing endpoint visibility rules so hidden endpoint details are not exposed.
+
+Safety boundary:
+
+- The viewer does not create, update, or delete endpoints.
+- The viewer does not create, update, or delete monitoring dependencies.
+- The viewer does not change endpoint monitoring, state evaluation, dependency suppression, alerting, agents, startup-gate behaviour, topology inference, or SNMP behaviour.

--- a/docs/network_diagrams_v_0_1_1_design_notes.md
+++ b/docs/network_diagrams_v_0_1_1_design_notes.md
@@ -478,3 +478,33 @@ Link labels and notes are drawn on-canvas near the link midpoint, and multiple l
 ## Link VLAN metadata addendum
 
 Visual links may carry structured VLAN documentation metadata. VLAN entries support an ID, optional label, mode (Tagged, Untagged, Native, Management, Other), optional notes, and deterministic ordering. This metadata is intentionally scoped to the diagram link as documentation only: it must not configure network devices, infer topology, create endpoints, create dependencies, or influence monitoring state, suppression, or alerting.
+
+## Read-only viewer/live status implementation notes
+
+The read-only viewer is a separate saved-diagram route from the editor. It is intended for operations users who need to look at a saved diagram with live monitoring context, not for modifying the diagram.
+
+Implementation boundaries:
+
+- The viewer renders saved diagram geometry and documentation-only links.
+- Editing tools, mutable inputs, save actions, delete actions, draw-link mode, and add-node controls are not rendered in viewer mode.
+- Live data is provided by a lightweight JSON endpoint that reuses current assignment state and 24-hour assignment metrics.
+- The live endpoint overlay shows server-calculated state, uptime, and RTT data only; it does not evaluate monitoring state itself.
+- Multi-assignment endpoint nodes use the UI-only diagram urgency order Down, Unknown, Suppressed, Degraded, Up for the node badge while preserving per-assignment state details in the read-only details panel.
+- Non-admin access is filtered using existing endpoint visibility rules; hidden monitored endpoint nodes and connected links are omitted from non-admin static diagram JSON and live overlay JSON.
+- Diagram links remain visual documentation and still do not create monitoring dependencies or alter suppression.
+
+Manual regression checklist for this slice:
+
+1. Enable `NetworkDiagramsEnabled`.
+2. Open the diagram list and confirm saved diagrams offer View as the primary action.
+3. Open a saved diagram in View mode and confirm no toolbox, editable Properties form, Save, Delete selected, Draw link, or add-node controls are visible.
+4. Confirm pan, mouse-wheel zoom, toolbar zoom, reset view, and fit content work.
+5. Confirm monitored endpoint nodes show state, 24-hour uptime, and last RTT.
+6. Confirm custom diagram nodes show diagram-only presentation and do not show fake live endpoint data.
+7. Wait for the polling interval and confirm live data refresh timestamp changes without reloading the page.
+8. Click a monitored node and confirm the details panel is read-only and includes endpoint/assignment status data.
+9. Click a visual link and confirm the details panel is read-only and states that the link is visual documentation only.
+10. Confirm admin users can navigate to Edit from the viewer.
+11. Confirm non-admin users cannot access the edit/save/delete/export routes and do not receive endpoint details they cannot access.
+12. Disable `NetworkDiagramsEnabled` and confirm viewer and live-data API access are blocked.
+13. Confirm no endpoint, dependency, state-evaluation, alert, agent, or startup-gate behaviour changed.

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -1,3 +1,5 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Controllers;
 using PingMonitor.Web.Models;
@@ -65,7 +67,9 @@ public sealed class NetworkDiagramsFeatureTests
             new FakeApplicationSettingsService(new ApplicationSettingsDto { NetworkDiagramsEnabled = false }),
             new FakeEndpointManagementQueryService(),
             new FakeNetworkDiagramService(),
-            new FakeNetworkDiagramPdfExportService());
+            new FakeNetworkDiagramPdfExportService(),
+            new FakeNetworkDiagramLiveOverlayService(),
+            new FakeUserAccessScopeService());
 
         var result = await controller.Index(CancellationToken.None);
 
@@ -88,7 +92,9 @@ public sealed class NetworkDiagramsFeatureTests
                 CurrentState = EndpointStateKind.Up
             }),
             new FakeNetworkDiagramService(new NetworkDiagram { DiagramId = "diagram-1", Name = "Core", UpdatedAtUtc = DateTimeOffset.UtcNow }),
-            new FakeNetworkDiagramPdfExportService());
+            new FakeNetworkDiagramPdfExportService(),
+            new FakeNetworkDiagramLiveOverlayService(),
+            new FakeUserAccessScopeService());
 
         var result = await controller.Index(CancellationToken.None);
 
@@ -441,14 +447,24 @@ public sealed class NetworkDiagramsFeatureTests
     }
 
     [Fact]
-    public void NetworkDiagramsController_RequiresAdminAuthorizationForExport()
+    public void NetworkDiagramsController_AllowsAuthenticatedViewerAndRequiresAdminForEditAndExport()
     {
-        var authorize = typeof(NetworkDiagramsController)
+        var controllerAuthorize = typeof(NetworkDiagramsController)
+            .GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AuthorizeAttribute), inherit: true)
+            .Cast<Microsoft.AspNetCore.Authorization.AuthorizeAttribute>()
+            .Single();
+        var editAuthorize = typeof(NetworkDiagramsController).GetMethod(nameof(NetworkDiagramsController.Edit))!
+            .GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AuthorizeAttribute), inherit: true)
+            .Cast<Microsoft.AspNetCore.Authorization.AuthorizeAttribute>()
+            .Single();
+        var exportAuthorize = typeof(NetworkDiagramsController).GetMethod(nameof(NetworkDiagramsController.ExportPdf))!
             .GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AuthorizeAttribute), inherit: true)
             .Cast<Microsoft.AspNetCore.Authorization.AuthorizeAttribute>()
             .Single();
 
-        Assert.Equal(ApplicationRoles.Admin, authorize.Roles);
+        Assert.Null(controllerAuthorize.Roles);
+        Assert.Equal(ApplicationRoles.Admin, editAuthorize.Roles);
+        Assert.Equal(ApplicationRoles.Admin, exportAuthorize.Roles);
     }
 
     [Fact]
@@ -458,7 +474,9 @@ public sealed class NetworkDiagramsFeatureTests
             new FakeApplicationSettingsService(new ApplicationSettingsDto { NetworkDiagramsEnabled = false }),
             new FakeEndpointManagementQueryService(),
             new FakeNetworkDiagramService(),
-            new FakeNetworkDiagramPdfExportService());
+            new FakeNetworkDiagramPdfExportService(),
+            new FakeNetworkDiagramLiveOverlayService(),
+            new FakeUserAccessScopeService());
 
         var result = await controller.ExportPdf("missing", "A4", CancellationToken.None);
 
@@ -473,7 +491,9 @@ public sealed class NetworkDiagramsFeatureTests
             new FakeApplicationSettingsService(new ApplicationSettingsDto { NetworkDiagramsEnabled = true }),
             new FakeEndpointManagementQueryService(),
             new FakeNetworkDiagramService(),
-            new FakeNetworkDiagramPdfExportService());
+            new FakeNetworkDiagramPdfExportService(),
+            new FakeNetworkDiagramLiveOverlayService(),
+            new FakeUserAccessScopeService());
 
         var result = await controller.ExportPdf("missing", "A4", CancellationToken.None);
 
@@ -496,7 +516,9 @@ public sealed class NetworkDiagramsFeatureTests
             new FakeApplicationSettingsService(new ApplicationSettingsDto { NetworkDiagramsEnabled = true }),
             new FakeEndpointManagementQueryService(),
             service,
-            new FakeNetworkDiagramPdfExportService());
+            new FakeNetworkDiagramPdfExportService(),
+            new FakeNetworkDiagramLiveOverlayService(),
+            new FakeUserAccessScopeService());
 
         var result = await controller.ExportPdf("diagram-1", "A4", CancellationToken.None);
 
@@ -504,6 +526,65 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Equal("application/pdf", file.ContentType);
         Assert.StartsWith("PingMonitor-NetworkDiagram-Core", file.FileDownloadName);
         Assert.StartsWith("%PDF", System.Text.Encoding.ASCII.GetString(file.FileContents));
+    }
+
+
+    [Fact]
+    public void NetworkDiagramViewer_HasReadOnlyCanvasAndLiveOverlayControls()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var viewMarkup = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "Views", "NetworkDiagrams", "View.cshtml"));
+        var script = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "wwwroot", "js", "network-diagrams-viewer.js"));
+
+        Assert.Contains("data-network-diagram-viewer", viewMarkup);
+        Assert.Contains("data-live-data-url", viewMarkup);
+        Assert.Contains("Read-only viewer", viewMarkup);
+        Assert.DoesNotContain("data-save-diagram", viewMarkup);
+        Assert.DoesNotContain("data-add-endpoint-node", viewMarkup);
+        Assert.DoesNotContain("data-delete-selection", viewMarkup);
+        Assert.DoesNotContain("Draw link", viewMarkup);
+        Assert.Contains("refreshIntervalMs = 20000", script);
+        Assert.Contains("State: ${stateLabel(stateValue)}", script);
+        Assert.Contains("24h:", script);
+        Assert.Contains("RTT:", script);
+    }
+
+    [Fact]
+    public async Task NetworkDiagramsViewer_ReturnsViewer_WhenFeatureEnabled()
+    {
+        var controller = new NetworkDiagramsController(
+            new FakeApplicationSettingsService(new ApplicationSettingsDto { NetworkDiagramsEnabled = true }),
+            new FakeEndpointManagementQueryService(),
+            new FakeNetworkDiagramService(new NetworkDiagram { DiagramId = "diagram-1", Name = "Core", UpdatedAtUtc = DateTimeOffset.UtcNow }),
+            new FakeNetworkDiagramPdfExportService(),
+            new FakeNetworkDiagramLiveOverlayService(),
+            new FakeUserAccessScopeService(isAdmin: true));
+        controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(new ClaimsIdentity("test")) } };
+
+        var result = await controller.ViewDiagram("diagram-1", CancellationToken.None);
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Equal("View", view.ViewName);
+        var model = Assert.IsType<NetworkDiagramViewerPageViewModel>(view.Model);
+        Assert.Equal("diagram-1", model.DiagramId);
+        Assert.True(model.IsAdmin);
+    }
+
+    [Fact]
+    public async Task NetworkDiagramsLiveData_ReturnsNotFound_WhenFeatureDisabled()
+    {
+        var controller = new NetworkDiagramsController(
+            new FakeApplicationSettingsService(new ApplicationSettingsDto { NetworkDiagramsEnabled = false }),
+            new FakeEndpointManagementQueryService(),
+            new FakeNetworkDiagramService(new NetworkDiagram { DiagramId = "diagram-1", Name = "Core", UpdatedAtUtc = DateTimeOffset.UtcNow }),
+            new FakeNetworkDiagramPdfExportService(),
+            new FakeNetworkDiagramLiveOverlayService(),
+            new FakeUserAccessScopeService());
+
+        var result = await controller.LiveData("diagram-1", CancellationToken.None);
+
+        var notFound = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Contains("Network diagrams are not enabled", notFound.Value!.ToString());
     }
 
     private static string FindRepositoryRoot()
@@ -607,6 +688,52 @@ public sealed class NetworkDiagramsFeatureTests
         {
             return new NetworkDiagramPdfExportResult(System.Text.Encoding.ASCII.GetBytes("%PDF test"), "application/pdf", $"PingMonitor-NetworkDiagram-{diagram.Name}-{options.ExportedAtUtc:yyyyMMdd-HHmm}.pdf");
         }
+    }
+
+
+    private sealed class FakeNetworkDiagramLiveOverlayService : INetworkDiagramLiveOverlayService
+    {
+        public Task<NetworkDiagramLiveOverlayResponse> GetOverlayAsync(string diagramId, ClaimsPrincipal user, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new NetworkDiagramLiveOverlayResponse
+            {
+                DiagramId = diagramId,
+                RefreshedAtUtc = DateTimeOffset.UtcNow,
+                Nodes =
+                [
+                    new NetworkDiagramNodeLiveOverlayDto
+                    {
+                        NodeId = "node-1",
+                        EndpointId = "endpoint-1",
+                        SummaryState = EndpointStateKind.Up,
+                        SummaryStateLabel = "Up",
+                        UptimePercent24h = 99.9,
+                        UptimeDisplay = "99.9%",
+                        LastRttMs = 4.2
+                    }
+                ]
+            });
+        }
+    }
+
+    private sealed class FakeUserAccessScopeService : IUserAccessScopeService
+    {
+        private readonly bool _isAdmin;
+
+        public FakeUserAccessScopeService(bool isAdmin = true)
+        {
+            _isAdmin = isAdmin;
+        }
+
+        public Task<bool> IsAdminAsync(ClaimsPrincipal principal) => Task.FromResult(_isAdmin);
+
+        public Task<IReadOnlySet<string>> GetVisibleEndpointIdsAsync(ClaimsPrincipal principal, CancellationToken cancellationToken)
+        {
+            IReadOnlySet<string> result = new HashSet<string>(StringComparer.Ordinal) { "endpoint-1" };
+            return Task.FromResult(result);
+        }
+
+        public Task<bool> CanAccessAssignmentAsync(ClaimsPrincipal principal, string assignmentId, CancellationToken cancellationToken) => Task.FromResult(_isAdmin);
     }
 
     private sealed class FakeApplicationSettingsService : IApplicationSettingsService

--- a/src/WebApp/PingMonitor.Web/Controllers/NetworkDiagramsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/NetworkDiagramsController.cs
@@ -10,7 +10,7 @@ using PingMonitor.Web.ViewModels.NetworkDiagrams;
 
 namespace PingMonitor.Web.Controllers;
 
-[Authorize(Roles = ApplicationRoles.Admin)]
+[Authorize]
 [Route("network-diagrams")]
 public sealed class NetworkDiagramsController : Controller
 {
@@ -18,17 +18,23 @@ public sealed class NetworkDiagramsController : Controller
     private readonly IEndpointManagementQueryService _endpointManagementQueryService;
     private readonly INetworkDiagramService _networkDiagramService;
     private readonly INetworkDiagramPdfExportService _pdfExportService;
+    private readonly INetworkDiagramLiveOverlayService _liveOverlayService;
+    private readonly IUserAccessScopeService _userAccessScopeService;
 
     public NetworkDiagramsController(
         IApplicationSettingsService applicationSettingsService,
         IEndpointManagementQueryService endpointManagementQueryService,
         INetworkDiagramService networkDiagramService,
-        INetworkDiagramPdfExportService pdfExportService)
+        INetworkDiagramPdfExportService pdfExportService,
+        INetworkDiagramLiveOverlayService liveOverlayService,
+        IUserAccessScopeService userAccessScopeService)
     {
         _applicationSettingsService = applicationSettingsService;
         _endpointManagementQueryService = endpointManagementQueryService;
         _networkDiagramService = networkDiagramService;
         _pdfExportService = pdfExportService;
+        _liveOverlayService = liveOverlayService;
+        _userAccessScopeService = userAccessScopeService;
     }
 
     [HttpGet("")]
@@ -42,6 +48,7 @@ public sealed class NetworkDiagramsController : Controller
         var diagrams = await _networkDiagramService.ListAsync(cancellationToken);
         return View("Index", new NetworkDiagramListPageViewModel
         {
+            IsAdmin = await IsAdminAsync(),
             Diagrams = diagrams.Select(x => new NetworkDiagramListItemViewModel
             {
                 DiagramId = x.DiagramId,
@@ -54,6 +61,7 @@ public sealed class NetworkDiagramsController : Controller
         });
     }
 
+    [Authorize(Roles = ApplicationRoles.Admin)]
     [HttpPost("create")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Create(CreateNetworkDiagramViewModel model, CancellationToken cancellationToken)
@@ -68,6 +76,7 @@ public sealed class NetworkDiagramsController : Controller
             var diagrams = await _networkDiagramService.ListAsync(cancellationToken);
             return View("Index", new NetworkDiagramListPageViewModel
             {
+                IsAdmin = await IsAdminAsync(),
                 CreateDiagram = model,
                 Diagrams = diagrams.Select(x => new NetworkDiagramListItemViewModel
                 {
@@ -86,6 +95,36 @@ public sealed class NetworkDiagramsController : Controller
     }
 
     [HttpGet("{diagramId}")]
+    public async Task<IActionResult> ViewDiagram(string diagramId, CancellationToken cancellationToken)
+    {
+        if (!await NetworkDiagramsEnabledAsync(cancellationToken))
+        {
+            return NotFound("Network diagrams are not enabled.");
+        }
+
+        var diagram = await _networkDiagramService.GetDiagramAsync(diagramId, cancellationToken);
+        if (diagram is null)
+        {
+            return NotFound("Network diagram was not found.");
+        }
+
+        var isAdmin = await IsAdminAsync();
+        return View("View", new NetworkDiagramViewerPageViewModel
+        {
+            PageTitle = diagram.Name,
+            DiagramId = diagram.DiagramId,
+            DiagramName = diagram.Name,
+            DiagramDescription = diagram.Description,
+            LoadUrl = Url?.Action(nameof(Load), new { diagramId = diagram.DiagramId }) ?? string.Empty,
+            LiveDataUrl = Url?.Action(nameof(LiveData), new { diagramId = diagram.DiagramId }) ?? string.Empty,
+            EditUrl = isAdmin ? Url?.Action(nameof(Edit), new { diagramId = diagram.DiagramId }) : null,
+            ExportPdfUrl = isAdmin ? Url?.Action(nameof(ExportPdf), new { diagramId = diagram.DiagramId }) : null,
+            IsAdmin = isAdmin
+        });
+    }
+
+    [Authorize(Roles = ApplicationRoles.Admin)]
+    [HttpGet("{diagramId}/edit")]
     public async Task<IActionResult> Edit(string diagramId, CancellationToken cancellationToken)
     {
         if (!await NetworkDiagramsEnabledAsync(cancellationToken))
@@ -107,9 +146,10 @@ public sealed class NetworkDiagramsController : Controller
             DiagramId = diagram.DiagramId,
             DiagramName = diagram.Name,
             DiagramDescription = diagram.Description,
-            LoadUrl = Url.Action(nameof(Load), new { diagramId = diagram.DiagramId }) ?? string.Empty,
-            SaveUrl = Url.Action(nameof(Save), new { diagramId = diagram.DiagramId }) ?? string.Empty,
-            ExportPdfUrl = Url.Action(nameof(ExportPdf), new { diagramId = diagram.DiagramId }) ?? string.Empty,
+            LoadUrl = Url?.Action(nameof(Load), new { diagramId = diagram.DiagramId }) ?? string.Empty,
+            SaveUrl = Url?.Action(nameof(Save), new { diagramId = diagram.DiagramId }) ?? string.Empty,
+            ExportPdfUrl = Url?.Action(nameof(ExportPdf), new { diagramId = diagram.DiagramId }) ?? string.Empty,
+            ViewerUrl = Url?.Action(nameof(ViewDiagram), new { diagramId = diagram.DiagramId }) ?? string.Empty,
             MonitoredEndpoints = BuildEndpointToolbox(endpoints.Rows)
         });
     }
@@ -123,9 +163,37 @@ public sealed class NetworkDiagramsController : Controller
         }
 
         var diagram = await _networkDiagramService.LoadAsync(diagramId, cancellationToken);
-        return diagram is null ? NotFound(new { error = "Network diagram was not found." }) : Json(diagram);
+        if (diagram is null)
+        {
+            return NotFound(new { error = "Network diagram was not found." });
+        }
+
+        if (!await IsAdminAsync())
+        {
+            diagram = await FilterDiagramForViewerAsync(diagram, cancellationToken);
+        }
+
+        return Json(diagram);
     }
 
+    [HttpGet("{diagramId}/live-data")]
+    public async Task<IActionResult> LiveData(string diagramId, CancellationToken cancellationToken)
+    {
+        if (!await NetworkDiagramsEnabledAsync(cancellationToken))
+        {
+            return NotFound(new { error = "Network diagrams are not enabled." });
+        }
+
+        var diagram = await _networkDiagramService.GetDiagramAsync(diagramId, cancellationToken);
+        if (diagram is null)
+        {
+            return NotFound(new { error = "Network diagram was not found." });
+        }
+
+        return Json(await _liveOverlayService.GetOverlayAsync(diagramId, User, cancellationToken));
+    }
+
+    [Authorize(Roles = ApplicationRoles.Admin)]
     [HttpPost("{diagramId}/save")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Save(string diagramId, [FromBody] NetworkDiagramSaveRequest request, CancellationToken cancellationToken)
@@ -147,6 +215,7 @@ public sealed class NetworkDiagramsController : Controller
     }
 
 
+    [Authorize(Roles = ApplicationRoles.Admin)]
     [HttpGet("{diagramId}/export/pdf")]
     public async Task<IActionResult> ExportPdf(string diagramId, [FromQuery] string paper = "A4", CancellationToken cancellationToken = default)
     {
@@ -165,6 +234,7 @@ public sealed class NetworkDiagramsController : Controller
         return File(export.Content, export.ContentType, export.FileName);
     }
 
+    [Authorize(Roles = ApplicationRoles.Admin)]
     [HttpPost("{diagramId}/delete")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Delete(string diagramId, CancellationToken cancellationToken)
@@ -182,6 +252,34 @@ public sealed class NetworkDiagramsController : Controller
     {
         var settings = await _applicationSettingsService.GetCurrentAsync(cancellationToken);
         return settings.NetworkDiagramsEnabled;
+    }
+
+
+    private async Task<bool> IsAdminAsync() => await _userAccessScopeService.IsAdminAsync(User);
+
+    private async Task<NetworkDiagramDto> FilterDiagramForViewerAsync(NetworkDiagramDto diagram, CancellationToken cancellationToken)
+    {
+        var visibleEndpointIds = await _userAccessScopeService.GetVisibleEndpointIdsAsync(User, cancellationToken);
+        var visibleNodes = diagram.Nodes
+            .Where(node => !string.Equals(node.NodeType, nameof(NetworkDiagramNodeType.MonitoredEndpoint), StringComparison.Ordinal) ||
+                (!string.IsNullOrWhiteSpace(node.EndpointId) && visibleEndpointIds.Contains(node.EndpointId)))
+            .ToArray();
+        var visibleNodeIds = visibleNodes.Select(node => node.NodeId).ToHashSet(StringComparer.Ordinal);
+
+        return new NetworkDiagramDto
+        {
+            DiagramId = diagram.DiagramId,
+            Name = diagram.Name,
+            Description = diagram.Description,
+            CanvasWidth = diagram.CanvasWidth,
+            CanvasHeight = diagram.CanvasHeight,
+            ViewportPanX = diagram.ViewportPanX,
+            ViewportPanY = diagram.ViewportPanY,
+            ViewportZoom = diagram.ViewportZoom,
+            UpdatedAtUtc = diagram.UpdatedAtUtc,
+            Nodes = visibleNodes,
+            Links = diagram.Links.Where(link => visibleNodeIds.Contains(link.SourceNodeId) && visibleNodeIds.Contains(link.TargetNodeId)).ToArray()
+        };
     }
 
     private static IReadOnlyList<NetworkDiagramEndpointToolboxItemViewModel> BuildEndpointToolbox(
@@ -231,12 +329,12 @@ public sealed class NetworkDiagramsController : Controller
     {
         return state switch
         {
-            EndpointStateKind.Down => 4,
+            EndpointStateKind.Down => 5,
+            EndpointStateKind.Unknown => 4,
             EndpointStateKind.Suppressed => 3,
             EndpointStateKind.Degraded => 2,
-            EndpointStateKind.Unknown => 1,
-            EndpointStateKind.Up => 0,
-            _ => 1
+            EndpointStateKind.Up => 1,
+            _ => 4
         };
     }
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -231,6 +231,7 @@ builder.Services.AddScoped<IEndpointCreationQueryService, EndpointCreationQueryS
 builder.Services.AddScoped<IEndpointManagementQueryService, EndpointManagementQueryService>();
 builder.Services.AddScoped<PingMonitor.Web.Services.NetworkDiagrams.INetworkDiagramService, PingMonitor.Web.Services.NetworkDiagrams.NetworkDiagramService>();
 builder.Services.AddScoped<PingMonitor.Web.Services.NetworkDiagrams.INetworkDiagramPdfExportService, PingMonitor.Web.Services.NetworkDiagrams.NetworkDiagramPdfExportService>();
+builder.Services.AddScoped<PingMonitor.Web.Services.NetworkDiagrams.INetworkDiagramLiveOverlayService, PingMonitor.Web.Services.NetworkDiagrams.NetworkDiagramLiveOverlayService>();
 builder.Services.AddScoped<IEndpointManagementService, EndpointManagementService>();
 builder.Services.AddScoped<IEndpointPerformanceQueryService, EndpointPerformanceQueryService>();
 builder.Services.AddScoped<IGroupManagementService, GroupManagementService>();

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/INetworkDiagramLiveOverlayService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/INetworkDiagramLiveOverlayService.cs
@@ -1,0 +1,50 @@
+using System.Security.Claims;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.NetworkDiagrams;
+
+public interface INetworkDiagramLiveOverlayService
+{
+    Task<NetworkDiagramLiveOverlayResponse> GetOverlayAsync(string diagramId, ClaimsPrincipal user, CancellationToken cancellationToken);
+}
+
+public sealed class NetworkDiagramLiveOverlayResponse
+{
+    public string DiagramId { get; init; } = string.Empty;
+    public DateTimeOffset RefreshedAtUtc { get; init; }
+    public IReadOnlyList<NetworkDiagramNodeLiveOverlayDto> Nodes { get; init; } = [];
+}
+
+public sealed class NetworkDiagramNodeLiveOverlayDto
+{
+    public string NodeId { get; init; } = string.Empty;
+    public string EndpointId { get; init; } = string.Empty;
+    public string EndpointName { get; init; } = string.Empty;
+    public string Target { get; init; } = string.Empty;
+    public EndpointStateKind SummaryState { get; init; } = EndpointStateKind.Unknown;
+    public string SummaryStateLabel { get; init; } = "Unknown";
+    public double? UptimePercent24h { get; init; }
+    public string UptimeDisplay { get; init; } = "—";
+    public double? LastRttMs { get; init; }
+    public double? AverageRttMs { get; init; }
+    public DateTimeOffset? LastCheckUtc { get; init; }
+    public DateTimeOffset? LastSuccessfulCheckUtc { get; init; }
+    public IReadOnlyList<NetworkDiagramAssignmentLiveOverlayDto> Assignments { get; init; } = [];
+}
+
+public sealed class NetworkDiagramAssignmentLiveOverlayDto
+{
+    public string AssignmentId { get; init; } = string.Empty;
+    public string AgentId { get; init; } = string.Empty;
+    public string AgentName { get; init; } = string.Empty;
+    public EndpointStateKind State { get; init; } = EndpointStateKind.Unknown;
+    public string StateLabel { get; init; } = "Unknown";
+    public double? UptimePercent24h { get; init; }
+    public string UptimeDisplay { get; init; } = "—";
+    public double? LastRttMs { get; init; }
+    public double? AverageRttMs { get; init; }
+    public DateTimeOffset? LastCheckUtc { get; init; }
+    public DateTimeOffset? LastSuccessfulCheckUtc { get; init; }
+    public string? SuppressedByEndpointId { get; init; }
+    public string? SuppressedByEndpointName { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramLiveOverlayService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramLiveOverlayService.cs
@@ -1,0 +1,237 @@
+using System.Linq.Expressions;
+using System.Security.Claims;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.Diagnostics;
+using PingMonitor.Web.Services.Identity;
+using PingMonitor.Web.Services.Metrics;
+
+namespace PingMonitor.Web.Services.NetworkDiagrams;
+
+internal sealed class NetworkDiagramLiveOverlayService : INetworkDiagramLiveOverlayService
+{
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly INetworkDiagramService _networkDiagramService;
+    private readonly IAssignmentMetrics24hService _assignmentMetrics24hService;
+    private readonly IUserAccessScopeService _userAccessScopeService;
+    private readonly IDbActivityScope _dbActivityScope;
+
+    public NetworkDiagramLiveOverlayService(
+        PingMonitorDbContext dbContext,
+        INetworkDiagramService networkDiagramService,
+        IAssignmentMetrics24hService assignmentMetrics24hService,
+        IUserAccessScopeService userAccessScopeService,
+        IDbActivityScope dbActivityScope)
+    {
+        _dbContext = dbContext;
+        _networkDiagramService = networkDiagramService;
+        _assignmentMetrics24hService = assignmentMetrics24hService;
+        _userAccessScopeService = userAccessScopeService;
+        _dbActivityScope = dbActivityScope;
+    }
+
+    public async Task<NetworkDiagramLiveOverlayResponse> GetOverlayAsync(string diagramId, ClaimsPrincipal user, CancellationToken cancellationToken)
+    {
+        using var scope = _dbActivityScope.BeginScope("NetworkDiagramLiveOverlay");
+        var diagram = await _networkDiagramService.LoadAsync(diagramId, cancellationToken);
+        if (diagram is null)
+        {
+            return new NetworkDiagramLiveOverlayResponse
+            {
+                DiagramId = diagramId,
+                RefreshedAtUtc = DateTimeOffset.UtcNow
+            };
+        }
+
+        var nodeEndpointPairs = diagram.Nodes
+            .Where(node => string.Equals(node.NodeType, nameof(NetworkDiagramNodeType.MonitoredEndpoint), StringComparison.Ordinal) && !string.IsNullOrWhiteSpace(node.EndpointId))
+            .Select(node => new { node.NodeId, EndpointId = node.EndpointId!.Trim() })
+            .Distinct()
+            .ToArray();
+
+        if (nodeEndpointPairs.Length == 0)
+        {
+            return new NetworkDiagramLiveOverlayResponse
+            {
+                DiagramId = diagram.DiagramId,
+                RefreshedAtUtc = DateTimeOffset.UtcNow
+            };
+        }
+
+        var endpointIds = nodeEndpointPairs.Select(x => x.EndpointId).Distinct(StringComparer.Ordinal).ToArray();
+        var isAdmin = await _userAccessScopeService.IsAdminAsync(user);
+        if (!isAdmin)
+        {
+            var visibleEndpointIds = await _userAccessScopeService.GetVisibleEndpointIdsAsync(user, cancellationToken);
+            endpointIds = endpointIds.Where(visibleEndpointIds.Contains).ToArray();
+        }
+
+        if (endpointIds.Length == 0)
+        {
+            return new NetworkDiagramLiveOverlayResponse
+            {
+                DiagramId = diagram.DiagramId,
+                RefreshedAtUtc = DateTimeOffset.UtcNow
+            };
+        }
+
+        var assignmentsQuery = ApplyEndpointFilter(_dbContext.MonitorAssignments.AsNoTracking(), endpointIds);
+        var assignmentRows = await (
+            from assignment in assignmentsQuery
+            join endpoint in _dbContext.Endpoints.AsNoTracking() on assignment.EndpointId equals endpoint.EndpointId
+            join agent in _dbContext.Agents.AsNoTracking() on assignment.AgentId equals agent.AgentId
+            join state in _dbContext.EndpointStates.AsNoTracking() on assignment.AssignmentId equals state.AssignmentId into stateJoin
+            from state in stateJoin.DefaultIfEmpty()
+            join suppressedByEndpoint in _dbContext.Endpoints.AsNoTracking() on state!.SuppressedByEndpointId equals suppressedByEndpoint.EndpointId into suppressedByEndpointJoin
+            from suppressedByEndpoint in suppressedByEndpointJoin.DefaultIfEmpty()
+            orderby endpoint.Name, agent.InstanceId
+            select new
+            {
+                assignment.AssignmentId,
+                assignment.EndpointId,
+                EndpointName = endpoint.Name,
+                endpoint.Target,
+                agent.AgentId,
+                AgentName = string.IsNullOrWhiteSpace(agent.Name) ? agent.InstanceId : agent.Name,
+                State = state != null ? state.CurrentState : EndpointStateKind.Unknown,
+                LastCheckUtc = state != null ? state.LastCheckUtc : null,
+                SuppressedByEndpointId = state != null ? state.SuppressedByEndpointId : null,
+                SuppressedByEndpointName = suppressedByEndpoint != null ? suppressedByEndpoint.Name : null
+            }).ToArrayAsync(cancellationToken);
+
+        var metricsByAssignmentId = await _assignmentMetrics24hService.GetSummariesAsync(
+            assignmentRows.Select(x => x.AssignmentId).ToArray(),
+            cancellationToken);
+
+        var assignmentsByEndpointId = assignmentRows
+            .Select(row =>
+            {
+                metricsByAssignmentId.TryGetValue(row.AssignmentId, out var metrics);
+                return new EndpointAssignmentOverlay(row.EndpointId, new NetworkDiagramAssignmentLiveOverlayDto
+                {
+                    AssignmentId = row.AssignmentId,
+                    AgentId = row.AgentId,
+                    AgentName = row.AgentName,
+                    State = row.State,
+                    StateLabel = FormatState(row.State),
+                    UptimePercent24h = metrics?.UptimePercent,
+                    UptimeDisplay = FormatPercent(metrics?.UptimePercent),
+                    LastRttMs = metrics?.LastRttMs,
+                    AverageRttMs = metrics?.AverageRttMs,
+                    LastCheckUtc = row.LastCheckUtc,
+                    LastSuccessfulCheckUtc = metrics?.LastSuccessfulCheckUtc,
+                    SuppressedByEndpointId = row.SuppressedByEndpointId,
+                    SuppressedByEndpointName = row.SuppressedByEndpointName
+                }, row.EndpointName, row.Target);
+            })
+            .GroupBy(x => x.EndpointId, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.ToArray(), StringComparer.Ordinal);
+
+        var nodes = new List<NetworkDiagramNodeLiveOverlayDto>();
+        foreach (var pair in nodeEndpointPairs)
+        {
+            if (!assignmentsByEndpointId.TryGetValue(pair.EndpointId, out var endpointAssignments))
+            {
+                continue;
+            }
+
+            var assignmentDetails = endpointAssignments.Select(x => x.Assignment).ToArray();
+            var summaryState = SelectSummaryState(assignmentDetails.Select(x => x.State));
+            nodes.Add(new NetworkDiagramNodeLiveOverlayDto
+            {
+                NodeId = pair.NodeId,
+                EndpointId = pair.EndpointId,
+                EndpointName = endpointAssignments[0].EndpointName,
+                Target = endpointAssignments[0].Target,
+                SummaryState = summaryState,
+                SummaryStateLabel = FormatState(summaryState),
+                UptimePercent24h = SummarizeUptime(assignmentDetails),
+                UptimeDisplay = FormatPercent(SummarizeUptime(assignmentDetails)),
+                LastRttMs = assignmentDetails.Where(x => x.LastRttMs.HasValue).OrderByDescending(x => x.LastCheckUtc).Select(x => x.LastRttMs).FirstOrDefault(),
+                AverageRttMs = AverageNullable(assignmentDetails.Select(x => x.AverageRttMs)),
+                LastCheckUtc = assignmentDetails.Select(x => x.LastCheckUtc).Where(x => x.HasValue).DefaultIfEmpty().Max(),
+                LastSuccessfulCheckUtc = assignmentDetails.Select(x => x.LastSuccessfulCheckUtc).Where(x => x.HasValue).DefaultIfEmpty().Max(),
+                Assignments = assignmentDetails
+            });
+        }
+
+        return new NetworkDiagramLiveOverlayResponse
+        {
+            DiagramId = diagram.DiagramId,
+            RefreshedAtUtc = DateTimeOffset.UtcNow,
+            Nodes = nodes
+        };
+    }
+
+    private static IQueryable<MonitorAssignment> ApplyEndpointFilter(IQueryable<MonitorAssignment> assignments, IReadOnlyCollection<string> endpointIds)
+    {
+        if (endpointIds.Count == 0)
+        {
+            return assignments.Where(static _ => false);
+        }
+
+        var parameter = Expression.Parameter(typeof(MonitorAssignment), "assignment");
+        var endpointId = Expression.Property(parameter, nameof(MonitorAssignment.EndpointId));
+        Expression? predicate = null;
+        foreach (var id in endpointIds)
+        {
+            var equals = Expression.Equal(endpointId, Expression.Constant(id));
+            predicate = predicate is null ? equals : Expression.OrElse(predicate, equals);
+        }
+
+        return assignments.Where(Expression.Lambda<Func<MonitorAssignment, bool>>(predicate!, parameter));
+    }
+
+    private static EndpointStateKind SelectSummaryState(IEnumerable<EndpointStateKind> states)
+    {
+        var summary = EndpointStateKind.Unknown;
+        var priority = -1;
+        foreach (var state in states)
+        {
+            var current = GetSummaryPriority(state);
+            if (current > priority)
+            {
+                summary = state;
+                priority = current;
+            }
+        }
+
+        return summary;
+    }
+
+    private static int GetSummaryPriority(EndpointStateKind state) => state switch
+    {
+        EndpointStateKind.Down => 5,
+        EndpointStateKind.Unknown => 4,
+        EndpointStateKind.Suppressed => 3,
+        EndpointStateKind.Degraded => 2,
+        EndpointStateKind.Up => 1,
+        _ => 4
+    };
+
+    private static string FormatState(EndpointStateKind state) => state switch
+    {
+        EndpointStateKind.Up => "Up",
+        EndpointStateKind.Degraded => "Degraded",
+        EndpointStateKind.Down => "Down",
+        EndpointStateKind.Suppressed => "Suppressed",
+        _ => "Unknown"
+    };
+
+    private static double? SummarizeUptime(IReadOnlyCollection<NetworkDiagramAssignmentLiveOverlayDto> assignments)
+    {
+        var values = assignments.Where(x => x.UptimePercent24h.HasValue).Select(x => x.UptimePercent24h!.Value).ToArray();
+        return values.Length == 0 ? null : values.Min();
+    }
+
+    private static double? AverageNullable(IEnumerable<double?> values)
+    {
+        var concrete = values.Where(x => x.HasValue).Select(x => x!.Value).ToArray();
+        return concrete.Length == 0 ? null : concrete.Average();
+    }
+
+    private static string FormatPercent(double? value) => value.HasValue ? $"{value.Value:0.##}%" : "—";
+
+    private sealed record EndpointAssignmentOverlay(string EndpointId, NetworkDiagramAssignmentLiveOverlayDto Assignment, string EndpointName, string Target);
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/NetworkDiagrams/NetworkDiagramPersistenceViewModels.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/NetworkDiagrams/NetworkDiagramPersistenceViewModels.cs
@@ -4,6 +4,8 @@ namespace PingMonitor.Web.ViewModels.NetworkDiagrams;
 
 public sealed class NetworkDiagramListPageViewModel
 {
+    public bool IsAdmin { get; init; }
+
     public IReadOnlyList<NetworkDiagramListItemViewModel> Diagrams { get; init; } = [];
     public CreateNetworkDiagramViewModel CreateDiagram { get; init; } = new();
 }
@@ -51,6 +53,8 @@ public sealed class NetworkDiagramEditorPageViewModel
 
     public string ExportPdfUrl { get; init; } = string.Empty;
 
+    public string ViewerUrl { get; init; } = string.Empty;
+
     public IReadOnlyList<NetworkDiagramEndpointToolboxItemViewModel> MonitoredEndpoints { get; init; } = [];
 }
 
@@ -65,4 +69,31 @@ public sealed class NetworkDiagramEndpointToolboxItemViewModel
     public string IconKey { get; init; } = "generic";
 
     public Models.EndpointStateKind SummaryState { get; init; } = Models.EndpointStateKind.Unknown;
+}
+
+
+public sealed class NetworkDiagramViewerPageViewModel
+{
+    public const string DocumentationOnlyNotice =
+        "Viewer overlays existing monitoring status only. Visual links remain documentation-only.";
+
+    public string PageTitle { get; init; } = "Network diagram";
+
+    public string Notice { get; init; } = DocumentationOnlyNotice;
+
+    public string DiagramId { get; init; } = string.Empty;
+
+    public string DiagramName { get; init; } = string.Empty;
+
+    public string? DiagramDescription { get; init; }
+
+    public string LoadUrl { get; init; } = string.Empty;
+
+    public string LiveDataUrl { get; init; } = string.Empty;
+
+    public string? EditUrl { get; init; }
+
+    public string? ExportPdfUrl { get; init; }
+
+    public bool IsAdmin { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
@@ -145,6 +145,10 @@
                         </select>
                     </label>
                     <button type="button" class="diagram-tool-button" data-export-pdf>Export PDF</button>
+                    @if (!string.IsNullOrWhiteSpace(Model.ViewerUrl))
+                    {
+                        <a class="diagram-tool-button" href="@Model.ViewerUrl">View diagram</a>
+                    }
                     <button type="button" class="diagram-tool-button" data-save-diagram>Save</button>
                     <span class="diagram-tool-hint" data-tool-hint>Select nodes to move them. Draw link mode creates documentation-only links. Drag empty space to pan. Use mouse wheel to zoom.</span>
                 </div>

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Index.cshtml
@@ -20,22 +20,25 @@
             </div>
         </header>
 
-        <section class="diagram-list-create" aria-labelledby="create-diagram-title">
-            <h2 id="create-diagram-title">Create diagram</h2>
-            <form asp-action="Create" method="post" class="diagram-create-form">
-                @Html.AntiForgeryToken()
-                <label>
-                    Name
-                    <input asp-for="CreateDiagram.Name" name="Name" maxlength="255" required />
-                </label>
-                <label>
-                    Description
-                    <textarea asp-for="CreateDiagram.Description" name="Description" maxlength="2048" rows="3"></textarea>
-                </label>
-                <button type="submit" class="diagram-tool-button">Create diagram</button>
-                <div asp-validation-summary="All"></div>
-            </form>
-        </section>
+        @if (Model.IsAdmin)
+        {
+            <section class="diagram-list-create" aria-labelledby="create-diagram-title">
+                <h2 id="create-diagram-title">Create diagram</h2>
+                <form asp-action="Create" method="post" class="diagram-create-form">
+                    @Html.AntiForgeryToken()
+                    <label>
+                        Name
+                        <input asp-for="CreateDiagram.Name" name="Name" maxlength="255" required />
+                    </label>
+                    <label>
+                        Description
+                        <textarea asp-for="CreateDiagram.Description" name="Description" maxlength="2048" rows="3"></textarea>
+                    </label>
+                    <button type="submit" class="diagram-tool-button">Create diagram</button>
+                    <div asp-validation-summary="All"></div>
+                </form>
+            </section>
+        }
 
         @if (Model.Diagrams.Count == 0)
         {
@@ -51,18 +54,24 @@
                 {
                     <article class="diagram-list-card">
                         <div>
-                            <h2><a asp-action="Edit" asp-route-diagramId="@diagram.DiagramId">@diagram.Name</a></h2>
+                            <h2><a asp-action="ViewDiagram" asp-route-diagramId="@diagram.DiagramId">@diagram.Name</a></h2>
                             @if (!string.IsNullOrWhiteSpace(diagram.Description))
                             {
                                 <p>@diagram.Description</p>
                             }
                             <p class="toolbox-help">@diagram.NodeCount nodes • @diagram.LinkCount visual links • Updated @diagram.UpdatedAtUtc.ToLocalTime().ToString("g")</p>
                         </div>
-                        <form asp-action="Delete" asp-route-diagramId="@diagram.DiagramId" method="post" onsubmit="return window.confirm('This deletes only the saved network diagram. Monitoring endpoints and monitoring data will not be deleted.');">
-                            @Html.AntiForgeryToken()
-                            <a class="diagram-tool-button" asp-action="Edit" asp-route-diagramId="@diagram.DiagramId">Open</a>
-                            <button type="submit" class="diagram-tool-button danger-button">Delete diagram</button>
-                        </form>
+                        <div class="diagram-list-actions">
+                            <a class="diagram-tool-button" asp-action="ViewDiagram" asp-route-diagramId="@diagram.DiagramId">View</a>
+                            @if (Model.IsAdmin)
+                            {
+                                <a class="diagram-tool-button" asp-action="Edit" asp-route-diagramId="@diagram.DiagramId">Edit</a>
+                                <form asp-action="Delete" asp-route-diagramId="@diagram.DiagramId" method="post" onsubmit="return window.confirm('This deletes only the saved network diagram. Monitoring endpoints and monitoring data will not be deleted.');">
+                                    @Html.AntiForgeryToken()
+                                    <button type="submit" class="diagram-tool-button danger-button">Delete diagram</button>
+                                </form>
+                            }
+                        </div>
                     </article>
                 }
             </section>

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
@@ -1,0 +1,83 @@
+@model PingMonitor.Web.ViewModels.NetworkDiagrams.NetworkDiagramViewerPageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    @await Html.PartialAsync("_ThemeHead")
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>@Model.PageTitle - Network diagram</title>
+    <link rel="stylesheet" href="/css/network-diagrams.css" />
+</head>
+<body>
+@await Html.PartialAsync("_AuthenticatedNav")
+<main class="network-diagrams-main">
+    <section class="diagram-editor-shell diagram-viewer-shell" data-network-diagram-viewer data-load-url="@Model.LoadUrl" data-live-data-url="@Model.LiveDataUrl" aria-labelledby="network-diagram-viewer-title">
+        <header class="diagram-editor-toolbar">
+            <div class="diagram-editor-heading">
+                <h1 id="network-diagram-viewer-title">@Model.DiagramName</h1>
+                @if (!string.IsNullOrWhiteSpace(Model.DiagramDescription))
+                {
+                    <p>@Model.DiagramDescription</p>
+                }
+                <p class="diagram-viewer-note">@Model.Notice</p>
+            </div>
+            <div class="diagram-viewer-actions">
+                @if (Model.IsAdmin && !string.IsNullOrWhiteSpace(Model.EditUrl))
+                {
+                    <a class="diagram-tool-button" href="@Model.EditUrl">Edit diagram</a>
+                }
+            </div>
+        </header>
+
+        <div class="diagram-viewer-layout">
+            <section class="diagram-workspace" aria-label="Read-only network diagram viewer">
+                <div class="diagram-workspace-toolbar diagram-viewer-toolbar">
+                    <button type="button" class="diagram-tool-button" data-zoom-out>Zoom out</button>
+                    <span class="diagram-zoom-label" data-zoom-label>100%</span>
+                    <button type="button" class="diagram-tool-button" data-zoom-in>Zoom in</button>
+                    <button type="button" class="diagram-tool-button" data-reset-view>Reset view</button>
+                    <button type="button" class="diagram-tool-button" data-fit-content>Fit content</button>
+                    @if (Model.IsAdmin && !string.IsNullOrWhiteSpace(Model.ExportPdfUrl))
+                    {
+                        <label class="diagram-toolbar-select-label">
+                            PDF paper
+                            <select data-export-paper aria-label="PDF paper size">
+                                <option value="A4">A4 landscape</option>
+                                <option value="A3">A3 landscape</option>
+                            </select>
+                        </label>
+                        <button type="button" class="diagram-tool-button" data-export-pdf data-export-pdf-url="@Model.ExportPdfUrl">Export PDF</button>
+                    }
+                    <span class="diagram-tool-hint" data-refresh-status>Live overlay pending</span>
+                </div>
+                <div class="diagram-canvas-host" data-diagram-canvas-host>
+                    <div class="diagram-canvas" data-diagram-canvas role="application" aria-label="Read-only network diagram canvas" tabindex="0">
+                        <div class="diagram-empty-state" data-empty-state>Loading saved diagram…</div>
+                        <div class="diagram-world" data-diagram-world>
+                            <svg class="diagram-link-layer" data-link-layer></svg>
+                            <div class="diagram-node-layer" data-node-layer></div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <aside class="diagram-properties diagram-viewer-details" aria-label="Read-only diagram details">
+                <h2>Details</h2>
+                <div data-no-selection-panel>
+                    <p>Select a monitored endpoint node or visual link to view read-only details.</p>
+                    <p class="toolbox-help">The viewer does not edit diagrams, endpoints, monitoring dependencies, alerts, or agents.</p>
+                </div>
+                <div class="diagram-viewer-detail-card" data-node-detail hidden></div>
+                <div class="diagram-viewer-detail-card" data-link-detail hidden></div>
+            </aside>
+        </div>
+
+        <footer class="diagram-status-bar">
+            <span>Read-only viewer. Visual links do not create monitoring dependencies.</span>
+            <span data-canvas-size>Canvas size pending</span>
+        </footer>
+    </section>
+</main>
+<script src="/js/network-diagrams-viewer.js" defer></script>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -1005,3 +1005,137 @@ html[data-theme="dark"] .diagram-link-port-label {
     min-height: 36px;
     padding: .35rem .55rem;
 }
+
+.diagram-viewer-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(220px, 300px);
+    min-height: 0;
+    min-width: 0;
+}
+
+.diagram-viewer-actions,
+.diagram-list-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+    align-items: center;
+}
+
+.diagram-list-actions form {
+    display: contents;
+}
+
+.diagram-viewer-note {
+    color: var(--diagram-muted) !important;
+    font-weight: 700;
+}
+
+.diagram-viewer-node {
+    cursor: pointer;
+}
+
+.diagram-viewer-node .diagram-node-symbol {
+    background: #e8f0ff;
+    color: #0f62fe;
+}
+
+.diagram-live-state,
+.diagram-live-metrics {
+    display: block;
+    margin-top: .25rem;
+    font-size: .78rem;
+    font-weight: 800;
+    line-height: 1.25;
+}
+
+.diagram-live-metrics {
+    color: var(--diagram-muted);
+    font-weight: 700;
+}
+
+.diagram-node-readonly {
+    background: var(--diagram-accent-soft);
+    color: var(--diagram-accent);
+}
+
+.diagram-node[data-live-state="up"] {
+    border-color: #16a34a;
+}
+
+.diagram-node[data-live-state="up"] .diagram-node-symbol {
+    background: #dcfce7;
+    color: #166534;
+}
+
+.diagram-node[data-live-state="degraded"] {
+    border-color: #f59e0b;
+}
+
+.diagram-node[data-live-state="degraded"] .diagram-node-symbol {
+    background: #fef3c7;
+    color: #92400e;
+}
+
+.diagram-node[data-live-state="down"] {
+    border-color: #dc2626;
+    box-shadow: 0 0 0 3px rgba(220, 38, 38, .15), 0 3px 8px rgba(16, 24, 40, .13);
+}
+
+.diagram-node[data-live-state="down"] .diagram-node-symbol {
+    background: #fee2e2;
+    color: #991b1b;
+}
+
+.diagram-node[data-live-state="suppressed"] {
+    border-color: #7c3aed;
+}
+
+.diagram-node[data-live-state="suppressed"] .diagram-node-symbol {
+    background: #ede9fe;
+    color: #5b21b6;
+}
+
+.diagram-node[data-live-state="unknown"] {
+    border-color: #94a3b8;
+}
+
+.diagram-node[data-live-state="unknown"] .diagram-node-symbol {
+    background: #e2e8f0;
+    color: #475569;
+}
+
+.diagram-viewer-detail-card[hidden] {
+    display: none;
+}
+
+.diagram-viewer-detail-card {
+    display: grid;
+    gap: .65rem;
+}
+
+.diagram-viewer-detail-card h3 {
+    margin: .25rem 0 0 0;
+    font-size: .95rem;
+}
+
+.diagram-viewer-assignment-list {
+    display: grid;
+    gap: .35rem;
+    margin: 0;
+    padding-left: 1.1rem;
+    color: var(--diagram-muted);
+    font-size: .86rem;
+    line-height: 1.35;
+}
+
+[data-refresh-status][data-error="true"] {
+    color: #b42318;
+    font-weight: 800;
+}
+
+@media (max-width: 980px) {
+    .diagram-viewer-layout {
+        grid-template-columns: minmax(0, 1fr);
+        grid-template-rows: minmax(60vh, 1fr) auto;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
@@ -1,0 +1,398 @@
+(() => {
+    const viewer = document.querySelector('[data-network-diagram-viewer]');
+    if (!viewer) {
+        return;
+    }
+
+    const nav = document.querySelector('.site-nav');
+    const loadUrl = viewer.dataset.loadUrl || '';
+    const liveDataUrl = viewer.dataset.liveDataUrl || '';
+    const canvasHost = viewer.querySelector('[data-diagram-canvas-host]');
+    const canvas = viewer.querySelector('[data-diagram-canvas]');
+    const world = viewer.querySelector('[data-diagram-world]');
+    const nodeLayer = viewer.querySelector('[data-node-layer]');
+    const linkLayer = viewer.querySelector('[data-link-layer]');
+    const emptyState = viewer.querySelector('[data-empty-state]');
+    const zoomLabel = viewer.querySelector('[data-zoom-label]');
+    const sizeLabel = viewer.querySelector('[data-canvas-size]');
+    const refreshStatus = viewer.querySelector('[data-refresh-status]');
+    const nodeDetail = viewer.querySelector('[data-node-detail]');
+    const linkDetail = viewer.querySelector('[data-link-detail]');
+    const noSelectionPanel = viewer.querySelector('[data-no-selection-panel]');
+    const exportPdfButton = viewer.querySelector('[data-export-pdf]');
+    const exportPaperSelect = viewer.querySelector('[data-export-paper]');
+
+    const zoomStep = 1.15;
+    const minZoom = 0.15;
+    const maxZoom = 3;
+    const parallelLinkOffsetStep = 34;
+    const refreshIntervalMs = 20000;
+    const statePriority = { Down: 5, Unknown: 4, Suppressed: 3, Degraded: 2, Up: 1 };
+    const state = {
+        nodes: [],
+        links: [],
+        overlayByNodeId: new Map(),
+        selectedNodeId: null,
+        selectedLinkId: null,
+        zoom: 1,
+        panX: 0,
+        panY: 0,
+        virtualCanvasWidth: 4000,
+        virtualCanvasHeight: 2828
+    };
+    let panState = null;
+    let refreshTimer = null;
+
+    function updateNavHeight() {
+        const height = nav ? nav.getBoundingClientRect().height : 0;
+        document.documentElement.style.setProperty('--network-diagrams-nav-height', `${height}px`);
+    }
+
+    function applyViewTransform() {
+        world.style.width = `${state.virtualCanvasWidth}px`;
+        world.style.height = `${state.virtualCanvasHeight}px`;
+        world.style.transform = `translate(${state.panX}px, ${state.panY}px) scale(${state.zoom})`;
+        linkLayer.setAttribute('viewBox', `0 0 ${state.virtualCanvasWidth} ${state.virtualCanvasHeight}`);
+        linkLayer.setAttribute('width', String(state.virtualCanvasWidth));
+        linkLayer.setAttribute('height', String(state.virtualCanvasHeight));
+        canvasHost.style.setProperty('--diagram-world-width', `${state.virtualCanvasWidth}px`);
+        canvasHost.style.setProperty('--diagram-world-height', `${state.virtualCanvasHeight}px`);
+        if (zoomLabel) {
+            zoomLabel.textContent = `${Math.round(state.zoom * 100)}%`;
+        }
+    }
+
+    function updateCanvasSize() {
+        updateNavHeight();
+        const rect = canvas.getBoundingClientRect();
+        if (sizeLabel) {
+            sizeLabel.textContent = `${Math.round(rect.width)} x ${Math.round(rect.height)} visible • ${state.virtualCanvasWidth} x ${state.virtualCanvasHeight} world • ${Math.round(state.zoom * 100)}% zoom`;
+        }
+        applyViewTransform();
+        renderLinks();
+    }
+
+    function getNodeWidth(node) { return node.element.offsetWidth || node.width || 178; }
+    function getNodeHeight(node) { return node.element.offsetHeight || node.height || 78; }
+    function getNodeCenter(node) { return { x: node.x + getNodeWidth(node) / 2, y: node.y + getNodeHeight(node) / 2 }; }
+    function findNodeById(id) { return state.nodes.find(node => node.id === id); }
+    function findLinkById(id) { return state.links.find(link => link.id === id); }
+    function createSvgElement(name) { return document.createElementNS('http://www.w3.org/2000/svg', name); }
+    function escapeHtml(value) {
+        return String(value ?? '').replace(/[&<>"']/g, ch => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch]));
+    }
+
+    function normalizeNodeType(serverType) {
+        if (serverType === 'MonitoredEndpoint') { return { nodeType: 'monitored-endpoint', nodeKind: 'monitored-endpoint' }; }
+        if (serverType === 'Note') { return { nodeType: 'note', nodeKind: 'custom-device' }; }
+        return { nodeType: 'generic-device', nodeKind: 'custom-device' };
+    }
+
+    function formatNodeType(type) {
+        if (type === 'monitored-endpoint') { return 'monitored endpoint'; }
+        if (type === 'note') { return 'note'; }
+        return 'custom device';
+    }
+
+    function createNodeElement(node) {
+        const element = document.createElement('div');
+        element.className = 'diagram-node diagram-viewer-node';
+        element.tabIndex = 0;
+        element.setAttribute('role', 'button');
+        element.setAttribute('aria-label', `${node.label} ${formatNodeType(node.nodeType)} node`);
+        element.dataset.nodeId = node.id;
+        element.dataset.nodeKind = node.nodeKind;
+        element.dataset.selected = 'false';
+
+        const symbol = document.createElement('span');
+        symbol.className = 'diagram-node-symbol';
+        symbol.textContent = node.iconKey || 'DEV';
+        symbol.setAttribute('aria-hidden', 'true');
+
+        const main = document.createElement('span');
+        main.className = 'diagram-node-main';
+        main.innerHTML = `<span class="diagram-node-name">${escapeHtml(node.label)}</span><span class="diagram-node-type">${node.nodeKind === 'monitored-endpoint' ? 'monitored endpoint' : formatNodeType(node.nodeType)}</span>`;
+
+        if (node.nodeKind === 'monitored-endpoint') {
+            main.innerHTML += '<span class="diagram-live-state" data-live-state>State: pending</span><span class="diagram-live-metrics" data-live-metrics>24h: — • RTT: —</span>';
+        } else {
+            main.innerHTML += '<span class="diagram-node-draft diagram-node-readonly">Diagram only</span>';
+        }
+
+        element.append(symbol, main);
+        element.addEventListener('click', event => { selectNode(node.id); event.stopPropagation(); });
+        element.addEventListener('keydown', event => {
+            if (event.key === 'Enter' || event.key === ' ') { selectNode(node.id); event.preventDefault(); }
+        });
+        return element;
+    }
+
+    function addLoadedNode(savedNode) {
+        const normalized = normalizeNodeType(savedNode.nodeType);
+        const node = {
+            id: savedNode.nodeId,
+            nodeType: normalized.nodeType,
+            nodeKind: normalized.nodeKind,
+            endpointId: savedNode.endpointId || '',
+            label: savedNode.displayLabel || 'Diagram node',
+            iconKey: savedNode.iconKey || 'DEV',
+            notes: savedNode.notes || '',
+            x: Number(savedNode.x) || 0,
+            y: Number(savedNode.y) || 0,
+            width: Number(savedNode.width) || 178,
+            height: Number(savedNode.height) || 78
+        };
+        node.element = createNodeElement(node);
+        node.element.style.width = `${node.width}px`;
+        node.element.style.minHeight = `${node.height}px`;
+        node.element.style.transform = `translate(${Math.round(node.x)}px, ${Math.round(node.y)}px)`;
+        nodeLayer.appendChild(node.element);
+        state.nodes.push(node);
+    }
+
+    function normalizeMediaType(value, linkType) {
+        const media = String(value || '').trim().toLowerCase();
+        if (media === 'fibre' || media === 'fiber') { return 'Fibre'; }
+        if (['wireless', 'dac', 'vpn', 'virtual', 'other'].includes(media)) { return media === 'dac' ? 'DAC' : media.charAt(0).toUpperCase() + media.slice(1); }
+        if (String(linkType || '').toLowerCase() === 'vpn') { return 'VPN'; }
+        return 'Copper';
+    }
+
+    function normalizeLinkType(value) {
+        const allowed = ['Standard', 'Trunk', 'Access', 'LACP', 'PointToPoint', 'Backhaul', 'WAN', 'Management', 'Logical', 'Other'];
+        const requested = String(value || '').trim();
+        return allowed.find(item => item.toLowerCase() === requested.toLowerCase()) || 'Standard';
+    }
+
+    function normalizeVlans(vlans) {
+        return Array.isArray(vlans) ? vlans.map((vlan, index) => ({ vlanId: vlan?.vlanId == null ? '' : String(vlan.vlanId), name: String(vlan?.name || ''), mode: String(vlan?.mode || 'Tagged'), notes: String(vlan?.notes || ''), sortOrder: Number(vlan?.sortOrder) || index })).sort((a, b) => a.sortOrder - b.sortOrder) : [];
+    }
+
+    function formatSpeed(value, unit) { return value == null || value === '' ? '' : `${value} ${unit || 'Mbps'}`; }
+    function buildVlanSummary(link) {
+        const vlans = normalizeVlans(link.vlans).filter(vlan => vlan.vlanId);
+        if (vlans.length === 0) { return ''; }
+        return vlans.map(vlan => `${vlan.mode}:${vlan.vlanId}${vlan.name ? ` ${vlan.name}` : ''}`).join(' · ');
+    }
+    function truncate(value, max) { const text = String(value || '').replace(/\s+/g, ' ').trim(); return text.length <= max ? text : `${text.slice(0, max - 1)}…`; }
+    function buildLinkSummary(link) {
+        const type = normalizeLinkType(link.linkType);
+        const media = normalizeMediaType(link.mediaType, link.linkType);
+        const speed = formatSpeed(link.linkSpeedValue, link.linkSpeedUnit);
+        return [type === 'Standard' ? '' : type, speed, media.toLowerCase()].filter(Boolean).join(' ');
+    }
+    function buildVisibleLinkLabel(link) {
+        const ports = normalizeLinkType(link.linkType) !== 'LACP' && (link.sourcePort || link.targetPort) ? `${link.sourcePort || '?'} ↔ ${link.targetPort || '?'}` : '';
+        return truncate([buildLinkSummary(link), link.label, ports, buildVlanSummary(link), link.notes].filter(Boolean).join(' • '), 116);
+    }
+
+    function getUnorderedLinkPairKey(link) { return [link.sourceNodeId, link.targetNodeId].sort().join('::'); }
+    function getParallelOffsetIndexes() {
+        const groups = new Map();
+        state.links.forEach(link => { const key = getUnorderedLinkPairKey(link); const group = groups.get(key) || []; group.push(link); groups.set(key, group); });
+        const offsets = new Map();
+        groups.forEach(group => { const ordered = [...group].sort((a, b) => String(a.id).localeCompare(String(b.id))); const center = (ordered.length - 1) / 2; ordered.forEach((link, index) => offsets.set(link.id, index - center)); });
+        return offsets;
+    }
+
+    function buildLinkGeometry(source, target, offsetIndex) {
+        const start = getNodeCenter(source);
+        const end = getNodeCenter(target);
+        const dx = end.x - start.x;
+        const dy = end.y - start.y;
+        const length = Math.hypot(dx, dy) || 1;
+        const perpendicularX = -dy / length;
+        const perpendicularY = dx / length;
+        const offset = offsetIndex * parallelLinkOffsetStep;
+        const control = { x: (start.x + end.x) / 2 + perpendicularX * offset, y: (start.y + end.y) / 2 + perpendicularY * offset };
+        const midpoint = { x: start.x * 0.25 + control.x * 0.5 + end.x * 0.25, y: start.y * 0.25 + control.y * 0.5 + end.y * 0.25 };
+        return { path: `M ${start.x} ${start.y} Q ${control.x} ${control.y} ${end.x} ${end.y}`, label: { x: midpoint.x + perpendicularX * 14, y: midpoint.y + perpendicularY * 14 - 4 } };
+    }
+
+    function renderLinks() {
+        linkLayer.replaceChildren();
+        const offsetIndexes = getParallelOffsetIndexes();
+        state.links.forEach(link => {
+            const source = findNodeById(link.sourceNodeId);
+            const target = findNodeById(link.targetNodeId);
+            if (!source || !target) { return; }
+            const geometry = buildLinkGeometry(source, target, offsetIndexes.get(link.id) || 0);
+            const group = createSvgElement('g');
+            group.classList.add('diagram-link-group');
+            group.dataset.linkId = link.id;
+            group.dataset.selected = state.selectedLinkId === link.id ? 'true' : 'false';
+            group.dataset.mediaType = normalizeMediaType(link.mediaType, link.linkType).toLowerCase();
+            group.dataset.linkType = normalizeLinkType(link.linkType).toLowerCase();
+            const line = createSvgElement('path');
+            line.classList.add('diagram-link-line');
+            line.setAttribute('d', geometry.path);
+            const hit = createSvgElement('path');
+            hit.classList.add('diagram-link-hit');
+            hit.setAttribute('d', geometry.path);
+            const select = event => { selectLink(link.id); event.preventDefault(); event.stopPropagation(); };
+            line.addEventListener('pointerdown', select);
+            hit.addEventListener('pointerdown', select);
+            group.append(line, hit);
+            const labelText = buildVisibleLinkLabel(link);
+            if (labelText) {
+                const label = createSvgElement('text');
+                label.classList.add('diagram-link-label');
+                label.setAttribute('x', String(geometry.label.x));
+                label.setAttribute('y', String(geometry.label.y));
+                label.setAttribute('text-anchor', 'middle');
+                label.textContent = labelText;
+                label.addEventListener('pointerdown', select);
+                group.appendChild(label);
+            }
+            linkLayer.appendChild(group);
+        });
+    }
+
+    function setEmptyState() { emptyState.hidden = state.nodes.length > 0; }
+    function formatRtt(value) { return value == null ? '—' : `${Number(value).toFixed(1)} ms`; }
+    function formatDate(value) { return value ? new Date(value).toLocaleString() : '—'; }
+    function stateLabel(value) { return value || 'Unknown'; }
+
+    function applyOverlay() {
+        state.nodes.forEach(node => {
+            if (node.nodeKind !== 'monitored-endpoint') { return; }
+            const overlay = state.overlayByNodeId.get(node.id);
+            const stateValue = overlay?.summaryStateLabel || 'Unknown';
+            node.element.dataset.liveState = stateValue.toLowerCase();
+            const stateElement = node.element.querySelector('[data-live-state]');
+            const metricsElement = node.element.querySelector('[data-live-metrics]');
+            if (stateElement) { stateElement.textContent = `State: ${stateLabel(stateValue)}`; }
+            if (metricsElement) { metricsElement.textContent = `24h: ${overlay?.uptimeDisplay || '—'} • RTT: ${formatRtt(overlay?.lastRttMs)}`; }
+        });
+        updateDetails();
+    }
+
+    async function refreshLiveData() {
+        if (!liveDataUrl) { return; }
+        try {
+            const response = await fetch(liveDataUrl, { headers: { Accept: 'application/json' } });
+            if (!response.ok) { throw new Error(`HTTP ${response.status}`); }
+            const data = await response.json();
+            state.overlayByNodeId = new Map((data.nodes || []).map(node => [node.nodeId, node]));
+            applyOverlay();
+            if (refreshStatus) {
+                refreshStatus.dataset.error = 'false';
+                refreshStatus.textContent = `Live overlay refreshed ${new Date(data.refreshedAtUtc || Date.now()).toLocaleTimeString()} • polling every 20s`;
+            }
+        } catch (error) {
+            if (refreshStatus) {
+                refreshStatus.dataset.error = 'true';
+                refreshStatus.textContent = 'Live overlay stale; refresh failed.';
+            }
+        }
+    }
+
+    function updateSelectionDom() {
+        state.nodes.forEach(node => { node.element.dataset.selected = node.id === state.selectedNodeId ? 'true' : 'false'; });
+        renderLinks();
+    }
+
+    function selectNode(id) { state.selectedNodeId = id; state.selectedLinkId = null; updateSelectionDom(); updateDetails(); }
+    function selectLink(id) { state.selectedNodeId = null; state.selectedLinkId = id; updateSelectionDom(); updateDetails(); }
+    function clearSelection() { state.selectedNodeId = null; state.selectedLinkId = null; updateSelectionDom(); updateDetails(); }
+
+    function updateDetails() {
+        const selectedNode = state.selectedNodeId ? findNodeById(state.selectedNodeId) : null;
+        const selectedLink = state.selectedLinkId ? findLinkById(state.selectedLinkId) : null;
+        noSelectionPanel.hidden = Boolean(selectedNode || selectedLink);
+        nodeDetail.hidden = !selectedNode;
+        linkDetail.hidden = !selectedLink;
+        if (selectedNode) {
+            const overlay = state.overlayByNodeId.get(selectedNode.id);
+            const assignmentRows = (overlay?.assignments || []).map(a => `<li><strong>${escapeHtml(a.agentName)}</strong>: ${escapeHtml(a.stateLabel)} • 24h ${escapeHtml(a.uptimeDisplay)} • RTT ${escapeHtml(formatRtt(a.lastRttMs))}${a.suppressedByEndpointName ? ` • Suppressed by ${escapeHtml(a.suppressedByEndpointName)}` : ''}</li>`).join('');
+            nodeDetail.innerHTML = `<h3>${escapeHtml(selectedNode.label)}</h3><dl class="diagram-property-summary"><div><dt>Type</dt><dd>${escapeHtml(formatNodeType(selectedNode.nodeType))}</dd></div>${overlay ? `<div><dt>Endpoint</dt><dd>${escapeHtml(overlay.endpointName)}<br>${escapeHtml(overlay.target)}</dd></div><div><dt>Summary state</dt><dd>${escapeHtml(overlay.summaryStateLabel)}</dd></div><div><dt>24h uptime</dt><dd>${escapeHtml(overlay.uptimeDisplay)}</dd></div><div><dt>Last RTT</dt><dd>${escapeHtml(formatRtt(overlay.lastRttMs))}</dd></div><div><dt>Last check</dt><dd>${escapeHtml(formatDate(overlay.lastCheckUtc))}</dd></div>` : '<div><dt>Live data</dt><dd>No visible live endpoint data.</dd></div>'}</dl>${assignmentRows ? `<h3>Assignments</h3><ul class="diagram-viewer-assignment-list">${assignmentRows}</ul>` : ''}${selectedNode.notes ? `<h3>Notes</h3><p>${escapeHtml(selectedNode.notes)}</p>` : ''}`;
+        }
+        if (selectedLink) {
+            linkDetail.innerHTML = `<h3>Visual link</h3><p class="toolbox-help">Visual link only; does not create monitoring dependency.</p><dl class="diagram-property-summary"><div><dt>Media</dt><dd>${escapeHtml(normalizeMediaType(selectedLink.mediaType, selectedLink.linkType))}</dd></div><div><dt>Link type</dt><dd>${escapeHtml(normalizeLinkType(selectedLink.linkType))}</dd></div><div><dt>Speed</dt><dd>${escapeHtml(formatSpeed(selectedLink.linkSpeedValue, selectedLink.linkSpeedUnit) || '—')}</dd></div><div><dt>Ports</dt><dd>${escapeHtml([selectedLink.sourcePort || '?', selectedLink.targetPort || '?'].join(' ↔ '))}</dd></div><div><dt>VLANs</dt><dd>${escapeHtml(buildVlanSummary(selectedLink) || '—')}</dd></div><div><dt>Notes</dt><dd>${escapeHtml(selectedLink.notes || '—')}</dd></div></dl>`;
+        }
+    }
+
+    function zoomAt(clientX, clientY, requestedZoom) {
+        const nextZoom = Math.min(Math.max(requestedZoom, minZoom), maxZoom);
+        const rect = canvas.getBoundingClientRect();
+        const worldX = (clientX - rect.left - state.panX) / state.zoom;
+        const worldY = (clientY - rect.top - state.panY) / state.zoom;
+        state.zoom = nextZoom;
+        state.panX = clientX - rect.left - worldX * nextZoom;
+        state.panY = clientY - rect.top - worldY * nextZoom;
+        updateCanvasSize();
+    }
+
+    function resetView() { state.zoom = 1; state.panX = 0; state.panY = 0; updateCanvasSize(); }
+    function fitContent() {
+        if (state.nodes.length === 0) { resetView(); return; }
+        const bounds = state.nodes.reduce((acc, node) => ({ minX: Math.min(acc.minX, node.x), minY: Math.min(acc.minY, node.y), maxX: Math.max(acc.maxX, node.x + getNodeWidth(node)), maxY: Math.max(acc.maxY, node.y + getNodeHeight(node)) }), { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity });
+        const rect = canvas.getBoundingClientRect();
+        const padding = 80;
+        state.zoom = Math.min(Math.max(Math.min((rect.width - padding) / Math.max(bounds.maxX - bounds.minX, 1), (rect.height - padding) / Math.max(bounds.maxY - bounds.minY, 1)), minZoom), maxZoom);
+        state.panX = (rect.width - (bounds.maxX - bounds.minX) * state.zoom) / 2 - bounds.minX * state.zoom;
+        state.panY = (rect.height - (bounds.maxY - bounds.minY) * state.zoom) / 2 - bounds.minY * state.zoom;
+        updateCanvasSize();
+    }
+
+    function beginPan(event) {
+        if (event.target !== canvas && event.target !== world && event.target !== linkLayer) { return; }
+        clearSelection();
+        panState = { pointerId: event.pointerId, startX: event.clientX, startY: event.clientY, panX: state.panX, panY: state.panY };
+        canvas.dataset.panning = 'true';
+        canvas.setPointerCapture(event.pointerId);
+        event.preventDefault();
+    }
+    function movePan(event) {
+        if (!panState || panState.pointerId !== event.pointerId) { return; }
+        state.panX = panState.panX + event.clientX - panState.startX;
+        state.panY = panState.panY + event.clientY - panState.startY;
+        applyViewTransform();
+        event.preventDefault();
+    }
+    function endPan(event) {
+        if (!panState || panState.pointerId !== event.pointerId) { return; }
+        panState = null;
+        canvas.dataset.panning = 'false';
+        canvas.releasePointerCapture(event.pointerId);
+    }
+
+    async function loadDiagram() {
+        const response = await fetch(loadUrl, { headers: { Accept: 'application/json' } });
+        if (!response.ok) {
+            emptyState.textContent = 'Failed to load diagram.';
+            return;
+        }
+        const diagram = await response.json();
+        state.virtualCanvasWidth = diagram.canvasWidth || state.virtualCanvasWidth;
+        state.virtualCanvasHeight = diagram.canvasHeight || state.virtualCanvasHeight;
+        state.panX = diagram.viewportPanX || 0;
+        state.panY = diagram.viewportPanY || 0;
+        state.zoom = diagram.viewportZoom || 1;
+        nodeLayer.replaceChildren();
+        state.nodes = [];
+        (diagram.nodes || []).forEach(addLoadedNode);
+        state.links = (diagram.links || []).map(link => ({ id: link.linkId, sourceNodeId: link.sourceNodeId, targetNodeId: link.targetNodeId, label: link.label || '', sourcePort: link.sourcePortLabel || '', targetPort: link.targetPortLabel || '', notes: link.notes || '', mediaType: normalizeMediaType(link.mediaType, link.linkType), linkType: normalizeLinkType(link.linkType), linkSpeedValue: link.linkSpeedValue, linkSpeedUnit: link.linkSpeedUnit, vlans: normalizeVlans(link.vlans) }));
+        setEmptyState();
+        updateCanvasSize();
+        await refreshLiveData();
+        refreshTimer = window.setInterval(refreshLiveData, refreshIntervalMs);
+    }
+
+    viewer.querySelector('[data-zoom-in]')?.addEventListener('click', () => zoomAt(canvas.getBoundingClientRect().left + canvas.clientWidth / 2, canvas.getBoundingClientRect().top + canvas.clientHeight / 2, state.zoom * zoomStep));
+    viewer.querySelector('[data-zoom-out]')?.addEventListener('click', () => zoomAt(canvas.getBoundingClientRect().left + canvas.clientWidth / 2, canvas.getBoundingClientRect().top + canvas.clientHeight / 2, state.zoom / zoomStep));
+    viewer.querySelector('[data-reset-view]')?.addEventListener('click', resetView);
+    viewer.querySelector('[data-fit-content]')?.addEventListener('click', fitContent);
+    exportPdfButton?.addEventListener('click', () => { const base = exportPdfButton.dataset.exportPdfUrl; if (base) { window.location.href = `${base}?paper=${encodeURIComponent(exportPaperSelect?.value || 'A4')}`; } });
+    canvas.addEventListener('pointerdown', beginPan);
+    canvas.addEventListener('pointermove', movePan);
+    canvas.addEventListener('pointerup', endPan);
+    canvas.addEventListener('pointercancel', endPan);
+    canvas.addEventListener('wheel', event => { zoomAt(event.clientX, event.clientY, state.zoom * (event.deltaY < 0 ? zoomStep : 1 / zoomStep)); event.preventDefault(); }, { passive: false });
+    window.addEventListener('resize', updateCanvasSize);
+    if ('ResizeObserver' in window) { new ResizeObserver(updateCanvasSize).observe(canvasHost); }
+    window.addEventListener('beforeunload', () => { if (refreshTimer) { window.clearInterval(refreshTimer); } });
+    applyViewTransform();
+    updateCanvasSize();
+    loadDiagram();
+})();


### PR DESCRIPTION
### Motivation
- Provide an operational, read-only Network Diagram viewer that displays saved diagrams without editor controls so users can view topology documentation with live monitoring context.
- Surface existing server-calculated monitoring state, 24h uptime, and last RTT on monitored endpoint nodes without changing monitoring semantics, dependency suppression, alerts, or agents.
- Keep the editor as the admin-only edit surface and enforce feature-gate and endpoint-visibility rules so the viewer cannot expose unauthorized endpoint details.

### Description
- Adds a new viewer route and page at `/network-diagrams/{diagramId}` (admin edit remains at `/network-diagrams/{diagramId}/edit`) and updates the diagram list so primary action is View; the controller now enforces `NetworkDiagramsEnabled` and respects admin vs authenticated roles when returning full vs filtered diagram JSON. (Fixes #518)
- Implements a lightweight server-side live overlay service `INetworkDiagramLiveOverlayService` and `NetworkDiagramLiveOverlayService` which batches assignment/state lookups and reuses `IAssignmentMetrics24hService` for uptime/RTT summaries, applies existing endpoint visibility for non-admin users, and returns per-node and per-assignment overlay DTOs.
- Adds a read-only viewer view `View.cshtml`, a dedicated viewer JS `wwwroot/js/network-diagrams-viewer.js`, and viewer CSS updates to render pan/zoom/fit, parallel links, compact live metrics, node badges for Up/Degraded/Down/Suppressed/Unknown, and a details panel that shows per-assignment read-only info; polling is implemented at 20s and failures mark the overlay as stale while preserving displayed diagram geometry.
- Wire-up: DI registration for the live overlay service, view-model additions for viewer/editor navigation, controller changes for new `Load`/`LiveData` semantics and visibility-filtering for non-admin users, new unit tests, and documentation updates describing the viewer behaviour and safety boundaries.

### Testing
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the build succeeded with no errors or warnings.
- Ran automated unit tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` (and `--no-build`) and all tests passed (`Passed: 136, Failed: 0`).
- Performed static checks including `git diff --check`; there were no check failures and new files/tests were committed; CI/MySQL provider-specific runtime validation should be run in deployment CI/staging as noted in the PR description.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f212e5e10832a8b0dde474d8d510b)