### PR TITLE
Include Network Diagrams in configuration backup & restore (Fixes #528)

### DIFF
--- a/docs/config-backup-and-restore.md
+++ b/docs/config-backup-and-restore.md
@@ -29,6 +29,7 @@ The following entities are included in configuration backups:
 - Notification infrastructure settings (SMTP/Telegram/global notification config)
 - User notification settings
 - Endpoint metadata (tags, attributes if applicable)
+- Network diagrams, including diagram canvas/viewport settings, nodes, visual links, link media/speed/LACP metadata, and link VLAN metadata
 
 ---
 
@@ -75,7 +76,7 @@ Example:
 
 ```json
 {
-  "formatVersion": 2,
+  "formatVersion": 3,
   "appVersion": "1.0.3",
   "backupName": "prod-before-vlan-work",
   "notes": "Taken before changing core switch and endpoint dependency layout. Known-good production config.",
@@ -94,7 +95,10 @@ Example:
     "security_settings": {...},
     "notification_settings": {...},
     "user_notification_settings": [...],
-    "identity": [...]
+    "identity": [...],
+    "network_diagrams": {
+      "diagrams": [...]
+    }
   }
 }
 ```
@@ -118,7 +122,11 @@ Example:
   - `notification_settings`
   - `user_notification_settings`
   - `identity` (optional and explicit, sensitive)
-- Network Diagrams are not included in configuration backup/restore yet. This is a release-blocking known limitation for the Network Diagrams preview and is tracked in issue #528.
+  - `network_diagrams`
+- Network diagrams are restored as configuration/documentation data only. Diagram restore does not create endpoints, monitor assignments, endpoint dependencies, alerts, or any network-device configuration.
+- Monitored endpoint diagram nodes keep matching endpoint IDs when those endpoints exist. When endpoints are restored in the same operation and are remapped by existing endpoint merge logic, monitored diagram node endpoint references are remapped to the restored endpoint IDs.
+- If a monitored diagram node references an endpoint that cannot be resolved, restore keeps the diagram node with `EndpointId` cleared and reports a warning. The restore process never creates a monitored endpoint solely because a diagram references it and never attaches a diagram node to an endpoint by name alone.
+- Diagram visual links remain documentation only and do not create monitoring dependencies. Links whose source/target nodes cannot be restored are skipped with warnings; VLAN metadata for skipped links is also skipped.
 - Restore supports two modes:
   - `merge`
   - `replace`
@@ -132,6 +140,7 @@ Example:
 - Replace requests with missing/incorrect confirmation must be rejected.
 - Identity replace is not supported in this phase; identity restore remains merge-only and explicit.
 - Restore does **not** import operational data (results, state transitions, alerts, logs, metrics, runtime state).
+- Replace mode for `network_diagrams` deletes/replaces only diagram tables (`NetworkDiagramLinkVlans`, `NetworkDiagramLinks`, `NetworkDiagramNodes`, `NetworkDiagrams`) and must not delete endpoints, agents, monitor assignments, endpoint dependencies, check results, states, alerts, events, or logs.
 - Upload does **not** trigger restore automatically; restore remains an explicit separate operator action.
 - Upload supports **JSON only**. Invalid or unsupported files must be rejected and must not be stored.
 

--- a/src/WebApp/PingMonitor.Web.Tests/ConfigurationBackupNetworkDiagramTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/ConfigurationBackupNetworkDiagramTests.cs
@@ -1,0 +1,218 @@
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.Backups;
+using PingMonitor.Web.Services.NetworkDiagrams;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class ConfigurationBackupNetworkDiagramTests
+{
+    [Fact]
+    public void ConfigurationBackupSections_IncludesNetworkDiagramsSection()
+    {
+        Assert.Contains(ConfigurationBackupSections.NetworkDiagrams, ConfigurationBackupSections.All);
+    }
+
+    [Fact]
+    public async Task RestorePreview_ReportsNetworkDiagramCounts()
+    {
+        var document = BuildDocument(BuildNetworkDiagramSection());
+        var service = new ConfigurationRestorePreviewService(
+            new FakeDocumentLoader(document),
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<ConfigurationRestorePreviewService>.Instance);
+
+        var preview = await service.GetPreviewAsync("backup.json", CancellationToken.None);
+
+        Assert.Contains(ConfigurationBackupSections.NetworkDiagrams, preview.IncludedSections);
+        Assert.Equal(1, preview.Counts.NetworkDiagrams);
+        Assert.Equal(2, preview.Counts.NetworkDiagramNodes);
+        Assert.Equal(1, preview.Counts.NetworkDiagramLinks);
+        Assert.Equal(1, preview.Counts.NetworkDiagramLinkVlans);
+    }
+
+    [Fact]
+    public async Task RestorePreview_OlderBackupWithoutNetworkDiagramsSectionStillSucceeds()
+    {
+        var document = new ConfigurationBackupDocument
+        {
+            FormatVersion = ConfigurationBackupMetadata.CurrentFormatVersion,
+            AppVersion = "test",
+            BackupName = "old-backup",
+            ExportedAtUtc = DateTimeOffset.UtcNow,
+            MachineName = "test-machine",
+            Sections = new ConfigurationBackupSectionData
+            {
+                Endpoints =
+                [
+                    new BackupEndpointRecord
+                    {
+                        EndpointId = "endpoint-1",
+                        Name = "Gateway",
+                        Target = "192.0.2.1",
+                        IconKey = "router",
+                        Enabled = true,
+                        CreatedAtUtc = DateTimeOffset.UtcNow
+                    }
+                ]
+            }
+        };
+        var service = new ConfigurationRestorePreviewService(
+            new FakeDocumentLoader(document),
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<ConfigurationRestorePreviewService>.Instance);
+
+        var preview = await service.GetPreviewAsync("old-backup.json", CancellationToken.None);
+
+        Assert.DoesNotContain(ConfigurationBackupSections.NetworkDiagrams, preview.IncludedSections);
+        Assert.Equal(0, preview.Counts.NetworkDiagrams);
+        Assert.Equal(1, preview.Counts.Endpoints);
+    }
+
+    [Fact]
+    public void Validator_AcceptsNetworkDiagramBackupData()
+    {
+        var validator = new ConfigurationBackupDocumentValidator();
+        var document = BuildDocument(BuildNetworkDiagramSection());
+
+        validator.Validate(document, "backup.json");
+    }
+
+    [Fact]
+    public void Validator_RejectsInvalidNetworkDiagramLinkVlan()
+    {
+        var validator = new ConfigurationBackupDocumentValidator();
+        var section = BuildNetworkDiagramSection(vlanId: 4095);
+        var document = BuildDocument(section);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => validator.Validate(document, "backup.json"));
+        Assert.Contains("invalid VLAN metadata", exception.Message);
+    }
+
+    private static ConfigurationBackupDocument BuildDocument(BackupNetworkDiagramSection? networkDiagrams)
+    {
+        return new ConfigurationBackupDocument
+        {
+            FormatVersion = ConfigurationBackupMetadata.CurrentFormatVersion,
+            AppVersion = "test",
+            BackupName = "test-backup",
+            ExportedAtUtc = DateTimeOffset.UtcNow,
+            MachineName = "test-machine",
+            Sections = new ConfigurationBackupSectionData
+            {
+                NetworkDiagrams = networkDiagrams
+            }
+        };
+    }
+
+    private static BackupNetworkDiagramSection BuildNetworkDiagramSection(int vlanId = 10)
+    {
+        return new BackupNetworkDiagramSection
+        {
+            Diagrams =
+            [
+                new BackupNetworkDiagramRecord
+                {
+                    DiagramId = "diagram-1",
+                    Name = "Core network",
+                    Description = "Documentation diagram",
+                    CanvasWidth = 5000,
+                    CanvasHeight = 3000,
+                    ViewportPanX = -120,
+                    ViewportPanY = 80,
+                    ViewportZoom = 1.25,
+                    CreatedAtUtc = DateTimeOffset.UtcNow.AddDays(-1),
+                    UpdatedAtUtc = DateTimeOffset.UtcNow,
+                    Nodes =
+                    [
+                        new BackupNetworkDiagramNodeRecord
+                        {
+                            NodeId = "node-endpoint",
+                            NodeType = nameof(NetworkDiagramNodeType.MonitoredEndpoint),
+                            EndpointId = "endpoint-1",
+                            DisplayLabel = "Gateway",
+                            IconKey = "router",
+                            X = 100,
+                            Y = 200,
+                            Width = 178,
+                            Height = 78,
+                            CreatedAtUtc = DateTimeOffset.UtcNow.AddDays(-1),
+                            UpdatedAtUtc = DateTimeOffset.UtcNow
+                        },
+                        new BackupNetworkDiagramNodeRecord
+                        {
+                            NodeId = "node-custom",
+                            NodeType = nameof(NetworkDiagramNodeType.CustomDevice),
+                            DisplayLabel = "Switch",
+                            IconKey = "switch",
+                            X = 450,
+                            Y = 225,
+                            Width = 178,
+                            Height = 78,
+                            CreatedAtUtc = DateTimeOffset.UtcNow.AddDays(-1),
+                            UpdatedAtUtc = DateTimeOffset.UtcNow
+                        }
+                    ],
+                    Links =
+                    [
+                        new BackupNetworkDiagramLinkRecord
+                        {
+                            LinkId = "link-1",
+                            SourceNodeId = "node-endpoint",
+                            TargetNodeId = "node-custom",
+                            Label = "uplink",
+                            SourcePortLabel = "eth0",
+                            TargetPortLabel = "Gi1/0/1",
+                            MediaType = NetworkDiagramLinkMediaTypes.Fibre,
+                            MediaSubtype = "OS2",
+                            FibreSubtype = "OS2",
+                            LinkType = NetworkDiagramLinkTypes.Trunk,
+                            LinkSpeedValue = 10,
+                            LinkSpeedUnit = NetworkDiagramLinkSpeedUnits.Gbps,
+                            CreatedAtUtc = DateTimeOffset.UtcNow.AddDays(-1),
+                            UpdatedAtUtc = DateTimeOffset.UtcNow,
+                            Vlans =
+                            [
+                                new BackupNetworkDiagramLinkVlanRecord
+                                {
+                                    LinkVlanId = "vlan-1",
+                                    VlanId = vlanId,
+                                    Name = "Users",
+                                    Mode = NetworkDiagramVlanModes.Tagged,
+                                    Notes = "documentation only",
+                                    SortOrder = 0,
+                                    CreatedAtUtc = DateTimeOffset.UtcNow.AddDays(-1),
+                                    UpdatedAtUtc = DateTimeOffset.UtcNow
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+
+    private sealed class FakeDocumentLoader : IConfigurationBackupDocumentLoader
+    {
+        private readonly ConfigurationBackupDocument _document;
+
+        public FakeDocumentLoader(ConfigurationBackupDocument document)
+        {
+            _document = document;
+        }
+
+        public Task<IReadOnlyList<BackupFileListItem>> ListBackupsAsync(CancellationToken cancellationToken)
+        {
+            IReadOnlyList<BackupFileListItem> result = [];
+            return Task.FromResult(result);
+        }
+
+        public string ResolveBackupPath(string fileId)
+        {
+            return fileId;
+        }
+
+        public Task<ConfigurationBackupDocument> LoadValidatedDocumentAsync(string fileId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_document);
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminBackupsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminBackupsController.cs
@@ -135,6 +135,7 @@ public sealed class AdminBackupsController : Controller
                 IncludeNotificationSettings = preview.IncludedSections.Contains(ConfigurationBackupSections.NotificationSettings, StringComparer.Ordinal),
                 IncludeUserNotificationSettings = preview.IncludedSections.Contains(ConfigurationBackupSections.UserNotificationSettings, StringComparer.Ordinal),
                 IncludeIdentity = false,
+                IncludeNetworkDiagrams = preview.IncludedSections.Contains(ConfigurationBackupSections.NetworkDiagrams, StringComparer.Ordinal),
                 RestoreMode = ConfigurationRestoreModes.Merge
             };
 
@@ -382,6 +383,11 @@ public sealed class AdminBackupsController : Controller
             sections.Add(ConfigurationBackupSections.Identity);
         }
 
+        if (form.IncludeNetworkDiagrams)
+        {
+            sections.Add(ConfigurationBackupSections.NetworkDiagrams);
+        }
+
         return sections;
     }
 
@@ -433,6 +439,11 @@ public sealed class AdminBackupsController : Controller
             sections.Add(ConfigurationBackupSections.Identity);
         }
 
+        if (form.IncludeNetworkDiagrams)
+        {
+            sections.Add(ConfigurationBackupSections.NetworkDiagrams);
+        }
+
         return sections;
     }
 
@@ -447,6 +458,7 @@ public sealed class AdminBackupsController : Controller
             AppVersion = preview.Metadata.AppVersion,
             FormatVersion = preview.Metadata.FormatVersion,
             IncludedSections = preview.IncludedSections,
+            Warnings = preview.Warnings,
             Counts = new ConfigurationBackupSectionCountViewModel
             {
                 Agents = preview.Counts.Agents,
@@ -460,7 +472,11 @@ public sealed class AdminBackupsController : Controller
                 UserNotificationSettings = preview.Counts.UserNotificationSettings,
                 IdentityUsers = preview.Counts.IdentityUsers,
                 IdentityRoles = preview.Counts.IdentityRoles,
-                IdentityUserRoles = preview.Counts.IdentityUserRoles
+                IdentityUserRoles = preview.Counts.IdentityUserRoles,
+                NetworkDiagrams = preview.Counts.NetworkDiagrams,
+                NetworkDiagramNodes = preview.Counts.NetworkDiagramNodes,
+                NetworkDiagramLinks = preview.Counts.NetworkDiagramLinks,
+                NetworkDiagramLinkVlans = preview.Counts.NetworkDiagramLinkVlans
             }
         };
     }
@@ -499,6 +515,7 @@ public sealed class AdminBackupsController : Controller
             ConfigurationBackupSections.NotificationSettings => "Notification infrastructure settings",
             ConfigurationBackupSections.UserNotificationSettings => "User notification settings",
             ConfigurationBackupSections.Identity => "Identity",
+            ConfigurationBackupSections.NetworkDiagrams => "Network diagrams",
             _ => section
         };
     }

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationAutoBackupBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationAutoBackupBackgroundService.cs
@@ -146,7 +146,8 @@ public sealed class ConfigurationAutoBackupBackgroundService : BackgroundService
             ConfigurationBackupSections.Assignments,
             ConfigurationBackupSections.SecuritySettings,
             ConfigurationBackupSections.NotificationSettings,
-            ConfigurationBackupSections.UserNotificationSettings
+            ConfigurationBackupSections.UserNotificationSettings,
+            ConfigurationBackupSections.NetworkDiagrams
         };
 
         if (_options.AutoBackup.IncludeIdentityByDefault)

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentValidator.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentValidator.cs
@@ -1,3 +1,6 @@
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.NetworkDiagrams;
+
 namespace PingMonitor.Web.Services.Backups;
 
 public interface IConfigurationBackupDocumentValidator
