### PR TITLE
Fix network diagram viewer summary lifecycle

### DIFF
--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -366,7 +366,8 @@ Live endpoint overlay behaviour:
 - Endpoint state remains assignment-scoped. When a diagram node references an endpoint with multiple assignments, the viewer uses a UI-only urgency summary: Down, Unknown, Suppressed, Degraded, then Up.
 - The UI-only summary does not redefine the monitoring state machine and is not fed back into monitoring, alerting, suppression, agents, endpoint configuration, or dependency configuration.
 - The live overlay endpoint batches assignment/current-state lookup for all monitored nodes on the diagram and uses existing 24-hour assignment metrics snapshots for uptime and RTT fields instead of scanning raw check results on every refresh.
-- Live data refresh uses lightweight polling every 20 seconds. If refresh fails, the existing diagram stays visible and the viewer marks the live overlay as stale.
+- Live data refresh uses lightweight polling every 20 seconds. If refresh fails, the existing diagram stays visible and the viewer marks the live overlay and summary as stale instead of leaving the details pane in a loading state.
+- With no node or link selected, the right-hand details pane shows the saved diagram totals immediately after static diagram load, then refreshes diagram-wide counts, affected endpoint sections, and highest-RTT data from the server-provided live overlay. The viewer remains read-only and never derives endpoint state independently.
 
 Access and feature-gate behaviour:
 

--- a/docs/network_diagrams_v_0_1_1_design_notes.md
+++ b/docs/network_diagrams_v_0_1_1_design_notes.md
@@ -489,8 +489,9 @@ Implementation boundaries:
 - Editing tools, mutable inputs, save actions, delete actions, draw-link mode, and add-node controls are not rendered in viewer mode.
 - Live data is provided by a lightweight JSON endpoint that reuses current assignment state and 24-hour assignment metrics.
 - The live endpoint overlay shows server-calculated state, uptime, and RTT data only; it does not evaluate monitoring state itself.
-- When no node or link is selected, the right-hand details pane shows a diagram-wide live summary with total nodes, monitored nodes, diagram-only nodes, visual links, overlay refresh time, and Up/Degraded/Down/Suppressed/Unknown counts based on the same server-provided overlay state used by monitored endpoint nodes.
+- When no node or link is selected, the right-hand details pane shows a diagram-wide live summary with total nodes, monitored nodes, diagram-only nodes, visual links, overlay refresh time, and Up/Degraded/Down/Suppressed/Unknown counts based on the same server-provided overlay state used by monitored endpoint nodes. The saved-diagram counts render as soon as the static diagram loads; live counts update after the first overlay response and on each later polling refresh.
 - The no-selection summary includes compact affected endpoint lists for Down, Degraded, Suppressed, and Unknown states, plus a highest-RTT list when fetched RTT values are available. Selecting an endpoint from these lists centres and zooms the read-only viewer to the existing diagram node and opens that node's read-only details.
+- Summary rendering must not leave the right-hand panel in an indefinite loading state. If live overlay data is missing, filtered, stale, or temporarily unavailable, the viewer keeps the saved diagram visible and shows an empty, unknown, or stale summary message instead of calculating monitoring state locally.
 - Multi-assignment endpoint nodes use the UI-only diagram urgency order Down, Unknown, Suppressed, Degraded, Up for the node badge, diagram summary counts, and affected lists while preserving per-assignment state details in the read-only details panel.
 - Non-admin access is filtered using existing endpoint visibility rules; hidden monitored endpoint nodes and connected links are omitted from non-admin static diagram JSON and live overlay JSON.
 - Diagram links remain visual documentation and still do not create monitoring dependencies or alter suppression.
@@ -508,10 +509,11 @@ Manual regression checklist for this slice:
 9. Confirm monitored endpoint nodes show state, 24-hour uptime, and last RTT.
 10. Confirm custom diagram nodes show diagram-only presentation and do not show fake live endpoint data.
 11. Wait for the polling interval and confirm live data refresh timestamp and summary counts update without reloading the page.
