### PR TITLE
Improve network diagram endpoint toolbox filtering (search + group filter)

### DIFF
--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -427,3 +427,47 @@ Safety boundary:
 13. Wait for live overlay refresh and confirm summary counts update without resetting the selected node or link.
 14. Test in dark mode and light mode.
 15. Confirm no monitoring, dependency, alerting, agent, or Startup Gate behaviour changed.
+
+## Editor Endpoint Toolbox Search and Group Filter Slice
+
+Issue: #531
+
+This slice improves only the Network Diagram editor placement toolbox for monitored endpoints.
+
+Included:
+
+- The monitored endpoint toolbox includes a compact search box with placeholder text: “Search endpoints by name or host…”.
+- Search runs client-side against the already-loaded authorized endpoint toolbox data and matches endpoint name/display text plus the existing endpoint target/host/IP field.
+- The endpoint toolbox includes a group dropdown with “All groups”, “Ungrouped”, and the endpoint groups represented by the currently visible toolbox endpoints.
+- Search text and group selection combine, so operators can narrow a large endpoint list without additional server requests on every keystroke.
+- A compact result count reports all endpoints or filtered counts, and a no-match empty state includes a clear-filters action.
+- An optional “Hide endpoints already on this diagram” checkbox hides endpoints that already have at least one visual node in the current draft diagram; this remains only a filter and does not block duplicate visual instances when unchecked.
+- Existing Add behaviour is unchanged: adding a monitored endpoint still creates a visual diagram node in the current viewport/visible area and does not create endpoints or monitoring dependencies.
+
+Authorization and safety boundary:
+
+- The toolbox continues to use the existing endpoint management query path and therefore follows the same endpoint visibility/access rules already enforced by the application.
+- Group names shown in the filter are derived from endpoints already present in the authorized toolbox list, so the filter does not expose additional endpoints or groups outside that list.
+- This change affects diagram placement only. It does not alter monitoring configuration, endpoint checks, state evaluation, dependency suppression, alerting, agents, SNMP, topology inference, or Startup Gate behaviour.
+
+## Manual Regression Checklist - Endpoint Toolbox Search and Group Filter
+
+- Open the diagram editor.
+- Confirm the endpoint list loads.
+- Search by endpoint name.
+- Search by IP/host/target.
+- Clear search.
+- Filter by a group.
+- Filter by Ungrouped when ungrouped endpoints exist.
+- Combine group filter and search.
+- Confirm the result count updates.
+- Confirm the empty state appears for no matches.
+- Use Clear filters from the empty state.
+- Add an endpoint after filtering.
+- Save, refresh, and confirm the endpoint node persists.
+- Enable “Hide endpoints already on this diagram” and confirm existing visual endpoint nodes are hidden from the toolbox.
+- Disable “Hide endpoints already on this diagram” and confirm duplicate visual instances can still be added.
+- Test in dark mode and light mode.
+- Test at 1366x768.
+- Confirm custom device buttons still work.
+- Confirm no monitoring, dependency, alerting, Startup Gate, or agent behaviour changed.

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -165,6 +165,94 @@ public sealed class NetworkDiagramsFeatureTests
 
 
     [Fact]