@@ -43,7 +46,8 @@ public sealed class ConfigurationBackupDocumentValidator : IConfigurationBackupD
             || document.Sections.SecuritySettings is not null
             || document.Sections.NotificationSettings is not null
             || document.Sections.UserNotificationSettings is not null
-            || document.Sections.Identity is not null;
+            || document.Sections.Identity is not null
+            || document.Sections.NetworkDiagrams is not null;
 
         if (!hasAtLeastOneSection)
         {
@@ -129,5 +133,109 @@ public sealed class ConfigurationBackupDocumentValidator : IConfigurationBackupD
                 }
             }
         }
+
+        if (document.Sections.NetworkDiagrams is not null)
+        {
+            ValidateNetworkDiagrams(document.Sections.NetworkDiagrams);
+        }
+
     }
+
+
+    private static void ValidateNetworkDiagrams(BackupNetworkDiagramSection section)
+    {
+        foreach (var diagram in section.Diagrams)
+        {
+            if (string.IsNullOrWhiteSpace(diagram.DiagramId) || string.IsNullOrWhiteSpace(diagram.Name))
+            {
+                throw new InvalidOperationException("Network diagrams section contains an invalid diagram record (id/name missing).");
+            }
+
+            ValidateFinite(diagram.CanvasWidth, "diagram canvas width");
+            ValidateFinite(diagram.CanvasHeight, "diagram canvas height");
+            ValidateFinite(diagram.ViewportPanX, "diagram viewport pan X");
+            ValidateFinite(diagram.ViewportPanY, "diagram viewport pan Y");
+            ValidateFinite(diagram.ViewportZoom, "diagram viewport zoom");
+
+            var nodeIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var node in diagram.Nodes)
+            {
+                if (string.IsNullOrWhiteSpace(node.NodeId) || string.IsNullOrWhiteSpace(node.DisplayLabel) || string.IsNullOrWhiteSpace(node.IconKey))
+                {
+                    throw new InvalidOperationException($"Network diagram '{diagram.Name}' contains an invalid node record.");
+                }
+
+                if (!nodeIds.Add(node.NodeId))
+                {
+                    throw new InvalidOperationException($"Network diagram '{diagram.Name}' contains duplicate node id '{node.NodeId}'.");
+                }
+
+                if (!Enum.TryParse<NetworkDiagramNodeType>(node.NodeType, ignoreCase: true, out var nodeType) || !Enum.IsDefined(nodeType))
+                {
+                    throw new InvalidOperationException($"Network diagram '{diagram.Name}' contains unsupported node type '{node.NodeType}'.");
+                }
+
+                ValidateFinite(node.X, "node X");
+                ValidateFinite(node.Y, "node Y");
+                ValidateFinite(node.Width, "node width");
+                ValidateFinite(node.Height, "node height");
+            }
+
+            var linkIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var link in diagram.Links)
+            {
+                if (string.IsNullOrWhiteSpace(link.LinkId) || string.IsNullOrWhiteSpace(link.SourceNodeId) || string.IsNullOrWhiteSpace(link.TargetNodeId))
+                {
+                    throw new InvalidOperationException($"Network diagram '{diagram.Name}' contains an invalid link record.");
+                }
+
+                if (!linkIds.Add(link.LinkId))
+                {
+                    throw new InvalidOperationException($"Network diagram '{diagram.Name}' contains duplicate link id '{link.LinkId}'.");
+                }
+
+                if (string.Equals(link.SourceNodeId, link.TargetNodeId, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException($"Network diagram '{diagram.Name}' contains an invalid self-link '{link.LinkId}'.");
+                }
+
+                if (!NetworkDiagramLinkMediaTypes.IsAllowed(link.MediaType))
+                {
+                    throw new InvalidOperationException($"Network diagram '{diagram.Name}' contains unsupported media type '{link.MediaType}'.");
+                }
+
+                if (!NetworkDiagramMediaSubtypes.IsAllowed(link.MediaSubtype ?? link.FibreSubtype, link.MediaType))
+                {
+                    throw new InvalidOperationException($"Network diagram '{diagram.Name}' contains unsupported media subtype on link '{link.LinkId}'.");
+                }
+
+                if (!NetworkDiagramLinkTypes.IsAllowed(link.LinkType))
+                {
+                    throw new InvalidOperationException($"Network diagram '{diagram.Name}' contains unsupported link type '{link.LinkType}'.");
+                }
+
+                if (link.LinkSpeedValue is <= 0 or > 1000000 || !NetworkDiagramLinkSpeedUnits.IsAllowed(link.LinkSpeedUnit))
+                {
+                    throw new InvalidOperationException($"Network diagram '{diagram.Name}' contains invalid link speed metadata on link '{link.LinkId}'.");
+                }
+
+                foreach (var vlan in link.Vlans)
+                {
+                    if (vlan.VlanId is < 1 or > 4094 || !NetworkDiagramVlanModes.IsAllowed(vlan.Mode))
+                    {
+                        throw new InvalidOperationException($"Network diagram '{diagram.Name}' contains invalid VLAN metadata on link '{link.LinkId}'.");
+                    }
+                }
+            }
+        }
+    }
+
+    private static void ValidateFinite(double value, string fieldName)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+        {
+            throw new InvalidOperationException($"Network diagrams section contains invalid {fieldName}.");
+        }
+    }
+
 }

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
+using PingMonitor.Web.Services.NetworkDiagrams;
 
 namespace PingMonitor.Web.Services.Backups;
 