-12. Click a monitored node and confirm the details panel is read-only and includes endpoint/assignment status data.
-13. Click a visual link and confirm the details panel is read-only and states that the link is visual documentation only.
-14. Test the viewer details pane in dark mode and light mode.
-15. Confirm admin users can navigate to Edit from the viewer.
-16. Confirm non-admin users cannot access the edit/save/delete/export routes and do not receive endpoint details they cannot access.
-17. Disable `NetworkDiagramsEnabled` and confirm viewer and live-data API access are blocked.
-18. Confirm no endpoint, dependency, state-evaluation, alert, agent, or startup-gate behaviour changed.
+12. Temporarily block or break the live overlay fetch if practical and confirm the summary shows a stale/error message rather than returning to `Loading diagram summary`.
+13. Click a monitored node and confirm the details panel is read-only and includes endpoint/assignment status data.
+14. Click a visual link and confirm the details panel is read-only and states that the link is visual documentation only.
+15. Test the viewer details pane in dark mode and light mode.
+16. Confirm admin users can navigate to Edit from the viewer.
+17. Confirm non-admin users cannot access the edit/save/delete/export routes and do not receive endpoint details they cannot access.
+18. Disable `NetworkDiagramsEnabled` and confirm viewer and live-data API access are blocked.
+19. Confirm no endpoint, dependency, state-evaluation, alert, agent, or startup-gate behaviour changed.

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -567,6 +567,14 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("Visual links", script);
         Assert.Contains("Live overlay refresh", script);
         Assert.Contains("Up: 0, Degraded: 0, Down: 0, Suppressed: 0, Unknown: 0", script);
+        Assert.Contains("Live overlay data is pending. Saved diagram summary is available.", script);
+        Assert.Contains("Live overlay data is currently unavailable. Showing saved diagram only.", script);
+        Assert.Contains("No visible live overlay data is available for monitored endpoint nodes.", script);
+        Assert.Contains("No affected endpoints.", script);
+        Assert.Contains("Array.isArray(data?.nodes) ? data.nodes : []", script);
+        Assert.Contains("assignments: Array.isArray(node.assignments) ? node.assignments : []", script);
+        Assert.Contains("state.liveOverlayAttempted = true", script);
+        Assert.Contains("state.liveOverlayStale = true", script);
         Assert.Contains("Down endpoints", script);
         Assert.Contains("Degraded endpoints", script);
         Assert.Contains("Suppressed endpoints", script);

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
@@ -40,6 +40,8 @@
         virtualCanvasWidth: 4000,
         virtualCanvasHeight: 2828,
         liveOverlayRefreshedAtUtc: null,
+        liveOverlayAttempted: false,
+        liveOverlayStale: false,
         summaryMessage: ''
     };
     let panState = null;
@@ -251,14 +253,25 @@
     }
 
     function setEmptyState() { emptyState.hidden = state.nodes.length > 0; }
-    function formatRtt(value) { return value == null ? '—' : `${Number(value).toFixed(1)} ms`; }
-    function formatDate(value) { return value ? new Date(value).toLocaleString() : '—'; }
+    function formatRtt(value) {
+        if (value == null || value === '') { return '—'; }
+        const numericValue = Number(value);
+        return Number.isFinite(numericValue) ? `${numericValue.toFixed(1)} ms` : '—';
+    }
+    function formatDate(value) {
+        if (!value) { return '—'; }
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? '—' : date.toLocaleString();
+    }
     function stateLabel(value) { return value || 'Unknown'; }
     function normalizeSummaryState(value) {
-        const label = stateLabel(value);
-        return Object.prototype.hasOwnProperty.call(statePriority, label) ? label : 'Unknown';
+        const requested = String(stateLabel(value)).trim().toLowerCase();
+        return Object.keys(statePriority).find(key => key.toLowerCase() === requested) || 'Unknown';
     }
-    function formatRefreshTime() { return state.liveOverlayRefreshedAtUtc ? formatDate(state.liveOverlayRefreshedAtUtc) : 'Pending'; }
+    function formatRefreshTime() {
+        if (state.liveOverlayRefreshedAtUtc) { return state.liveOverlayStale ? `${formatDate(state.liveOverlayRefreshedAtUtc)} (stale)` : formatDate(state.liveOverlayRefreshedAtUtc); }
+        return state.liveOverlayAttempted ? 'Unavailable' : 'Pending';
+    }
 
     function getMonitoredNodes() { return state.nodes.filter(node => node.nodeKind === 'monitored-endpoint'); }
     function getOverlayForNode(node) { return state.overlayByNodeId.get(node.id); }
