### PR TITLE
Add native-scale network diagram image export (PNG/SVG) and ExportImage route; wire UI controls

### DIFF
--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -240,6 +240,32 @@ Manual regression checklist for this slice:
 9. Disable `NetworkDiagramsEnabled` and confirm the export route is blocked.
 10. Confirm no endpoint dependency, alerting, state-evaluation, or agent data is created or changed.
 
+## Native-scale image export slice
+
+This slice adds Network Diagram image export as documentation/output only. It does not change endpoint monitoring, dependency suppression, alerting, agents, topology discovery, SNMP, or monitoring dependencies.
+
+- PNG and SVG export are server-side, authenticated, admin-only through the Network Diagrams controller, and continue to respect `NetworkDiagramsEnabled`.
+- Image export renders the full last-saved diagram layout by default. Unsaved browser edits are not included until the diagram is saved.
+- PNG export uses the saved `CanvasWidth` and `CanvasHeight` as the native 1x pixel dimensions. For example, a saved `4000 × 2828` canvas exports as a `4000 × 2828` PNG at 1x and preserves the same canvas ratio at 2x or 0.5x.
+- SVG export uses `viewBox="0 0 {CanvasWidth} {CanvasHeight}"`, writes width/height from the saved canvas dimensions, and draws nodes and links in saved world coordinates.
+- Image export does not use the existing PDF page-fit scaling path and does not squash the diagram into A4/A3. Saved node positions, node sizes, link geometry, parallel-link offsets, media/link styling, link labels, VLAN summaries, and node labels are rendered from the native diagram layout.
+- Export options are intentionally small: PNG, SVG, and 0.5x/1x/2x scale. Light background is used from the current UI; dark/transparent backgrounds are validated server-side for later UI exposure.
+- Server-side validation rejects unsupported formats/backgrounds/scales and clamps excessive pixel dimensions before rendering.
+- SVG output is static markup only: user-provided labels/notes/VLAN text are escaped, scripts and external resources are not emitted, and safe font fallbacks are used.
+- PDF export is unchanged in this slice and still uses the older A4/A3 page-fit renderer. Follow-up work should refactor PDF export to embed or reuse the native export renderer so dense diagrams are not compressed by the PDF-specific layout.
+- Visual links remain documentation-only and do not create, update, or delete monitoring dependencies.
+
+Manual regression checklist for native image export:
+
+1. Open the saved Home diagram.
+2. Export PNG at 1x and confirm the image dimensions match the saved canvas, for example `4000 × 2828` when that is the saved canvas.
+3. Open the PNG at 100% and confirm relative scale matches the original diagram canvas rather than the compressed PDF layout.
+4. Confirm node positions, node sizes, link geometry, parallel links, VLAN/link/media labels, and node labels are present and readable.
+5. Export PNG at 2x and confirm the same layout is rendered at higher resolution.
+6. Export SVG and confirm a browser displays the same saved full-canvas layout.
+7. Disable `NetworkDiagramsEnabled` and confirm image export routes are blocked.
+8. Confirm no monitoring/dependency/agent behaviour changed.
+
 ## Link Styling, Labels, and Parallel Links Slice
 
 This slice enhances saved Network Diagram links while preserving the architectural boundary that links are documentation/status-overlay data only.

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -68,6 +68,7 @@ public sealed class NetworkDiagramsFeatureTests
             new FakeEndpointManagementQueryService(),
             new FakeNetworkDiagramService(),
             new FakeNetworkDiagramPdfExportService(),
+            new FakeNetworkDiagramImageExportService(),
             new FakeNetworkDiagramLiveOverlayService(),
             new FakeUserAccessScopeService());
 
@@ -93,6 +94,7 @@ public sealed class NetworkDiagramsFeatureTests
             }),
             new FakeNetworkDiagramService(new NetworkDiagram { DiagramId = "diagram-1", Name = "Core", UpdatedAtUtc = DateTimeOffset.UtcNow }),
             new FakeNetworkDiagramPdfExportService(),
+            new FakeNetworkDiagramImageExportService(),
             new FakeNetworkDiagramLiveOverlayService(),
             new FakeUserAccessScopeService());
 
@@ -183,6 +185,10 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("data-canvas-size-preset", viewMarkup);
         Assert.Contains("Small (4000 × 2828)", viewMarkup);
         Assert.Contains("data-export-pdf", viewMarkup);
+        Assert.Contains("data-export-png", viewMarkup);
+        Assert.Contains("data-export-svg", viewMarkup);
+        Assert.Contains("data-export-scale", viewMarkup);
+        Assert.Contains("Exports saved diagram layout", viewMarkup);
         Assert.Contains("A4 landscape", viewMarkup);
         Assert.Contains("A3 landscape", viewMarkup);
         Assert.Contains("Canvas cannot shrink", script);
@@ -461,10 +467,15 @@ public sealed class NetworkDiagramsFeatureTests
             .GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AuthorizeAttribute), inherit: true)
             .Cast<Microsoft.AspNetCore.Authorization.AuthorizeAttribute>()
             .Single();
+        var imageExportAuthorize = typeof(NetworkDiagramsController).GetMethod(nameof(NetworkDiagramsController.ExportImage))!
+            .GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AuthorizeAttribute), inherit: true)
+            .Cast<Microsoft.AspNetCore.Authorization.AuthorizeAttribute>()
+            .Single();
 
         Assert.Null(controllerAuthorize.Roles);
         Assert.Equal(ApplicationRoles.Admin, editAuthorize.Roles);
         Assert.Equal(ApplicationRoles.Admin, exportAuthorize.Roles);
+        Assert.Equal(ApplicationRoles.Admin, imageExportAuthorize.Roles);
     }
 
     [Fact]
@@ -475,6 +486,7 @@ public sealed class NetworkDiagramsFeatureTests
             new FakeEndpointManagementQueryService(),
             new FakeNetworkDiagramService(),
             new FakeNetworkDiagramPdfExportService(),
+            new FakeNetworkDiagramImageExportService(),
             new FakeNetworkDiagramLiveOverlayService(),
             new FakeUserAccessScopeService());
 
@@ -492,6 +504,7 @@ public sealed class NetworkDiagramsFeatureTests
             new FakeEndpointManagementQueryService(),
             new FakeNetworkDiagramService(),
             new FakeNetworkDiagramPdfExportService(),
+            new FakeNetworkDiagramImageExportService(),
             new FakeNetworkDiagramLiveOverlayService(),
             new FakeUserAccessScopeService());
 
@@ -517,6 +530,7 @@ public sealed class NetworkDiagramsFeatureTests
             new FakeEndpointManagementQueryService(),
             service,
             new FakeNetworkDiagramPdfExportService(),
+            new FakeNetworkDiagramImageExportService(),
             new FakeNetworkDiagramLiveOverlayService(),
             new FakeUserAccessScopeService());
 
@@ -526,6 +540,95 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Equal("application/pdf", file.ContentType);
         Assert.StartsWith("PingMonitor-NetworkDiagram-Core", file.FileDownloadName);
         Assert.StartsWith("%PDF", System.Text.Encoding.ASCII.GetString(file.FileContents));