@@ -15,6 +16,7 @@ public static class ConfigurationBackupSections
     public const string NotificationSettings = "notification_settings";
     public const string UserNotificationSettings = "user_notification_settings";
     public const string Identity = "identity";
+    public const string NetworkDiagrams = "network_diagrams";
 
     public static readonly string[] All =
     [
@@ -26,7 +28,8 @@ public static class ConfigurationBackupSections
         SecuritySettings,
         NotificationSettings,
         UserNotificationSettings,
-        Identity
+        Identity,
+        NetworkDiagrams
     ];
 }
 
@@ -65,7 +68,7 @@ public static class BackupDeleteModes
 
 public sealed class ConfigurationBackupMetadata
 {
-    public const int CurrentFormatVersion = 2;
+    public const int CurrentFormatVersion = 3;
 
     public int FormatVersion { get; init; } = CurrentFormatVersion;
     public string AppVersion { get; init; } = string.Empty;
@@ -160,6 +163,9 @@ public sealed class ConfigurationBackupSectionData
 
     [JsonPropertyName("identity")]
     public BackupIdentitySection? Identity { get; init; }
+
+    [JsonPropertyName("network_diagrams")]
+    public BackupNetworkDiagramSection? NetworkDiagrams { get; init; }
 }
 
 public sealed class BackupAgentRecord
@@ -349,6 +355,81 @@ public sealed class BackupIdentityUserRoleRecord
     public string RoleId { get; init; } = string.Empty;
 }
 
+public sealed class BackupNetworkDiagramSection
+{
+    public IReadOnlyList<BackupNetworkDiagramRecord> Diagrams { get; init; } = [];
+}
+
+public sealed class BackupNetworkDiagramRecord
+{
+    public string DiagramId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public double CanvasWidth { get; init; }
+    public double CanvasHeight { get; init; }
+    public double ViewportPanX { get; init; }
+    public double ViewportPanY { get; init; }
+    public double ViewportZoom { get; init; }
+    public DateTimeOffset CreatedAtUtc { get; init; }
+    public DateTimeOffset UpdatedAtUtc { get; init; }
+    public string? CreatedByUserId { get; init; }
+    public string? UpdatedByUserId { get; init; }
+    public IReadOnlyList<BackupNetworkDiagramNodeRecord> Nodes { get; init; } = [];
+    public IReadOnlyList<BackupNetworkDiagramLinkRecord> Links { get; init; } = [];
+}
+
+public sealed class BackupNetworkDiagramNodeRecord
+{
+    public string NodeId { get; init; } = string.Empty;
+    public string NodeType { get; init; } = string.Empty;
+    public string? EndpointId { get; init; }
+    public string DisplayLabel { get; init; } = string.Empty;
+    public string IconKey { get; init; } = "generic";
+    public double X { get; init; }
+    public double Y { get; init; }
+    public double Width { get; init; }
+    public double Height { get; init; }
+    public string? Notes { get; init; }
+    public string? MetadataJson { get; init; }
+    public DateTimeOffset CreatedAtUtc { get; init; }
+    public DateTimeOffset UpdatedAtUtc { get; init; }
+}
+
+public sealed class BackupNetworkDiagramLinkRecord
+{
+    public string LinkId { get; init; } = string.Empty;
+    public string SourceNodeId { get; init; } = string.Empty;
+    public string TargetNodeId { get; init; } = string.Empty;
+    public string? Label { get; init; }
+    public string? SourcePortLabel { get; init; }
+    public string? TargetPortLabel { get; init; }
+    public string? Notes { get; init; }
+    public string MediaType { get; init; } = NetworkDiagramLinkMediaTypes.Copper;
+    public string? MediaSubtype { get; init; }
+    public string? FibreSubtype { get; init; }
+    public string LinkType { get; init; } = NetworkDiagramLinkTypes.Standard;
+    public decimal? LinkSpeedValue { get; init; }
+    public string? LinkSpeedUnit { get; init; }
+    public int? LacpMemberCount { get; init; }
+    public string? LacpMemberPortsJson { get; init; }
+    public string? MetadataJson { get; init; }
+    public DateTimeOffset CreatedAtUtc { get; init; }
+    public DateTimeOffset UpdatedAtUtc { get; init; }
+    public IReadOnlyList<BackupNetworkDiagramLinkVlanRecord> Vlans { get; init; } = [];
+}
+
+public sealed class BackupNetworkDiagramLinkVlanRecord
+{
+    public string LinkVlanId { get; init; } = string.Empty;
+    public int VlanId { get; init; }
+    public string? Name { get; init; }
+    public string Mode { get; init; } = NetworkDiagramVlanModes.Tagged;
+    public string? Notes { get; init; }
+    public int SortOrder { get; init; }
+    public DateTimeOffset CreatedAtUtc { get; init; }
+    public DateTimeOffset UpdatedAtUtc { get; init; }
+}
+
 public sealed class BackupFileListItem
 {
     public string FileName { get; init; } = string.Empty;
@@ -456,6 +537,10 @@ public sealed class ConfigurationBackupSectionCounts
     public int IdentityUsers { get; init; }
     public int IdentityRoles { get; init; }
     public int IdentityUserRoles { get; init; }
+    public int NetworkDiagrams { get; init; }
+    public int NetworkDiagramNodes { get; init; }
+    public int NetworkDiagramLinks { get; init; }
+    public int NetworkDiagramLinkVlans { get; init; }
 }
 
 public sealed class ConfigurationBackupPreview