@@ -273,29 +286,56 @@
     }
 
     function buildAffectedSection(title, nodes) {
-        if (nodes.length === 0) {
+        const safeNodes = Array.isArray(nodes) ? nodes : [];
+        if (safeNodes.length === 0) {
             return `<section class="diagram-summary-section"><h3>${escapeHtml(title)}</h3><p class="diagram-summary-none">None</p></section>`;
         }
 
-        return `<section class="diagram-summary-section"><h3>${escapeHtml(title)}</h3><ul class="diagram-summary-endpoint-list">${nodes.map(buildSummaryEndpointItem).join('')}</ul></section>`;
+        return `<section class="diagram-summary-section"><h3>${escapeHtml(title)}</h3><ul class="diagram-summary-endpoint-list">${safeNodes.map(buildSummaryEndpointItem).join('')}</ul></section>`;
+    }
+
+    function buildSummaryMessage(monitoredNodes, affectedNodes) {
+        if (state.summaryMessage) { return state.summaryMessage; }
+        if (state.liveOverlayStale) { return state.overlayByNodeId.size > 0 ? 'Live overlay data is currently unavailable. Showing last known live overlay.' : 'Live overlay data is currently unavailable. Showing saved diagram only.'; }
+        if (monitoredNodes.length === 0) { return 'This diagram has no monitored endpoint nodes. Showing saved diagram only.'; }
+        if (!state.liveOverlayAttempted) { return 'Live overlay data is pending. Saved diagram summary is available.'; }
+        if (state.overlayByNodeId.size === 0) { return 'No visible live overlay data is available for monitored endpoint nodes.'; }
+        if (affectedNodes.length === 0) { return 'No affected endpoints.'; }
+        return '';
     }
 
     function buildDiagramSummaryHtml() {
-        const monitoredNodes = getMonitoredNodes();
-        const customNodeCount = state.nodes.length - monitoredNodes.length;
-        const counts = { Up: 0, Degraded: 0, Down: 0, Suppressed: 0, Unknown: 0 };
-        monitoredNodes.forEach(node => { counts[getSummaryStateForNode(node)] += 1; });
+        try {
+            const monitoredNodes = getMonitoredNodes();
+            const customNodeCount = Math.max(state.nodes.length - monitoredNodes.length, 0);
+            const counts = { Up: 0, Degraded: 0, Down: 0, Suppressed: 0, Unknown: 0 };
+            monitoredNodes.forEach(node => {
+                const summaryState = getSummaryStateForNode(node);
+                counts[summaryState] = (counts[summaryState] || 0) + 1;
+            });
 
-        const nodesByState = stateName => monitoredNodes
-            .filter(node => getSummaryStateForNode(node) === stateName)
-            .sort((a, b) => String(getOverlayForNode(a)?.endpointName || a.label).localeCompare(String(getOverlayForNode(b)?.endpointName || b.label)));
+            const nodesByState = stateName => monitoredNodes
+                .filter(node => getSummaryStateForNode(node) === stateName)
+                .sort((a, b) => String(getOverlayForNode(a)?.endpointName || a.label).localeCompare(String(getOverlayForNode(b)?.endpointName || b.label)));
 
-        const highestRttNodes = monitoredNodes
-            .filter(node => getOverlayForNode(node)?.lastRttMs != null)
-            .sort((a, b) => Number(getOverlayForNode(b).lastRttMs) - Number(getOverlayForNode(a).lastRttMs))
-            .slice(0, 5);
+            const downNodes = nodesByState('Down');
+            const degradedNodes = nodesByState('Degraded');
+            const suppressedNodes = nodesByState('Suppressed');
+            const unknownNodes = nodesByState('Unknown');
+            const affectedNodes = [...downNodes, ...degradedNodes, ...suppressedNodes, ...unknownNodes];
+            const highestRttNodes = monitoredNodes
+                .filter(node => {
+                    const rtt = getOverlayForNode(node)?.lastRttMs;
+                    return rtt != null && rtt !== '' && Number.isFinite(Number(rtt));
+                })
+                .sort((a, b) => Number(getOverlayForNode(b).lastRttMs) - Number(getOverlayForNode(a).lastRttMs))
+                .slice(0, 5);
+            const message = buildSummaryMessage(monitoredNodes, affectedNodes);
 
-        return `<div class="diagram-summary-panel"><p class="toolbox-help">Viewer overlays existing monitoring status only. Visual links remain documentation-only.</p>${state.summaryMessage ? `<p class="diagram-summary-message" role="status">${escapeHtml(state.summaryMessage)}</p>` : ''}<div class="diagram-summary-stat-grid"><div><span>Total nodes</span><strong>${state.nodes.length}</strong></div><div><span>Monitored</span><strong>${monitoredNodes.length}</strong></div><div><span>Diagram-only</span><strong>${customNodeCount}</strong></div><div><span>Visual links</span><strong>${state.links.length}</strong></div></div><dl class="diagram-property-summary diagram-summary-refresh"><div><dt>Live overlay refresh</dt><dd>${escapeHtml(formatRefreshTime())}</dd></div></dl><div class="diagram-summary-state-grid">${Object.keys(counts).map(key => `<div data-summary-state="${key.toLowerCase()}"><span>${escapeHtml(key)}</span><strong>${counts[key]}</strong></div>`).join('')}</div>${buildAffectedSection('Down endpoints', nodesByState('Down'))}${buildAffectedSection('Degraded endpoints', nodesByState('Degraded'))}${buildAffectedSection('Suppressed endpoints', nodesByState('Suppressed'))}${buildAffectedSection('Unknown endpoints', nodesByState('Unknown'))}${highestRttNodes.length > 0 ? `<section class="diagram-summary-section"><h3>Highest RTT</h3><ul class="diagram-summary-endpoint-list">${highestRttNodes.map(buildSummaryEndpointItem).join('')}</ul></section>` : ''}</div>`;
+            return `<div class="diagram-summary-panel"><p class="toolbox-help">Viewer overlays existing monitoring status only. Visual links remain documentation-only.</p>${message ? `<p class="diagram-summary-message" role="status">${escapeHtml(message)}</p>` : ''}<div class="diagram-summary-stat-grid"><div><span>Total nodes</span><strong>${state.nodes.length}</strong></div><div><span>Monitored</span><strong>${monitoredNodes.length}</strong></div><div><span>Diagram-only</span><strong>${customNodeCount}</strong></div><div><span>Visual links</span><strong>${state.links.length}</strong></div></div><dl class="diagram-property-summary diagram-summary-refresh"><div><dt>Live overlay refresh</dt><dd>${escapeHtml(formatRefreshTime())}</dd></div></dl><div class="diagram-summary-state-grid">${Object.keys(counts).map(key => `<div data-summary-state="${key.toLowerCase()}"><span>${escapeHtml(key)}</span><strong>${counts[key]}</strong></div>`).join('')}</div>${buildAffectedSection('Down endpoints', downNodes)}${buildAffectedSection('Degraded endpoints', degradedNodes)}${buildAffectedSection('Suppressed endpoints', suppressedNodes)}${buildAffectedSection('Unknown endpoints', unknownNodes)}${highestRttNodes.length > 0 ? `<section class="diagram-summary-section"><h3>Highest RTT</h3><ul class="diagram-summary-endpoint-list">${highestRttNodes.map(buildSummaryEndpointItem).join('')}</ul></section>` : ''}</div>`;
+        } catch (error) {
+            return '<div class="diagram-summary-panel"><p class="diagram-summary-message" role="alert">Diagram summary is unavailable. Showing saved diagram only.</p><p class="toolbox-help">Viewer overlays existing monitoring status only. Visual links remain documentation-only.</p></div>';
+        }
     }
 
     function applyOverlay() {
@@ -303,7 +343,7 @@
             if (node.nodeKind !== 'monitored-endpoint') { return; }
             const overlay = state.overlayByNodeId.get(node.id);
             const stateValue = overlay?.summaryStateLabel || 'Unknown';
-            node.element.dataset.liveState = stateValue.toLowerCase();
+            node.element.dataset.liveState = String(stateValue).toLowerCase();
             const stateElement = node.element.querySelector('[data-live-state]');
             const metricsElement = node.element.querySelector('[data-live-metrics]');
             if (stateElement) { stateElement.textContent = `State: ${stateLabel(stateValue)}`; }
@@ -313,19 +353,31 @@
     }
 
     async function refreshLiveData() {
-        if (!liveDataUrl) { return; }
+        if (!liveDataUrl) {
+            state.liveOverlayAttempted = true;
+            state.liveOverlayStale = true;
+            applyOverlay();
+            return;
+        }
         try {
             const response = await fetch(liveDataUrl, { headers: { Accept: 'application/json' } });
             if (!response.ok) { throw new Error(`HTTP ${response.status}`); }
             const data = await response.json();
-            state.overlayByNodeId = new Map((data.nodes || []).map(node => [node.nodeId, node]));
-            state.liveOverlayRefreshedAtUtc = data.refreshedAtUtc || new Date().toISOString();
+            const overlayNodes = Array.isArray(data?.nodes) ? data.nodes : [];
+            state.overlayByNodeId = new Map(overlayNodes.filter(node => node?.nodeId).map(node => [node.nodeId, { ...node, assignments: Array.isArray(node.assignments) ? node.assignments : [] }]));
+            state.liveOverlayRefreshedAtUtc = data?.refreshedAtUtc || new Date().toISOString();
+            state.liveOverlayAttempted = true;
+            state.liveOverlayStale = false;
+            state.summaryMessage = '';
             applyOverlay();
             if (refreshStatus) {
                 refreshStatus.dataset.error = 'false';
-                refreshStatus.textContent = `Live overlay refreshed ${new Date(data.refreshedAtUtc || Date.now()).toLocaleTimeString()} • polling every 20s`;
+                refreshStatus.textContent = `Live overlay refreshed ${new Date(data?.refreshedAtUtc || Date.now()).toLocaleTimeString()} • polling every 20s`;
             }
         } catch (error) {
+            state.liveOverlayAttempted = true;
+            state.liveOverlayStale = true;
+            applyOverlay();
             if (refreshStatus) {
                 refreshStatus.dataset.error = 'true';
                 refreshStatus.textContent = 'Live overlay stale; refresh failed.';


### PR DESCRIPTION
### Motivation
- The read-only Network Diagram viewer could remain stuck on the Razor placeholder "Loading diagram summary…" because the client-side summary renderer did not track first-load/failed/stale overlay states or defensively handle missing/malformed live-overlay data.
- The change ensures the no-selection details pane renders a saved-diagram summary immediately and updates deterministically after the first live overlay response and on subsequent polls while preserving the viewer's read-only, server-state-only boundary.

### Description
- Track overlay lifecycle with new state fields `liveOverlayAttempted` and `liveOverlayStale` and use them to decide summary messaging and refresh-time display.
- Harden live overlay handling in `refreshLiveData()` by normalizing `data.nodes` and `node.assignments`, guarding against missing/invalid RTT and date values, and ensuring `overlayByNodeId` is always a safe map.
- Replace fragile summary rendering with defensive helpers: `formatRtt`, `formatDate`, `normalizeSummaryState`, `buildSummaryMessage`, and a try/catch-backed `buildDiagramSummaryHtml` that renders one of: loaded summary, empty/stale message, or an explicit error message instead of a perpetual loading state.
- Ensure `applyOverlay()` calls `updateDetails()` so node UI and the no-selection summary are re-rendered after overlay updates; mark summary stale on fetch failure and keep previous overlay data visible.
- Add a no-live-data fallback path when `data-live-data-url` is not provided so the pane shows an appropriate stale/unavailable message instead of remaining in loading state.
- Update tests (`NetworkDiagramsFeatureTests`) to assert presence of the summary container, defensive overlay handling, and new summary messages/flags; update docs (`docs/...`) and design notes to document the summary lifecycle and add a manual regression checklist item for blocking the live overlay.

### Testing
- Ran `node --check src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js` to validate JS syntax; check passed.
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj --no-restore`; build succeeded.
- Ran server tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj --no-restore`; all tests passed (137 tests, 0 failures).
- Performed packaging smoke `pwsh -NoLogo -NoProfile -File scripts/build-dev.ps1 -Runtime linux-x64`; dev package completed successfully.
- Rendered a headless page screenshot exercising the viewer harness with Playwright; screenshot was produced at `/tmp/network-diagram-summary.png` (used for visual verification, not committed).
- All automated checks run in this rollout completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a202adae930832ab4fc3a2b23bbd797)