### PR TITLE
Add live diagram summary and click-to-centre in network diagram viewer

### DIFF
--- a/docs/network_diagrams_v_0_1_1_design_notes.md
+++ b/docs/network_diagrams_v_0_1_1_design_notes.md
@@ -489,7 +489,9 @@ Implementation boundaries:
 - Editing tools, mutable inputs, save actions, delete actions, draw-link mode, and add-node controls are not rendered in viewer mode.
 - Live data is provided by a lightweight JSON endpoint that reuses current assignment state and 24-hour assignment metrics.
 - The live endpoint overlay shows server-calculated state, uptime, and RTT data only; it does not evaluate monitoring state itself.
-- Multi-assignment endpoint nodes use the UI-only diagram urgency order Down, Unknown, Suppressed, Degraded, Up for the node badge while preserving per-assignment state details in the read-only details panel.
+- When no node or link is selected, the right-hand details pane shows a diagram-wide live summary with total nodes, monitored nodes, diagram-only nodes, visual links, overlay refresh time, and Up/Degraded/Down/Suppressed/Unknown counts based on the same server-provided overlay state used by monitored endpoint nodes.
+- The no-selection summary includes compact affected endpoint lists for Down, Degraded, Suppressed, and Unknown states, plus a highest-RTT list when fetched RTT values are available. Selecting an endpoint from these lists centres and zooms the read-only viewer to the existing diagram node and opens that node's read-only details.
+- Multi-assignment endpoint nodes use the UI-only diagram urgency order Down, Unknown, Suppressed, Degraded, Up for the node badge, diagram summary counts, and affected lists while preserving per-assignment state details in the read-only details panel.
 - Non-admin access is filtered using existing endpoint visibility rules; hidden monitored endpoint nodes and connected links are omitted from non-admin static diagram JSON and live overlay JSON.
 - Diagram links remain visual documentation and still do not create monitoring dependencies or alter suppression.
 
@@ -498,13 +500,18 @@ Manual regression checklist for this slice:
 1. Enable `NetworkDiagramsEnabled`.
 2. Open the diagram list and confirm saved diagrams offer View as the primary action.
 3. Open a saved diagram in View mode and confirm no toolbox, editable Properties form, Save, Delete selected, Draw link, or add-node controls are visible.
-4. Confirm pan, mouse-wheel zoom, toolbar zoom, reset view, and fit content work.
-5. Confirm monitored endpoint nodes show state, 24-hour uptime, and last RTT.
-6. Confirm custom diagram nodes show diagram-only presentation and do not show fake live endpoint data.
-7. Wait for the polling interval and confirm live data refresh timestamp changes without reloading the page.
-8. Click a monitored node and confirm the details panel is read-only and includes endpoint/assignment status data.
-9. Click a visual link and confirm the details panel is read-only and states that the link is visual documentation only.
-10. Confirm admin users can navigate to Edit from the viewer.
-11. Confirm non-admin users cannot access the edit/save/delete/export routes and do not receive endpoint details they cannot access.
-12. Disable `NetworkDiagramsEnabled` and confirm viewer and live-data API access are blocked.
-13. Confirm no endpoint, dependency, state-evaluation, alert, agent, or startup-gate behaviour changed.
+4. Confirm no item is selected by default and the right pane shows the diagram summary, not generic help text.
+5. Confirm total nodes, monitored nodes, diagram-only nodes, visual links, overlay refresh time, and Up/Down/Degraded/Suppressed/Unknown counts are shown.
+6. Confirm affected endpoint lists appear when endpoints are not healthy, and click an affected endpoint to confirm the viewer centres/zooms to that endpoint, selects it, and opens node details.
+7. Clear selection by panning/clicking the canvas background and confirm the summary returns.
+8. Confirm pan, mouse-wheel zoom, toolbar zoom, reset view, and fit content work.
+9. Confirm monitored endpoint nodes show state, 24-hour uptime, and last RTT.
+10. Confirm custom diagram nodes show diagram-only presentation and do not show fake live endpoint data.
+11. Wait for the polling interval and confirm live data refresh timestamp and summary counts update without reloading the page.
+12. Click a monitored node and confirm the details panel is read-only and includes endpoint/assignment status data.
+13. Click a visual link and confirm the details panel is read-only and states that the link is visual documentation only.
+14. Test the viewer details pane in dark mode and light mode.
+15. Confirm admin users can navigate to Edit from the viewer.
+16. Confirm non-admin users cannot access the edit/save/delete/export routes and do not receive endpoint details they cannot access.
+17. Disable `NetworkDiagramsEnabled` and confirm viewer and live-data API access are blocked.
+18. Confirm no endpoint, dependency, state-evaluation, alert, agent, or startup-gate behaviour changed.

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -550,6 +550,37 @@ public sealed class NetworkDiagramsFeatureTests
     }
 
     [Fact]