@@ -465,6 +550,7 @@ public sealed class ConfigurationBackupPreview
     public RestorePreviewMetadata Metadata { get; init; } = new();
     public IReadOnlyList<string> IncludedSections { get; init; } = [];
     public ConfigurationBackupSectionCounts Counts { get; init; } = new();
+    public IReadOnlyList<string> Warnings { get; init; } = [];
 }
 
 public sealed class RestoreConfigurationRequest

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupService.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Options;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Options;
+using PingMonitor.Web.Services.NetworkDiagrams;
 
 namespace PingMonitor.Web.Services.Backups;
 
@@ -105,6 +106,9 @@ public sealed class ConfigurationBackupService : IConfigurationBackupService
                 : null,
             Identity = selectedSections.Contains(ConfigurationBackupSections.Identity, StringComparer.Ordinal)
                 ? await LoadIdentityAsync(cancellationToken)
+                : null,
+            NetworkDiagrams = selectedSections.Contains(ConfigurationBackupSections.NetworkDiagrams, StringComparer.Ordinal)
+                ? await LoadNetworkDiagramsAsync(cancellationToken)
                 : null
         };
 
@@ -262,6 +266,86 @@ public sealed class ConfigurationBackupService : IConfigurationBackupService
                 UpdatedAtUtc = x.UpdatedAtUtc
             })
             .ToListAsync(cancellationToken);
+    }
+
+    private async Task<BackupNetworkDiagramSection> LoadNetworkDiagramsAsync(CancellationToken cancellationToken)
+    {
+        var diagrams = await _dbContext.NetworkDiagrams
+            .AsNoTracking()
+            .Include(x => x.Nodes)
+            .Include(x => x.Links)
+                .ThenInclude(x => x.Vlans)
+            .OrderBy(x => x.Name)
+            .ToListAsync(cancellationToken);
+
+        return new BackupNetworkDiagramSection
+        {
+            Diagrams = diagrams.Select(diagram => new BackupNetworkDiagramRecord
+            {
+                DiagramId = diagram.DiagramId,
+                Name = diagram.Name,
+                Description = diagram.Description,
+                CanvasWidth = diagram.CanvasWidth,
+                CanvasHeight = diagram.CanvasHeight,
+                ViewportPanX = diagram.ViewportPanX,
+                ViewportPanY = diagram.ViewportPanY,
+                ViewportZoom = diagram.ViewportZoom,
+                CreatedAtUtc = diagram.CreatedAtUtc,
+                UpdatedAtUtc = diagram.UpdatedAtUtc,
+                CreatedByUserId = diagram.CreatedByUserId,
+                UpdatedByUserId = diagram.UpdatedByUserId,
+                Nodes = diagram.Nodes.OrderBy(x => x.CreatedAtUtc).ThenBy(x => x.NodeId).Select(node => new BackupNetworkDiagramNodeRecord
+                {
+                    NodeId = node.NodeId,
+                    NodeType = node.NodeType.ToString(),
+                    EndpointId = node.EndpointId,
+                    DisplayLabel = node.DisplayLabel,
+                    IconKey = node.IconKey,
+                    X = node.X,
+                    Y = node.Y,
+                    Width = node.Width,
+                    Height = node.Height,
+                    Notes = node.Notes,
+                    MetadataJson = node.MetadataJson,
+                    CreatedAtUtc = node.CreatedAtUtc,
+                    UpdatedAtUtc = node.UpdatedAtUtc
+                }).ToArray(),
+                Links = diagram.Links.OrderBy(x => x.CreatedAtUtc).ThenBy(x => x.LinkId).Select(link => new BackupNetworkDiagramLinkRecord
+                {
+                    LinkId = link.LinkId,
+                    SourceNodeId = link.SourceNodeId,
+                    TargetNodeId = link.TargetNodeId,
+                    Label = link.Label,
+                    SourcePortLabel = link.SourcePortLabel,
+                    TargetPortLabel = link.TargetPortLabel,
+                    Notes = link.Notes,
+                    MediaType = NetworkDiagramLinkMediaTypes.Normalize(link.MediaType),
+                    MediaSubtype = NetworkDiagramMediaSubtypes.Normalize(link.FibreSubtype, link.MediaType),
+                    FibreSubtype = string.Equals(NetworkDiagramLinkMediaTypes.Normalize(link.MediaType), NetworkDiagramLinkMediaTypes.Fibre, StringComparison.Ordinal)
+                        ? NetworkDiagramMediaSubtypes.Normalize(link.FibreSubtype, NetworkDiagramLinkMediaTypes.Fibre)
+                        : null,
+                    LinkType = NetworkDiagramLinkTypes.Normalize(link.LinkType),
+                    LinkSpeedValue = link.LinkSpeedValue,
+                    LinkSpeedUnit = NetworkDiagramLinkSpeedUnits.Normalize(link.LinkSpeedUnit),
+                    LacpMemberCount = link.LacpMemberCount,
+                    LacpMemberPortsJson = link.LacpMemberPortsJson,
+                    MetadataJson = link.MetadataJson,
+                    CreatedAtUtc = link.CreatedAtUtc,
+                    UpdatedAtUtc = link.UpdatedAtUtc,
+                    Vlans = link.Vlans.OrderBy(x => x.SortOrder).ThenBy(x => x.VlanId).Select(vlan => new BackupNetworkDiagramLinkVlanRecord
+                    {
+                        LinkVlanId = vlan.LinkVlanId,
+                        VlanId = vlan.VlanId,
+                        Name = vlan.Name,
+                        Mode = NetworkDiagramVlanModes.Normalize(vlan.Mode),
+                        Notes = vlan.Notes,
+                        SortOrder = vlan.SortOrder,
+                        CreatedAtUtc = vlan.CreatedAtUtc,
+                        UpdatedAtUtc = vlan.UpdatedAtUtc
+                    }).ToArray()
+                }).ToArray()
+            }).ToArray()
+        };
     }
 
     private async Task<BackupIdentitySection> LoadIdentityAsync(CancellationToken cancellationToken)

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestorePreviewService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestorePreviewService.cs
@@ -1,5 +1,10 @@
-namespace PingMonitor.Web.Services.Backups;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.NetworkDiagrams;
 using PingMonitor.Web.Support;
+
+namespace PingMonitor.Web.Services.Backups;
 
 public interface IConfigurationRestorePreviewService
 {
@@ -10,13 +15,16 @@ public sealed class ConfigurationRestorePreviewService : IConfigurationRestorePr
 {
     private readonly IConfigurationBackupDocumentLoader _documentLoader;
     private readonly ILogger<ConfigurationRestorePreviewService> _logger;
+    private readonly PingMonitorDbContext? _dbContext;
 
     public ConfigurationRestorePreviewService(
         IConfigurationBackupDocumentLoader documentLoader,
-        ILogger<ConfigurationRestorePreviewService> logger)
+        ILogger<ConfigurationRestorePreviewService> logger,
+        PingMonitorDbContext? dbContext = null)
     {
         _documentLoader = documentLoader;
         _logger = logger;
+        _dbContext = dbContext;
     }
 
     public async Task<ConfigurationBackupPreview> GetPreviewAsync(string fileId, CancellationToken cancellationToken)
@@ -24,6 +32,7 @@ public sealed class ConfigurationRestorePreviewService : IConfigurationRestorePr
         var document = await _documentLoader.LoadValidatedDocumentAsync(fileId, cancellationToken);
 
         var includedSections = GetIncludedSections(document).ToArray();
+        var warnings = await BuildNetworkDiagramPreviewWarningsAsync(document, cancellationToken);
         var preview = new ConfigurationBackupPreview
         {
             FileId = fileId,
@@ -50,8 +59,13 @@ public sealed class ConfigurationRestorePreviewService : IConfigurationRestorePr
                 UserNotificationSettings = document.Sections.UserNotificationSettings?.Count ?? 0,
                 IdentityUsers = document.Sections.Identity?.Users.Count ?? 0,
                 IdentityRoles = document.Sections.Identity?.Roles.Count ?? 0,
-                IdentityUserRoles = document.Sections.Identity?.UserRoles.Count ?? 0
-            }
+                IdentityUserRoles = document.Sections.Identity?.UserRoles.Count ?? 0,
+                NetworkDiagrams = document.Sections.NetworkDiagrams?.Diagrams.Count ?? 0,
+                NetworkDiagramNodes = document.Sections.NetworkDiagrams?.Diagrams.Sum(x => x.Nodes.Count) ?? 0,
+                NetworkDiagramLinks = document.Sections.NetworkDiagrams?.Diagrams.Sum(x => x.Links.Count) ?? 0,
+                NetworkDiagramLinkVlans = document.Sections.NetworkDiagrams?.Diagrams.Sum(x => x.Links.Sum(link => link.Vlans.Count)) ?? 0
+            },
+            Warnings = warnings
         };
 
         _logger.LogInformation(
@@ -60,6 +74,90 @@ public sealed class ConfigurationRestorePreviewService : IConfigurationRestorePr
             string.Join(",", includedSections));
 
         return preview;