+    }
+
+
+    [Fact]
+    public async Task NetworkDiagramsExportImage_ReturnsNotFound_WhenFeatureDisabled()
+    {
+        var controller = CreateNetworkDiagramController(
+            new FakeApplicationSettingsService(new ApplicationSettingsDto { NetworkDiagramsEnabled = false }),
+            new FakeNetworkDiagramService(),
+            new FakeNetworkDiagramImageExportService());
+
+        var result = await controller.ExportImage("diagram-1", "png", 1, "light", CancellationToken.None);
+
+        var notFound = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal("Network diagrams are not enabled.", notFound.Value);
+    }
+
+    [Fact]
+    public async Task NetworkDiagramsExportImage_ReturnsPngForExistingDiagram()
+    {
+        var service = new FakeNetworkDiagramService();
+        service.LoadResult = BuildExportTestDiagram();
+        var controller = CreateNetworkDiagramController(
+            new FakeApplicationSettingsService(new ApplicationSettingsDto { NetworkDiagramsEnabled = true }),
+            service,
+            new FakeNetworkDiagramImageExportService());
+
+        var result = await controller.ExportImage("diagram-1", "png", 1, "light", CancellationToken.None);
+
+        var file = Assert.IsType<FileContentResult>(result);
+        Assert.Equal("image/png", file.ContentType);
+        Assert.StartsWith("PingMonitor-NetworkDiagram-Core", file.FileDownloadName);
+        Assert.Equal("4000", controller.Response.Headers["X-Network-Diagram-Canvas-Width"]);
+        Assert.Equal("2828", controller.Response.Headers["X-Network-Diagram-Canvas-Height"]);
+    }
+
+    [Fact]
+    public void NetworkDiagramImageExport_ReturnsNativeSvgViewBoxAndNodeCoordinates()
+    {
+        var service = new NetworkDiagramImageExportService();
+        var diagram = BuildExportTestDiagram();
+
+        var export = service.Export(diagram, new NetworkDiagramImageExportOptions("svg", 1, "light", new DateTimeOffset(2026, 6, 1, 17, 0, 0, TimeSpan.Zero)));
+        var svg = System.Text.Encoding.UTF8.GetString(export.Content);
+
+        Assert.Equal("image/svg+xml; charset=utf-8", export.ContentType);
+        Assert.Contains(@"viewBox=""0 0 4000 2828""", svg);
+        Assert.Contains(@"width=""4000""", svg);
+        Assert.Contains(@"height=""2828""", svg);
+        Assert.Contains(@"transform=""translate(123 456)""", svg);
+        Assert.Contains("Users", svg, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(@"stroke-dasharray=""12 8""", svg);
+        Assert.DoesNotContain("841.89", svg);
+        Assert.DoesNotContain("595.28", svg);
+    }
+
+    [Fact]
+    public void NetworkDiagramImageExport_ReturnsNativePngDimensionsAndSignature()
+    {
+        var service = new NetworkDiagramImageExportService();
+        var diagram = BuildExportTestDiagram();
+
+        var export = service.Export(diagram, new NetworkDiagramImageExportOptions("png", 1, "light", new DateTimeOffset(2026, 6, 1, 17, 0, 0, TimeSpan.Zero)));
+
+        Assert.Equal("image/png", export.ContentType);
+        Assert.Equal(4000, export.PixelWidth);
+        Assert.Equal(2828, export.PixelHeight);
+        Assert.Equal([0x89, 0x50, 0x4e, 0x47], export.Content.Take(4).ToArray());
+    }
+
+    [Fact]
+    public void NetworkDiagramImageExport_ClampsExcessiveScaleDimensions()
+    {
+        var service = new NetworkDiagramImageExportService();
+        var source = BuildExportTestDiagram();
+        var diagram = new NetworkDiagramDto
+        {
+            DiagramId = source.DiagramId,
+            Name = source.Name,
+            CanvasWidth = 8000,
+            CanvasHeight = 5657,
+            Nodes = source.Nodes,
+            Links = source.Links
+        };
+
+        var ex = Assert.Throws<NetworkDiagramImageExportException>(() =>
+            service.Export(diagram, new NetworkDiagramImageExportOptions("png", 2, "light", DateTimeOffset.UtcNow)));
+
+        Assert.Contains("exceeds the safe limit", ex.Message);
     }
 
 
@@ -549,6 +652,10 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("RTT:", script);
         Assert.Contains("data-summary-panel", viewMarkup);
         Assert.Contains("renderSummaryPanel", script);
+        Assert.Contains("data-export-png", viewMarkup);
+        Assert.Contains("data-export-svg", viewMarkup);
+        Assert.Contains("data-export-scale", viewMarkup);
+        Assert.Contains("Exports saved diagram layout", viewMarkup);
         Assert.Contains("Diagram live summary", script);
         Assert.Contains("Total nodes", script);
         Assert.Contains("Monitored", script);
@@ -590,6 +697,7 @@ public sealed class NetworkDiagramsFeatureTests
             new FakeEndpointManagementQueryService(),
             new FakeNetworkDiagramService(new NetworkDiagram { DiagramId = "diagram-1", Name = "Core", UpdatedAtUtc = DateTimeOffset.UtcNow }),
             new FakeNetworkDiagramPdfExportService(),
+            new FakeNetworkDiagramImageExportService(),
             new FakeNetworkDiagramLiveOverlayService(),
             new FakeUserAccessScopeService(isAdmin: true));
         controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(new ClaimsIdentity("test")) } };
@@ -611,6 +719,7 @@ public sealed class NetworkDiagramsFeatureTests
             new FakeEndpointManagementQueryService(),
             new FakeNetworkDiagramService(new NetworkDiagram { DiagramId = "diagram-1", Name = "Core", UpdatedAtUtc = DateTimeOffset.UtcNow }),
             new FakeNetworkDiagramPdfExportService(),
+            new FakeNetworkDiagramImageExportService(),
             new FakeNetworkDiagramLiveOverlayService(),
             new FakeUserAccessScopeService());
 
@@ -636,6 +745,93 @@ public sealed class NetworkDiagramsFeatureTests
         }
 
         throw new InvalidOperationException("Could not locate repository root.");
+    }
+
+
+    private static NetworkDiagramsController CreateNetworkDiagramController(
+        IApplicationSettingsService settingsService,
+        INetworkDiagramService diagramService,
+        INetworkDiagramImageExportService imageExportService)
+    {
+        var controller = new NetworkDiagramsController(
+            settingsService,
+            new FakeEndpointManagementQueryService(),
+            diagramService,
+            new FakeNetworkDiagramPdfExportService(),
+            imageExportService,
+            new FakeNetworkDiagramLiveOverlayService(),
+            new FakeUserAccessScopeService());
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+        return controller;
+    }
+
+    private static NetworkDiagramDto BuildExportTestDiagram()
+    {
+        return new NetworkDiagramDto
+        {
+            DiagramId = "diagram-1",
+            Name = "Core",
+            CanvasWidth = 4000,
+            CanvasHeight = 2828,
+            Nodes =
+            [
+                new NetworkDiagramNodeDto
+                {
+                    NodeId = "node-a",
+                    NodeType = "CustomDevice",
+                    DisplayLabel = "Core switch with very long label",
+                    IconKey = "SW",
+                    X = 123,
+                    Y = 456,
+                    Width = 190,
+                    Height = 86,
+                    Notes = "aggregation"
+                },
+                new NetworkDiagramNodeDto
+                {
+                    NodeId = "node-b",
+                    NodeType = "MonitoredEndpoint",
+                    DisplayLabel = "Wireless bridge",
+                    IconKey = "AP",
+                    X = 620,
+                    Y = 700,
+                    Width = 190,
+                    Height = 86
+                }
+            ],
+            Links =
+            [
+                new NetworkDiagramLinkDto
+                {
+                    LinkId = "link-a",
+                    SourceNodeId = "node-a",
+                    TargetNodeId = "node-b",
+                    Label = "uplink",
+                    MediaType = NetworkDiagramLinkMediaTypes.Wireless,
+                    LinkType = NetworkDiagramLinkTypes.Trunk,
+                    SourcePortLabel = "Gi1/0/1",
+                    TargetPortLabel = "eth0",
+                    LinkSpeedValue = 1,
+                    LinkSpeedUnit = NetworkDiagramLinkSpeedUnits.Gbps,
+                    Vlans =
+                    [
+                        new NetworkDiagramLinkVlanDto { VlanId = 10, Name = "Users", Mode = NetworkDiagramVlanModes.Tagged, SortOrder = 0 }
+                    ]
+                },
+                new NetworkDiagramLinkDto
+                {
+                    LinkId = "link-b",
+                    SourceNodeId = "node-a",
+                    TargetNodeId = "node-b",
+                    Label = "parallel",
+                    MediaType = NetworkDiagramLinkMediaTypes.Fibre,
+                    LinkType = NetworkDiagramLinkTypes.Lacp
+                }
+            ]
+        };
     }
 
     private sealed class FakeEndpointManagementQueryService : IEndpointManagementQueryService
@@ -723,6 +919,13 @@ public sealed class NetworkDiagramsFeatureTests
         }
     }
 