+    public void NetworkDiagramViewer_RendersNoSelectionSummaryAndClickToCentreHooks()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var viewMarkup = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "Views", "NetworkDiagrams", "View.cshtml"));
+        var script = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "wwwroot", "js", "network-diagrams-viewer.js"));
+        var styles = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "wwwroot", "css", "network-diagrams.css"));
+
+        Assert.Contains("data-no-selection-panel", viewMarkup);
+        Assert.Contains("Loading diagram summary", viewMarkup);
+        Assert.Contains("Viewer overlays existing monitoring status only. Visual links remain documentation-only.", viewMarkup);
+        Assert.Contains("buildDiagramSummaryHtml", script);
+        Assert.Contains("Total nodes", script);
+        Assert.Contains("Monitored", script);
+        Assert.Contains("Diagram-only", script);
+        Assert.Contains("Visual links", script);
+        Assert.Contains("Live overlay refresh", script);
+        Assert.Contains("Up: 0, Degraded: 0, Down: 0, Suppressed: 0, Unknown: 0", script);
+        Assert.Contains("Down endpoints", script);
+        Assert.Contains("Degraded endpoints", script);
+        Assert.Contains("Suppressed endpoints", script);
+        Assert.Contains("Unknown endpoints", script);
+        Assert.Contains("Highest RTT", script);
+        Assert.Contains("data-summary-node-id", script);
+        Assert.Contains("function centreOnNode(nodeId, preferredZoom = 1)", script);
+        Assert.Contains("selectNode(node.id)", script);
+        Assert.Contains("clampPan();", script);
+        Assert.Contains("diagram-summary-stat-grid", styles);
+        Assert.Contains("diagram-summary-endpoint:focus-visible", styles);
+    }
+
+    [Fact]
     public async Task NetworkDiagramsViewer_ReturnsViewer_WhenFeatureEnabled()
     {
         var controller = new NetworkDiagramsController(

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
@@ -64,8 +64,8 @@
             <aside class="diagram-properties diagram-viewer-details" aria-label="Read-only diagram details">
                 <h2>Details</h2>
                 <div data-no-selection-panel>
-                    <p>Select a monitored endpoint node or visual link to view read-only details.</p>
-                    <p class="toolbox-help">The viewer does not edit diagrams, endpoints, monitoring dependencies, alerts, or agents.</p>
+                    <p>Loading diagram summary…</p>
+                    <p class="toolbox-help">Viewer overlays existing monitoring status only. Visual links remain documentation-only.</p>
                 </div>
                 <div class="diagram-viewer-detail-card" data-node-detail hidden></div>
                 <div class="diagram-viewer-detail-card" data-link-detail hidden></div>

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -1139,3 +1139,143 @@ html[data-theme="dark"] .diagram-link-port-label {
         grid-template-rows: minmax(60vh, 1fr) auto;
     }
 }
+
+.diagram-summary-panel {
+    display: grid;
+    gap: .7rem;
+}
+
+.diagram-summary-stat-grid,
+.diagram-summary-state-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: .45rem;
+}
+
+.diagram-summary-stat-grid div,
+.diagram-summary-state-grid div {
+    display: grid;
+    gap: .2rem;
+    min-height: 58px;
+    padding: .55rem;
+    border: 1px solid var(--diagram-border);
+    border-radius: 8px;
+    background: var(--diagram-panel);
+}
+
+.diagram-summary-stat-grid span,
+.diagram-summary-state-grid span {
+    color: var(--diagram-muted);
+    font-size: .72rem;
+    font-weight: 800;
+    letter-spacing: .02em;
+    text-transform: uppercase;
+}
+
+.diagram-summary-stat-grid strong,
+.diagram-summary-state-grid strong {
+    color: var(--diagram-text);
+    font-size: 1.25rem;
+    line-height: 1;
+}
+
+.diagram-summary-state-grid [data-summary-state="up"] {
+    border-color: #16a34a;
+}
+
+.diagram-summary-state-grid [data-summary-state="degraded"] {
+    border-color: #f59e0b;
+}
+
+.diagram-summary-state-grid [data-summary-state="down"] {
+    border-color: #dc2626;
+}
+
+.diagram-summary-state-grid [data-summary-state="suppressed"] {
+    border-color: #7c3aed;
+}
+
+.diagram-summary-state-grid [data-summary-state="unknown"] {
+    border-color: #94a3b8;
+}
+
+.diagram-summary-refresh {
+    padding: .55rem;
+}
+
+.diagram-summary-section {
+    display: grid;
+    gap: .35rem;
+}
+
+.diagram-summary-section h3 {
+    margin: .2rem 0 0 0;
+    font-size: .88rem;
+}
+
+.diagram-summary-none,
+.diagram-summary-message {
+    margin: 0;
+    color: var(--diagram-muted);
+    font-size: .84rem;
+    line-height: 1.35;
+}
+
+.diagram-summary-message {
+    padding: .5rem .6rem;
+    border: 1px solid var(--diagram-border);
+    border-radius: 8px;
+    background: var(--diagram-panel-subtle);
+    color: var(--diagram-text);
+    font-weight: 700;
+}
+
+.diagram-summary-endpoint-list {
+    display: grid;
+    gap: .35rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.diagram-summary-endpoint {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 48px;
+    width: 100%;
+    border: 1px solid var(--diagram-border);
+    border-radius: 8px;
+    background: var(--diagram-panel);
+    color: var(--diagram-text);
+    cursor: pointer;
+    font: inherit;
+    padding: .5rem .55rem;
+    text-align: left;
+}
+
+.diagram-summary-endpoint:hover,
+.diagram-summary-endpoint:focus-visible {
+    outline: none;
+    border-color: var(--diagram-accent);
+    box-shadow: 0 0 0 3px var(--diagram-accent-soft);
+}
+
+.diagram-summary-endpoint span {
+    display: grid;
+    gap: .15rem;
+    min-width: 0;
+}
+
+.diagram-summary-endpoint strong,
+.diagram-summary-endpoint small {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.diagram-summary-endpoint small {
+    color: var(--diagram-muted);
+    font-size: .78rem;
+    font-weight: 700;
+}

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
@@ -38,7 +38,9 @@
         panX: 0,
         panY: 0,
         virtualCanvasWidth: 4000,
-        virtualCanvasHeight: 2828
+        virtualCanvasHeight: 2828,
+        liveOverlayRefreshedAtUtc: null,
+        summaryMessage: ''
     };
     let panState = null;
     let refreshTimer = null;
@@ -252,6 +254,49 @@
     function formatRtt(value) { return value == null ? '—' : `${Number(value).toFixed(1)} ms`; }
     function formatDate(value) { return value ? new Date(value).toLocaleString() : '—'; }
     function stateLabel(value) { return value || 'Unknown'; }
+    function normalizeSummaryState(value) {
+        const label = stateLabel(value);
+        return Object.prototype.hasOwnProperty.call(statePriority, label) ? label : 'Unknown';
+    }
+    function formatRefreshTime() { return state.liveOverlayRefreshedAtUtc ? formatDate(state.liveOverlayRefreshedAtUtc) : 'Pending'; }
+
+    function getMonitoredNodes() { return state.nodes.filter(node => node.nodeKind === 'monitored-endpoint'); }
+    function getOverlayForNode(node) { return state.overlayByNodeId.get(node.id); }
+    function getSummaryStateForNode(node) { return normalizeSummaryState(getOverlayForNode(node)?.summaryStateLabel); }
+
+    function buildSummaryEndpointItem(node) {
+        const overlay = getOverlayForNode(node);
+        const summaryState = getSummaryStateForNode(node);
+        const displayName = overlay?.endpointName || node.label;
+        const subline = [summaryState, `RTT ${formatRtt(overlay?.lastRttMs)}`, `24h ${overlay?.uptimeDisplay || '—'}`].join(' • ');
+        return `<li><button type="button" class="diagram-summary-endpoint" data-summary-node-id="${escapeHtml(node.id)}"><span><strong>${escapeHtml(displayName)}</strong><small>${escapeHtml(subline)}</small></span></button></li>`;
+    }
+
+    function buildAffectedSection(title, nodes) {
+        if (nodes.length === 0) {
+            return `<section class="diagram-summary-section"><h3>${escapeHtml(title)}</h3><p class="diagram-summary-none">None</p></section>`;
+        }
+
+        return `<section class="diagram-summary-section"><h3>${escapeHtml(title)}</h3><ul class="diagram-summary-endpoint-list">${nodes.map(buildSummaryEndpointItem).join('')}</ul></section>`;
+    }
+
+    function buildDiagramSummaryHtml() {
+        const monitoredNodes = getMonitoredNodes();
+        const customNodeCount = state.nodes.length - monitoredNodes.length;
+        const counts = { Up: 0, Degraded: 0, Down: 0, Suppressed: 0, Unknown: 0 };
+        monitoredNodes.forEach(node => { counts[getSummaryStateForNode(node)] += 1; });
+
+        const nodesByState = stateName => monitoredNodes
+            .filter(node => getSummaryStateForNode(node) === stateName)
+            .sort((a, b) => String(getOverlayForNode(a)?.endpointName || a.label).localeCompare(String(getOverlayForNode(b)?.endpointName || b.label)));
+
+        const highestRttNodes = monitoredNodes
+            .filter(node => getOverlayForNode(node)?.lastRttMs != null)
+            .sort((a, b) => Number(getOverlayForNode(b).lastRttMs) - Number(getOverlayForNode(a).lastRttMs))
+            .slice(0, 5);
+
+        return `<div class="diagram-summary-panel"><p class="toolbox-help">Viewer overlays existing monitoring status only. Visual links remain documentation-only.</p>${state.summaryMessage ? `<p class="diagram-summary-message" role="status">${escapeHtml(state.summaryMessage)}</p>` : ''}<div class="diagram-summary-stat-grid"><div><span>Total nodes</span><strong>${state.nodes.length}</strong></div><div><span>Monitored</span><strong>${monitoredNodes.length}</strong></div><div><span>Diagram-only</span><strong>${customNodeCount}</strong></div><div><span>Visual links</span><strong>${state.links.length}</strong></div></div><dl class="diagram-property-summary diagram-summary-refresh"><div><dt>Live overlay refresh</dt><dd>${escapeHtml(formatRefreshTime())}</dd></div></dl><div class="diagram-summary-state-grid">${Object.keys(counts).map(key => `<div data-summary-state="${key.toLowerCase()}"><span>${escapeHtml(key)}</span><strong>${counts[key]}</strong></div>`).join('')}</div>${buildAffectedSection('Down endpoints', nodesByState('Down'))}${buildAffectedSection('Degraded endpoints', nodesByState('Degraded'))}${buildAffectedSection('Suppressed endpoints', nodesByState('Suppressed'))}${buildAffectedSection('Unknown endpoints', nodesByState('Unknown'))}${highestRttNodes.length > 0 ? `<section class="diagram-summary-section"><h3>Highest RTT</h3><ul class="diagram-summary-endpoint-list">${highestRttNodes.map(buildSummaryEndpointItem).join('')}</ul></section>` : ''}</div>`;
+    }
 
     function applyOverlay() {
         state.nodes.forEach(node => {
@@ -274,6 +319,7 @@
             if (!response.ok) { throw new Error(`HTTP ${response.status}`); }
             const data = await response.json();
             state.overlayByNodeId = new Map((data.nodes || []).map(node => [node.nodeId, node]));
+            state.liveOverlayRefreshedAtUtc = data.refreshedAtUtc || new Date().toISOString();
             applyOverlay();
             if (refreshStatus) {
                 refreshStatus.dataset.error = 'false';
@@ -302,6 +348,9 @@
         noSelectionPanel.hidden = Boolean(selectedNode || selectedLink);
         nodeDetail.hidden = !selectedNode;
         linkDetail.hidden = !selectedLink;
+        if (!selectedNode && !selectedLink) {
+            noSelectionPanel.innerHTML = buildDiagramSummaryHtml();
+        }
         if (selectedNode) {
             const overlay = state.overlayByNodeId.get(selectedNode.id);
             const assignmentRows = (overlay?.assignments || []).map(a => `<li><strong>${escapeHtml(a.agentName)}</strong>: ${escapeHtml(a.stateLabel)} • 24h ${escapeHtml(a.uptimeDisplay)} • RTT ${escapeHtml(formatRtt(a.lastRttMs))}${a.suppressedByEndpointName ? ` • Suppressed by ${escapeHtml(a.suppressedByEndpointName)}` : ''}</li>`).join('');
@@ -309,6 +358,23 @@
         }
         if (selectedLink) {
             linkDetail.innerHTML = `<h3>Visual link</h3><p class="toolbox-help">Visual link only; does not create monitoring dependency.</p><dl class="diagram-property-summary"><div><dt>Media</dt><dd>${escapeHtml(normalizeMediaType(selectedLink.mediaType, selectedLink.linkType))}</dd></div><div><dt>Link type</dt><dd>${escapeHtml(normalizeLinkType(selectedLink.linkType))}</dd></div><div><dt>Speed</dt><dd>${escapeHtml(formatSpeed(selectedLink.linkSpeedValue, selectedLink.linkSpeedUnit) || '—')}</dd></div><div><dt>Ports</dt><dd>${escapeHtml([selectedLink.sourcePort || '?', selectedLink.targetPort || '?'].join(' ↔ '))}</dd></div><div><dt>VLANs</dt><dd>${escapeHtml(buildVlanSummary(selectedLink) || '—')}</dd></div><div><dt>Notes</dt><dd>${escapeHtml(selectedLink.notes || '—')}</dd></div></dl>`;
+        }
+    }
+
+    function clampPan() {
+        const rect = canvas.getBoundingClientRect();
+        const scaledWidth = state.virtualCanvasWidth * state.zoom;
+        const scaledHeight = state.virtualCanvasHeight * state.zoom;
+        const margin = 80;
+        if (scaledWidth <= rect.width) {
+            state.panX = (rect.width - scaledWidth) / 2;
+        } else {
+            state.panX = Math.min(margin, Math.max(rect.width - scaledWidth - margin, state.panX));
+        }
+        if (scaledHeight <= rect.height) {
+            state.panY = (rect.height - scaledHeight) / 2;
+        } else {
+            state.panY = Math.min(margin, Math.max(rect.height - scaledHeight - margin, state.panY));
         }
     }
 
@@ -320,7 +386,28 @@
         state.zoom = nextZoom;
         state.panX = clientX - rect.left - worldX * nextZoom;
         state.panY = clientY - rect.top - worldY * nextZoom;
+        clampPan();
         updateCanvasSize();
+    }
+
+    function centreOnNode(nodeId, preferredZoom = 1) {
+        const node = findNodeById(nodeId);
+        if (!node) {
+            state.summaryMessage = 'That endpoint node is no longer visible on this diagram.';
+            updateDetails();
+            return;
+        }
+
+        const rect = canvas.getBoundingClientRect();
+        const nextZoom = Math.min(Math.max(Math.max(preferredZoom, 0.75), minZoom), maxZoom);
+        const center = getNodeCenter(node);
+        state.zoom = nextZoom;
+        state.panX = rect.width / 2 - center.x * nextZoom;
+        state.panY = rect.height / 2 - center.y * nextZoom;
+        clampPan();
+        selectNode(node.id);
+        updateCanvasSize();
+        node.element.focus({ preventScroll: true });
     }
 
     function resetView() { state.zoom = 1; state.panX = 0; state.panY = 0; updateCanvasSize(); }
@@ -375,6 +462,7 @@
         state.links = (diagram.links || []).map(link => ({ id: link.linkId, sourceNodeId: link.sourceNodeId, targetNodeId: link.targetNodeId, label: link.label || '', sourcePort: link.sourcePortLabel || '', targetPort: link.targetPortLabel || '', notes: link.notes || '', mediaType: normalizeMediaType(link.mediaType, link.linkType), linkType: normalizeLinkType(link.linkType), linkSpeedValue: link.linkSpeedValue, linkSpeedUnit: link.linkSpeedUnit, vlans: normalizeVlans(link.vlans) }));
         setEmptyState();
         updateCanvasSize();
+        updateDetails();
         await refreshLiveData();
         refreshTimer = window.setInterval(refreshLiveData, refreshIntervalMs);
     }
@@ -384,6 +472,12 @@
     viewer.querySelector('[data-reset-view]')?.addEventListener('click', resetView);
     viewer.querySelector('[data-fit-content]')?.addEventListener('click', fitContent);
     exportPdfButton?.addEventListener('click', () => { const base = exportPdfButton.dataset.exportPdfUrl; if (base) { window.location.href = `${base}?paper=${encodeURIComponent(exportPaperSelect?.value || 'A4')}`; } });
+    noSelectionPanel?.addEventListener('click', event => {
+        const button = event.target.closest('[data-summary-node-id]');
+        if (!button) { return; }
+        state.summaryMessage = '';
+        centreOnNode(button.dataset.summaryNodeId, 1);
+    });
     canvas.addEventListener('pointerdown', beginPan);
     canvas.addEventListener('pointermove', movePan);
     canvas.addEventListener('pointerup', endPan);


### PR DESCRIPTION
### Motivation
- Improve the read-only Network Diagram viewer so the right-hand details pane shows a live diagram-wide summary when nothing is selected, surfacing counts and affected endpoint lists derived from the existing server-provided live overlay data. 
- Make affected endpoints actionable from the summary so operators can quickly centre/zoom to an endpoint on the diagram and open its read-only details. 
- Preserve architecture constraints: use only server-calculated overlay data, do not change monitoring/evaluation/agent/startup-gate behaviour, and respect endpoint visibility rules (Fixes #520).

### Description
- Viewer UI/UX: replaced the generic no-selection help text with a generated diagram summary that shows total nodes, monitored nodes, diagram-only/custom nodes, visual links, live overlay refresh time, and Up/Degraded/Down/Suppressed/Unknown counts sourced from the existing live overlay payload. (files changed: `View.cshtml`, `network-diagrams-viewer.js`, `network-diagrams.css`).
- Affected lists & RTT: added compact lists for Down/Degraded/Suppressed/Unknown endpoints and an optional "Highest RTT" top-5 list using already-fetched overlay metrics; empty sections show "None". (JS + CSS changes).
- Click-to-centre/zoom: implemented `centreOnNode(nodeId, preferredZoom)` and viewport clamping (`clampPan`) to centre and zoom to a node, select it, focus it, and open its details; summary list items are clickable and wired to call this helper. (JS changes in `network-diagrams-viewer.js`).
- Non-functional updates: added styling for summary cards and accessible button states in `network-diagrams.css`, updated the viewer documentation and manual regression checklist in `docs/network_diagrams_v_0_1_1_design_notes.md`, and added a source-level test asserting presence of the new summary hooks and styles in `NetworkDiagramsFeatureTests.cs`.
- Safety/architecture: no server-side monitoring logic, database schema, startup-gate, background service, or agent runtime changes were made; live overlay API and visibility enforcement remain unchanged.

### Testing
- `node --check src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js` — syntax check passed.
- `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` — build succeeded.
- `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` — all tests passed (existing suite plus the new source-level assertion).
- `pwsh -NoProfile -File scripts/build-dev.ps1 -Runtime linux-x64` — dev packaging completed successfully (used as a full repo smoke-packaging validation).
- Note: UI screenshot capture was not possible in this environment (no browser available); manual regression checklist was updated in docs for interactive verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a201efdf918832a80c84756767379d3)