### PR TITLE
Improve network diagram viewer summary pane

### DIFF
--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -361,6 +361,9 @@ This slice adds a read-only Network Diagram viewer for operational display while
 
 Live endpoint overlay behaviour:
 
+- When no node or link is selected, the read-only viewer details pane shows a diagram-wide live summary instead of generic help text. The summary includes total diagram nodes, monitored endpoint nodes, diagram-only/custom nodes, visual links, the live overlay refresh time, and monitored-node counts for Up, Degraded, Down, Suppressed, and Unknown.
+- Diagram summary counts and affected endpoint lists are based on the existing live overlay response and its server-calculated monitoring state labels. The viewer does not derive endpoint state from raw check results.
+- Affected endpoint lists for Down, Degraded, Suppressed, and Unknown states are compact dashboard aids. Clicking an endpoint in those lists centres/zooms the read-only canvas to the corresponding diagram node and opens the normal read-only node details.
 - Monitored endpoint nodes display existing server-calculated monitoring data: summary state, 24-hour uptime, and last RTT.
 - The viewer does not calculate endpoint state, dependency suppression, degraded state, uptime windows, or alerting decisions independently.
 - Endpoint state remains assignment-scoped. When a diagram node references an endpoint with multiple assignments, the viewer uses a UI-only urgency summary: Down, Unknown, Suppressed, Degraded, then Up.
@@ -380,3 +383,21 @@ Safety boundary:
 - The viewer does not create, update, or delete endpoints.
 - The viewer does not create, update, or delete monitoring dependencies.
 - The viewer does not change endpoint monitoring, state evaluation, dependency suppression, alerting, agents, startup-gate behaviour, topology inference, or SNMP behaviour.
+
+### Manual Regression Checklist - Viewer Summary Pane
+
+1. Enable `NetworkDiagramsEnabled`.
+2. Open a saved diagram in the read-only viewer.
+3. Confirm no item is selected by default.
+4. Confirm the right pane shows the diagram live summary, not generic help text.
+5. Confirm total nodes, monitored nodes, diagram-only nodes, and visual links are shown.
+6. Confirm Up, Down, Degraded, Suppressed, and Unknown counts are shown.
+7. Confirm affected endpoint lists appear when endpoints are not healthy.
+8. Click an endpoint in an affected list.
+9. Confirm the viewer centres/zooms to that endpoint.
+10. Confirm the endpoint becomes selected and read-only node details are shown.
+11. Clear selection by panning/clicking empty canvas and confirm the summary returns.
+12. Click a visual link and confirm read-only link details still work.
+13. Wait for live overlay refresh and confirm summary counts update without resetting the selected node or link.
+14. Test in dark mode and light mode.
+15. Confirm no monitoring, dependency, alerting, agent, or Startup Gate behaviour changed.

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -547,6 +547,39 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("State: ${stateLabel(stateValue)}", script);
         Assert.Contains("24h:", script);
         Assert.Contains("RTT:", script);
+        Assert.Contains("data-summary-panel", viewMarkup);
+        Assert.Contains("renderSummaryPanel", script);
+        Assert.Contains("Diagram live summary", script);
+        Assert.Contains("Total nodes", script);
+        Assert.Contains("Monitored", script);
+        Assert.Contains("Diagram-only", script);
+        Assert.Contains("Visual links", script);
+        Assert.Contains("['Up', stateCounts.Up]", script);
+        Assert.Contains("['Degraded', stateCounts.Degraded]", script);
+        Assert.Contains("['Down', stateCounts.Down]", script);
+        Assert.Contains("['Suppressed', stateCounts.Suppressed]", script);
+        Assert.Contains("['Unknown', stateCounts.Unknown]", script);
+        Assert.Contains("Down endpoints", script);
+        Assert.Contains("Degraded endpoints", script);
+        Assert.Contains("Suppressed endpoints", script);
+        Assert.Contains("Unknown endpoints", script);
+        Assert.Contains("Highest RTT", script);
+        Assert.Contains("centreOnNode", script);
+        Assert.Contains("data-summary-node-id", script);
+        Assert.Contains("selectNode(node.id)", script);
+        Assert.Contains("Viewer overlays existing monitoring status only. Visual links remain documentation-only.", script);
+    }
+
+    [Fact]
+    public void NetworkDiagramViewer_DocumentsSummaryPaneRegressionChecklist()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var documentation = File.ReadAllText(Path.Combine(repoRoot, "docs", "network-diagrams-v0.1.1.md"));
+
+        Assert.Contains("diagram-wide live summary", documentation);
+        Assert.Contains("server-calculated monitoring state labels", documentation);
+        Assert.Contains("centres/zooms", documentation);
+        Assert.Contains("Manual Regression Checklist - Viewer Summary Pane", documentation);
     }
 
     [Fact]

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
@@ -63,9 +63,8 @@
 
             <aside class="diagram-properties diagram-viewer-details" aria-label="Read-only diagram details">
                 <h2>Details</h2>