+    private sealed class FakeNetworkDiagramImageExportService : INetworkDiagramImageExportService
+    {
+        public NetworkDiagramImageExportResult Export(NetworkDiagramDto diagram, NetworkDiagramImageExportOptions options)
+        {
+            return new NetworkDiagramImageExportResult([0x89, 0x50, 0x4e, 0x47], "image/png", $"PingMonitor-NetworkDiagram-{diagram.Name}-{options.ExportedAtUtc:yyyyMMdd-HHmm}.png", (int)(diagram.CanvasWidth * options.Scale), (int)(diagram.CanvasHeight * options.Scale));
+        }
+    }
 
     private sealed class FakeNetworkDiagramLiveOverlayService : INetworkDiagramLiveOverlayService
     {

--- a/src/WebApp/PingMonitor.Web/Controllers/NetworkDiagramsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/NetworkDiagramsController.cs
@@ -18,6 +18,7 @@ public sealed class NetworkDiagramsController : Controller
     private readonly IEndpointManagementQueryService _endpointManagementQueryService;
     private readonly INetworkDiagramService _networkDiagramService;
     private readonly INetworkDiagramPdfExportService _pdfExportService;
+    private readonly INetworkDiagramImageExportService _imageExportService;
     private readonly INetworkDiagramLiveOverlayService _liveOverlayService;
     private readonly IUserAccessScopeService _userAccessScopeService;
 
@@ -26,6 +27,7 @@ public sealed class NetworkDiagramsController : Controller
         IEndpointManagementQueryService endpointManagementQueryService,
         INetworkDiagramService networkDiagramService,
         INetworkDiagramPdfExportService pdfExportService,
+        INetworkDiagramImageExportService imageExportService,
         INetworkDiagramLiveOverlayService liveOverlayService,
         IUserAccessScopeService userAccessScopeService)
     {
@@ -33,6 +35,7 @@ public sealed class NetworkDiagramsController : Controller
         _endpointManagementQueryService = endpointManagementQueryService;
         _networkDiagramService = networkDiagramService;
         _pdfExportService = pdfExportService;
+        _imageExportService = imageExportService;
         _liveOverlayService = liveOverlayService;
         _userAccessScopeService = userAccessScopeService;
     }
@@ -119,6 +122,8 @@ public sealed class NetworkDiagramsController : Controller
             LiveDataUrl = Url?.Action(nameof(LiveData), new { diagramId = diagram.DiagramId }) ?? string.Empty,
             EditUrl = isAdmin ? Url?.Action(nameof(Edit), new { diagramId = diagram.DiagramId }) : null,
             ExportPdfUrl = isAdmin ? Url?.Action(nameof(ExportPdf), new { diagramId = diagram.DiagramId }) : null,
+            ExportPngUrl = isAdmin ? Url?.Action(nameof(ExportImage), new { diagramId = diagram.DiagramId, format = "png" }) : null,
+            ExportSvgUrl = isAdmin ? Url?.Action(nameof(ExportImage), new { diagramId = diagram.DiagramId, format = "svg" }) : null,
             IsAdmin = isAdmin
         });
     }
@@ -149,6 +154,8 @@ public sealed class NetworkDiagramsController : Controller
             LoadUrl = Url?.Action(nameof(Load), new { diagramId = diagram.DiagramId }) ?? string.Empty,
             SaveUrl = Url?.Action(nameof(Save), new { diagramId = diagram.DiagramId }) ?? string.Empty,
             ExportPdfUrl = Url?.Action(nameof(ExportPdf), new { diagramId = diagram.DiagramId }) ?? string.Empty,
+            ExportPngUrl = Url?.Action(nameof(ExportImage), new { diagramId = diagram.DiagramId, format = "png" }) ?? string.Empty,
+            ExportSvgUrl = Url?.Action(nameof(ExportImage), new { diagramId = diagram.DiagramId, format = "svg" }) ?? string.Empty,
             ViewerUrl = Url?.Action(nameof(ViewDiagram), new { diagramId = diagram.DiagramId }) ?? string.Empty,
             MonitoredEndpoints = BuildEndpointToolbox(endpoints.Rows)
         });
@@ -232,6 +239,43 @@ public sealed class NetworkDiagramsController : Controller
 
         var export = _pdfExportService.Export(diagram, new NetworkDiagramPdfExportOptions(paper, DateTimeOffset.UtcNow));
         return File(export.Content, export.ContentType, export.FileName);
+    }
+
+
+    [Authorize(Roles = ApplicationRoles.Admin)]
+    [HttpGet("{diagramId}/export/{format}")]
+    public async Task<IActionResult> ExportImage(
+        string diagramId,
+        string format,
+        [FromQuery] double scale = 1d,
+        [FromQuery] string background = "light",
+        CancellationToken cancellationToken = default)
+    {
+        if (!await NetworkDiagramsEnabledAsync(cancellationToken))
+        {
+            return NotFound("Network diagrams are not enabled.");
+        }
+
+        var diagram = await _networkDiagramService.LoadAsync(diagramId, cancellationToken);
+        if (diagram is null)
+        {
+            return NotFound("Network diagram was not found.");
+        }
+
+        try
+        {
+            var export = _imageExportService.Export(diagram, new NetworkDiagramImageExportOptions(format, scale, background, DateTimeOffset.UtcNow));
+            Response.Headers.ContentLength = export.Content.Length;
+            Response.Headers["X-Network-Diagram-Canvas-Width"] = diagram.CanvasWidth.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture);
+            Response.Headers["X-Network-Diagram-Canvas-Height"] = diagram.CanvasHeight.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture);
+            Response.Headers["X-Network-Diagram-Export-Pixel-Width"] = export.PixelWidth.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            Response.Headers["X-Network-Diagram-Export-Pixel-Height"] = export.PixelHeight.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            return File(export.Content, export.ContentType, export.FileName);
+        }
+        catch (NetworkDiagramImageExportException ex)
+        {
+            return BadRequest(ex.Message);
+        }
     }
 
     [Authorize(Roles = ApplicationRoles.Admin)]

--- a/src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj
+++ b/src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="10.0.1" />
     <PackageReference Include="MySqlConnector" Version="2.5.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -231,6 +231,7 @@ builder.Services.AddScoped<IEndpointCreationQueryService, EndpointCreationQueryS
 builder.Services.AddScoped<IEndpointManagementQueryService, EndpointManagementQueryService>();
 builder.Services.AddScoped<PingMonitor.Web.Services.NetworkDiagrams.INetworkDiagramService, PingMonitor.Web.Services.NetworkDiagrams.NetworkDiagramService>();
 builder.Services.AddScoped<PingMonitor.Web.Services.NetworkDiagrams.INetworkDiagramPdfExportService, PingMonitor.Web.Services.NetworkDiagrams.NetworkDiagramPdfExportService>();