+    public void NetworkDiagramEditor_ViewIncludesEndpointToolboxFilters()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var viewMarkup = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "Views", "NetworkDiagrams", "Edit.cshtml"));
+        var script = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "wwwroot", "js", "network-diagrams-editor.js"));
+
+        Assert.Contains("Search endpoints by name or host…", viewMarkup);
+        Assert.Contains("data-endpoint-search", viewMarkup);
+        Assert.Contains("data-endpoint-group-filter", viewMarkup);
+        Assert.Contains("Ungrouped", viewMarkup);
+        Assert.Contains("data-hide-existing-endpoints", viewMarkup);
+        Assert.Contains("data-endpoint-result-count", viewMarkup);
+        Assert.Contains("No endpoints match", viewMarkup);
+        Assert.Contains("data-clear-endpoint-filters", viewMarkup);
+        Assert.Contains("updateEndpointToolboxFilters", script);
+        Assert.Contains("dataset.endpointSearchText", script);
+        Assert.Contains("dataset.endpointGroups", script);
+        Assert.Contains("getExistingEndpointIdsOnDiagram", script);
+        Assert.Contains("event.key === 'Escape'", script);
+    }
+
+    [Fact]
+    public async Task NetworkDiagramsEdit_BuildsEndpointToolboxGroupFiltersFromVisibleEndpoints()
+    {
+        var controller = new NetworkDiagramsController(
+            new FakeApplicationSettingsService(new ApplicationSettingsDto { NetworkDiagramsEnabled = true }),
+            new FakeEndpointManagementQueryService(
+                new ManageEndpointRowViewModel
+                {
+                    AssignmentId = "assignment-1",
+                    EndpointId = "endpoint-1",
+                    EndpointName = "Core router",
+                    Target = "192.0.2.1",
+                    IconKey = "router",
+                    CurrentState = EndpointStateKind.Up,
+                    GroupNames = ["Core", "WAN"]
+                },
+                new ManageEndpointRowViewModel
+                {
+                    AssignmentId = "assignment-2",
+                    EndpointId = "endpoint-1",
+                    EndpointName = "Core router",
+                    Target = "192.0.2.1",
+                    IconKey = "router",
+                    CurrentState = EndpointStateKind.Down,
+                    GroupNames = ["Core"]
+                },
+                new ManageEndpointRowViewModel
+                {
+                    AssignmentId = "assignment-3",
+                    EndpointId = "endpoint-2",
+                    EndpointName = "Branch switch",
+                    Target = "branch-switch.example.test",
+                    IconKey = "switch",
+                    CurrentState = EndpointStateKind.Unknown,
+                    GroupNames = []
+                }),
+            new FakeNetworkDiagramService(new NetworkDiagram { DiagramId = "diagram-1", Name = "Core", UpdatedAtUtc = DateTimeOffset.UtcNow }),
+            new FakeNetworkDiagramPdfExportService(),
+            new FakeNetworkDiagramImageExportService(),
+            new FakeNetworkDiagramLiveOverlayService(),
+            new FakeUserAccessScopeService());
+
+        var result = await controller.Edit("diagram-1", CancellationToken.None);
+
+        var view = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<NetworkDiagramEditorPageViewModel>(view.Model);
+        Assert.Equal(["Core", "WAN"], model.EndpointGroups.Select(group => group.Name).ToArray());
+        var endpoint = Assert.Single(model.MonitoredEndpoints, item => item.EndpointId == "endpoint-1");
+        Assert.Equal(["Core", "WAN"], endpoint.GroupNames);
+        Assert.Equal(EndpointStateKind.Down, endpoint.SummaryState);
+        Assert.Contains(model.MonitoredEndpoints, item => item.EndpointId == "endpoint-2" && item.GroupNames.Count == 0);
+    }
+
+    [Fact]
+    public void NetworkDiagramDocumentation_IncludesEndpointToolboxSearchChecklist()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var documentation = File.ReadAllText(Path.Combine(repoRoot, "docs", "network-diagrams-v0.1.1.md"));
+
+        Assert.Contains("Editor Endpoint Toolbox Search and Group Filter Slice", documentation);
+        Assert.Contains("Search by IP/host/target", documentation);
+        Assert.Contains("Endpoint visibility/access rules", documentation, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("does not alter monitoring configuration", documentation);
+        Assert.Contains("Manual Regression Checklist - Endpoint Toolbox Search and Group Filter", documentation);
+    }
+
+    [Fact]
     public void NetworkDiagram_DefaultCanvasUsesASeriesLandscapeRatio()
     {
         var diagram = new NetworkDiagram();

--- a/src/WebApp/PingMonitor.Web/Controllers/NetworkDiagramsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/NetworkDiagramsController.cs
@@ -144,6 +144,7 @@ public sealed class NetworkDiagramsController : Controller
         }
 
         var endpoints = await _endpointManagementQueryService.GetManagePageAsync(groupId: null, cancellationToken);