-                <div data-no-selection-panel>
-                    <p>Select a monitored endpoint node or visual link to view read-only details.</p>
-                    <p class="toolbox-help">The viewer does not edit diagrams, endpoints, monitoring dependencies, alerts, or agents.</p>
+                <div class="diagram-summary-panel" data-no-selection-panel data-summary-panel>
+                    <p class="toolbox-help">Loading diagram summary…</p>
                 </div>
                 <div class="diagram-viewer-detail-card" data-node-detail hidden></div>
                 <div class="diagram-viewer-detail-card" data-link-detail hidden></div>

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -1139,3 +1139,128 @@ html[data-theme="dark"] .diagram-link-port-label {
         grid-template-rows: minmax(60vh, 1fr) auto;
     }
 }
+
+.diagram-summary-panel {
+    display: grid;
+    gap: .75rem;
+    min-height: 0;
+}
+
+.diagram-summary-header {
+    display: grid;
+    gap: .2rem;
+}
+
+.diagram-summary-header h3 {
+    margin: 0;
+    font-size: .95rem;
+}
+
+.diagram-summary-header span,
+.diagram-summary-message,
+.diagram-summary-none {
+    color: var(--diagram-muted);
+    font-size: .78rem;
+    font-weight: 700;
+}
+
+.diagram-summary-count-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: .45rem;
+}
+
+.diagram-summary-count {
+    display: grid;
+    gap: .15rem;
+    padding: .55rem;
+    border: 1px solid var(--diagram-border);
+    border-radius: 10px;
+    background: var(--diagram-panel);
+}
+
+.diagram-summary-count span {
+    color: var(--diagram-muted);
+    font-size: .72rem;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.diagram-summary-count strong {
+    color: var(--diagram-text);
+    font-size: 1.05rem;
+}
+
+.diagram-summary-sections {
+    display: grid;
+    gap: .65rem;
+    max-height: min(48vh, 520px);
+    overflow: auto;
+    padding-right: .15rem;
+}
+
+.diagram-summary-section {
+    display: grid;
+    gap: .35rem;
+}
+
+.diagram-summary-section h3 {
+    margin: 0;
+    font-size: .85rem;
+}
+
+.diagram-summary-endpoint-list {
+    display: grid;
+    gap: .35rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.diagram-summary-endpoint {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .5rem;
+    width: 100%;
+    min-height: 44px;
+    border: 1px solid var(--diagram-border);
+    border-radius: 10px;
+    background: var(--diagram-panel);
+    color: var(--diagram-text);
+    cursor: pointer;
+    font: inherit;
+    padding: .5rem .6rem;
+    text-align: left;
+}
+
+.diagram-summary-endpoint:hover,
+.diagram-summary-endpoint:focus-visible {
+    border-color: var(--diagram-accent);
+    box-shadow: 0 0 0 3px var(--diagram-accent-soft);
+    outline: none;
+}
+
+.diagram-summary-endpoint-main {
+    display: grid;
+    gap: .15rem;
+    min-width: 0;
+}
+
+.diagram-summary-endpoint-main strong,
+.diagram-summary-endpoint-main span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.diagram-summary-endpoint-main span,
+.diagram-summary-endpoint-meta {
+    color: var(--diagram-muted);
+    font-size: .76rem;
+    font-weight: 700;
+}
+
+.diagram-summary-endpoint-meta {
+    flex: 0 0 auto;
+}

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
@@ -32,6 +32,8 @@
         nodes: [],
         links: [],
         overlayByNodeId: new Map(),
+        lastOverlayRefreshUtc: null,
+        summaryMessage: '',
         selectedNodeId: null,
         selectedLinkId: null,
         zoom: 1,
@@ -252,6 +254,77 @@
     function formatRtt(value) { return value == null ? '—' : `${Number(value).toFixed(1)} ms`; }
     function formatDate(value) { return value ? new Date(value).toLocaleString() : '—'; }
     function stateLabel(value) { return value || 'Unknown'; }
+    function normalizeSummaryState(value) {
+        const text = String(value || 'Unknown').trim().toLowerCase();
+        if (text === 'up') { return 'Up'; }
+        if (text === 'degraded') { return 'Degraded'; }
+        if (text === 'down') { return 'Down'; }
+        if (text === 'suppressed') { return 'Suppressed'; }
+        return 'Unknown';
+    }
+
+    function getNodeSummaryState(node) {
+        if (node.nodeKind !== 'monitored-endpoint') { return null; }
+        return normalizeSummaryState(state.overlayByNodeId.get(node.id)?.summaryStateLabel);
+    }
+
+    function formatAssignmentSummary(overlay) {
+        const count = Array.isArray(overlay?.assignments) ? overlay.assignments.length : 0;
+        if (count === 0) { return ''; }
+        return `${count} assignment${count === 1 ? '' : 's'}`;
+    }
+
+    function buildEndpointSummaryItem(node, overlay, summaryState) {
+        const label = overlay?.endpointName || node.label;
+        const uptime = overlay?.uptimeDisplay || '—';
+        const assignmentSummary = formatAssignmentSummary(overlay);
+        return `<li><button type="button" class="diagram-summary-endpoint" data-summary-node-id="${escapeHtml(node.id)}"><span class="diagram-summary-endpoint-main"><strong>${escapeHtml(label)}</strong><span>${escapeHtml(summaryState)} • RTT ${escapeHtml(formatRtt(overlay?.lastRttMs))} • 24h ${escapeHtml(uptime)}</span></span>${assignmentSummary ? `<span class="diagram-summary-endpoint-meta">${escapeHtml(assignmentSummary)}</span>` : ''}</button></li>`;
+    }
+
+    function renderAffectedSection(title, entries) {
+        const body = entries.length > 0
+            ? `<ul class="diagram-summary-endpoint-list">${entries.join('')}</ul>`
+            : '<p class="diagram-summary-none">None</p>';
+        return `<section class="diagram-summary-section"><h3>${escapeHtml(title)}</h3>${body}</section>`;
+    }
+
+    function renderSummaryPanel() {
+        if (!noSelectionPanel) { return; }
+        const monitoredNodes = state.nodes.filter(node => node.nodeKind === 'monitored-endpoint');
+        const customNodes = state.nodes.filter(node => node.nodeKind !== 'monitored-endpoint');
+        const stateCounts = { Up: 0, Degraded: 0, Down: 0, Suppressed: 0, Unknown: 0 };
+        const affected = { Down: [], Degraded: [], Suppressed: [], Unknown: [] };
+        const highestRtt = [];
+
+        monitoredNodes.forEach(node => {
+            const overlay = state.overlayByNodeId.get(node.id);
+            const summaryState = getNodeSummaryState(node);
+            stateCounts[summaryState] = (stateCounts[summaryState] || 0) + 1;
+            if (affected[summaryState]) {
+                affected[summaryState].push(buildEndpointSummaryItem(node, overlay, summaryState));
+            }
+            if (overlay?.lastRttMs != null && Number.isFinite(Number(overlay.lastRttMs))) {
+                highestRtt.push({ node, overlay, lastRttMs: Number(overlay.lastRttMs) });
+            }
+        });
+
+        highestRtt.sort((a, b) => b.lastRttMs - a.lastRttMs);
+        const highestRttItems = highestRtt.slice(0, 5).map(item => buildEndpointSummaryItem(item.node, item.overlay, getNodeSummaryState(item.node)));
+        const refreshedAt = state.lastOverlayRefreshUtc ? formatDate(state.lastOverlayRefreshUtc) : 'Pending';
+        const countCards = [
+            ['Total nodes', state.nodes.length],
+            ['Monitored', monitoredNodes.length],
+            ['Diagram-only', customNodes.length],
+            ['Visual links', state.links.length],
+            ['Up', stateCounts.Up],
+            ['Degraded', stateCounts.Degraded],
+            ['Down', stateCounts.Down],
+            ['Suppressed', stateCounts.Suppressed],
+            ['Unknown', stateCounts.Unknown]
+        ].map(([label, value]) => `<div class="diagram-summary-count"><span>${escapeHtml(label)}</span><strong>${escapeHtml(value)}</strong></div>`).join('');
+
+        noSelectionPanel.innerHTML = `<div class="diagram-summary-header"><h3>Diagram live summary</h3><span>Live overlay refresh: ${escapeHtml(refreshedAt)}</span></div><div class="diagram-summary-count-grid">${countCards}</div>${state.summaryMessage ? `<p class="diagram-summary-message" role="status">${escapeHtml(state.summaryMessage)}</p>` : '<p class="diagram-summary-message" data-summary-action-status></p>'}<div class="diagram-summary-sections">${renderAffectedSection('Down endpoints', affected.Down)}${renderAffectedSection('Degraded endpoints', affected.Degraded)}${renderAffectedSection('Suppressed endpoints', affected.Suppressed)}${renderAffectedSection('Unknown endpoints', affected.Unknown)}${highestRttItems.length > 0 ? renderAffectedSection('Highest RTT', highestRttItems) : ''}</div><p class="toolbox-help">Viewer overlays existing monitoring status only. Visual links remain documentation-only.</p>`;
+    }
 
     function applyOverlay() {
         state.nodes.forEach(node => {
@@ -267,6 +340,43 @@
         updateDetails();
     }
 
+    function clampPanForView() {
+        const rect = canvas.getBoundingClientRect();
+        const margin = 120;
+        const scaledWidth = state.virtualCanvasWidth * state.zoom;
+        const scaledHeight = state.virtualCanvasHeight * state.zoom;
+        if (scaledWidth <= rect.width) {
+            state.panX = (rect.width - scaledWidth) / 2;
+        } else {
+            state.panX = Math.min(margin, Math.max(rect.width - scaledWidth - margin, state.panX));
+        }
+        if (scaledHeight <= rect.height) {
+            state.panY = (rect.height - scaledHeight) / 2;
+        } else {
+            state.panY = Math.min(margin, Math.max(rect.height - scaledHeight - margin, state.panY));
+        }
+    }
+
+    function centreOnNode(nodeId, preferredZoom = 1) {
+        const node = findNodeById(nodeId);
+        if (!node) {
+            state.summaryMessage = 'That endpoint is no longer available on this diagram.';
+            renderSummaryPanel();
+            return false;
+        }
+        const rect = canvas.getBoundingClientRect();
+        const center = getNodeCenter(node);
+        state.zoom = Math.min(Math.max(Math.max(preferredZoom, 0.75), minZoom), maxZoom);
+        state.panX = rect.width / 2 - center.x * state.zoom;
+        state.panY = rect.height / 2 - center.y * state.zoom;
+        clampPanForView();
+        updateCanvasSize();
+        selectNode(node.id);
+        node.element.focus({ preventScroll: true });
+        state.summaryMessage = '';
+        return true;
+    }
+
     async function refreshLiveData() {
         if (!liveDataUrl) { return; }
         try {
@@ -274,6 +384,7 @@
             if (!response.ok) { throw new Error(`HTTP ${response.status}`); }
             const data = await response.json();
             state.overlayByNodeId = new Map((data.nodes || []).map(node => [node.nodeId, node]));
+            state.lastOverlayRefreshUtc = data.refreshedAtUtc || new Date().toISOString();
             applyOverlay();
             if (refreshStatus) {
                 refreshStatus.dataset.error = 'false';
@@ -300,6 +411,7 @@
         const selectedNode = state.selectedNodeId ? findNodeById(state.selectedNodeId) : null;
         const selectedLink = state.selectedLinkId ? findLinkById(state.selectedLinkId) : null;
         noSelectionPanel.hidden = Boolean(selectedNode || selectedLink);
+        if (!selectedNode && !selectedLink) { renderSummaryPanel(); }
         nodeDetail.hidden = !selectedNode;
         linkDetail.hidden = !selectedLink;
         if (selectedNode) {
@@ -375,6 +487,7 @@
         state.links = (diagram.links || []).map(link => ({ id: link.linkId, sourceNodeId: link.sourceNodeId, targetNodeId: link.targetNodeId, label: link.label || '', sourcePort: link.sourcePortLabel || '', targetPort: link.targetPortLabel || '', notes: link.notes || '', mediaType: normalizeMediaType(link.mediaType, link.linkType), linkType: normalizeLinkType(link.linkType), linkSpeedValue: link.linkSpeedValue, linkSpeedUnit: link.linkSpeedUnit, vlans: normalizeVlans(link.vlans) }));
         setEmptyState();
         updateCanvasSize();
+        updateDetails();
         await refreshLiveData();
         refreshTimer = window.setInterval(refreshLiveData, refreshIntervalMs);
     }
@@ -384,6 +497,12 @@
     viewer.querySelector('[data-reset-view]')?.addEventListener('click', resetView);
     viewer.querySelector('[data-fit-content]')?.addEventListener('click', fitContent);
     exportPdfButton?.addEventListener('click', () => { const base = exportPdfButton.dataset.exportPdfUrl; if (base) { window.location.href = `${base}?paper=${encodeURIComponent(exportPaperSelect?.value || 'A4')}`; } });
+    noSelectionPanel?.addEventListener('click', event => {
+        const target = event.target instanceof Element ? event.target : event.target?.parentElement;
+        const button = target?.closest('[data-summary-node-id]');
+        if (!button) { return; }
+        centreOnNode(button.dataset.summaryNodeId, 1);
+    });
     canvas.addEventListener('pointerdown', beginPan);
     canvas.addEventListener('pointermove', movePan);
     canvas.addEventListener('pointerup', endPan);


### PR DESCRIPTION
### Motivation
- Replace the generic no-selection help text in the read-only Network Diagram viewer with an actionable, live diagram summary so operators can see whole-diagram health at a glance.  Fixes #523.
- Use only server-provided live overlay data and preserve the existing architectural safety boundary so the viewer remains read-only and does not change monitoring, suppression, or alerts.

### Description
- Add a responsive summary panel UI and styles shown when no node or link is selected, rendering totals (nodes, monitored, diagram-only, links), live overlay refresh time, counts by summary state (Up, Degraded, Down, Suppressed, Unknown), affected endpoint lists, and a top-RTT section. (changed View.cshtml, network-diagrams.css)
- Render the summary from the already-fetched live overlay JSON, track `lastOverlayRefreshUtc`, and update the panel on each polling refresh without recalculating monitoring state. (changed network-diagrams-viewer.js)
- Add click-to-centre/zoom/select behaviour: `centreOnNode(nodeId, preferredZoom)` with pan/zoom clamping and focus selection; summary list items are clickable and open the normal node details or show a subtle not-found message if the node is absent. (changed network-diagrams-viewer.js)
- Update docs with the new summary behaviour and a Manual Regression Checklist, and add static test assertions to cover the presence of the summary panel and its wiring. (changed docs/network-diagrams-v0.1.1.md and NetworkDiagramsFeatureTests.cs)

### Testing
- Static JS check: `node --check src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js` succeeded. 
- Project build: `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` succeeded. 
- Unit tests: `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` ran and all tests passed. 
- Visual verification: a headless screenshot of the summary panel was captured via Playwright for local visual review; CSS and accessible focus states added and inspected manually.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2033507fa4832aa333055140e918f1)