+    }
+
+    private async Task<IReadOnlyList<string>> BuildNetworkDiagramPreviewWarningsAsync(ConfigurationBackupDocument document, CancellationToken cancellationToken)
+    {
+        var section = document.Sections.NetworkDiagrams;
+        if (section is null)
+        {
+            return [];
+        }
+
+        var warnings = new List<string>();
+        var existingEndpointIds = _dbContext is null
+            ? new HashSet<string>(StringComparer.Ordinal)
+            : (await _dbContext.Endpoints.AsNoTracking().Select(x => x.EndpointId).ToListAsync(cancellationToken)).ToHashSet(StringComparer.Ordinal);
+        var backupEndpointIds = (document.Sections.Endpoints ?? []).Select(x => x.EndpointId).Where(x => !string.IsNullOrWhiteSpace(x)).ToHashSet(StringComparer.Ordinal);
+
+        IReadOnlyList<NetworkDiagram> existingDiagrams = [];
+        if (_dbContext is not null)
+        {
+            existingDiagrams = await _dbContext.NetworkDiagrams.AsNoTracking().ToListAsync(cancellationToken);
+            var createCount = section.Diagrams.Count(source => !existingDiagrams.Any(existing => string.Equals(existing.DiagramId, source.DiagramId, StringComparison.Ordinal) || string.Equals(existing.Name, source.Name, StringComparison.OrdinalIgnoreCase)));
+            var updateCount = section.Diagrams.Count - createCount;
+            warnings.Add($"Network diagrams preview: {createCount} diagram(s) to create and {updateCount} diagram(s) to update by matching diagram ID or name.");
+        }
+        else
+        {
+            warnings.Add("Network diagrams preview: existing diagram create/update matching requires database context; backup structure validation still ran.");
+        }
+
+        foreach (var diagram in section.Diagrams)
+        {
+            var validNodeIds = diagram.Nodes.Select(x => x.NodeId).Where(x => !string.IsNullOrWhiteSpace(x)).ToHashSet(StringComparer.Ordinal);
+            foreach (var node in diagram.Nodes)
+            {
+                if (!Enum.TryParse<NetworkDiagramNodeType>(node.NodeType, ignoreCase: true, out var nodeType) || !Enum.IsDefined(nodeType))
+                {
+                    warnings.Add($"Network diagram '{diagram.Name}' node '{node.NodeId}' has unsupported node type '{node.NodeType}' and will be skipped.");
+                    continue;
+                }
+
+                if (nodeType == NetworkDiagramNodeType.MonitoredEndpoint && !string.IsNullOrWhiteSpace(node.EndpointId))
+                {
+                    if (existingEndpointIds.Contains(node.EndpointId))
+                    {
+                        continue;
+                    }
+
+                    if (backupEndpointIds.Contains(node.EndpointId))
+                    {
+                        warnings.Add($"Network diagram '{diagram.Name}' monitored node '{node.NodeId}' references endpoint '{node.EndpointId}', which can be remapped if the endpoints section is restored in the same operation.");
+                    }
+                    else
+                    {
+                        warnings.Add($"Network diagram '{diagram.Name}' monitored node '{node.NodeId}' references missing endpoint '{node.EndpointId}'; restore will keep the node but clear EndpointId instead of creating an endpoint.");
+                    }
+                }
+            }
+
+            foreach (var link in diagram.Links)
+            {
+                if (string.Equals(link.SourceNodeId, link.TargetNodeId, StringComparison.Ordinal)
+                    || !validNodeIds.Contains(link.SourceNodeId)
+                    || !validNodeIds.Contains(link.TargetNodeId)
+                    || !NetworkDiagramLinkMediaTypes.IsAllowed(link.MediaType)
+                    || !NetworkDiagramMediaSubtypes.IsAllowed(link.MediaSubtype ?? link.FibreSubtype, link.MediaType)
+                    || !NetworkDiagramLinkTypes.IsAllowed(link.LinkType)
+                    || link.LinkSpeedValue is <= 0 or > 1000000
+                    || !NetworkDiagramLinkSpeedUnits.IsAllowed(link.LinkSpeedUnit))
+                {
+                    warnings.Add($"Network diagram '{diagram.Name}' link '{link.LinkId}' has invalid references or metadata and will be skipped with its VLAN metadata.");
+                    continue;
+                }
+
+                foreach (var vlan in link.Vlans)
+                {
+                    if (vlan.VlanId is < 1 or > 4094 || !NetworkDiagramVlanModes.IsAllowed(vlan.Mode))
+                    {
+                        warnings.Add($"Network diagram '{diagram.Name}' link '{link.LinkId}' VLAN '{vlan.VlanId}' is invalid and will be skipped.");
+                    }
+                }
+            }
+        }
+
+        return warnings;
     }
 
     private static IEnumerable<string> GetIncludedSections(ConfigurationBackupDocument document)
@@ -108,6 +206,11 @@ public sealed class ConfigurationRestorePreviewService : IConfigurationRestorePr
         if (document.Sections.Identity is not null)
         {
             yield return ConfigurationBackupSections.Identity;
+        }
+
+        if (document.Sections.NetworkDiagrams is not null)
+        {
+            yield return ConfigurationBackupSections.NetworkDiagrams;
         }
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Models.Identity;
+using PingMonitor.Web.Services.NetworkDiagrams;
 using PingMonitor.Web.Support;
 using EndpointModel = PingMonitor.Web.Models.Endpoint;
 
@@ -138,6 +139,13 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
             sectionResults.Add(section);
         }
 
+        if (selectedSections.Contains(ConfigurationBackupSections.NetworkDiagrams, StringComparer.Ordinal))
+        {
+            var section = await RestoreNetworkDiagramsAsync(backup, endpointIdMapping, cancellationToken);
+            section.DeletedCount = GetDeletedCount(deletedCounts, section.Section);
+            sectionResults.Add(section);
+        }
+
         await transaction.CommitAsync(cancellationToken);
 
         _logger.LogInformation(
@@ -267,6 +275,22 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
             _logger.LogInformation("Replace delete completed for section {Section}. Deleted {DeletedCount} records.", ConfigurationBackupSections.UserNotificationSettings, deleted);
         }
 
+        if (selectedSections.Contains(ConfigurationBackupSections.NetworkDiagrams, StringComparer.Ordinal))
+        {
+            var deletedVlans = await _dbContext.NetworkDiagramLinkVlans.ExecuteDeleteAsync(cancellationToken);
+            var deletedLinks = await _dbContext.NetworkDiagramLinks.ExecuteDeleteAsync(cancellationToken);
+            var deletedNodes = await _dbContext.NetworkDiagramNodes.ExecuteDeleteAsync(cancellationToken);
+            var deletedDiagrams = await _dbContext.NetworkDiagrams.ExecuteDeleteAsync(cancellationToken);
+            deletedCounts[ConfigurationBackupSections.NetworkDiagrams] = deletedVlans + deletedLinks + deletedNodes + deletedDiagrams;
+            _logger.LogInformation(
+                "Replace delete completed for section {Section}. Deleted diagrams {DiagramCount}, nodes {NodeCount}, links {LinkCount}, VLAN metadata {VlanCount}.",
+                ConfigurationBackupSections.NetworkDiagrams,
+                deletedDiagrams,
+                deletedNodes,
+                deletedLinks,
+                deletedVlans);
+        }
+
         if (selectedSections.Contains(ConfigurationBackupSections.Agents, StringComparer.Ordinal))
         {
             var deletedAgents = await _dbContext.Agents.ExecuteDeleteAsync(cancellationToken);
@@ -296,6 +320,7 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
                 ConfigurationBackupSections.NotificationSettings => backup.Sections.NotificationSettings is not null,
                 ConfigurationBackupSections.UserNotificationSettings => backup.Sections.UserNotificationSettings is not null,
                 ConfigurationBackupSections.Identity => backup.Sections.Identity is not null,
+                ConfigurationBackupSections.NetworkDiagrams => backup.Sections.NetworkDiagrams is not null,
                 _ => false
             };
 