+        var endpointToolboxItems = BuildEndpointToolbox(endpoints.Rows);
 
         return View("Edit", new NetworkDiagramEditorPageViewModel
         {
@@ -157,7 +158,8 @@ public sealed class NetworkDiagramsController : Controller
             ExportPngUrl = Url?.Action(nameof(ExportImage), new { diagramId = diagram.DiagramId, format = "png" }) ?? string.Empty,
             ExportSvgUrl = Url?.Action(nameof(ExportImage), new { diagramId = diagram.DiagramId, format = "svg" }) ?? string.Empty,
             ViewerUrl = Url?.Action(nameof(ViewDiagram), new { diagramId = diagram.DiagramId }) ?? string.Empty,
-            MonitoredEndpoints = BuildEndpointToolbox(endpoints.Rows)
+            MonitoredEndpoints = endpointToolboxItems,
+            EndpointGroups = BuildEndpointGroupFilters(endpointToolboxItems)
         });
     }
 
@@ -343,11 +345,30 @@ public sealed class NetworkDiagramsController : Controller
                     Name = first.EndpointName,
                     Target = first.Target,
                     IconKey = first.IconKey,
-                    SummaryState = SelectSummaryState(group.Select(row => row.CurrentState))
+                    SummaryState = SelectSummaryState(group.Select(row => row.CurrentState)),
+                    GroupNames = group
+                        .SelectMany(row => row.GroupNames)
+                        .Where(name => !string.IsNullOrWhiteSpace(name))
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+                        .ToArray()
                 };
             })
             .OrderBy(item => item.Name, StringComparer.OrdinalIgnoreCase)
             .ThenBy(item => item.Target, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+
+    private static IReadOnlyList<NetworkDiagramEndpointGroupFilterOptionViewModel> BuildEndpointGroupFilters(
+        IReadOnlyList<NetworkDiagramEndpointToolboxItemViewModel> endpoints)
+    {
+        return endpoints
+            .SelectMany(endpoint => endpoint.GroupNames)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .Select(name => new NetworkDiagramEndpointGroupFilterOptionViewModel { Name = name })
             .ToArray();
     }
 

--- a/src/WebApp/PingMonitor.Web/ViewModels/NetworkDiagrams/NetworkDiagramPersistenceViewModels.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/NetworkDiagrams/NetworkDiagramPersistenceViewModels.cs
@@ -60,6 +60,13 @@ public sealed class NetworkDiagramEditorPageViewModel
     public string ViewerUrl { get; init; } = string.Empty;
 
     public IReadOnlyList<NetworkDiagramEndpointToolboxItemViewModel> MonitoredEndpoints { get; init; } = [];
+
+    public IReadOnlyList<NetworkDiagramEndpointGroupFilterOptionViewModel> EndpointGroups { get; init; } = [];
+}
+
+public sealed class NetworkDiagramEndpointGroupFilterOptionViewModel
+{
+    public string Name { get; init; } = string.Empty;
 }
 
 public sealed class NetworkDiagramEndpointToolboxItemViewModel
@@ -73,6 +80,8 @@ public sealed class NetworkDiagramEndpointToolboxItemViewModel
     public string IconKey { get; init; } = "generic";
 
     public Models.EndpointStateKind SummaryState { get; init; } = Models.EndpointStateKind.Unknown;