+builder.Services.AddScoped<PingMonitor.Web.Services.NetworkDiagrams.INetworkDiagramImageExportService, PingMonitor.Web.Services.NetworkDiagrams.NetworkDiagramImageExportService>();
 builder.Services.AddScoped<PingMonitor.Web.Services.NetworkDiagrams.INetworkDiagramLiveOverlayService, PingMonitor.Web.Services.NetworkDiagrams.NetworkDiagramLiveOverlayService>();
 builder.Services.AddScoped<IEndpointManagementService, EndpointManagementService>();
 builder.Services.AddScoped<IEndpointPerformanceQueryService, EndpointPerformanceQueryService>();

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramImageExportService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramImageExportService.cs
@@ -1,0 +1,562 @@
+using System.Globalization;
+using System.Text;
+using SixLabors.Fonts;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace PingMonitor.Web.Services.NetworkDiagrams;
+
+public interface INetworkDiagramImageExportService
+{
+    NetworkDiagramImageExportResult Export(NetworkDiagramDto diagram, NetworkDiagramImageExportOptions options);
+}
+
+public sealed record NetworkDiagramImageExportOptions(string Format, double Scale, string Background, DateTimeOffset ExportedAtUtc);
+
+public sealed record NetworkDiagramImageExportResult(byte[] Content, string ContentType, string FileName, int PixelWidth, int PixelHeight);
+
+public sealed class NetworkDiagramImageExportException : Exception
+{
+    public NetworkDiagramImageExportException(string message) : base(message)
+    {
+    }
+}
+
+internal sealed class NetworkDiagramImageExportService : INetworkDiagramImageExportService
+{
+    private const int MaximumPixelDimension = 12000;
+    private const int MaximumTotalPixels = 48_000_000;
+    private const double ParallelLinkOffsetStep = 34d;
+    private const double NodePadding = 10d;
+    private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    public NetworkDiagramImageExportResult Export(NetworkDiagramDto diagram, NetworkDiagramImageExportOptions options)
+    {
+        var format = NormalizeFormat(options.Format);
+        var scale = NormalizeScale(options.Scale);
+        var background = NormalizeBackground(options.Background);
+        var layout = NetworkDiagramNativeExportLayout.Create(diagram);
+        var pixelWidth = CheckedPixelDimension(layout.CanvasWidth, scale, nameof(diagram.CanvasWidth));
+        var pixelHeight = CheckedPixelDimension(layout.CanvasHeight, scale, nameof(diagram.CanvasHeight));
+        ValidatePixelBudget(pixelWidth, pixelHeight);
+
+        var safeName = MakeSafeFileName(diagram.Name);
+        var extension = format.ToLowerInvariant();
+        var fileName = $"PingMonitor-NetworkDiagram-{safeName}-{options.ExportedAtUtc:yyyyMMdd-HHmm}.{extension}";
+
+        var svg = RenderSvg(layout, background, scale);
+        if (format == "SVG")
+        {
+            return new NetworkDiagramImageExportResult(Utf8NoBom.GetBytes(svg), "image/svg+xml; charset=utf-8", fileName, pixelWidth, pixelHeight);
+        }
+
+        var png = RenderPng(layout, background, pixelWidth, pixelHeight, scale);
+        return new NetworkDiagramImageExportResult(png, "image/png", fileName, pixelWidth, pixelHeight);
+    }
+
+    internal static string RenderSvg(NetworkDiagramNativeExportLayout layout, string background, double scale = 1d)
+    {
+        var backgroundStyle = ResolveBackground(background);
+        var width = Format(layout.CanvasWidth * scale);
+        var height = Format(layout.CanvasHeight * scale);
+        var svg = new StringBuilder();
+        svg.AppendLine($"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{width}\" height=\"{height}\" viewBox=\"0 0 {Format(layout.CanvasWidth)} {Format(layout.CanvasHeight)}\" role=\"img\" aria-label=\"{EscapeXml(layout.DiagramName)} network diagram\">");
+        svg.AppendLine("<defs><style><![CDATA[");
+        svg.AppendLine(".pm-node-label{font:700 14px Arial,Helvetica,sans-serif;fill:#101828}.pm-node-type{font:600 11px Arial,Helvetica,sans-serif;fill:#475467}.pm-node-notes{font:500 10px Arial,Helvetica,sans-serif;fill:#667085}.pm-link-label{font:800 12px Arial,Helvetica,sans-serif;fill:#101828;paint-order:stroke;stroke:#fff;stroke-width:4px;stroke-linejoin:round}.pm-link-label-dark{stroke:#111827;fill:#f9fafb}.pm-node-icon{font:800 13px Arial,Helvetica,sans-serif}.pm-footer{font:600 11px Arial,Helvetica,sans-serif;fill:#667085}");
+        svg.AppendLine("]]></style></defs>");
+        if (backgroundStyle.IsTransparent)
+        {
+            svg.AppendLine("<rect x=\"0\" y=\"0\" width=\"100%\" height=\"100%\" fill=\"none\"/>");
+        }
+        else
+        {
+            svg.AppendLine($"<rect x=\"0\" y=\"0\" width=\"{Format(layout.CanvasWidth)}\" height=\"{Format(layout.CanvasHeight)}\" fill=\"{backgroundStyle.CanvasFill}\"/>");
+        }
+
+        svg.AppendLine("<g data-layer=\"links\">");
+        foreach (var link in layout.Links)
+        {
+            var style = ResolveLinkStyle(link.MediaType, link.LinkType);
+            svg.Append($"<g data-link-id=\"{EscapeXml(link.LinkId)}\" data-media-type=\"{EscapeXml(link.MediaType.ToLowerInvariant())}\" data-link-type=\"{EscapeXml(link.LinkType.ToLowerInvariant())}\">");
+            svg.Append($"<path d=\"M {Format(link.StartX)} {Format(link.StartY)} Q {Format(link.ControlX)} {Format(link.ControlY)} {Format(link.EndX)} {Format(link.EndY)}\" fill=\"none\" stroke=\"{style.Color}\" stroke-width=\"{Format(style.Width)}\" stroke-linecap=\"round\" stroke-linejoin=\"round\"");
+            if (!string.IsNullOrWhiteSpace(style.DashArray))
+            {
+                svg.Append($" stroke-dasharray=\"{EscapeXml(style.DashArray)}\"");
+            }
+            if (style.Opacity < 1d)
+            {
+                svg.Append($" opacity=\"{Format(style.Opacity)}\"");
+            }
+            svg.Append("/>");
+            if (!string.IsNullOrWhiteSpace(link.Label))
+            {
+                var labelClass = backgroundStyle.IsDark ? "pm-link-label pm-link-label-dark" : "pm-link-label";
+                svg.Append($"<text class=\"{labelClass}\" x=\"{Format(link.LabelX)}\" y=\"{Format(link.LabelY)}\" text-anchor=\"middle\">{EscapeXml(link.Label)}</text>");
+            }
+            svg.AppendLine("</g>");
+        }
+        svg.AppendLine("</g>");
+
+        svg.AppendLine("<g data-layer=\"nodes\">");
+        foreach (var node in layout.Nodes)
+        {
+            var style = ResolveNodeStyle(node.NodeType, backgroundStyle.IsDark);
+            svg.AppendLine($"<g data-node-id=\"{EscapeXml(node.NodeId)}\" transform=\"translate({Format(node.X)} {Format(node.Y)})\">");
+            svg.AppendLine($"<rect x=\"0\" y=\"0\" width=\"{Format(node.Width)}\" height=\"{Format(node.Height)}\" rx=\"14\" ry=\"14\" fill=\"{style.Fill}\" stroke=\"{style.Stroke}\" stroke-width=\"2\"/>");
+            svg.AppendLine($"<rect x=\"10\" y=\"10\" width=\"34\" height=\"34\" rx=\"10\" ry=\"10\" fill=\"{style.IconFill}\" stroke=\"{style.Stroke}\" stroke-width=\"1\"/>");
+            svg.AppendLine($"<text class=\"pm-node-icon\" x=\"27\" y=\"32\" text-anchor=\"middle\" fill=\"{style.IconText}\">{EscapeXml(Truncate(node.IconKey, 4))}</text>");
+            var textX = Math.Min(node.Width - NodePadding, 54d);
+            var contentWidth = Math.Max(1d, node.Width - textX - NodePadding);
+            var labelLines = FitText(node.DisplayLabel, contentWidth, maxLines: 2, fontSize: 14d);
+            var y = 23d;
+            foreach (var line in labelLines)
+            {
+                svg.AppendLine($"<text class=\"pm-node-label\" x=\"{Format(textX)}\" y=\"{Format(y)}\">{EscapeXml(line)}</text>");
+                y += 16d;
+            }
+            svg.AppendLine($"<text class=\"pm-node-type\" x=\"{Format(textX)}\" y=\"{Format(Math.Min(node.Height - 24d, y + 2d))}\">{EscapeXml(FormatNodeType(node.NodeType))}</text>");
+            if (!string.IsNullOrWhiteSpace(node.Notes) && node.Height >= 72d)
+            {
+                var notes = FitText(node.Notes, Math.Max(1d, node.Width - NodePadding * 2), maxLines: 1, fontSize: 10d).FirstOrDefault();
+                if (!string.IsNullOrWhiteSpace(notes))
+                {
+                    svg.AppendLine($"<text class=\"pm-node-notes\" x=\"{Format(NodePadding)}\" y=\"{Format(node.Height - 12d)}\">{EscapeXml(notes)}</text>");
+                }
+            }
+            svg.AppendLine("</g>");
+        }
+        svg.AppendLine("</g>");
+        svg.AppendLine("</svg>");
+        return svg.ToString();
+    }
+
+    private static byte[] RenderPng(NetworkDiagramNativeExportLayout layout, string background, int pixelWidth, int pixelHeight, double scale)
+    {
+        var bg = ResolveBackground(background);
+        var canvasColor = bg.IsTransparent ? Color.Transparent : Color.ParseHex(bg.CanvasFill.TrimStart('#'));
+        using var image = new Image<Rgba32>(pixelWidth, pixelHeight, canvasColor);
+        var font = CreateFont(12f * (float)scale, FontStyle.Regular);
+        var boldFont = CreateFont(14f * (float)scale, FontStyle.Bold);
+        var smallFont = CreateFont(10f * (float)scale, FontStyle.Regular);
+        var iconFont = CreateFont(13f * (float)scale, FontStyle.Bold);
+
+        PointF P(double x, double y) => new((float)(x * scale), (float)(y * scale));
+        float S(double value) => (float)(value * scale);
+
+        image.Mutate(ctx =>
+        {
+            foreach (var link in layout.Links)
+            {
+                var style = ResolveLinkStyle(link.MediaType, link.LinkType);
+                var path = new PathBuilder().AddQuadraticBezier(P(link.StartX, link.StartY), P(link.ControlX, link.ControlY), P(link.EndX, link.EndY)).Build();
+                var pen = Pens.Solid(Color.ParseHex(style.Color.TrimStart('#')), S(style.Width));
+                ctx.Draw(pen, path);
+                if (!string.IsNullOrWhiteSpace(link.Label))
+                {
+                    var textOptions = new RichTextOptions(font) { Origin = P(link.LabelX, link.LabelY - 12), HorizontalAlignment = HorizontalAlignment.Center };
+                    ctx.DrawText(textOptions, link.Label, bg.IsDark ? Color.White : Color.Black);
+                }
+            }
+
+            foreach (var node in layout.Nodes)
+            {
+                var style = ResolveNodeStyle(node.NodeType, bg.IsDark);
+                var rect = new RectangularPolygon(S(node.X), S(node.Y), S(node.Width), S(node.Height));
+                ctx.Fill(Color.ParseHex(style.Fill.TrimStart('#')), rect);
+                ctx.Draw(Color.ParseHex(style.Stroke.TrimStart('#')), S(2), rect);
+                var iconRect = new RectangularPolygon(S(node.X + 10), S(node.Y + 10), S(34), S(34));
+                ctx.Fill(Color.ParseHex(style.IconFill.TrimStart('#')), iconRect);
+                ctx.Draw(Color.ParseHex(style.Stroke.TrimStart('#')), S(1), iconRect);
+                ctx.DrawText(Truncate(node.IconKey, 4), iconFont, Color.ParseHex(style.IconText.TrimStart('#')), P(node.X + 14, node.Y + 18));
+
+                var textX = node.X + Math.Min(node.Width - NodePadding, 54d);
+                var contentWidth = Math.Max(1d, node.Width - (textX - node.X) - NodePadding);
+                var y = node.Y + 10d;
+                foreach (var line in FitText(node.DisplayLabel, contentWidth, maxLines: 2, fontSize: 14d))
+                {
+                    ctx.DrawText(line, boldFont, Color.ParseHex("101828"), P(textX, y));
+                    y += 16d;
+                }
+                ctx.DrawText(FormatNodeType(node.NodeType), smallFont, Color.ParseHex("475467"), P(textX, Math.Min(node.Y + node.Height - 32d, y + 2d)));
+                if (!string.IsNullOrWhiteSpace(node.Notes) && node.Height >= 72d)
+                {
+                    var notes = FitText(node.Notes, Math.Max(1d, node.Width - NodePadding * 2), maxLines: 1, fontSize: 10d).FirstOrDefault();
+                    if (!string.IsNullOrWhiteSpace(notes))
+                    {
+                        ctx.DrawText(notes, smallFont, Color.ParseHex("667085"), P(node.X + NodePadding, node.Y + node.Height - 24d));
+                    }
+                }
+            }
+        });
+
+        using var stream = new MemoryStream();
+        image.SaveAsPng(stream);
+        return stream.ToArray();
+    }
+
+    private static Font CreateFont(float size, FontStyle style)
+    {
+        foreach (var preferred in new[] { "Arial", "DejaVu Sans", "Liberation Sans" })
+        {
+            var match = SystemFonts.Families.FirstOrDefault(f => string.Equals(f.Name, preferred, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrWhiteSpace(match.Name))
+            {
+                return match.CreateFont(size, style);
+            }
+        }
+
+        return SystemFonts.Families.First().CreateFont(size, style);
+    }
+
+    private static string NormalizeFormat(string? format)
+    {
+        var normalized = string.IsNullOrWhiteSpace(format) ? "PNG" : format.Trim().ToUpperInvariant();
+        return normalized is "PNG" or "SVG" ? normalized : throw new NetworkDiagramImageExportException("Unsupported network diagram export format.");
+    }
+
+    private static double NormalizeScale(double scale)
+    {
+        if (double.IsNaN(scale) || double.IsInfinity(scale) || scale <= 0)
+        {
+            throw new NetworkDiagramImageExportException("Export scale must be greater than zero.");
+        }
+
+        var allowed = new[] { 0.5d, 1d, 2d };
+        return allowed.FirstOrDefault(candidate => Math.Abs(candidate - scale) < 0.001d) is var matched && matched > 0
+            ? matched
+            : throw new NetworkDiagramImageExportException("Unsupported export scale. Choose 0.5x, 1x, or 2x.");
+    }
+
+    private static string NormalizeBackground(string? background)
+    {
+        var normalized = string.IsNullOrWhiteSpace(background) ? "light" : background.Trim().ToLowerInvariant();
+        return normalized is "light" or "dark" or "transparent" ? normalized : throw new NetworkDiagramImageExportException("Unsupported export background. Choose light, dark, or transparent.");
+    }
+
+    private static int CheckedPixelDimension(double logicalDimension, double scale, string name)
+    {
+        if (double.IsNaN(logicalDimension) || double.IsInfinity(logicalDimension) || logicalDimension <= 0)
+        {
+            throw new NetworkDiagramImageExportException($"{name} must be greater than zero for image export.");
+        }
+
+        var pixels = (int)Math.Ceiling(logicalDimension * scale);
+        if (pixels > MaximumPixelDimension)
+        {
+            throw new NetworkDiagramImageExportException($"Export image dimension {pixels}px exceeds the safe limit of {MaximumPixelDimension}px. Choose a smaller scale or canvas.");
+        }
+
+        return pixels;
+    }
+
+    private static void ValidatePixelBudget(int width, int height)
+    {
+        if ((long)width * height > MaximumTotalPixels)
+        {
+            throw new NetworkDiagramImageExportException($"Export image size {width} × {height} exceeds the safe limit of {MaximumTotalPixels:N0} pixels. Choose a smaller scale or canvas.");
+        }
+    }
+
+    private static NetworkDiagramExportBackground ResolveBackground(string background)
+    {
+        return background switch
+        {
+            "dark" => new NetworkDiagramExportBackground("#111827", true, false),
+            "transparent" => new NetworkDiagramExportBackground("#ffffff", false, true),
+            _ => new NetworkDiagramExportBackground("#f8fafc", false, false)
+        };
+    }
+
+    private static NetworkDiagramExportLinkStyle ResolveLinkStyle(string mediaType, string linkType)
+    {
+        var width = NetworkDiagramLinkTypes.Normalize(linkType) switch
+        {
+            NetworkDiagramLinkTypes.Lacp => 5d,
+            NetworkDiagramLinkTypes.Trunk or NetworkDiagramLinkTypes.Wan or NetworkDiagramLinkTypes.Backhaul => 4d,
+            _ => 3d
+        };
+        var normalizedMedia = NetworkDiagramLinkMediaTypes.Normalize(mediaType);
+        var color = normalizedMedia switch
+        {
+            NetworkDiagramLinkMediaTypes.Fibre => "#7c3aed",
+            NetworkDiagramLinkMediaTypes.Copper => "#9a6700",
+            NetworkDiagramLinkMediaTypes.Dac => "#0f766e",
+            NetworkDiagramLinkMediaTypes.Other => "#667085",
+            _ => "#475467"
+        };
+        var dash = normalizedMedia switch
+        {
+            NetworkDiagramLinkMediaTypes.Wireless => "12 8",
+            NetworkDiagramLinkMediaTypes.Vpn or NetworkDiagramLinkMediaTypes.Virtual => "14 6 3 6",
+            _ when NetworkDiagramLinkTypes.Normalize(linkType) == NetworkDiagramLinkTypes.Logical => "5 7",
+            _ => string.Empty
+        };
+        var opacity = NetworkDiagramLinkTypes.Normalize(linkType) == NetworkDiagramLinkTypes.Logical ? 0.72d : 1d;
+        return new NetworkDiagramExportLinkStyle(color, width, dash, opacity);
+    }
+
+    private static NetworkDiagramExportNodeStyle ResolveNodeStyle(string nodeType, bool dark)
+    {
+        if (string.Equals(nodeType, "MonitoredEndpoint", StringComparison.OrdinalIgnoreCase))
+        {
+            return new NetworkDiagramExportNodeStyle("#f4f8ff", "#7aa7ff", "#e7f0ff", "#1d4ed8");
+        }
+
+        if (string.Equals(nodeType, "Note", StringComparison.OrdinalIgnoreCase))
+        {
+            return new NetworkDiagramExportNodeStyle("#fff8db", "#d7a900", "#fff0a6", "#7a4f00");
+        }
+
+        return dark
+            ? new NetworkDiagramExportNodeStyle("#ffffff", "#94a3b8", "#eef2f7", "#334155")
+            : new NetworkDiagramExportNodeStyle("#ffffff", "#98a2b3", "#eef2f7", "#334155");
+    }
+
+    internal static string BuildLinkLabel(NetworkDiagramLinkDto link)
+    {
+        var linkType = NetworkDiagramLinkTypes.Normalize(link.LinkType);
+        var media = NetworkDiagramLinkMediaTypes.Normalize(link.MediaType).ToLowerInvariant();
+        var speed = link.LinkSpeedValue is null || string.IsNullOrWhiteSpace(link.LinkSpeedUnit)
+            ? string.Empty
+            : $"{link.LinkSpeedValue:0.###} {NetworkDiagramLinkSpeedUnits.Normalize(link.LinkSpeedUnit)}";
+        var summary = linkType == NetworkDiagramLinkTypes.Lacp
+            ? string.Join(" ", new[] { "LACP", $"{link.LacpMemberCount ?? 2} x", speed, media }.Where(x => !string.IsNullOrWhiteSpace(x)))
+            : string.Join(" ", new[] { linkType == NetworkDiagramLinkTypes.Standard ? string.Empty : linkType, speed, media }.Where(x => !string.IsNullOrWhiteSpace(x)));
+        var ports = linkType != NetworkDiagramLinkTypes.Lacp && (!string.IsNullOrWhiteSpace(link.SourcePortLabel) || !string.IsNullOrWhiteSpace(link.TargetPortLabel))
+            ? $"{link.SourcePortLabel ?? "?"} ↔ {link.TargetPortLabel ?? "?"}"
+            : string.Empty;
+        var vlanSummary = BuildVlanSummary(link);
+        return Truncate(string.Join(" • ", new[] { summary, link.Label, ports, vlanSummary, link.Notes }.Where(x => !string.IsNullOrWhiteSpace(x))), 116);
+    }
+
+    private static string BuildVlanSummary(NetworkDiagramLinkDto link)
+    {
+        if (link.Vlans.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        return string.Join(" · ", link.Vlans
+            .OrderBy(vlan => vlan.SortOrder)
+            .ThenBy(vlan => vlan.VlanId)
+            .Select(vlan => $"{NetworkDiagramVlanModes.Normalize(vlan.Mode)}:{vlan.VlanId}{(string.IsNullOrWhiteSpace(vlan.Name) ? string.Empty : " " + vlan.Name)}"));
+    }
+
+    private static IReadOnlyList<string> FitText(string? value, double maxWidth, int maxLines, double fontSize)
+    {
+        var normalized = NormalizeSingleLine(value);
+        if (string.IsNullOrWhiteSpace(normalized) || maxWidth <= 0)
+        {
+            return [];
+        }
+
+        var words = normalized.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var lines = new List<string>();
+        var current = string.Empty;
+        foreach (var word in words)
+        {
+            var candidate = string.IsNullOrEmpty(current) ? word : current + " " + word;
+            if (MeasureText(candidate, fontSize) <= maxWidth || string.IsNullOrEmpty(current))
+            {
+                current = candidate;
+            }
+            else
+            {
+                lines.Add(current);
+                current = word;
+            }
+
+            if (lines.Count == maxLines)
+            {
+                break;
+            }
+        }
+
+        if (lines.Count < maxLines && !string.IsNullOrEmpty(current))
+        {
+            lines.Add(current);
+        }
+
+        return lines.Take(maxLines).Select(line => TrimToWidth(line, maxWidth, fontSize)).ToArray();
+    }
+
+    private static string TrimToWidth(string text, double maxWidth, double fontSize)
+    {
+        var normalized = NormalizeSingleLine(text);
+        if (MeasureText(normalized, fontSize) <= maxWidth)
+        {
+            return normalized;
+        }
+
+        const string ellipsis = "…";
+        while (normalized.Length > 0 && MeasureText(normalized + ellipsis, fontSize) > maxWidth)
+        {
+            normalized = normalized[..^1].TrimEnd();
+        }
+
+        return normalized + ellipsis;
+    }
+
+    private static double MeasureText(string text, double fontSize)
+    {
+        return NormalizeSingleLine(text).Sum(ch => CharacterWidthFactor(ch) * fontSize);
+    }
+
+    private static double CharacterWidthFactor(char ch)
+    {
+        return ch switch
+        {
+            ' ' => 0.28d,
+            '.' or ',' or ':' or ';' or '!' or '|' => 0.25d,
+            'i' or 'l' or 'I' or '1' => 0.28d,
+            'm' or 'w' or 'M' or 'W' => 0.86d,
+            >= 'A' and <= 'Z' => 0.68d,
+            >= '0' and <= '9' => 0.56d,
+            _ => 0.52d
+        };
+    }
+
+    private static string FormatNodeType(string nodeType)
+    {
+        return nodeType switch
+        {
+            "MonitoredEndpoint" => "monitored endpoint",
+            "Note" => "note",
+            _ => "custom device"
+        };
+    }
+
+    private static string MakeSafeFileName(string value)
+    {
+        var invalid = System.IO.Path.GetInvalidFileNameChars();
+        var safe = new string(value.Select(ch => invalid.Contains(ch) || char.IsWhiteSpace(ch) ? '-' : ch).ToArray()).Trim('-');
+        return string.IsNullOrWhiteSpace(safe) ? "Diagram" : Truncate(safe, 80);
+    }
+
+    private static string Truncate(string? value, int maxLength)
+    {
+        var text = NormalizeSingleLine(value);
+        return text.Length <= maxLength ? text : text[..Math.Max(0, maxLength - 1)] + "…";
+    }
+
+    private static string NormalizeSingleLine(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? string.Empty : value.Replace("\r", " ").Replace("\n", " ").Trim();
+    }
+
+    private static string EscapeXml(string? value)
+    {
+        return System.Security.SecurityElement.Escape(value ?? string.Empty) ?? string.Empty;
+    }
+
+    private static string Format(double value)
+    {
+        return value.ToString("0.###", CultureInfo.InvariantCulture);
+    }
+
+    private sealed record NetworkDiagramExportBackground(string CanvasFill, bool IsDark, bool IsTransparent);
+    private sealed record NetworkDiagramExportLinkStyle(string Color, double Width, string DashArray, double Opacity);
+    private sealed record NetworkDiagramExportNodeStyle(string Fill, string Stroke, string IconFill, string IconText);
+
+    internal sealed record NetworkDiagramNativeExportLayout(
+        string DiagramName,
+        double CanvasWidth,
+        double CanvasHeight,
+        IReadOnlyList<NetworkDiagramNativeExportNode> Nodes,
+        IReadOnlyList<NetworkDiagramNativeExportLink> Links)
+    {
+        public static NetworkDiagramNativeExportLayout Create(NetworkDiagramDto diagram)
+        {
+            var canvasWidth = Math.Max(1d, diagram.CanvasWidth);
+            var canvasHeight = Math.Max(1d, diagram.CanvasHeight);
+            var nodes = diagram.Nodes.Select(node => new NetworkDiagramNativeExportNode(
+                node.NodeId,
+                node.NodeType,
+                node.DisplayLabel,
+                node.IconKey,
+                node.Notes,
+                node.X,
+                node.Y,
+                Math.Max(1d, node.Width),
+                Math.Max(1d, node.Height))).ToArray();
+            var nodeLookup = nodes.ToDictionary(node => node.NodeId, StringComparer.Ordinal);
+            var offsetIndexes = GetParallelOffsetIndexes(diagram.Links);
+            var links = new List<NetworkDiagramNativeExportLink>();
+            foreach (var link in diagram.Links)
+            {
+                if (!nodeLookup.TryGetValue(link.SourceNodeId, out var source) || !nodeLookup.TryGetValue(link.TargetNodeId, out var target))
+                {
+                    continue;
+                }
+
+                var geometry = BuildLinkGeometry(source, target, offsetIndexes.GetValueOrDefault(link.LinkId));
+                links.Add(new NetworkDiagramNativeExportLink(
+                    link.LinkId,
+                    NetworkDiagramLinkMediaTypes.Normalize(link.MediaType),
+                    NetworkDiagramLinkTypes.Normalize(link.LinkType),
+                    BuildLinkLabel(link),
+                    geometry.StartX,
+                    geometry.StartY,
+                    geometry.ControlX,
+                    geometry.ControlY,
+                    geometry.EndX,
+                    geometry.EndY,
+                    geometry.LabelX,
+                    geometry.LabelY));
+            }
+
+            return new NetworkDiagramNativeExportLayout(diagram.Name, canvasWidth, canvasHeight, nodes, links);
+        }
+    }
+
+    internal sealed record NetworkDiagramNativeExportNode(string NodeId, string NodeType, string DisplayLabel, string IconKey, string? Notes, double X, double Y, double Width, double Height);
+
+    internal sealed record NetworkDiagramNativeExportLink(string LinkId, string MediaType, string LinkType, string Label, double StartX, double StartY, double ControlX, double ControlY, double EndX, double EndY, double LabelX, double LabelY);
+
+    private sealed record LinkGeometry(double StartX, double StartY, double ControlX, double ControlY, double EndX, double EndY, double LabelX, double LabelY);
+
+    private static Dictionary<string, double> GetParallelOffsetIndexes(IReadOnlyList<NetworkDiagramLinkDto> links)
+    {
+        var result = new Dictionary<string, double>(StringComparer.Ordinal);
+        foreach (var group in links.GroupBy(link => string.CompareOrdinal(link.SourceNodeId, link.TargetNodeId) <= 0
+            ? $"{link.SourceNodeId}::{link.TargetNodeId}"
+            : $"{link.TargetNodeId}::{link.SourceNodeId}"))
+        {
+            var ordered = group.OrderBy(link => link.LinkId, StringComparer.Ordinal).ToArray();
+            var center = (ordered.Length - 1) / 2d;
+            for (var i = 0; i < ordered.Length; i++)
+            {
+                result[ordered[i].LinkId] = i - center;
+            }
+        }
+
+        return result;
+    }
+
+    private static LinkGeometry BuildLinkGeometry(NetworkDiagramNativeExportNode source, NetworkDiagramNativeExportNode target, double offsetIndex)
+    {
+        var startX = source.X + source.Width / 2d;
+        var startY = source.Y + source.Height / 2d;
+        var endX = target.X + target.Width / 2d;
+        var endY = target.Y + target.Height / 2d;
+        var dx = endX - startX;
+        var dy = endY - startY;
+        var length = Math.Sqrt(dx * dx + dy * dy);
+        if (length <= 0.01d)
+        {
+            length = 1d;
+        }
+
+        var perpendicularX = -dy / length;
+        var perpendicularY = dx / length;
+        var offset = offsetIndex * ParallelLinkOffsetStep;
+        var controlX = (startX + endX) / 2d + perpendicularX * offset;
+        var controlY = (startY + endY) / 2d + perpendicularY * offset;
+        var midpointX = startX * 0.25d + controlX * 0.5d + endX * 0.25d;
+        var midpointY = startY * 0.25d + controlY * 0.5d + endY * 0.25d;
+        return new LinkGeometry(startX, startY, controlX, controlY, endX, endY, midpointX + perpendicularX * 14d, midpointY + perpendicularY * 14d - 4d);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/NetworkDiagrams/NetworkDiagramPersistenceViewModels.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/NetworkDiagrams/NetworkDiagramPersistenceViewModels.cs
@@ -53,6 +53,10 @@ public sealed class NetworkDiagramEditorPageViewModel
 
     public string ExportPdfUrl { get; init; } = string.Empty;
 
+    public string ExportPngUrl { get; init; } = string.Empty;
+
+    public string ExportSvgUrl { get; init; } = string.Empty;
+
     public string ViewerUrl { get; init; } = string.Empty;
 
     public IReadOnlyList<NetworkDiagramEndpointToolboxItemViewModel> MonitoredEndpoints { get; init; } = [];
@@ -94,6 +98,10 @@ public sealed class NetworkDiagramViewerPageViewModel
     public string? EditUrl { get; init; }
 
     public string? ExportPdfUrl { get; init; }
+
+    public string? ExportPngUrl { get; init; }
+
+    public string? ExportSvgUrl { get; init; }
 
     public bool IsAdmin { get; init; }
 }

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
@@ -10,7 +10,7 @@
 </head>
 <body>
 @await Html.PartialAsync("_AuthenticatedNav")
-<main class="network-diagrams-main" data-network-diagram-editor data-diagram-id="@Model.DiagramId" data-load-url="@Model.LoadUrl" data-save-url="@Model.SaveUrl" data-export-pdf-url="@Model.ExportPdfUrl">
+<main class="network-diagrams-main" data-network-diagram-editor data-diagram-id="@Model.DiagramId" data-load-url="@Model.LoadUrl" data-save-url="@Model.SaveUrl" data-export-pdf-url="@Model.ExportPdfUrl" data-export-png-url="@Model.ExportPngUrl" data-export-svg-url="@Model.ExportSvgUrl">
     @Html.AntiForgeryToken()
     <section class="diagram-editor-shell" aria-labelledby="network-diagrams-title">
         <header class="diagram-editor-toolbar">
@@ -136,6 +136,18 @@
                         </select>
                     </label>
                     <span class="diagram-canvas-ratio-warning" data-canvas-ratio-warning hidden>Legacy canvas ratio loaded. Choose a canvas size to normalise safely.</span>
+                    <span class="diagram-toolbar-divider" aria-hidden="true"></span>
+                    <label class="diagram-toolbar-select-label">
+                        Export scale
+                        <select data-export-scale aria-label="Image export scale">
+                            <option value="1">1x native</option>
+                            <option value="2">2x high resolution</option>
+                            <option value="0.5">0.5x smaller</option>
+                        </select>
+                    </label>
+                    <button type="button" class="diagram-tool-button" data-export-png>Export PNG</button>
+                    <button type="button" class="diagram-tool-button" data-export-svg>Export SVG</button>
+                    <span class="diagram-tool-hint">Exports saved diagram layout.</span>
                     <span class="diagram-toolbar-divider" aria-hidden="true"></span>
                     <label class="diagram-toolbar-select-label">
                         PDF paper

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
@@ -37,8 +37,20 @@
                     <button type="button" class="diagram-tool-button" data-zoom-in>Zoom in</button>
                     <button type="button" class="diagram-tool-button" data-reset-view>Reset view</button>
                     <button type="button" class="diagram-tool-button" data-fit-content>Fit content</button>
-                    @if (Model.IsAdmin && !string.IsNullOrWhiteSpace(Model.ExportPdfUrl))
+                    @if (Model.IsAdmin && (!string.IsNullOrWhiteSpace(Model.ExportPdfUrl) || !string.IsNullOrWhiteSpace(Model.ExportPngUrl) || !string.IsNullOrWhiteSpace(Model.ExportSvgUrl)))
                     {
+                        <label class="diagram-toolbar-select-label">
+                            Export scale
+                            <select data-export-scale aria-label="Image export scale">
+                                <option value="1">1x native</option>
+                                <option value="2">2x high resolution</option>
+                                <option value="0.5">0.5x smaller</option>
+                            </select>
+                        </label>
+                        <button type="button" class="diagram-tool-button" data-export-png data-export-image-url="@Model.ExportPngUrl">Export PNG</button>
+                        <button type="button" class="diagram-tool-button" data-export-svg data-export-image-url="@Model.ExportSvgUrl">Export SVG</button>
+                        <span class="diagram-tool-hint">Exports saved diagram layout.</span>
+                        <span class="diagram-toolbar-divider" aria-hidden="true"></span>
                         <label class="diagram-toolbar-select-label">
                             PDF paper
                             <select data-export-paper aria-label="PDF paper size">

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
@@ -39,7 +39,10 @@
     const selectedNodeCount = editor.querySelector('[data-selected-node-count]');
     const saveButton = editor.querySelector('[data-save-diagram]');
     const exportPdfButton = editor.querySelector('[data-export-pdf]');
+    const exportPngButton = editor.querySelector('[data-export-png]');
+    const exportSvgButton = editor.querySelector('[data-export-svg]');
     const exportPaperSelect = editor.querySelector('[data-export-paper]');
+    const exportScaleSelect = editor.querySelector('[data-export-scale]');
     const canvasSizePresetSelect = editor.querySelector('[data-canvas-size-preset]');
     const canvasRatioWarning = editor.querySelector('[data-canvas-ratio-warning]');
     const drawMediaTypeSelect = editor.querySelector('[data-draw-media-type]');
@@ -57,6 +60,8 @@
     const loadUrl = editor.dataset.loadUrl || '';
     const saveUrl = editor.dataset.saveUrl || '';
     const exportPdfUrl = editor.dataset.exportPdfUrl || '';
+    const exportPngUrl = editor.dataset.exportPngUrl || '';
+    const exportSvgUrl = editor.dataset.exportSvgUrl || '';
 
     if (!canvasHost || !canvas || !world || !nodeLayer || !linkLayer) {
         return;
@@ -1685,6 +1690,24 @@
         window.location.href = `${exportPdfUrl}${separator}paper=${encodeURIComponent(paper)}`;
     }
 
+
+    function exportImage(baseUrl, label) {
+        if (!baseUrl) {
+            return;
+        }
+
+        if (state.dirty) {
+            const confirmed = window.confirm(`Export uses the last saved diagram layout. Save your changes before exporting if you want them in the ${label}. Continue exporting the saved version?`);
+            if (!confirmed) {
+                return;
+            }
+        }
+
+        const scale = exportScaleSelect ? exportScaleSelect.value : '1';
+        const separator = baseUrl.includes('?') ? '&' : '?';
+        window.location.href = `${baseUrl}${separator}scale=${encodeURIComponent(scale)}&background=light`;
+    }
+
     async function saveDiagram() {
         if (!saveUrl || !saveButton) {
             return;
@@ -1784,6 +1807,12 @@
 
     if (exportPdfButton) {
         exportPdfButton.addEventListener('click', exportPdf);
+    }
+    if (exportPngButton) {
+        exportPngButton.addEventListener('click', () => exportImage(exportPngUrl, 'PNG'));
+    }
+    if (exportSvgButton) {
+        exportSvgButton.addEventListener('click', () => exportImage(exportSvgUrl, 'SVG'));
     }
 
     if (addLinkVlanButton) {

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
@@ -20,7 +20,10 @@
     const linkDetail = viewer.querySelector('[data-link-detail]');
     const noSelectionPanel = viewer.querySelector('[data-no-selection-panel]');
     const exportPdfButton = viewer.querySelector('[data-export-pdf]');
+    const exportPngButton = viewer.querySelector('[data-export-png]');
+    const exportSvgButton = viewer.querySelector('[data-export-svg]');
     const exportPaperSelect = viewer.querySelector('[data-export-paper]');
+    const exportScaleSelect = viewer.querySelector('[data-export-scale]');
 
     const zoomStep = 1.15;
     const minZoom = 0.15;
@@ -497,6 +500,9 @@
     viewer.querySelector('[data-reset-view]')?.addEventListener('click', resetView);
     viewer.querySelector('[data-fit-content]')?.addEventListener('click', fitContent);
     exportPdfButton?.addEventListener('click', () => { const base = exportPdfButton.dataset.exportPdfUrl; if (base) { window.location.href = `${base}?paper=${encodeURIComponent(exportPaperSelect?.value || 'A4')}`; } });
+    const exportImage = button => { const base = button?.dataset.exportImageUrl; if (base) { const separator = base.includes('?') ? '&' : '?'; window.location.href = `${base}${separator}scale=${encodeURIComponent(exportScaleSelect?.value || '1')}&background=light`; } };
+    exportPngButton?.addEventListener('click', () => exportImage(exportPngButton));
+    exportSvgButton?.addEventListener('click', () => exportImage(exportSvgButton));
     noSelectionPanel?.addEventListener('click', event => {
         const target = event.target instanceof Element ? event.target : event.target?.parentElement;
         const button = target?.closest('[data-summary-node-id]');


### PR DESCRIPTION
### Motivation
- Provide faithful native-scale exports of saved network diagrams (preserve CanvasWidth/CanvasHeight, node positions/sizes, link geometry and parallel offsets) because the existing PDF page-fit renderer compresses and overlaps dense diagrams.
- Expose an image export path so PNG/SVG can be produced from a single native-scale renderer and later be reused by PDF export to avoid divergent layout logic.

### Description
- Add a new image export service `INetworkDiagramImageExportService` with concrete implementation `NetworkDiagramImageExportService` that builds a native-scale layout from `NetworkDiagramDto` and can emit SVG (deterministic markup) or raster PNG (via ImageSharp) at requested scales (0.5×, 1×, 2×) while clamping pixel budgets and rejecting unsafe options. Key file: `src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramImageExportService.cs`.
- Add controller route `GET /network-diagrams/{diagramId}/export/{format}` implemented as `ExportImage` in `NetworkDiagramsController`, requiring admin auth and honoring `NetworkDiagramsEnabled`; the endpoint returns content-type, filename, and helpful headers with canvas + pixel dimensions for operator visibility.
- Wire editor and viewer UI to expose image export controls (scale selector, Export PNG, Export SVG) and minimal client-side handlers that invoke the new export endpoints while preserving the current behavior of PDF export; modified views and JS: `Views/NetworkDiagrams/Edit.cshtml`, `Views/NetworkDiagrams/View.cshtml`, `wwwroot/js/network-diagrams-editor.js`, and `wwwroot/js/network-diagrams-viewer.js`.
- Add ViewModel fields for new export URLs (`ExportPngUrl`, `ExportSvgUrl`) and register the new service in `Program.cs`; add package references for `SixLabors.ImageSharp`/`SixLabors.ImageSharp.Drawing` to the web project file so PNG rasterization can be compiled in CI.
- Created a GitHub issue to track the work and follow-ups: https://github.com/ijyates1992/ping-monitor/issues/525.

### Testing
- Automated test suites were not executed in this environment because the `dotnet` CLI and restore/build tools were not available here; CI must run `dotnet build` and `dotnet test` to validate compilation and unit tests (including existing `NetworkDiagramsFeatureTests`).
- Performed static repository inspections and updated view and JS integration points; client-side behavior delegates to existing PDF export UX where present and adds new PNG/SVG flows that request `scale` and `background` query parameters.
- Safety/runtime guards added and exercised via code paths: export scale validation (allowed 0.5/1/2), maximum per-dimension pixel clamp, and maximum total pixel budget; the controller returns `400 Bad Request` when an unsafe export is requested (implemented in `NetworkDiagramImageExportService`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2039a5736c832aa8f066f23aa9f6c3)