@@ -977,6 +1002,385 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
 
         return result;
     }
+
+
+    private async Task<RestoreSectionResult> RestoreNetworkDiagramsAsync(
+        ConfigurationBackupDocument backup,
+        IDictionary<string, string> endpointIdMapping,
+        CancellationToken cancellationToken)
+    {
+        var result = new RestoreSectionResult { Section = ConfigurationBackupSections.NetworkDiagrams };
+        var sourceSection = backup.Sections.NetworkDiagrams;
+        if (sourceSection is null)
+        {
+            throw new InvalidOperationException("Network diagrams section is missing in selected backup.");
+        }
+
+        var existingEndpointIds = await _dbContext.Endpoints.AsNoTracking().Select(x => x.EndpointId).ToListAsync(cancellationToken);
+        var existingEndpointIdSet = existingEndpointIds.ToHashSet(StringComparer.Ordinal);
+        var existingDiagrams = await _dbContext.NetworkDiagrams
+            .Include(x => x.Nodes)
+            .Include(x => x.Links)
+                .ThenInclude(x => x.Vlans)
+            .ToListAsync(cancellationToken);
+
+        foreach (var sourceDiagram in sourceSection.Diagrams)
+        {
+            if (!ValidateBackupDiagramShell(sourceDiagram, result))
+            {
+                result.SkippedCount++;
+                continue;
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            var target = existingDiagrams.FirstOrDefault(x => string.Equals(x.DiagramId, sourceDiagram.DiagramId, StringComparison.Ordinal))
+                ?? existingDiagrams.FirstOrDefault(x => string.Equals(x.Name, sourceDiagram.Name, StringComparison.OrdinalIgnoreCase));
+            var isInsert = target is null;
+            if (target is null)
+            {
+                target = new NetworkDiagram
+                {
+                    DiagramId = string.IsNullOrWhiteSpace(sourceDiagram.DiagramId) ? Guid.NewGuid().ToString("N") : sourceDiagram.DiagramId,
+                    CreatedAtUtc = sourceDiagram.CreatedAtUtc == default ? now : sourceDiagram.CreatedAtUtc
+                };
+                _dbContext.NetworkDiagrams.Add(target);
+                existingDiagrams.Add(target);
+                result.InsertedCount++;
+            }
+            else
+            {
+                result.UpdatedCount++;
+            }
+
+            target.Name = TrimOrDefault(sourceDiagram.Name, 255, "Restored diagram");
+            target.Description = TrimOptional(sourceDiagram.Description, 2048);
+            target.CanvasWidth = ClampFinite(sourceDiagram.CanvasWidth <= 0 ? 4000 : sourceDiagram.CanvasWidth, 1000, 20000);
+            target.CanvasHeight = ClampFinite(sourceDiagram.CanvasHeight <= 0 ? 2828 : sourceDiagram.CanvasHeight, 1000, 20000);
+            target.ViewportPanX = ClampFinite(sourceDiagram.ViewportPanX, -100000, 100000);
+            target.ViewportPanY = ClampFinite(sourceDiagram.ViewportPanY, -100000, 100000);
+            target.ViewportZoom = ClampFinite(sourceDiagram.ViewportZoom <= 0 ? 1 : sourceDiagram.ViewportZoom, 0.1, 5);
+            target.UpdatedAtUtc = sourceDiagram.UpdatedAtUtc == default ? now : sourceDiagram.UpdatedAtUtc;
+            target.CreatedByUserId = TrimOptional(sourceDiagram.CreatedByUserId, 255);
+            target.UpdatedByUserId = TrimOptional(sourceDiagram.UpdatedByUserId, 255);
+
+            _dbContext.NetworkDiagramLinkVlans.RemoveRange(target.Links.SelectMany(x => x.Vlans));
+            _dbContext.NetworkDiagramLinks.RemoveRange(target.Links);
+            _dbContext.NetworkDiagramNodes.RemoveRange(target.Nodes);
+            target.Links.Clear();
+            target.Nodes.Clear();
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+            var restoredNodeIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var sourceNode in sourceDiagram.Nodes)
+            {
+                if (!TryBuildNetworkDiagramNode(sourceDiagram, sourceNode, target.DiagramId, endpointIdMapping, existingEndpointIdSet, result, out var node))
+                {
+                    result.SkippedCount++;
+                    continue;
+                }
+
+                target.Nodes.Add(node);
+                restoredNodeIds.Add(node.NodeId);
+                if (!isInsert)
+                {
+                    result.UpdatedCount++;
+                }
+                else
+                {
+                    result.InsertedCount++;
+                }
+            }
+
+            var restoredLinkIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var sourceLink in sourceDiagram.Links)
+            {
+                if (!TryBuildNetworkDiagramLink(sourceDiagram, sourceLink, target.DiagramId, restoredNodeIds, result, out var link))
+                {
+                    result.SkippedCount++;
+                    continue;
+                }
+
+                foreach (var sourceVlan in sourceLink.Vlans.OrderBy(x => x.SortOrder).ThenBy(x => x.VlanId))
+                {
+                    if (!TryBuildNetworkDiagramLinkVlan(sourceDiagram, sourceLink, sourceVlan, target.DiagramId, link.LinkId, result, out var vlan))
+                    {
+                        result.SkippedCount++;
+                        continue;
+                    }
+
+                    link.Vlans.Add(vlan);
+                    if (!isInsert)
+                    {
+                        result.UpdatedCount++;
+                    }
+                    else
+                    {
+                        result.InsertedCount++;
+                    }
+                }
+
+                target.Links.Add(link);
+                restoredLinkIds.Add(link.LinkId);
+                if (!isInsert)
+                {
+                    result.UpdatedCount++;
+                }
+                else
+                {
+                    result.InsertedCount++;
+                }
+            }
+
+            _ = restoredLinkIds;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Restored section {Section}. Inserted {InsertedCount}, updated {UpdatedCount}, skipped {SkippedCount}, errors {ErrorCount}.",
+            result.Section,
+            result.InsertedCount,
+            result.UpdatedCount,
+            result.SkippedCount,
+            result.ErrorCount);
+
+        return result;
+    }
+
+    private static bool ValidateBackupDiagramShell(BackupNetworkDiagramRecord diagram, RestoreSectionResult result)
+    {
+        if (string.IsNullOrWhiteSpace(diagram.Name))
+        {
+            result.Warnings.Add($"Skipped network diagram '{diagram.DiagramId}' because the diagram name is missing.");
+            return false;
+        }
+
+        if (!IsFinite(diagram.CanvasWidth) || !IsFinite(diagram.CanvasHeight) || !IsFinite(diagram.ViewportPanX) || !IsFinite(diagram.ViewportPanY) || !IsFinite(diagram.ViewportZoom))
+        {
+            result.Warnings.Add($"Skipped network diagram '{diagram.Name}' because canvas or viewport values are invalid.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryBuildNetworkDiagramNode(
+        BackupNetworkDiagramRecord sourceDiagram,
+        BackupNetworkDiagramNodeRecord sourceNode,
+        string targetDiagramId,
+        IDictionary<string, string> endpointIdMapping,
+        IReadOnlySet<string> existingEndpointIds,
+        RestoreSectionResult result,
+        out NetworkDiagramNode node)
+    {
+        node = new NetworkDiagramNode();
+        if (string.IsNullOrWhiteSpace(sourceNode.NodeId)
+            || string.IsNullOrWhiteSpace(sourceNode.DisplayLabel)
+            || string.IsNullOrWhiteSpace(sourceNode.IconKey)
+            || !IsFinite(sourceNode.X)
+            || !IsFinite(sourceNode.Y)
+            || !IsFinite(sourceNode.Width)
+            || !IsFinite(sourceNode.Height))
+        {
+            result.Warnings.Add($"Skipped node '{sourceNode.NodeId}' in network diagram '{sourceDiagram.Name}' because required node data is invalid.");
+            return false;
+        }
+
+        if (!Enum.TryParse<NetworkDiagramNodeType>(sourceNode.NodeType, ignoreCase: true, out var nodeType) || !Enum.IsDefined(nodeType))
+        {
+            result.Warnings.Add($"Skipped node '{sourceNode.NodeId}' in network diagram '{sourceDiagram.Name}' because node type '{sourceNode.NodeType}' is unsupported.");
+            return false;
+        }
+
+        string? endpointId = null;
+        if (nodeType == NetworkDiagramNodeType.MonitoredEndpoint)
+        {
+            if (string.IsNullOrWhiteSpace(sourceNode.EndpointId))
+            {
+                result.Warnings.Add($"Restored monitored endpoint node '{sourceNode.NodeId}' in network diagram '{sourceDiagram.Name}' without an endpoint reference because the backup endpoint id is empty.");
+            }
+            else
+            {
+                endpointId = ResolveMappedOrExistingId(sourceNode.EndpointId, endpointIdMapping, existingEndpointIds);
+                if (endpointId is null)
+                {
+                    result.Warnings.Add($"Restored monitored endpoint node '{sourceNode.NodeId}' in network diagram '{sourceDiagram.Name}' with EndpointId cleared because endpoint '{sourceNode.EndpointId}' could not be resolved. Restore did not create an endpoint for this diagram reference.");
+                }
+                else if (!string.Equals(endpointId, sourceNode.EndpointId, StringComparison.Ordinal))
+                {
+                    result.Warnings.Add($"Remapped monitored endpoint node '{sourceNode.NodeId}' in network diagram '{sourceDiagram.Name}' from endpoint '{sourceNode.EndpointId}' to '{endpointId}'.");
+                }
+            }
+        }
+        else if (!string.IsNullOrWhiteSpace(sourceNode.EndpointId))
+        {
+            result.Warnings.Add($"Cleared endpoint reference on non-monitored node '{sourceNode.NodeId}' in network diagram '{sourceDiagram.Name}'.");
+        }
+
+        node = new NetworkDiagramNode
+        {
+            NodeId = TrimOrDefault(sourceNode.NodeId, 64, Guid.NewGuid().ToString("N")),
+            DiagramId = targetDiagramId,
+            NodeType = nodeType,
+            EndpointId = endpointId,
+            DisplayLabel = TrimOrDefault(sourceNode.DisplayLabel, 255, "Restored node"),
+            IconKey = TrimOrDefault(sourceNode.IconKey, 64, "generic"),
+            X = ClampFinite(sourceNode.X, -1000, 21000),
+            Y = ClampFinite(sourceNode.Y, -1000, 21000),
+            Width = ClampFinite(sourceNode.Width <= 0 ? 178 : sourceNode.Width, 40, 2000),
+            Height = ClampFinite(sourceNode.Height <= 0 ? 78 : sourceNode.Height, 30, 2000),
+            Notes = TrimOptional(sourceNode.Notes, 4096),
+            MetadataJson = TrimOptional(sourceNode.MetadataJson, 65535),
+            CreatedAtUtc = sourceNode.CreatedAtUtc == default ? DateTimeOffset.UtcNow : sourceNode.CreatedAtUtc,
+            UpdatedAtUtc = sourceNode.UpdatedAtUtc == default ? DateTimeOffset.UtcNow : sourceNode.UpdatedAtUtc
+        };
+        return true;
+    }
+
+    private static bool TryBuildNetworkDiagramLink(
+        BackupNetworkDiagramRecord sourceDiagram,
+        BackupNetworkDiagramLinkRecord sourceLink,
+        string targetDiagramId,
+        IReadOnlySet<string> restoredNodeIds,
+        RestoreSectionResult result,
+        out NetworkDiagramLink link)
+    {
+        link = new NetworkDiagramLink();
+        if (string.IsNullOrWhiteSpace(sourceLink.LinkId)
+            || string.IsNullOrWhiteSpace(sourceLink.SourceNodeId)
+            || string.IsNullOrWhiteSpace(sourceLink.TargetNodeId))
+        {
+            result.Warnings.Add($"Skipped link '{sourceLink.LinkId}' in network diagram '{sourceDiagram.Name}' because required link references are missing.");
+            return false;
+        }
+
+        if (string.Equals(sourceLink.SourceNodeId, sourceLink.TargetNodeId, StringComparison.Ordinal))
+        {
+            result.Warnings.Add($"Skipped self-link '{sourceLink.LinkId}' in network diagram '{sourceDiagram.Name}'.");
+            return false;
+        }
+
+        if (!restoredNodeIds.Contains(sourceLink.SourceNodeId) || !restoredNodeIds.Contains(sourceLink.TargetNodeId))
+        {
+            result.Warnings.Add($"Skipped link '{sourceLink.LinkId}' in network diagram '{sourceDiagram.Name}' because one or both endpoint nodes were not restored.");
+            return false;
+        }
+
+        var mediaType = NetworkDiagramLinkMediaTypes.Normalize(sourceLink.MediaType);
+        var mediaSubtype = NetworkDiagramMediaSubtypes.Normalize(sourceLink.MediaSubtype ?? sourceLink.FibreSubtype, mediaType);
+        var linkType = NetworkDiagramLinkTypes.Normalize(sourceLink.LinkType);
+        var speedUnit = NetworkDiagramLinkSpeedUnits.Normalize(sourceLink.LinkSpeedUnit);
+        if (!NetworkDiagramLinkMediaTypes.IsAllowed(mediaType)
+            || !NetworkDiagramMediaSubtypes.IsAllowed(mediaSubtype, mediaType)
+            || !NetworkDiagramLinkTypes.IsAllowed(linkType)
+            || !NetworkDiagramLinkSpeedUnits.IsAllowed(speedUnit)
+            || sourceLink.LinkSpeedValue is <= 0 or > 1000000
+            || (sourceLink.LinkSpeedValue is null && speedUnit is not null)
+            || (sourceLink.LinkSpeedValue is not null && speedUnit is null))
+        {
+            result.Warnings.Add($"Skipped link '{sourceLink.LinkId}' in network diagram '{sourceDiagram.Name}' because media, type, or speed metadata is invalid.");
+            return false;
+        }
+
+        var lacpMemberCount = string.Equals(linkType, NetworkDiagramLinkTypes.Lacp, StringComparison.Ordinal)
+            ? sourceLink.LacpMemberCount
+            : null;
+        if (lacpMemberCount is < 1 or > 16)
+        {
+            result.Warnings.Add($"Skipped link '{sourceLink.LinkId}' in network diagram '{sourceDiagram.Name}' because LACP member count is invalid.");
+            return false;
+        }
+
+        link = new NetworkDiagramLink
+        {
+            LinkId = TrimOrDefault(sourceLink.LinkId, 64, Guid.NewGuid().ToString("N")),
+            DiagramId = targetDiagramId,
+            SourceNodeId = sourceLink.SourceNodeId,
+            TargetNodeId = sourceLink.TargetNodeId,
+            Label = TrimOptional(sourceLink.Label, 255),
+            SourcePortLabel = TrimOptional(sourceLink.SourcePortLabel, 128),
+            TargetPortLabel = TrimOptional(sourceLink.TargetPortLabel, 128),
+            Notes = TrimOptional(sourceLink.Notes, 4096),
+            MediaType = mediaType,
+            FibreSubtype = mediaSubtype,
+            LinkType = linkType,
+            LinkSpeedValue = sourceLink.LinkSpeedValue is null ? null : Math.Round(sourceLink.LinkSpeedValue.Value, 3),
+            LinkSpeedUnit = speedUnit,
+            LacpMemberCount = lacpMemberCount,
+            LacpMemberPortsJson = string.Equals(linkType, NetworkDiagramLinkTypes.Lacp, StringComparison.Ordinal) ? TrimOptional(sourceLink.LacpMemberPortsJson, 65535) : null,
+            MetadataJson = TrimOptional(sourceLink.MetadataJson, 65535),
+            CreatedAtUtc = sourceLink.CreatedAtUtc == default ? DateTimeOffset.UtcNow : sourceLink.CreatedAtUtc,
+            UpdatedAtUtc = sourceLink.UpdatedAtUtc == default ? DateTimeOffset.UtcNow : sourceLink.UpdatedAtUtc
+        };
+        return true;
+    }
+
+    private static bool TryBuildNetworkDiagramLinkVlan(
+        BackupNetworkDiagramRecord sourceDiagram,
+        BackupNetworkDiagramLinkRecord sourceLink,
+        BackupNetworkDiagramLinkVlanRecord sourceVlan,
+        string targetDiagramId,
+        string targetLinkId,
+        RestoreSectionResult result,
+        out NetworkDiagramLinkVlan vlan)
+    {
+        vlan = new NetworkDiagramLinkVlan();
+        var mode = NetworkDiagramVlanModes.Normalize(sourceVlan.Mode);
+        if (sourceVlan.VlanId is < 1 or > 4094 || !NetworkDiagramVlanModes.IsAllowed(mode))
+        {
+            result.Warnings.Add($"Skipped VLAN metadata '{sourceVlan.VlanId}' on link '{sourceLink.LinkId}' in network diagram '{sourceDiagram.Name}' because VLAN data is invalid.");
+            return false;
+        }
+
+        vlan = new NetworkDiagramLinkVlan
+        {
+            LinkVlanId = string.IsNullOrWhiteSpace(sourceVlan.LinkVlanId) ? Guid.NewGuid().ToString("N") : TrimOrDefault(sourceVlan.LinkVlanId, 64, Guid.NewGuid().ToString("N")),
+            LinkId = targetLinkId,
+            DiagramId = targetDiagramId,
+            VlanId = sourceVlan.VlanId,
+            Name = TrimOptional(sourceVlan.Name, 128),
+            Mode = mode,
+            Notes = TrimOptional(sourceVlan.Notes, 512),
+            SortOrder = sourceVlan.SortOrder,
+            CreatedAtUtc = sourceVlan.CreatedAtUtc == default ? DateTimeOffset.UtcNow : sourceVlan.CreatedAtUtc,
+            UpdatedAtUtc = sourceVlan.UpdatedAtUtc == default ? DateTimeOffset.UtcNow : sourceVlan.UpdatedAtUtc
+        };
+        return true;
+    }
+
+    private static string TrimOrDefault(string? value, int maxLength, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return fallback;
+        }
+
+        var trimmed = value.Trim();
+        return trimmed.Length <= maxLength ? trimmed : trimmed[..maxLength];
+    }
+
+    private static string? TrimOptional(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        return trimmed.Length <= maxLength ? trimmed : trimmed[..maxLength];
+    }
+
+    private static double ClampFinite(double value, double min, double max)
+    {
+        if (!IsFinite(value))
+        {
+            return min;
+        }
+
+        return Math.Min(Math.Max(value, min), max);
+    }
+
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
 
     private static string? ResolveMappedOrExistingId(
         string sourceId,

--- a/src/WebApp/PingMonitor.Web/ViewModels/Backups/BackupsPageViewModels.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Backups/BackupsPageViewModels.cs
@@ -39,6 +39,9 @@ public sealed class CreateBackupPageForm
 
     [Display(Name = "Include identity")]
     public bool IncludeIdentity { get; set; }
+
+    [Display(Name = "Include network diagrams")]
+    public bool IncludeNetworkDiagrams { get; set; } = true;
 }
 
 public sealed class BackupRowViewModel
@@ -132,6 +135,9 @@ public sealed class RestoreApplyForm
     [Display(Name = "Restore identity")]
     public bool IncludeIdentity { get; set; }
 
+    [Display(Name = "Restore network diagrams")]
+    public bool IncludeNetworkDiagrams { get; set; } = true;
+
     [Display(Name = "Restore mode")]
     public string RestoreMode { get; set; } = ConfigurationRestoreModes.Merge;
 
@@ -149,6 +155,7 @@ public sealed class BackupRestorePreviewViewModel
     public int FormatVersion { get; init; }
     public IReadOnlyList<string> IncludedSections { get; init; } = [];
     public ConfigurationBackupSectionCountViewModel Counts { get; init; } = new();
+    public IReadOnlyList<string> Warnings { get; init; } = [];
 }
 
 public sealed class ConfigurationBackupSectionCountViewModel