+
+    public IReadOnlyList<string> GroupNames { get; init; } = [];
 }
 
 

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
@@ -35,10 +35,43 @@
                     else
                     {
                         <p class="toolbox-help">Use Add to place another visual instance of an endpoint on the diagram canvas.</p>
+                        <div class="endpoint-toolbox-filters" data-endpoint-toolbox-filters>
+                            <label class="endpoint-toolbox-search-label">
+                                <span class="sr-only">Search monitored endpoints</span>
+                                <input type="search"
+                                       data-endpoint-search
+                                       autocomplete="off"
+                                       placeholder="Search endpoints by name or host…" />
+                            </label>
+                            <button type="button" class="endpoint-toolbox-clear-search" data-clear-endpoint-search hidden>Clear</button>
+                            <label class="endpoint-toolbox-group-filter">
+                                <span>Group</span>
+                                <select data-endpoint-group-filter>
+                                    <option value="">All groups</option>
+                                    <option value="__ungrouped">Ungrouped</option>
+                                    @foreach (var group in Model.EndpointGroups)
+                                    {
+                                        <option value="@group.Name">@group.Name</option>
+                                    }
+                                </select>
+                            </label>
+                            <label class="endpoint-toolbox-hide-existing">
+                                <input type="checkbox" data-hide-existing-endpoints />
+                                <span>Hide endpoints already on this diagram</span>
+                            </label>
+                            <p class="endpoint-toolbox-count" data-endpoint-result-count aria-live="polite">@Model.MonitoredEndpoints.Count endpoints</p>
+                        </div>
+                        <div class="endpoint-toolbox-empty" data-endpoint-filter-empty hidden>
+                            <p>No endpoints match.</p>
+                            <button type="button" data-clear-endpoint-filters>Clear filters</button>
+                        </div>
                         <div class="endpoint-toolbox-list" data-endpoint-toolbox-list>
                             @foreach (var endpoint in Model.MonitoredEndpoints)
                             {
-                                <article class="endpoint-toolbox-item">
+                                <article class="endpoint-toolbox-item"
+                                         data-endpoint-toolbox-item
+                                         data-endpoint-search-text="@endpoint.Name @endpoint.Target"
+                                         data-endpoint-groups="@string.Join("|", endpoint.GroupNames)">
                                     <div class="endpoint-toolbox-main">
                                         <span class="endpoint-toolbox-icon" aria-hidden="true">@endpoint.IconKey</span>
                                         <span class="endpoint-toolbox-text">
@@ -46,6 +79,10 @@
                                             @if (!string.IsNullOrWhiteSpace(endpoint.Target))
                                             {
                                                 <span>@endpoint.Target</span>
+                                            }
+                                            @if (endpoint.GroupNames.Count > 0)
+                                            {
+                                                <span>Groups: @string.Join(", ", endpoint.GroupNames)</span>
                                             }
                                             <span class="endpoint-toolbox-state">State: @endpoint.SummaryState</span>
                                         </span>

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -95,6 +95,19 @@ body {
     color: var(--diagram-warning);
 }
 
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 .diagram-editor-layout {
     display: grid;
     grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
@@ -340,7 +353,20 @@ body {
         min-height: 0;
     }
 
-    .diagram-editor-layout {
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.diagram-editor-layout {
         grid-template-columns: minmax(0, 1fr);
         grid-template-rows: auto minmax(60vh, 1fr);
     }
@@ -370,6 +396,19 @@ body {
     font-weight: 700;
 }
 
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 .diagram-editor-layout {
     grid-template-columns: minmax(230px, 300px) minmax(0, 1fr) minmax(220px, 280px);
 }
@@ -379,6 +418,126 @@ body {
     color: var(--diagram-muted);
     font-size: .84rem;
     line-height: 1.35;
+}
+
+
+.endpoint-toolbox-filters {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: .45rem;
+    align-items: center;
+}
+
+.endpoint-toolbox-search-label,
+.endpoint-toolbox-group-filter {
+    display: grid;
+    gap: .25rem;
+    min-width: 0;
+    color: var(--diagram-muted);
+    font-size: .78rem;
+    font-weight: 700;
+}
+
+.endpoint-toolbox-search-label {
+    grid-column: 1;
+}
+
+.endpoint-toolbox-search-label input,
+.endpoint-toolbox-group-filter select {
+    min-height: 40px;
+    width: 100%;
+    border: 1px solid var(--diagram-border);
+    border-radius: 8px;
+    background: var(--diagram-panel);
+    color: var(--diagram-text);
+    font: inherit;
+    padding: .5rem .6rem;
+}
+
+.endpoint-toolbox-search-label input:focus,
+.endpoint-toolbox-group-filter select:focus {
+    outline: none;
+    border-color: var(--diagram-accent);
+    box-shadow: 0 0 0 3px var(--diagram-accent-soft);
+}
+
+.endpoint-toolbox-clear-search,
+.endpoint-toolbox-empty button {
+    min-height: 40px;
+    border: 1px solid var(--diagram-border);
+    border-radius: 8px;
+    background: var(--diagram-panel);
+    color: var(--diagram-text);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 700;
+    padding: .45rem .65rem;
+}
+
+.endpoint-toolbox-clear-search {
+    grid-column: 2;
+    grid-row: 1;
+    justify-self: end;
+}
+
+.endpoint-toolbox-group-filter {
+    grid-column: 1 / -1;
+}
+
+.endpoint-toolbox-hide-existing {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: flex-start;
+    gap: .45rem;
+    color: var(--diagram-muted);
+    font-size: .8rem;
+    line-height: 1.3;
+}
+
+.endpoint-toolbox-hide-existing input {
+    width: 1rem;
+    height: 1rem;
+    margin-top: .1rem;
+    accent-color: var(--diagram-accent);
+}
+
+.endpoint-toolbox-count {
+    grid-column: 1 / -1;
+    margin: 0;
+    color: var(--diagram-muted);
+    font-size: .8rem;
+    font-weight: 700;
+}
+
+.endpoint-toolbox-empty {
+    display: grid;
+    gap: .45rem;
+    padding: .65rem;
+    border: 1px dashed var(--diagram-border);
+    border-radius: 8px;
+    background: var(--diagram-panel);
+}
+
+.endpoint-toolbox-empty p {
+    margin: 0;
+    color: var(--diagram-muted);
+    font-size: .84rem;
+    line-height: 1.35;
+}
+
+.endpoint-toolbox-clear-search:hover,
+.endpoint-toolbox-clear-search:focus-visible,
+.endpoint-toolbox-empty button:hover,
+.endpoint-toolbox-empty button:focus-visible {
+    outline: none;
+    border-color: var(--diagram-accent);
+    box-shadow: 0 0 0 3px var(--diagram-accent-soft);
+}
+
+.endpoint-toolbox-clear-search[hidden],
+.endpoint-toolbox-empty[hidden],
+.endpoint-toolbox-item[hidden] {
+    display: none;
 }
 
 .endpoint-toolbox-list {
@@ -802,7 +961,20 @@ html[data-theme="dark"] .diagram-link-port-label {
 }
 
 @media (max-width: 980px) {
-    .diagram-editor-layout {
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.diagram-editor-layout {
         grid-template-columns: minmax(0, 1fr);
         grid-template-rows: auto minmax(60vh, 1fr) auto;
     }

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
@@ -22,6 +22,14 @@
     const deleteSelectionButtons = Array.from(editor.querySelectorAll('[data-delete-selection]'));
     const addButtons = Array.from(editor.querySelectorAll('[data-add-node]'));
     const addEndpointButtons = Array.from(editor.querySelectorAll('[data-add-endpoint-node]'));
+    const endpointSearchInput = editor.querySelector('[data-endpoint-search]');
+    const clearEndpointSearchButton = editor.querySelector('[data-clear-endpoint-search]');
+    const endpointGroupFilter = editor.querySelector('[data-endpoint-group-filter]');
+    const hideExistingEndpointsCheckbox = editor.querySelector('[data-hide-existing-endpoints]');
+    const endpointResultCount = editor.querySelector('[data-endpoint-result-count]');
+    const endpointFilterEmpty = editor.querySelector('[data-endpoint-filter-empty]');
+    const clearEndpointFiltersButton = editor.querySelector('[data-clear-endpoint-filters]');
+    const endpointToolboxItems = Array.from(editor.querySelectorAll('[data-endpoint-toolbox-item]'));
     const toolButtons = Array.from(editor.querySelectorAll('[data-tool-button]'));
     const toolHint = editor.querySelector('[data-tool-hint]');
     const nodeProperties = editor.querySelector('[data-node-properties]');
@@ -298,6 +306,85 @@
         };
     }
 
+
+    function getExistingEndpointIdsOnDiagram() {
+        return new Set(state.nodes
+            .filter(node => node.nodeKind === 'monitored-endpoint' && node.endpointId)
+            .map(node => node.endpointId));
+    }
+
+    function formatEndpointCount(visibleCount, totalCount, filtersActive) {
+        const endpointLabel = visibleCount === 1 ? 'endpoint' : 'endpoints';
+        if (visibleCount === 0) {
+            return 'No endpoints match';
+        }
+
+        if (filtersActive) {
+            const totalLabel = totalCount === 1 ? 'endpoint' : 'endpoints';
+            return `${visibleCount} of ${totalCount} ${totalLabel}`;
+        }
+
+        return `${visibleCount} ${endpointLabel}`;
+    }
+
+    function updateEndpointToolboxFilters() {
+        if (endpointToolboxItems.length === 0) {
+            return;
+        }
+
+        const searchTerm = (endpointSearchInput?.value || '').trim().toLocaleLowerCase();
+        const selectedGroup = endpointGroupFilter?.value || '';
+        const hideExisting = Boolean(hideExistingEndpointsCheckbox?.checked);
+        const existingEndpointIds = hideExisting ? getExistingEndpointIdsOnDiagram() : new Set();
+        let visibleCount = 0;
+
+        endpointToolboxItems.forEach(item => {
+            const searchText = (item.dataset.endpointSearchText || '').toLocaleLowerCase();
+            const groups = (item.dataset.endpointGroups || '')
+                .split('|')
+                .map(group => group.trim())
+                .filter(group => group.length > 0);
+            const endpointId = item.querySelector('[data-add-endpoint-node]')?.dataset.endpointId || '';
+
+            const matchesSearch = !searchTerm || searchText.includes(searchTerm);
+            const matchesGroup = !selectedGroup
+                || (selectedGroup === '__ungrouped' && groups.length === 0)
+                || groups.some(group => group.localeCompare(selectedGroup, undefined, { sensitivity: 'accent' }) === 0);
+            const matchesExisting = !hideExisting || !existingEndpointIds.has(endpointId);
+            const isVisible = matchesSearch && matchesGroup && matchesExisting;
+
+            item.hidden = !isVisible;
+            if (isVisible) {
+                visibleCount += 1;
+            }
+        });
+
+        const filtersActive = Boolean(searchTerm || selectedGroup || hideExisting);
+        if (endpointResultCount) {
+            endpointResultCount.textContent = formatEndpointCount(visibleCount, endpointToolboxItems.length, filtersActive);
+        }
+        if (endpointFilterEmpty) {
+            endpointFilterEmpty.hidden = visibleCount !== 0;
+        }
+        if (clearEndpointSearchButton) {
+            clearEndpointSearchButton.hidden = searchTerm.length === 0;
+        }
+    }
+
+    function clearEndpointFilters() {
+        if (endpointSearchInput) {
+            endpointSearchInput.value = '';
+        }
+        if (endpointGroupFilter) {
+            endpointGroupFilter.value = '';
+        }
+        if (hideExistingEndpointsCheckbox) {
+            hideExistingEndpointsCheckbox.checked = false;
+        }
+        updateEndpointToolboxFilters();
+        endpointSearchInput?.focus();
+    }
+
     function createNodeElement(options) {
         const node = document.createElement('div');
         node.className = 'diagram-node';
@@ -384,6 +471,7 @@
         setEmptyState();
         selectOnlyNode(node.id);
         node.element.focus({ preventScroll: true });
+        updateEndpointToolboxFilters();
     }
 
     function addCustomNode(button) {
@@ -1329,6 +1417,7 @@
             setPendingLinkSource(null);
             setEmptyState();
             syncSelectionDom();
+            updateEndpointToolboxFilters();
             return;
         }
 
@@ -1582,6 +1671,7 @@
         state.nodes = [];
         state.links = [];
         (diagram.nodes || []).forEach(addLoadedNode);
+        updateEndpointToolboxFilters();
         state.links = (diagram.links || []).map(link => ({
             id: link.linkId,
             sourceNodeId: link.sourceNodeId,
@@ -1746,6 +1836,28 @@
     addEndpointButtons.forEach(button => {
         button.addEventListener('click', () => addEndpointNode(button));
     });
+
+    endpointSearchInput?.addEventListener('input', updateEndpointToolboxFilters);
+    endpointSearchInput?.addEventListener('keydown', event => {
+        event.stopPropagation();
+        if (event.key === 'Escape' && endpointSearchInput.value) {
+            endpointSearchInput.value = '';
+            updateEndpointToolboxFilters();
+            event.preventDefault();
+        }
+    });
+    clearEndpointSearchButton?.addEventListener('click', () => {
+        if (endpointSearchInput) {
+            endpointSearchInput.value = '';
+        }
+        updateEndpointToolboxFilters();
+        endpointSearchInput?.focus();
+    });
+    endpointGroupFilter?.addEventListener('change', updateEndpointToolboxFilters);
+    endpointGroupFilter?.addEventListener('keydown', event => event.stopPropagation());
+    hideExistingEndpointsCheckbox?.addEventListener('change', updateEndpointToolboxFilters);
+    clearEndpointFiltersButton?.addEventListener('click', clearEndpointFilters);
+    updateEndpointToolboxFilters();
 
     toolButtons.forEach(button => {
         button.addEventListener('click', () => setTool(button.dataset.toolButton || 'select'));


### PR DESCRIPTION
### Motivation

- The monitored endpoint toolbox can become long and slow to scan when placing endpoints onto large diagrams, creating friction for operators.
- Provide quick, client-side narrowing by endpoint name/label and host/target/IP and by endpoint group while preserving existing visibility/access rules and placement semantics.

### Description

- Add server-side shaping: the Edit action now builds a deduplicated endpoint toolbox and derives visible group filter options from the already-authorised endpoint rows, and the editor view model was extended with `EndpointGroups` (Fixes #531). 
- Add compact UI controls to the editor toolbox: a search input with placeholder `"Search endpoints by name or host…"`, a clear button, a group dropdown with `All groups` and `Ungrouped`, a `Hide endpoints already on this diagram` checkbox, a result count, and a no-match empty state with `Clear filters` action. 
- Implement client-side filtering in `wwwroot/js/network-diagrams-editor.js` to perform case-insensitive partial matches against endpoint name and target/host text, combine group and search filters, hide existing diagram endpoints when requested, update counts/empty state, and handle keyboard behavior (Escape clears search without triggering editor shortcuts). 
- Add styling for the new controls in `wwwroot/css/network-diagrams.css` and surface endpoint group names in the toolbox items; preserve existing `Add` behavior and do not create or modify monitoring/config state. 
- Add tests covering the editor filter markup/script hooks, controller group-filter construction from visible endpoint rows, and documentation updates; documentation `docs/network-diagrams-v0.1.1.md` was updated with the feature description and a manual regression checklist.

### Testing

- Built the web app: `dotnet build src/WebApp/PingMonitor.WebApp.slnx` (succeeded). 
- Ran unit tests: `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` (151 tests passed, all green). 
- Ran the repository dev packaging script: `pwsh -NoProfile -File scripts/build-dev.ps1 -Runtime linux-x64` (succeeded). 
- Added new controller/view/js/css/tests; the updated test suite passed locally after the changes. 
- Performed `git diff --check` and ensured no agent code was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23676195a4832ab562019be427f76c)