@@ -165,6 +172,10 @@ public sealed class ConfigurationBackupSectionCountViewModel
     public int IdentityUsers { get; init; }
     public int IdentityRoles { get; init; }
     public int IdentityUserRoles { get; init; }
+    public int NetworkDiagrams { get; init; }
+    public int NetworkDiagramNodes { get; init; }
+    public int NetworkDiagramLinks { get; init; }
+    public int NetworkDiagramLinkVlans { get; init; }
 }
 
 public sealed class BackupRestoreSectionResultViewModel

--- a/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
@@ -103,6 +103,7 @@
                             <label class="check-item"><input asp-for="Form.IncludeNotificationSettings" /> Notification infrastructure settings</label>
                             <label class="check-item"><input asp-for="Form.IncludeUserNotificationSettings" /> User notification settings</label>
                             <label class="check-item"><input asp-for="Form.IncludeIdentity" /> Identity (optional; disabled by default)</label>
+                            <label class="check-item"><input asp-for="Form.IncludeNetworkDiagrams" /> Network diagrams</label>
                         </div>
                     </div>
                 </div>
@@ -168,6 +169,18 @@
                             <strong>Notes</strong>
                             <div class="notes">@(string.IsNullOrWhiteSpace(Model.Preview.Notes) ? "(none)" : Model.Preview.Notes)</div>
                         </div>
+                        @if (Model.Preview.Warnings.Count > 0)
+                        {
+                            <div class="warning" style="margin-top:.75rem;">
+                                <strong>Restore preview warnings</strong>
+                                <ul>
+                                    @foreach (var warning in Model.Preview.Warnings)
+                                    {
+                                        <li>@warning</li>
+                                    }
+                                </ul>
+                            </div>
+                        }
                         <div style="overflow-x:auto; margin-top:.75rem;">
                             <table>
                                 <thead>
@@ -189,6 +202,10 @@
                                     <tr><td>Identity users</td><td>@Model.Preview.Counts.IdentityUsers</td></tr>
                                     <tr><td>Identity roles</td><td>@Model.Preview.Counts.IdentityRoles</td></tr>
                                     <tr><td>Identity user-role links</td><td>@Model.Preview.Counts.IdentityUserRoles</td></tr>
+                                    <tr><td>Network diagrams</td><td>@Model.Preview.Counts.NetworkDiagrams</td></tr>
+                                    <tr><td>Network diagram nodes</td><td>@Model.Preview.Counts.NetworkDiagramNodes</td></tr>
+                                    <tr><td>Network diagram links</td><td>@Model.Preview.Counts.NetworkDiagramLinks</td></tr>
+                                    <tr><td>Network diagram VLAN metadata</td><td>@Model.Preview.Counts.NetworkDiagramLinkVlans</td></tr>
                                 </tbody>
                             </table>
                         </div>
@@ -209,6 +226,7 @@
                             <label class="check-item"><input asp-for="RestoreApplyForm.IncludeNotificationSettings" /> Notification infrastructure settings</label>
                             <label class="check-item"><input asp-for="RestoreApplyForm.IncludeUserNotificationSettings" /> User notification settings</label>
                             <label class="check-item"><input asp-for="RestoreApplyForm.IncludeIdentity" /> Identity (sensitive and optional)</label>
+                            <label class="check-item"><input asp-for="RestoreApplyForm.IncludeNetworkDiagrams" /> Network diagrams</label>
                         </div>
                         <div>
                             <label asp-for="RestoreApplyForm.RestoreMode"></label>


### PR DESCRIPTION
### Motivation
- Network Diagrams are configuration/documentation data that must round-trip in configuration backups before the preview release.\n- Backups and restores must treat diagrams as documentation-only and not affect monitoring, endpoints, assignments, or dependency logic.\n- This change implements the required backup/restore support tracked by issue #528 and bumps the backup format version to include the new section.

### Description
- Add `network_diagrams` backup section and DTOs by extending `ConfigurationBackupModels` and bumping `FormatVersion` from 2 to 3.\n- Export: implement `LoadNetworkDiagramsAsync` in `ConfigurationBackupService` to include diagrams, nodes, links, and VLAN metadata in backups.\n- Preview/Counts: include diagram counts in `ConfigurationRestorePreviewService` and display them in the admin preview UI.\n- Validation: extend `ConfigurationBackupDocumentValidator` to validate network diagram records (canvas/viewport, nodes, links, media/subtypes, speed, VLAN IDs, etc.).\n- Restore: add `RestoreNetworkDiagramsAsync` to `ConfigurationRestoreService` with safe merge and replace behaviour, endpoint ID remapping using existing endpoint remap logic, warnings for unresolved monitored endpoint references, and skipping invalid links/VLANs; implement replace-mode deletes limited to diagram tables (`NetworkDiagramLinkVlans`, `NetworkDiagramLinks`, `NetworkDiagramNodes`, `NetworkDiagrams`).\n- Admin UI & defaults: add network diagrams controls to the backup/restore admin pages and include `network_diagrams` in automatic backup defaults where appropriate.\n- Docs: update `docs/config-backup-and-restore.md` to document the new `network_diagrams` section and restore semantics (no endpoint creation, no monitoring dependency creation, remapping behaviour, replace-scoped deletes).\n- Tests: add `ConfigurationBackupNetworkDiagramTests` in `PingMonitor.Web.Tests` covering preview reporting and validator behaviour.\n
### Testing
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which succeeded.\n- Ran unit tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and all tests passed: "Passed! - Failed: 0, Passed: 148, Skipped: 0, Total: 148".\n- Performed a quick verification that backup format version was incremented and preview counts include diagrams and diagram subcounts (nodes/links/VLANs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a206d57af90832a8f278724c0aafb96)