### PR TITLE
Add persistent network-diagram area/location boxes (editor, viewer, export, backup/restore)

### DIFF
--- a/docs/config-backup-and-restore.md
+++ b/docs/config-backup-and-restore.md
@@ -197,3 +197,7 @@ Retention is safe and predictable by default:
 - Uploaded backups are not silently auto-pruned by default
 - Pruning may run after automatic backup creation and/or during maintenance passes
 - Max-count pruning for automatic backups is the baseline policy; optional age-based pruning may be added when needed
+
+## Network diagram area/location boxes
+
+Network diagram area/location boxes are included in the `network_diagrams` backup section with their diagram, nodes, visual links, and VLAN link metadata. Restore recreates area boxes as diagram-only visual annotations. Restoring or replacing network diagram data must not create monitoring groups, endpoint dependencies, alerts, endpoints, assignments, or agents, and deleting/replacing diagram data removes only diagram records such as areas, nodes, visual links, VLAN metadata, and diagrams.

--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -471,3 +471,37 @@ Authorization and safety boundary:
 - Test at 1366x768.
 - Confirm custom device buttons still work.
 - Confirm no monitoring, dependency, alerting, Startup Gate, or agent behaviour changed.
+
+## Area / Location Boxes
+
+Network diagrams support persistent area/location boxes for simple visual grouping. Operators can add rectangular boxes labelled for physical or logical regions such as **House**, **Garage**, **Rack**, **Office**, **Server Room**, or **Trading VMs**.
+
+Area boxes are visual annotations only:
+
+- They do **not** create application Groups.
+- They do **not** create endpoint dependencies.
+- They do **not** modify endpoints, agents, monitoring assignments, alerts, or state evaluation.
+- They do **not** perform SNMP discovery or topology discovery.
+
+Area boxes use saved diagram world coordinates and are rendered behind visual links and nodes in the editor, read-only viewer, PNG/SVG exports, and PDF exports. They are included with network diagram configuration backup and restore data so diagram documentation round-trips with the rest of the diagram canvas.
+
+### Manual Regression Checklist - Area / Location Boxes
+
+- Open the diagram editor.
+- Add an area box labelled `House`.
+- Move the area box.
+- Resize the area box using the visible handle.
+- Place nodes visually inside it.
+- Confirm nodes remain selectable and draggable.
+- Save and refresh.
+- Confirm the area box reloads.
+- Edit the label to `Garage` and add notes.
+- Save and refresh.
+- Confirm edits persist.
+- Delete the area box.
+- Confirm nodes and links inside it remain.
+- Add two boxes labelled `House` and `Garage`.
+- Open the read-only viewer and confirm boxes show behind nodes and links.
+- Export PNG and confirm boxes appear in the export.
+- Run configuration backup/restore when practical and confirm area boxes round-trip.
+- Confirm no monitoring, dependency, alert, endpoint, or agent behaviour changed.

--- a/src/WebApp/PingMonitor.Web.Tests/ConfigurationBackupNetworkDiagramTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/ConfigurationBackupNetworkDiagramTests.cs
@@ -25,6 +25,7 @@ public sealed class ConfigurationBackupNetworkDiagramTests
 
         Assert.Contains(ConfigurationBackupSections.NetworkDiagrams, preview.IncludedSections);
         Assert.Equal(1, preview.Counts.NetworkDiagrams);
+        Assert.Equal(1, preview.Counts.NetworkDiagramAreas);
         Assert.Equal(2, preview.Counts.NetworkDiagramNodes);
         Assert.Equal(1, preview.Counts.NetworkDiagramLinks);
         Assert.Equal(1, preview.Counts.NetworkDiagramLinkVlans);
@@ -87,6 +88,51 @@ public sealed class ConfigurationBackupNetworkDiagramTests
         Assert.Contains("invalid VLAN metadata", exception.Message);
     }
 
+    [Fact]
+    public void Validator_RejectsInvalidNetworkDiagramAreaDimensions()
+    {
+        var validator = new ConfigurationBackupDocumentValidator();
+        var section = BuildNetworkDiagramSection();
+        var diagram = section.Diagrams[0];
+        section = new BackupNetworkDiagramSection
+        {
+            Diagrams =
+            [
+                new BackupNetworkDiagramRecord
+                {
+                    DiagramId = diagram.DiagramId,
+                    Name = diagram.Name,
+                    CanvasWidth = diagram.CanvasWidth,
+                    CanvasHeight = diagram.CanvasHeight,
+                    ViewportZoom = diagram.ViewportZoom,
+                    Areas =
+                    [
+                        new BackupNetworkDiagramAreaRecord
+                        {
+                            AreaId = diagram.Areas[0].AreaId,
+                            Label = diagram.Areas[0].Label,
+                            Notes = diagram.Areas[0].Notes,
+                            X = diagram.Areas[0].X,
+                            Y = diagram.Areas[0].Y,
+                            Width = double.NaN,
+                            Height = diagram.Areas[0].Height,
+                            StyleKey = diagram.Areas[0].StyleKey,
+                            SortOrder = diagram.Areas[0].SortOrder,
+                            CreatedAtUtc = diagram.Areas[0].CreatedAtUtc,
+                            UpdatedAtUtc = diagram.Areas[0].UpdatedAtUtc
+                        }
+                    ],
+                    Nodes = diagram.Nodes,
+                    Links = diagram.Links
+                }
+            ]
+        };
+        var document = BuildDocument(section);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => validator.Validate(document, "backup.json"));
+        Assert.Contains("area width", exception.Message);
+    }
+
     private static ConfigurationBackupDocument BuildDocument(BackupNetworkDiagramSection? networkDiagrams)
     {
         return new ConfigurationBackupDocument
@@ -121,6 +167,23 @@ public sealed class ConfigurationBackupNetworkDiagramTests
                     ViewportZoom = 1.25,
                     CreatedAtUtc = DateTimeOffset.UtcNow.AddDays(-1),
                     UpdatedAtUtc = DateTimeOffset.UtcNow,
+                    Areas =
+                    [
+                        new BackupNetworkDiagramAreaRecord
+                        {
+                            AreaId = "area-house",
+                            Label = "House",
+                            Notes = "Main house network",
+                            X = 50,
+                            Y = 75,
+                            Width = 900,
+                            Height = 500,
+                            StyleKey = "blue",
+                            SortOrder = 0,
+                            CreatedAtUtc = DateTimeOffset.UtcNow.AddDays(-1),
+                            UpdatedAtUtc = DateTimeOffset.UtcNow
+                        }
+                    ],
                     Nodes =
                     [
                         new BackupNetworkDiagramNodeRecord

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -186,6 +186,9 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains(".diagram-area {", styles);
         Assert.Contains("pointer-events: none;", styles);
         Assert.Contains(".diagram-area-hit", styles);
+        Assert.Contains("Allow area border/header hit targets below the SVG layer to receive clicks.", styles);
+        Assert.Contains(".diagram-link-layer", styles);
+        Assert.Contains("pointer-events: none;", styles);
         Assert.Contains("pointer-events: auto;", styles);
         Assert.Contains(".diagram-area-resize-handle-nw", styles);
         Assert.Contains(".diagram-area-resize-handle-se", styles);

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -164,6 +164,35 @@ public sealed class NetworkDiagramsFeatureTests
     }
 
 
+
+    [Fact]
+    public void NetworkDiagramEditor_AreaBoxesUseCanvasObjectInteractionGuards()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var viewMarkup = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "Views", "NetworkDiagrams", "Edit.cshtml"));
+        var script = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "wwwroot", "js", "network-diagrams-editor.js"));
+        var styles = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "wwwroot", "css", "network-diagrams.css"));
+
+        Assert.Contains("Advanced coordinates", viewMarkup);
+        Assert.Contains("Drag the area border/header to move it", viewMarkup);
+        Assert.Contains("diagram-area-hit", script);
+        Assert.Contains("resize.dataset.areaResizeHandle = position", script);
+        Assert.Contains("['nw', 'ne', 'sw', 'se']", script);
+        Assert.Contains("resizeAreaFromDrag", script);
+        Assert.Contains("screenToWorld(event.clientX, event.clientY)", script);
+        Assert.Contains("areaLayer?.addEventListener('pointermove', moveDrag)", script);
+        Assert.Contains("areaLayer?.addEventListener('pointerup', endDrag)", script);
+        Assert.Contains("formatDiagramNumber(area[propertyName])", script);
+        Assert.Contains(".diagram-area {", styles);
+        Assert.Contains("pointer-events: none;", styles);
+        Assert.Contains(".diagram-area-hit", styles);
+        Assert.Contains("pointer-events: auto;", styles);
+        Assert.Contains(".diagram-area-resize-handle-nw", styles);
+        Assert.Contains(".diagram-area-resize-handle-se", styles);
+        Assert.Contains(@"html[data-theme=""dark""] .diagram-area[data-style-key=""blue""]", styles);
+        Assert.Contains(@"html[data-theme=""dark""] .diagram-area[data-style-key=""purple""]", styles);
+    }
+
     [Fact]
     public void NetworkDiagramEditor_ViewIncludesEndpointToolboxFilters()
     {

--- a/src/WebApp/PingMonitor.Web.Tests/StartupSchemaServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/StartupSchemaServiceTests.cs
@@ -40,7 +40,7 @@ public sealed class StartupSchemaServiceTests
 
 
     [Fact]
-    public void NetworkDiagramVlanSchema_IsDeclaredInStartupGateMetadata()
+    public void NetworkDiagramAreaAndVlanSchema_IsDeclaredInStartupGateMetadata()
     {
         var repoRoot = FindRepositoryRoot();
         var sourcePath = Path.Combine(
@@ -58,8 +58,9 @@ public sealed class StartupSchemaServiceTests
         var appRequiredSchemaVersion = ReadRequiredSchemaVersion(appSettingsPath);
         var developmentRequiredSchemaVersion = ReadRequiredSchemaVersion(developmentSettingsPath);
 
+        Assert.Contains("\"NetworkDiagramAreas\"", source);
         Assert.Contains("\"NetworkDiagramLinkVlans\"", source);
-        Assert.Equal(18, appRequiredSchemaVersion);
+        Assert.Equal(19, appRequiredSchemaVersion);
         Assert.Equal(appRequiredSchemaVersion, developmentRequiredSchemaVersion);
     }
 

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminBackupsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminBackupsController.cs
@@ -474,6 +474,7 @@ public sealed class AdminBackupsController : Controller
                 IdentityRoles = preview.Counts.IdentityRoles,
                 IdentityUserRoles = preview.Counts.IdentityUserRoles,
                 NetworkDiagrams = preview.Counts.NetworkDiagrams,
+                NetworkDiagramAreas = preview.Counts.NetworkDiagramAreas,
                 NetworkDiagramNodes = preview.Counts.NetworkDiagramNodes,
                 NetworkDiagramLinks = preview.Counts.NetworkDiagramLinks,
                 NetworkDiagramLinkVlans = preview.Counts.NetworkDiagramLinkVlans

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -43,6 +43,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
     public DbSet<PendingTelegramLink> PendingTelegramLinks => Set<PendingTelegramLink>();
     public DbSet<TelegramAccount> TelegramAccounts => Set<TelegramAccount>();
     public DbSet<NetworkDiagram> NetworkDiagrams => Set<NetworkDiagram>();
+    public DbSet<NetworkDiagramArea> NetworkDiagramAreas => Set<NetworkDiagramArea>();
     public DbSet<NetworkDiagramNode> NetworkDiagramNodes => Set<NetworkDiagramNode>();
     public DbSet<NetworkDiagramLink> NetworkDiagramLinks => Set<NetworkDiagramLink>();
     public DbSet<NetworkDiagramLinkVlan> NetworkDiagramLinkVlans => Set<NetworkDiagramLinkVlan>();
@@ -437,6 +438,23 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         networkDiagram.Property(x => x.CreatedByUserId).HasMaxLength(255);
         networkDiagram.Property(x => x.UpdatedByUserId).HasMaxLength(255);
         networkDiagram.HasIndex(x => x.Name);
+
+        var networkDiagramArea = modelBuilder.Entity<NetworkDiagramArea>();
+        networkDiagramArea.ToTable("NetworkDiagramAreas");
+        networkDiagramArea.HasKey(x => x.AreaId);
+        networkDiagramArea.Property(x => x.AreaId).HasMaxLength(64);
+        networkDiagramArea.Property(x => x.DiagramId).HasMaxLength(64).IsRequired();
+        networkDiagramArea.Property(x => x.Label).HasMaxLength(255).IsRequired();
+        networkDiagramArea.Property(x => x.Notes).HasMaxLength(2048);
+        networkDiagramArea.Property(x => x.StyleKey).HasMaxLength(64);
+        networkDiagramArea.Property(x => x.SortOrder).IsRequired();
+        networkDiagramArea.Property(x => x.CreatedAtUtc).IsRequired();
+        networkDiagramArea.Property(x => x.UpdatedAtUtc).IsRequired();
+        networkDiagramArea.HasIndex(x => x.DiagramId);
+        networkDiagramArea.HasOne(x => x.Diagram)
+            .WithMany(x => x.Areas)
+            .HasForeignKey(x => x.DiagramId)
+            .OnDelete(DeleteBehavior.Cascade);
 
         var networkDiagramNode = modelBuilder.Entity<NetworkDiagramNode>();
         networkDiagramNode.ToTable("NetworkDiagramNodes");

--- a/src/WebApp/PingMonitor.Web/Models/NetworkDiagram.cs
+++ b/src/WebApp/PingMonitor.Web/Models/NetworkDiagram.cs
@@ -14,6 +14,7 @@ public sealed class NetworkDiagram
     public DateTimeOffset UpdatedAtUtc { get; set; }
     public string? CreatedByUserId { get; set; }
     public string? UpdatedByUserId { get; set; }
+    public List<NetworkDiagramArea> Areas { get; set; } = [];
     public List<NetworkDiagramNode> Nodes { get; set; } = [];
     public List<NetworkDiagramLink> Links { get; set; } = [];
 }

--- a/src/WebApp/PingMonitor.Web/Models/NetworkDiagramArea.cs
+++ b/src/WebApp/PingMonitor.Web/Models/NetworkDiagramArea.cs
@@ -1,0 +1,18 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class NetworkDiagramArea
+{
+    public string AreaId { get; set; } = Guid.NewGuid().ToString("N");
+    public string DiagramId { get; set; } = string.Empty;
+    public string Label { get; set; } = string.Empty;
+    public string? Notes { get; set; }
+    public double X { get; set; }
+    public double Y { get; set; }
+    public double Width { get; set; } = 600;
+    public double Height { get; set; } = 350;
+    public string? StyleKey { get; set; }
+    public int SortOrder { get; set; }
+    public DateTimeOffset CreatedAtUtc { get; set; }
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+    public NetworkDiagram? Diagram { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
@@ -5,6 +5,6 @@ public sealed class StartupGateOptions
     public const string SectionName = "StartupGate";
 
     public string StorageDirectory { get; set; } = "App_Data/StartupGate";
-    public int RequiredSchemaVersion { get; set; } = 18;
+    public int RequiredSchemaVersion { get; set; } = 19;
     public int DefaultMySqlPort { get; set; } = 3306;
 }

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentValidator.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentValidator.cs
@@ -157,6 +157,31 @@ public sealed class ConfigurationBackupDocumentValidator : IConfigurationBackupD
             ValidateFinite(diagram.ViewportPanY, "diagram viewport pan Y");
             ValidateFinite(diagram.ViewportZoom, "diagram viewport zoom");
 
+
+            var areaIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var area in diagram.Areas)
+            {
+                if (string.IsNullOrWhiteSpace(area.AreaId) || string.IsNullOrWhiteSpace(area.Label))
+                {
+                    throw new InvalidOperationException($"Network diagram '{diagram.Name}' contains an invalid area record.");
+                }
+
+                if (!areaIds.Add(area.AreaId))
+                {
+                    throw new InvalidOperationException($"Network diagram '{diagram.Name}' contains duplicate area id '{area.AreaId}'.");
+                }
+
+                ValidateFinite(area.X, "area X");
+                ValidateFinite(area.Y, "area Y");
+                ValidateFinite(area.Width, "area width");
+                ValidateFinite(area.Height, "area height");
+                var styleKey = string.IsNullOrWhiteSpace(area.StyleKey) ? null : area.StyleKey.Trim().ToLowerInvariant();
+                if (styleKey is not null && styleKey is not ("neutral" or "blue" or "green" or "amber" or "red" or "purple"))
+                {
+                    throw new InvalidOperationException($"Network diagram '{diagram.Name}' contains unsupported area style '{area.StyleKey}'.");
+                }
+            }
+
             var nodeIds = new HashSet<string>(StringComparer.Ordinal);
             foreach (var node in diagram.Nodes)
             {

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs
@@ -374,8 +374,24 @@ public sealed class BackupNetworkDiagramRecord
     public DateTimeOffset UpdatedAtUtc { get; init; }
     public string? CreatedByUserId { get; init; }
     public string? UpdatedByUserId { get; init; }
+    public IReadOnlyList<BackupNetworkDiagramAreaRecord> Areas { get; init; } = [];
     public IReadOnlyList<BackupNetworkDiagramNodeRecord> Nodes { get; init; } = [];
     public IReadOnlyList<BackupNetworkDiagramLinkRecord> Links { get; init; } = [];
+}
+
+public sealed class BackupNetworkDiagramAreaRecord
+{
+    public string AreaId { get; init; } = string.Empty;
+    public string Label { get; init; } = string.Empty;
+    public string? Notes { get; init; }
+    public double X { get; init; }
+    public double Y { get; init; }
+    public double Width { get; init; }
+    public double Height { get; init; }
+    public string? StyleKey { get; init; }
+    public int SortOrder { get; init; }
+    public DateTimeOffset CreatedAtUtc { get; init; }
+    public DateTimeOffset UpdatedAtUtc { get; init; }
 }
 
 public sealed class BackupNetworkDiagramNodeRecord
@@ -538,6 +554,7 @@ public sealed class ConfigurationBackupSectionCounts
     public int IdentityRoles { get; init; }
     public int IdentityUserRoles { get; init; }
     public int NetworkDiagrams { get; init; }
+    public int NetworkDiagramAreas { get; init; }
     public int NetworkDiagramNodes { get; init; }
     public int NetworkDiagramLinks { get; init; }
     public int NetworkDiagramLinkVlans { get; init; }

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupService.cs
@@ -272,6 +272,7 @@ public sealed class ConfigurationBackupService : IConfigurationBackupService
     {
         var diagrams = await _dbContext.NetworkDiagrams
             .AsNoTracking()
+            .Include(x => x.Areas)
             .Include(x => x.Nodes)
             .Include(x => x.Links)
                 .ThenInclude(x => x.Vlans)
@@ -294,6 +295,20 @@ public sealed class ConfigurationBackupService : IConfigurationBackupService
                 UpdatedAtUtc = diagram.UpdatedAtUtc,
                 CreatedByUserId = diagram.CreatedByUserId,
                 UpdatedByUserId = diagram.UpdatedByUserId,
+                Areas = diagram.Areas.OrderBy(x => x.SortOrder).ThenBy(x => x.AreaId).Select(area => new BackupNetworkDiagramAreaRecord
+                {
+                    AreaId = area.AreaId,
+                    Label = area.Label,
+                    Notes = area.Notes,
+                    X = area.X,
+                    Y = area.Y,
+                    Width = area.Width,
+                    Height = area.Height,
+                    StyleKey = area.StyleKey,
+                    SortOrder = area.SortOrder,
+                    CreatedAtUtc = area.CreatedAtUtc,
+                    UpdatedAtUtc = area.UpdatedAtUtc
+                }).ToArray(),
                 Nodes = diagram.Nodes.OrderBy(x => x.CreatedAtUtc).ThenBy(x => x.NodeId).Select(node => new BackupNetworkDiagramNodeRecord
                 {
                     NodeId = node.NodeId,

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestorePreviewService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestorePreviewService.cs
@@ -61,6 +61,7 @@ public sealed class ConfigurationRestorePreviewService : IConfigurationRestorePr
                 IdentityRoles = document.Sections.Identity?.Roles.Count ?? 0,
                 IdentityUserRoles = document.Sections.Identity?.UserRoles.Count ?? 0,
                 NetworkDiagrams = document.Sections.NetworkDiagrams?.Diagrams.Count ?? 0,
+                NetworkDiagramAreas = document.Sections.NetworkDiagrams?.Diagrams.Sum(x => x.Areas.Count) ?? 0,
                 NetworkDiagramNodes = document.Sections.NetworkDiagrams?.Diagrams.Sum(x => x.Nodes.Count) ?? 0,
                 NetworkDiagramLinks = document.Sections.NetworkDiagrams?.Diagrams.Sum(x => x.Links.Count) ?? 0,
                 NetworkDiagramLinkVlans = document.Sections.NetworkDiagrams?.Diagrams.Sum(x => x.Links.Sum(link => link.Vlans.Count)) ?? 0

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs
@@ -280,12 +280,14 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
             var deletedVlans = await _dbContext.NetworkDiagramLinkVlans.ExecuteDeleteAsync(cancellationToken);
             var deletedLinks = await _dbContext.NetworkDiagramLinks.ExecuteDeleteAsync(cancellationToken);
             var deletedNodes = await _dbContext.NetworkDiagramNodes.ExecuteDeleteAsync(cancellationToken);
+            var deletedAreas = await _dbContext.NetworkDiagramAreas.ExecuteDeleteAsync(cancellationToken);
             var deletedDiagrams = await _dbContext.NetworkDiagrams.ExecuteDeleteAsync(cancellationToken);
-            deletedCounts[ConfigurationBackupSections.NetworkDiagrams] = deletedVlans + deletedLinks + deletedNodes + deletedDiagrams;
+            deletedCounts[ConfigurationBackupSections.NetworkDiagrams] = deletedVlans + deletedLinks + deletedNodes + deletedAreas + deletedDiagrams;
             _logger.LogInformation(
-                "Replace delete completed for section {Section}. Deleted diagrams {DiagramCount}, nodes {NodeCount}, links {LinkCount}, VLAN metadata {VlanCount}.",
+                "Replace delete completed for section {Section}. Deleted diagrams {DiagramCount}, areas {AreaCount}, nodes {NodeCount}, links {LinkCount}, VLAN metadata {VlanCount}.",
                 ConfigurationBackupSections.NetworkDiagrams,
                 deletedDiagrams,
+                deletedAreas,
                 deletedNodes,
                 deletedLinks,
                 deletedVlans);
@@ -1019,6 +1021,7 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
         var existingEndpointIds = await _dbContext.Endpoints.AsNoTracking().Select(x => x.EndpointId).ToListAsync(cancellationToken);
         var existingEndpointIdSet = existingEndpointIds.ToHashSet(StringComparer.Ordinal);
         var existingDiagrams = await _dbContext.NetworkDiagrams
+            .Include(x => x.Areas)
             .Include(x => x.Nodes)
             .Include(x => x.Links)
                 .ThenInclude(x => x.Vlans)
@@ -1066,9 +1069,31 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
             _dbContext.NetworkDiagramLinkVlans.RemoveRange(target.Links.SelectMany(x => x.Vlans));
             _dbContext.NetworkDiagramLinks.RemoveRange(target.Links);
             _dbContext.NetworkDiagramNodes.RemoveRange(target.Nodes);
+            _dbContext.NetworkDiagramAreas.RemoveRange(target.Areas);
             target.Links.Clear();
             target.Nodes.Clear();
+            target.Areas.Clear();
             await _dbContext.SaveChangesAsync(cancellationToken);
+
+
+            foreach (var sourceArea in sourceDiagram.Areas.OrderBy(x => x.SortOrder).ThenBy(x => x.AreaId))
+            {
+                if (!TryBuildNetworkDiagramArea(sourceDiagram, sourceArea, target.DiagramId, result, out var area))
+                {
+                    result.SkippedCount++;
+                    continue;
+                }
+
+                target.Areas.Add(area);
+                if (!isInsert)
+                {
+                    result.UpdatedCount++;
+                }
+                else
+                {
+                    result.InsertedCount++;
+                }
+            }
 
             var restoredNodeIds = new HashSet<string>(StringComparer.Ordinal);
             foreach (var sourceNode in sourceDiagram.Nodes)
@@ -1162,6 +1187,62 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
         }
 
         return true;
+    }
+
+
+    private static bool TryBuildNetworkDiagramArea(
+        BackupNetworkDiagramRecord sourceDiagram,
+        BackupNetworkDiagramAreaRecord sourceArea,
+        string targetDiagramId,
+        RestoreSectionResult result,
+        out NetworkDiagramArea area)
+    {
+        area = new NetworkDiagramArea();
+        if (string.IsNullOrWhiteSpace(sourceArea.AreaId)
+            || string.IsNullOrWhiteSpace(sourceArea.Label)
+            || !IsFinite(sourceArea.X)
+            || !IsFinite(sourceArea.Y)
+            || !IsFinite(sourceArea.Width)
+            || !IsFinite(sourceArea.Height))
+        {
+            result.Warnings.Add($"Skipped area '{sourceArea.AreaId}' in network diagram '{sourceDiagram.Name}' because required area data is invalid.");
+            return false;
+        }
+
+        var styleKey = NormalizeAreaStyle(sourceArea.StyleKey);
+        if (styleKey == "__invalid")
+        {
+            result.Warnings.Add($"Skipped area '{sourceArea.AreaId}' in network diagram '{sourceDiagram.Name}' because area style '{sourceArea.StyleKey}' is unsupported.");
+            return false;
+        }
+
+        area = new NetworkDiagramArea
+        {
+            AreaId = TrimOrDefault(sourceArea.AreaId, 64, Guid.NewGuid().ToString("N")),
+            DiagramId = targetDiagramId,
+            Label = TrimOrDefault(sourceArea.Label, 255, "Restored area"),
+            Notes = TrimOptional(sourceArea.Notes, 2048),
+            X = ClampFinite(sourceArea.X, -1000, 21000),
+            Y = ClampFinite(sourceArea.Y, -1000, 21000),
+            Width = ClampFinite(sourceArea.Width <= 0 ? 600 : sourceArea.Width, 80, 20000),
+            Height = ClampFinite(sourceArea.Height <= 0 ? 350 : sourceArea.Height, 60, 20000),
+            StyleKey = styleKey,
+            SortOrder = sourceArea.SortOrder,
+            CreatedAtUtc = sourceArea.CreatedAtUtc == default ? DateTimeOffset.UtcNow : sourceArea.CreatedAtUtc,
+            UpdatedAtUtc = sourceArea.UpdatedAtUtc == default ? DateTimeOffset.UtcNow : sourceArea.UpdatedAtUtc
+        };
+        return true;
+    }
+
+    private static string? NormalizeAreaStyle(string? styleKey)
+    {
+        if (string.IsNullOrWhiteSpace(styleKey))
+        {
+            return null;
+        }
+
+        var normalized = styleKey.Trim().ToLowerInvariant();
+        return normalized is "neutral" or "blue" or "green" or "amber" or "red" or "purple" ? normalized : "__invalid";
     }
 
     private static bool TryBuildNetworkDiagramNode(

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramImageExportService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramImageExportService.cs
@@ -65,7 +65,7 @@ internal sealed class NetworkDiagramImageExportService : INetworkDiagramImageExp
         var svg = new StringBuilder();
         svg.AppendLine($"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{width}\" height=\"{height}\" viewBox=\"0 0 {Format(layout.CanvasWidth)} {Format(layout.CanvasHeight)}\" role=\"img\" aria-label=\"{EscapeXml(layout.DiagramName)} network diagram\">");
         svg.AppendLine("<defs><style><![CDATA[");
-        svg.AppendLine(".pm-node-label{font:700 14px Arial,Helvetica,sans-serif;fill:#101828}.pm-node-type{font:600 11px Arial,Helvetica,sans-serif;fill:#475467}.pm-node-notes{font:500 10px Arial,Helvetica,sans-serif;fill:#667085}.pm-link-label{font:800 12px Arial,Helvetica,sans-serif;fill:#101828;paint-order:stroke;stroke:#fff;stroke-width:4px;stroke-linejoin:round}.pm-link-label-dark{stroke:#111827;fill:#f9fafb}.pm-node-icon{font:800 13px Arial,Helvetica,sans-serif}.pm-footer{font:600 11px Arial,Helvetica,sans-serif;fill:#667085}");
+        svg.AppendLine(".pm-area-label{font:800 16px Arial,Helvetica,sans-serif;fill:#1f2937}.pm-area-notes{font:600 11px Arial,Helvetica,sans-serif;fill:#4b5563}.pm-node-label{font:700 14px Arial,Helvetica,sans-serif;fill:#101828}.pm-node-type{font:600 11px Arial,Helvetica,sans-serif;fill:#475467}.pm-node-notes{font:500 10px Arial,Helvetica,sans-serif;fill:#667085}.pm-link-label{font:800 12px Arial,Helvetica,sans-serif;fill:#101828;paint-order:stroke;stroke:#fff;stroke-width:4px;stroke-linejoin:round}.pm-link-label-dark{stroke:#111827;fill:#f9fafb}.pm-node-icon{font:800 13px Arial,Helvetica,sans-serif}.pm-footer{font:600 11px Arial,Helvetica,sans-serif;fill:#667085}");
         svg.AppendLine("]]></style></defs>");
         if (backgroundStyle.IsTransparent)
         {
@@ -148,6 +148,25 @@ internal sealed class NetworkDiagramImageExportService : INetworkDiagramImageExp
 
         image.Mutate(ctx =>
         {
+            foreach (var area in layout.Areas)
+            {
+                var style = ResolveAreaStyle(area.StyleKey, bg.IsDark);
+                var rect = new RectangularPolygon(S(area.X), S(area.Y), S(area.Width), S(area.Height));
+                ctx.Fill(Color.ParseHex(style.Fill.TrimStart('#')).WithAlpha((float)style.FillOpacity), rect);
+                ctx.Draw(Color.ParseHex(style.Stroke.TrimStart('#')), S(3), rect);
+                var header = new RectangularPolygon(S(area.X), S(area.Y), S(area.Width), S(Math.Min(38d, area.Height)));
+                ctx.Fill(Color.ParseHex(style.HeaderFill.TrimStart('#')).WithAlpha((float)style.HeaderOpacity), header);
+                ctx.DrawText(area.Label, boldFont, bg.IsDark ? Color.White : Color.ParseHex("1f2937"), P(area.X + 16, area.Y + 9));
+                if (!string.IsNullOrWhiteSpace(area.Notes) && area.Height >= 90d)
+                {
+                    var notes = FitText(area.Notes, Math.Max(1d, area.Width - 32d), maxLines: 1, fontSize: 10d).FirstOrDefault();
+                    if (!string.IsNullOrWhiteSpace(notes))
+                    {
+                        ctx.DrawText(notes, smallFont, bg.IsDark ? Color.ParseHex("d1d5db") : Color.ParseHex("4b5563"), P(area.X + 16, area.Y + area.Height - 28));
+                    }
+                }
+            }
+
             foreach (var link in layout.Links)
             {
                 var style = ResolveLinkStyle(link.MediaType, link.LinkType);
@@ -296,6 +315,21 @@ internal sealed class NetworkDiagramImageExportService : INetworkDiagramImageExp
         };
         var opacity = NetworkDiagramLinkTypes.Normalize(linkType) == NetworkDiagramLinkTypes.Logical ? 0.72d : 1d;
         return new NetworkDiagramExportLinkStyle(color, width, dash, opacity);
+    }
+
+
+    private static NetworkDiagramExportAreaStyle ResolveAreaStyle(string? styleKey, bool dark)
+    {
+        var key = string.IsNullOrWhiteSpace(styleKey) ? "neutral" : styleKey.Trim().ToLowerInvariant();
+        return key switch
+        {
+            "blue" => new NetworkDiagramExportAreaStyle("#60a5fa", "#2563eb", "#2563eb", dark ? 0.18 : 0.13, dark ? 0.30 : 0.18),
+            "green" => new NetworkDiagramExportAreaStyle("#34d399", "#059669", "#059669", dark ? 0.18 : 0.13, dark ? 0.30 : 0.18),
+            "amber" => new NetworkDiagramExportAreaStyle("#fbbf24", "#d97706", "#d97706", dark ? 0.20 : 0.14, dark ? 0.32 : 0.20),
+            "red" => new NetworkDiagramExportAreaStyle("#f87171", "#dc2626", "#dc2626", dark ? 0.17 : 0.12, dark ? 0.30 : 0.18),
+            "purple" => new NetworkDiagramExportAreaStyle("#a78bfa", "#7c3aed", "#7c3aed", dark ? 0.18 : 0.13, dark ? 0.30 : 0.18),
+            _ => new NetworkDiagramExportAreaStyle(dark ? "#64748b" : "#94a3b8", dark ? "#94a3b8" : "#64748b", dark ? "#475569" : "#cbd5e1", dark ? 0.18 : 0.16, dark ? 0.28 : 0.38)
+        };
     }
 
     private static NetworkDiagramExportNodeStyle ResolveNodeStyle(string nodeType, bool dark)
@@ -460,11 +494,13 @@ internal sealed class NetworkDiagramImageExportService : INetworkDiagramImageExp
     private sealed record NetworkDiagramExportBackground(string CanvasFill, bool IsDark, bool IsTransparent);
     private sealed record NetworkDiagramExportLinkStyle(string Color, double Width, string DashArray, double Opacity);
     private sealed record NetworkDiagramExportNodeStyle(string Fill, string Stroke, string IconFill, string IconText);
+    private sealed record NetworkDiagramExportAreaStyle(string Fill, string Stroke, string HeaderFill, double FillOpacity, double HeaderOpacity);
 
     internal sealed record NetworkDiagramNativeExportLayout(
         string DiagramName,
         double CanvasWidth,
         double CanvasHeight,
+        IReadOnlyList<NetworkDiagramNativeExportArea> Areas,
         IReadOnlyList<NetworkDiagramNativeExportNode> Nodes,
         IReadOnlyList<NetworkDiagramNativeExportLink> Links)
     {
@@ -472,6 +508,15 @@ internal sealed class NetworkDiagramImageExportService : INetworkDiagramImageExp
         {
             var canvasWidth = Math.Max(1d, diagram.CanvasWidth);
             var canvasHeight = Math.Max(1d, diagram.CanvasHeight);
+            var areas = diagram.Areas.OrderBy(area => area.SortOrder).Select(area => new NetworkDiagramNativeExportArea(
+                area.AreaId,
+                area.Label,
+                area.Notes,
+                area.X,
+                area.Y,
+                Math.Max(1d, area.Width),
+                Math.Max(1d, area.Height),
+                area.StyleKey)).ToArray();
             var nodes = diagram.Nodes.Select(node => new NetworkDiagramNativeExportNode(
                 node.NodeId,
                 node.NodeType,
@@ -508,9 +553,11 @@ internal sealed class NetworkDiagramImageExportService : INetworkDiagramImageExp
                     geometry.LabelY));
             }
 
-            return new NetworkDiagramNativeExportLayout(diagram.Name, canvasWidth, canvasHeight, nodes, links);
+            return new NetworkDiagramNativeExportLayout(diagram.Name, canvasWidth, canvasHeight, areas, nodes, links);
         }
     }
+
+    internal sealed record NetworkDiagramNativeExportArea(string AreaId, string Label, string? Notes, double X, double Y, double Width, double Height, string? StyleKey);
 
     internal sealed record NetworkDiagramNativeExportNode(string NodeId, string NodeType, string DisplayLabel, string IconKey, string? Notes, double X, double Y, double Width, double Height);
 

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramModels.cs
@@ -216,8 +216,22 @@ public sealed class NetworkDiagramSaveRequest
     public double ViewportPanX { get; init; }
     public double ViewportPanY { get; init; }
     public double ViewportZoom { get; init; }
+    public IReadOnlyList<NetworkDiagramAreaSaveRequest> Areas { get; init; } = [];
     public IReadOnlyList<NetworkDiagramNodeSaveRequest> Nodes { get; init; } = [];
     public IReadOnlyList<NetworkDiagramLinkSaveRequest> Links { get; init; } = [];
+}
+
+public sealed class NetworkDiagramAreaSaveRequest
+{
+    public string AreaId { get; init; } = string.Empty;
+    public string Label { get; init; } = string.Empty;
+    public string? Notes { get; init; }
+    public double X { get; init; }
+    public double Y { get; init; }
+    public double Width { get; init; }
+    public double Height { get; init; }
+    public string? StyleKey { get; init; }
+    public int SortOrder { get; init; }
 }
 
 public sealed class NetworkDiagramNodeSaveRequest
@@ -275,8 +289,22 @@ public sealed class NetworkDiagramDto
     public double ViewportPanY { get; init; }
     public double ViewportZoom { get; init; }
     public DateTimeOffset UpdatedAtUtc { get; init; }
+    public IReadOnlyList<NetworkDiagramAreaDto> Areas { get; init; } = [];
     public IReadOnlyList<NetworkDiagramNodeDto> Nodes { get; init; } = [];
     public IReadOnlyList<NetworkDiagramLinkDto> Links { get; init; } = [];
+}
+
+public sealed class NetworkDiagramAreaDto
+{
+    public string AreaId { get; init; } = string.Empty;
+    public string Label { get; init; } = string.Empty;
+    public string? Notes { get; init; }
+    public double X { get; init; }
+    public double Y { get; init; }
+    public double Width { get; init; }
+    public double Height { get; init; }
+    public string? StyleKey { get; init; }
+    public int SortOrder { get; init; }
 }
 
 public sealed class NetworkDiagramNodeDto

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramPdfExportService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramPdfExportService.cs
@@ -268,6 +268,25 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
         double MapWidth(double worldWidth) => worldWidth * scale;
         double MapHeight(double worldHeight) => worldHeight * scale;
 
+
+        foreach (var area in diagram.Areas.OrderBy(x => x.SortOrder))
+        {
+            var x = MapX(area.X);
+            var y = MapY(area.Y + area.Height);
+            var width = Math.Max(1, MapWidth(area.Width));
+            var height = Math.Max(1, MapHeight(area.Height));
+            stream.AppendLine("q");
+            ApplyAreaStyle(stream, area.StyleKey);
+            stream.AppendFormat(CultureInfo.InvariantCulture, "{0:0.##} {1:0.##} {2:0.##} {3:0.##} re B\n", x, y, width, height);
+            stream.AppendLine("Q");
+            AddText(stream, x + 8, y + height - 18, 9, Truncate(area.Label, 60), bold: true);
+            if (!string.IsNullOrWhiteSpace(area.Notes) && height >= 45)
+            {
+                var fittedNotes = NetworkDiagramPdfTextFitter.Fit(area.Notes, maxWidth: Math.Max(20, width - 16), maxLines: 1, fontSize: 6.5, minimumFontSize: 5, useEllipsis: true);
+                AddFittedText(stream, x + 8, y + 8, fittedNotes, bold: false);
+            }
+        }
+
         var nodeLookup = diagram.Nodes.ToDictionary(x => x.NodeId, StringComparer.Ordinal);
         var offsetIndexes = GetParallelOffsetIndexes(diagram.Links);
         foreach (var link in diagram.Links)
@@ -375,6 +394,41 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
         return new LinkGeometry(startX, startY, endX, endY, (startX + endX) / 2, (startY + endY) / 2 + (offset == 0 ? 6 : Math.Sign(offset) * 6));
     }
 
+
+    private static void ApplyAreaStyle(StringBuilder stream, string? styleKey)
+    {
+        switch (string.IsNullOrWhiteSpace(styleKey) ? "neutral" : styleKey.Trim().ToLowerInvariant())
+        {
+            case "blue":
+                stream.AppendLine("0.88 0.94 1 rg");
+                stream.AppendLine("0.15 0.39 0.92 RG");
+                break;
+            case "green":
+                stream.AppendLine("0.88 0.98 0.94 rg");
+                stream.AppendLine("0.02 0.59 0.41 RG");
+                break;
+            case "amber":
+                stream.AppendLine("1 0.96 0.82 rg");
+                stream.AppendLine("0.85 0.47 0.02 RG");
+                break;
+            case "red":
+                stream.AppendLine("1 0.92 0.92 rg");
+                stream.AppendLine("0.86 0.15 0.15 RG");
+                break;
+            case "purple":
+                stream.AppendLine("0.95 0.91 1 rg");
+                stream.AppendLine("0.49 0.23 0.93 RG");
+                break;
+            default:
+                stream.AppendLine("0.94 0.96 0.98 rg");
+                stream.AppendLine("0.39 0.45 0.55 RG");
+                break;
+        }
+
+        stream.AppendLine("1.2 w");
+        stream.AppendLine("[7 4] 0 d");
+    }
+
     private static void ApplyLinkStyle(StringBuilder stream, NetworkDiagramLinkDto link)
     {
         var width = NetworkDiagramLinkTypes.Normalize(link.LinkType) == NetworkDiagramLinkTypes.Lacp ? 2.6d : 1.5d;
@@ -416,16 +470,24 @@ internal sealed class NetworkDiagramPdfExportService : INetworkDiagramPdfExportS
 
     private static DiagramBounds GetExportBounds(NetworkDiagramDto diagram)
     {
-        if (diagram.Nodes.Count == 0)
+        if (diagram.Nodes.Count == 0 && diagram.Areas.Count == 0)
         {
             return new DiagramBounds(0, 0, Math.Max(1, diagram.CanvasWidth), Math.Max(1, diagram.CanvasHeight));
         }
 
         var padding = 160d;
-        var minX = Math.Max(0, diagram.Nodes.Min(x => x.X) - padding);
-        var minY = Math.Max(0, diagram.Nodes.Min(x => x.Y) - padding);
-        var maxX = Math.Min(Math.Max(diagram.CanvasWidth, 1), diagram.Nodes.Max(x => x.X + x.Width) + padding);
-        var maxY = Math.Min(Math.Max(diagram.CanvasHeight, 1), diagram.Nodes.Max(x => x.Y + x.Height) + padding);
+        var minX = Math.Max(0, Math.Min(
+            diagram.Nodes.Count == 0 ? double.PositiveInfinity : diagram.Nodes.Min(x => x.X),
+            diagram.Areas.Count == 0 ? double.PositiveInfinity : diagram.Areas.Min(x => x.X)) - padding);
+        var minY = Math.Max(0, Math.Min(
+            diagram.Nodes.Count == 0 ? double.PositiveInfinity : diagram.Nodes.Min(x => x.Y),
+            diagram.Areas.Count == 0 ? double.PositiveInfinity : diagram.Areas.Min(x => x.Y)) - padding);
+        var maxX = Math.Min(Math.Max(diagram.CanvasWidth, 1), Math.Max(
+            diagram.Nodes.Count == 0 ? double.NegativeInfinity : diagram.Nodes.Max(x => x.X + x.Width),
+            diagram.Areas.Count == 0 ? double.NegativeInfinity : diagram.Areas.Max(x => x.X + x.Width)) + padding);
+        var maxY = Math.Min(Math.Max(diagram.CanvasHeight, 1), Math.Max(
+            diagram.Nodes.Count == 0 ? double.NegativeInfinity : diagram.Nodes.Max(x => x.Y + x.Height),
+            diagram.Areas.Count == 0 ? double.NegativeInfinity : diagram.Areas.Max(x => x.Y + x.Height)) + padding);
         if (maxX <= minX || maxY <= minY)
         {
             return new DiagramBounds(0, 0, Math.Max(1, diagram.CanvasWidth), Math.Max(1, diagram.CanvasHeight));

--- a/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/NetworkDiagrams/NetworkDiagramService.cs
@@ -88,6 +88,7 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
     {
         var diagram = await _dbContext.NetworkDiagrams
             .AsNoTracking()
+            .Include(x => x.Areas)
             .Include(x => x.Nodes)
             .Include(x => x.Links)
                 .ThenInclude(x => x.Vlans)
@@ -99,6 +100,7 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
     public async Task<NetworkDiagramDto> SaveAsync(string diagramId, NetworkDiagramSaveRequest request, string? userId, CancellationToken cancellationToken)
     {
         var diagram = await _dbContext.NetworkDiagrams
+            .Include(x => x.Areas)
             .Include(x => x.Nodes)
             .Include(x => x.Links)
                 .ThenInclude(x => x.Vlans)
@@ -120,8 +122,29 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
 
         _dbContext.NetworkDiagramLinks.RemoveRange(diagram.Links);
         _dbContext.NetworkDiagramNodes.RemoveRange(diagram.Nodes);
+        _dbContext.NetworkDiagramAreas.RemoveRange(diagram.Areas);
+        diagram.Areas.Clear();
         diagram.Nodes.Clear();
         diagram.Links.Clear();
+
+        foreach (var areaRequest in request.Areas.OrderBy(x => x.SortOrder))
+        {
+            diagram.Areas.Add(new NetworkDiagramArea
+            {
+                AreaId = TrimRequired(areaRequest.AreaId, 64, "Area ID"),
+                DiagramId = diagram.DiagramId,
+                Label = TrimRequired(areaRequest.Label, 255, "Area label"),
+                Notes = TrimOptional(areaRequest.Notes, 2048),
+                X = ClampFinite(areaRequest.X, -1000, 21000, "Area X"),
+                Y = ClampFinite(areaRequest.Y, -1000, 21000, "Area Y"),
+                Width = ClampFinite(areaRequest.Width, 80, 20000, "Area width"),
+                Height = ClampFinite(areaRequest.Height, 60, 20000, "Area height"),
+                StyleKey = NormalizeAreaStyle(areaRequest.StyleKey),
+                SortOrder = areaRequest.SortOrder,
+                CreatedAtUtc = now,
+                UpdatedAtUtc = now
+            });
+        }
 
         foreach (var nodeRequest in request.Nodes)
         {
@@ -212,6 +235,24 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
         _ = ClampFinite(request.CanvasHeight, 1000, 20000, "Canvas height");
         _ = ClampFinite(request.ViewportZoom, 0.1, 5, "Viewport zoom");
 
+        var areaIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var area in request.Areas)
+        {
+            var areaId = TrimRequired(area.AreaId, 64, "Area ID");
+            if (!areaIds.Add(areaId))
+            {
+                throw new NetworkDiagramValidationException($"Duplicate area ID '{areaId}'.");
+            }
+
+            _ = TrimRequired(area.Label, 255, "Area label");
+            _ = TrimOptional(area.Notes, 2048);
+            _ = ClampFinite(area.X, -1000, 21000, "Area X");
+            _ = ClampFinite(area.Y, -1000, 21000, "Area Y");
+            _ = ClampFinite(area.Width, 80, 20000, "Area width");
+            _ = ClampFinite(area.Height, 60, 20000, "Area height");
+            _ = NormalizeAreaStyle(area.StyleKey);
+        }
+
         var nodeIds = new HashSet<string>(StringComparer.Ordinal);
         foreach (var node in request.Nodes)
         {
@@ -285,6 +326,18 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
             ViewportPanY = diagram.ViewportPanY,
             ViewportZoom = diagram.ViewportZoom,
             UpdatedAtUtc = diagram.UpdatedAtUtc,
+            Areas = diagram.Areas.OrderBy(x => x.SortOrder).ThenBy(x => x.CreatedAtUtc).Select(x => new NetworkDiagramAreaDto
+            {
+                AreaId = x.AreaId,
+                Label = x.Label,
+                Notes = x.Notes,
+                X = x.X,
+                Y = x.Y,
+                Width = x.Width,
+                Height = x.Height,
+                StyleKey = NormalizeAreaStyle(x.StyleKey),
+                SortOrder = x.SortOrder
+            }).ToArray(),
             Nodes = diagram.Nodes.OrderBy(x => x.CreatedAtUtc).Select(x => new NetworkDiagramNodeDto
             {
                 NodeId = x.NodeId,
@@ -329,6 +382,20 @@ internal sealed class NetworkDiagramService : INetworkDiagramService
                 }).ToArray()
             }).ToArray()
         };
+    }
+
+
+    private static string? NormalizeAreaStyle(string? styleKey)
+    {
+        if (string.IsNullOrWhiteSpace(styleKey))
+        {
+            return null;
+        }
+
+        var normalized = styleKey.Trim().ToLowerInvariant();
+        return normalized is "neutral" or "blue" or "green" or "amber" or "red" or "purple"
+            ? normalized
+            : throw new NetworkDiagramValidationException($"Unsupported area style '{styleKey}'.");
     }
 
     private static void ValidateLinkMetadata(NetworkDiagramLinkSaveRequest link)

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -46,6 +46,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "PendingTelegramLinks",
         "TelegramAccounts",
         "NetworkDiagrams",
+        "NetworkDiagramAreas",
         "NetworkDiagramNodes",
         "NetworkDiagramLinks",
         "NetworkDiagramLinkVlans"
@@ -66,6 +67,22 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "CreatedByUserId",
         "UpdatedByUserId"
     ];
+    private static readonly string[] RequiredNetworkDiagramAreaColumns =
+    [
+        "AreaId",
+        "DiagramId",
+        "Label",
+        "Notes",
+        "X",
+        "Y",
+        "Width",
+        "Height",
+        "StyleKey",
+        "SortOrder",
+        "CreatedAtUtc",
+        "UpdatedAtUtc"
+    ];
+
     private static readonly string[] RequiredNetworkDiagramNodeColumns =
     [
         "NodeId",
@@ -419,6 +436,13 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         {
             var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
             status.Diagnostics.Add($"NetworkDiagrams table is missing required columns: {string.Join(", ", missingNetworkDiagramColumns)}.");
+            return status;
+        }
+        var missingNetworkDiagramAreaColumns = await GetMissingColumnsAsync(connection, "NetworkDiagramAreas", RequiredNetworkDiagramAreaColumns, cancellationToken);
+        if (missingNetworkDiagramAreaColumns.Length > 0)
+        {
+            var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
+            status.Diagnostics.Add($"NetworkDiagramAreas table is missing required columns: {string.Join(", ", missingNetworkDiagramAreaColumns)}.");
             return status;
         }
         var missingNetworkDiagramNodeColumns = await GetMissingColumnsAsync(connection, "NetworkDiagramNodes", RequiredNetworkDiagramNodeColumns, cancellationToken);
@@ -883,6 +907,27 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             );
             """;
 
+
+        const string createNetworkDiagramAreasSql = """
+            CREATE TABLE IF NOT EXISTS `NetworkDiagramAreas` (
+                `AreaId` varchar(64) NOT NULL,
+                `DiagramId` varchar(64) NOT NULL,
+                `Label` varchar(255) NOT NULL,
+                `Notes` varchar(2048) NULL,
+                `X` double NOT NULL,
+                `Y` double NOT NULL,
+                `Width` double NOT NULL DEFAULT 600,
+                `Height` double NOT NULL DEFAULT 350,
+                `StyleKey` varchar(64) NULL,
+                `SortOrder` int NOT NULL DEFAULT 0,
+                `CreatedAtUtc` datetime(6) NOT NULL,
+                `UpdatedAtUtc` datetime(6) NOT NULL,
+                PRIMARY KEY (`AreaId`),
+                KEY `IX_NetworkDiagramAreas_DiagramId` (`DiagramId`),
+                CONSTRAINT `FK_NetworkDiagramAreas_NetworkDiagrams_DiagramId` FOREIGN KEY (`DiagramId`) REFERENCES `NetworkDiagrams` (`DiagramId`) ON DELETE CASCADE
+            );
+            """;
+
         const string createNetworkDiagramNodesSql = """
             CREATE TABLE IF NOT EXISTS `NetworkDiagramNodes` (
                 `NodeId` varchar(64) NOT NULL,
@@ -974,6 +1019,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await dbContext.Database.ExecuteSqlRawAsync(createUserGroupAccessesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createUserEndpointAccessesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createNetworkDiagramsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createNetworkDiagramAreasSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createNetworkDiagramNodesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createNetworkDiagramLinksSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createNetworkDiagramLinkVlansSql, cancellationToken);
@@ -988,6 +1034,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await EnsureAspNetUsersColumnsAsync(dbContext, cancellationToken);
         await EnsureCheckResultsNormalizedSchemaAsync(dbContext, cancellationToken);
         await EnsureRttPrecisionSchemaAsync(dbContext, cancellationToken);
+        await EnsureNetworkDiagramAreaTableAsync(dbContext, cancellationToken);
         await EnsureNetworkDiagramLinkMetadataColumnsAsync(dbContext, cancellationToken);
         await EnsureNetworkDiagramLinkVlanTableAsync(dbContext, cancellationToken);
         await EnsureMetricsIndexesAsync(dbContext, cancellationToken);
@@ -995,6 +1042,30 @@ internal sealed class StartupSchemaService : IStartupSchemaService
     }
 
 
+
+
+    private static async Task EnsureNetworkDiagramAreaTableAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
+    {
+        await dbContext.Database.ExecuteSqlRawAsync("""
+            CREATE TABLE IF NOT EXISTS `NetworkDiagramAreas` (
+                `AreaId` varchar(64) NOT NULL,
+                `DiagramId` varchar(64) NOT NULL,
+                `Label` varchar(255) NOT NULL,
+                `Notes` varchar(2048) NULL,
+                `X` double NOT NULL,
+                `Y` double NOT NULL,
+                `Width` double NOT NULL DEFAULT 600,
+                `Height` double NOT NULL DEFAULT 350,
+                `StyleKey` varchar(64) NULL,
+                `SortOrder` int NOT NULL DEFAULT 0,
+                `CreatedAtUtc` datetime(6) NOT NULL,
+                `UpdatedAtUtc` datetime(6) NOT NULL,
+                PRIMARY KEY (`AreaId`),
+                KEY `IX_NetworkDiagramAreas_DiagramId` (`DiagramId`),
+                CONSTRAINT `FK_NetworkDiagramAreas_NetworkDiagrams_DiagramId` FOREIGN KEY (`DiagramId`) REFERENCES `NetworkDiagrams` (`DiagramId`) ON DELETE CASCADE
+            );
+            """, cancellationToken);
+    }
 
     private static async Task EnsureNetworkDiagramLinkVlanTableAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
     {

--- a/src/WebApp/PingMonitor.Web/ViewModels/Backups/BackupsPageViewModels.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Backups/BackupsPageViewModels.cs
@@ -173,6 +173,7 @@ public sealed class ConfigurationBackupSectionCountViewModel
     public int IdentityRoles { get; init; }
     public int IdentityUserRoles { get; init; }
     public int NetworkDiagrams { get; init; }
+    public int NetworkDiagramAreas { get; init; }
     public int NetworkDiagramNodes { get; init; }
     public int NetworkDiagramLinks { get; init; }
     public int NetworkDiagramLinkVlans { get; init; }

--- a/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminBackups/Index.cshtml
@@ -203,6 +203,7 @@
                                     <tr><td>Identity roles</td><td>@Model.Preview.Counts.IdentityRoles</td></tr>
                                     <tr><td>Identity user-role links</td><td>@Model.Preview.Counts.IdentityUserRoles</td></tr>
                                     <tr><td>Network diagrams</td><td>@Model.Preview.Counts.NetworkDiagrams</td></tr>
+                                    <tr><td>Network diagram areas</td><td>@Model.Preview.Counts.NetworkDiagramAreas</td></tr>
                                     <tr><td>Network diagram nodes</td><td>@Model.Preview.Counts.NetworkDiagramNodes</td></tr>
                                     <tr><td>Network diagram links</td><td>@Model.Preview.Counts.NetworkDiagramLinks</td></tr>
                                     <tr><td>Network diagram VLAN metadata</td><td>@Model.Preview.Counts.NetworkDiagramLinkVlans</td></tr>

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
@@ -242,12 +242,16 @@
                             <option value="purple">Purple</option>
                         </select>
                     </label>
-                    <div class="area-geometry-fields">
-                        <label>X<input type="number" data-area-field="x" step="1" /></label>
-                        <label>Y<input type="number" data-area-field="y" step="1" /></label>
-                        <label>Width<input type="number" data-area-field="width" min="80" step="1" /></label>
-                        <label>Height<input type="number" data-area-field="height" min="60" step="1" /></label>
-                    </div>
+                    <details class="area-geometry-details">
+                        <summary>Advanced coordinates</summary>
+                        <p class="toolbox-help">Drag the area border/header to move it and drag a visible corner handle to resize it. These fields are for precision adjustments only.</p>
+                        <div class="area-geometry-fields">
+                            <label>X<input type="number" data-area-field="x" step="1" /></label>
+                            <label>Y<input type="number" data-area-field="y" step="1" /></label>
+                            <label>Width<input type="number" data-area-field="width" min="80" step="1" /></label>
+                            <label>Height<input type="number" data-area-field="height" min="60" step="1" /></label>
+                        </div>
+                    </details>
                     <button type="button" class="danger-button" data-delete-selection>Delete selected area</button>
                 </form>
                 <form class="node-properties" data-node-properties hidden>

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
@@ -125,6 +125,7 @@
                 <div class="diagram-workspace-toolbar" aria-label="Network diagram tools">
                     <button type="button" class="diagram-tool-button" data-tool-button="select" aria-pressed="true">Select / move</button>
                     <button type="button" class="diagram-tool-button" data-tool-button="draw-link" aria-pressed="false">Draw link</button>
+                    <button type="button" class="diagram-tool-button" data-add-area>Add area box</button>
                     <label class="diagram-toolbar-select-label diagram-link-type-toolbar">
                         Media
                         <select data-draw-media-type aria-label="Media type for newly drawn links">
@@ -207,6 +208,7 @@
                             Add a monitored endpoint or custom device from the toolbox. Drag empty space to pan. Use mouse wheel to zoom.
                         </div>
                         <div class="diagram-world" data-diagram-world>
+                            <div class="diagram-area-layer" data-area-layer></div>
                             <svg class="diagram-link-layer" data-link-layer></svg>
                             <div class="diagram-node-layer" data-node-layer></div>
                         </div>
@@ -217,8 +219,37 @@
             <aside class="diagram-properties" aria-label="Diagram selection properties">
                 <h2>Properties</h2>
                 <div data-no-selection-panel>
-                    <p>Select a node or visual link to edit saved diagram properties. Shift/Ctrl-click nodes to multi-select and move them as a group.</p>
+                    <p>Select an area, node, or visual link to edit saved diagram properties. Shift/Ctrl-click nodes to multi-select and move them as a group.</p>
                 </div>
+                <form class="area-properties" data-area-properties hidden>
+                    <p class="toolbox-help">Area boxes are visual annotations only. They do not create groups, dependencies, alerts, endpoint changes, or agent behaviour.</p>
+                    <label>
+                        Area label
+                        <input type="text" data-area-field="label" maxlength="255" />
+                    </label>
+                    <label>
+                        Notes
+                        <textarea data-area-field="notes" rows="4" maxlength="2048"></textarea>
+                    </label>
+                    <label>
+                        Style
+                        <select data-area-field="styleKey">
+                            <option value="neutral">Neutral</option>
+                            <option value="blue">Blue</option>
+                            <option value="green">Green</option>
+                            <option value="amber">Amber</option>
+                            <option value="red">Red</option>
+                            <option value="purple">Purple</option>
+                        </select>
+                    </label>
+                    <div class="area-geometry-fields">
+                        <label>X<input type="number" data-area-field="x" step="1" /></label>
+                        <label>Y<input type="number" data-area-field="y" step="1" /></label>
+                        <label>Width<input type="number" data-area-field="width" min="80" step="1" /></label>
+                        <label>Height<input type="number" data-area-field="height" min="60" step="1" /></label>
+                    </div>
+                    <button type="button" class="danger-button" data-delete-selection>Delete selected area</button>
+                </form>
                 <form class="node-properties" data-node-properties hidden>
                     <p class="toolbox-help" data-selected-node-kind>Selected diagram node</p>
                     <p class="toolbox-help" data-selected-node-help>Node edits affect only this saved diagram. Monitored endpoints are not renamed or modified.</p>

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
@@ -66,6 +66,7 @@
                     <div class="diagram-canvas" data-diagram-canvas role="application" aria-label="Read-only network diagram canvas" tabindex="0">
                         <div class="diagram-empty-state" data-empty-state>Loading saved diagram…</div>
                         <div class="diagram-world" data-diagram-world>
+                            <div class="diagram-area-layer" data-area-layer></div>
                             <svg class="diagram-link-layer" data-link-layer></svg>
                             <div class="diagram-node-layer" data-node-layer></div>
                         </div>

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 18,
+    "RequiredSchemaVersion": 19,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 18,
+    "RequiredSchemaVersion": 19,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -693,7 +693,8 @@ body {
     width: 100%;
     height: 100%;
     overflow: visible;
-    pointer-events: auto;
+    /* Allow area border/header hit targets below the SVG layer to receive clicks. */
+    pointer-events: none;
     z-index: 1;
 }
 

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -1499,10 +1499,42 @@ html[data-theme="dark"] .diagram-link-port-label {
     pointer-events: none;
 }
 
+.diagram-area-hit {
+    position: absolute;
+    pointer-events: auto;
+    cursor: grab;
+}
+
+.diagram-area-hit-top {
+    top: -9px;
+    left: 18px;
+    right: 18px;
+    height: 18px;
+}
+
+.diagram-area-hit-right {
+    top: 18px;
+    right: -9px;
+    bottom: 18px;
+    width: 18px;
+}
+
+.diagram-area-hit-bottom {
+    right: 18px;
+    bottom: -9px;
+    left: 18px;
+    height: 18px;
+}
+
+.diagram-area-hit-left {
+    top: 18px;
+    bottom: 18px;
+    left: -9px;
+    width: 18px;
+}
+
 .diagram-area-resize-handle {
     position: absolute;
-    right: -9px;
-    bottom: -9px;
     width: 24px;
     height: 24px;
     border-radius: 999px;
@@ -1510,6 +1542,29 @@ html[data-theme="dark"] .diagram-link-port-label {
     background: var(--diagram-panel);
     box-shadow: 0 2px 8px rgba(16, 24, 40, .24);
     pointer-events: auto;
+}
+
+.diagram-area-resize-handle-nw {
+    top: -11px;
+    left: -11px;
+    cursor: nwse-resize;
+}
+
+.diagram-area-resize-handle-ne {
+    top: -11px;
+    right: -11px;
+    cursor: nesw-resize;
+}
+
+.diagram-area-resize-handle-sw {
+    bottom: -11px;
+    left: -11px;
+    cursor: nesw-resize;
+}
+
+.diagram-area-resize-handle-se {
+    right: -11px;
+    bottom: -11px;
     cursor: nwse-resize;
 }
 
@@ -1521,6 +1576,11 @@ html[data-theme="dark"] .diagram-link-port-label {
 
 .diagram-area[data-selected="false"] .diagram-area-resize-handle {
     display: none;
+}
+
+.diagram-area[data-dragging="true"] .diagram-area-header,
+.diagram-area[data-dragging="true"] .diagram-area-hit {
+    cursor: grabbing;
 }
 
 .area-geometry-fields {
@@ -1539,3 +1599,9 @@ html[data-theme="dark"] .diagram-area-header {
     background: rgba(15, 23, 42, .86);
     border-color: rgba(148, 163, 184, .32);
 }
+
+html[data-theme="dark"] .diagram-area[data-style-key="blue"] { border-color: rgba(96, 165, 250, .84); background: rgba(37, 99, 235, .22); }
+html[data-theme="dark"] .diagram-area[data-style-key="green"] { border-color: rgba(52, 211, 153, .84); background: rgba(5, 150, 105, .22); }
+html[data-theme="dark"] .diagram-area[data-style-key="amber"] { border-color: rgba(251, 191, 36, .88); background: rgba(217, 119, 6, .24); }
+html[data-theme="dark"] .diagram-area[data-style-key="red"] { border-color: rgba(248, 113, 113, .84); background: rgba(220, 38, 38, .2); }
+html[data-theme="dark"] .diagram-area[data-style-key="purple"] { border-color: rgba(196, 181, 253, .84); background: rgba(124, 58, 237, .24); }

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -1436,3 +1436,106 @@ html[data-theme="dark"] .diagram-link-port-label {
 .diagram-summary-endpoint-meta {
     flex: 0 0 auto;
 }
+
+.diagram-area-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.diagram-area {
+    position: absolute;
+    left: 0;
+    top: 0;
+    min-width: 80px;
+    min-height: 60px;
+    border: 3px dashed rgba(71, 85, 105, .72);
+    border-radius: 18px;
+    background: rgba(148, 163, 184, .16);
+    color: var(--diagram-text);
+    pointer-events: none;
+    box-shadow: inset 0 0 0 9999px rgba(255, 255, 255, .03);
+}
+
+.diagram-area[data-style-key="blue"] { border-color: rgba(37, 99, 235, .76); background: rgba(96, 165, 250, .14); }
+.diagram-area[data-style-key="green"] { border-color: rgba(5, 150, 105, .76); background: rgba(52, 211, 153, .14); }
+.diagram-area[data-style-key="amber"] { border-color: rgba(217, 119, 6, .82); background: rgba(251, 191, 36, .16); }
+.diagram-area[data-style-key="red"] { border-color: rgba(220, 38, 38, .76); background: rgba(248, 113, 113, .13); }
+.diagram-area[data-style-key="purple"] { border-color: rgba(124, 58, 237, .76); background: rgba(167, 139, 250, .14); }
+
+.diagram-area-header {
+    display: inline-flex;
+    align-items: center;
+    max-width: calc(100% - 1rem);
+    min-height: 34px;
+    margin: .45rem;
+    padding: .35rem .7rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, .86);
+    border: 1px solid rgba(71, 85, 105, .25);
+    color: var(--diagram-text);
+    font-size: .92rem;
+    font-weight: 900;
+    line-height: 1.15;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    pointer-events: auto;
+    cursor: grab;
+}
+
+.diagram-area-notes {
+    position: absolute;
+    left: .75rem;
+    right: .75rem;
+    bottom: .55rem;
+    color: var(--diagram-muted);
+    font-size: .78rem;
+    font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    pointer-events: none;
+}
+
+.diagram-area-resize-handle {
+    position: absolute;
+    right: -9px;
+    bottom: -9px;
+    width: 24px;
+    height: 24px;
+    border-radius: 999px;
+    border: 2px solid var(--diagram-accent);
+    background: var(--diagram-panel);
+    box-shadow: 0 2px 8px rgba(16, 24, 40, .24);
+    pointer-events: auto;
+    cursor: nwse-resize;
+}
+
+.diagram-area[data-selected="true"] {
+    border-style: solid;
+    border-color: var(--diagram-accent);
+    box-shadow: 0 0 0 3px var(--diagram-accent-soft), inset 0 0 0 9999px rgba(255, 255, 255, .04);
+}
+
+.diagram-area[data-selected="false"] .diagram-area-resize-handle {
+    display: none;
+}
+
+.area-geometry-fields {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: .55rem;
+}
+
+html[data-theme="dark"] .diagram-area {
+    background: rgba(100, 116, 139, .18);
+    border-color: rgba(148, 163, 184, .72);
+    box-shadow: inset 0 0 0 9999px rgba(15, 23, 42, .04);
+}
+
+html[data-theme="dark"] .diagram-area-header {
+    background: rgba(15, 23, 42, .86);
+    border-color: rgba(148, 163, 184, .32);
+}

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
@@ -9,6 +9,7 @@
     const canvas = editor.querySelector('[data-diagram-canvas]');
     const world = editor.querySelector('[data-diagram-world]');
     const nodeLayer = editor.querySelector('[data-node-layer]');
+    const areaLayer = editor.querySelector('[data-area-layer]');
     const linkLayer = editor.querySelector('[data-link-layer]');
     const emptyState = editor.querySelector('[data-empty-state]');
     const sizeLabel = editor.querySelector('[data-canvas-size]');
@@ -22,6 +23,7 @@
     const deleteSelectionButtons = Array.from(editor.querySelectorAll('[data-delete-selection]'));
     const addButtons = Array.from(editor.querySelectorAll('[data-add-node]'));
     const addEndpointButtons = Array.from(editor.querySelectorAll('[data-add-endpoint-node]'));
+    const addAreaButton = editor.querySelector('[data-add-area]');
     const endpointSearchInput = editor.querySelector('[data-endpoint-search]');
     const clearEndpointSearchButton = editor.querySelector('[data-clear-endpoint-search]');
     const endpointGroupFilter = editor.querySelector('[data-endpoint-group-filter]');
@@ -35,9 +37,11 @@
     const nodeProperties = editor.querySelector('[data-node-properties]');
     const multiNodeProperties = editor.querySelector('[data-multi-node-properties]');
     const linkProperties = editor.querySelector('[data-link-properties]');
+    const areaProperties = editor.querySelector('[data-area-properties]');
     const noSelectionPanel = editor.querySelector('[data-no-selection-panel]');
     const nodeFields = Array.from(editor.querySelectorAll('[data-node-field]'));
     const linkFields = Array.from(editor.querySelectorAll('[data-link-field]'));
+    const areaFields = Array.from(editor.querySelectorAll('[data-area-field]'));
     const selectedNodeKindLabel = editor.querySelector('[data-selected-node-kind]');
     const selectedNodeEndpointDetails = editor.querySelector('[data-selected-node-endpoint-details]');
     const selectedNodeEndpointName = editor.querySelector('[data-selected-node-endpoint-name]');
@@ -71,7 +75,7 @@
     const exportPngUrl = editor.dataset.exportPngUrl || '';
     const exportSvgUrl = editor.dataset.exportSvgUrl || '';
 
-    if (!canvasHost || !canvas || !world || !nodeLayer || !linkLayer) {
+    if (!canvasHost || !canvas || !world || !areaLayer || !nodeLayer || !linkLayer) {
         return;
     }
 
@@ -117,8 +121,10 @@
     const state = {
         nodes: [],
         links: [],
+        areas: [],
         selectedNodeIds: [],
         selectedLinkId: null,
+        selectedAreaId: null,
         activeSelectionType: 'none',
         currentTool: 'select',
         zoom: 1,
@@ -136,6 +142,7 @@
 
     let nodeSequence = 0;
     let linkSequence = 0;
+    let areaSequence = 0;
     let dragState = null;
     let panState = null;
     let pendingLinkSourceId = null;
@@ -270,7 +277,7 @@
 
     function setEmptyState() {
         if (emptyState) {
-            emptyState.hidden = state.nodes.length > 0;
+            emptyState.hidden = state.nodes.length > 0 || state.areas.length > 0;
         }
     }
 
@@ -292,6 +299,16 @@
 
     function makeClientId(prefix) {
         return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+    }
+
+    function getNextAreaPosition()
+    {
+        areaSequence += 1;
+        const center = getVisibleWorldCenter();
+        const width = 600;
+        const height = 350;
+        const offset = ((areaSequence - 1) % 6) * 34;
+        return { id: makeClientId('diagram-area'), x: clamp(center.x - width / 2 + offset, -1000, state.virtualCanvasWidth - 80), y: clamp(center.y - height / 2 + offset, -1000, state.virtualCanvasHeight - 60), width, height };
     }
 
     function getNextNodePosition() {
@@ -496,6 +513,64 @@
         });
     }
 
+
+    function normalizeAreaStyleKey(value) {
+        const requested = String(value || 'neutral').trim().toLowerCase();
+        return ['neutral', 'blue', 'green', 'amber', 'red', 'purple'].includes(requested) ? requested : 'neutral';
+    }
+
+    function applyAreaPosition(area) {
+        area.element.style.transform = `translate(${Math.round(area.x)}px, ${Math.round(area.y)}px)`;
+        area.element.style.width = `${Math.round(area.width)}px`;
+        area.element.style.height = `${Math.round(area.height)}px`;
+    }
+
+    function updateAreaElement(area) {
+        area.element.dataset.styleKey = normalizeAreaStyleKey(area.styleKey);
+        const label = area.element.querySelector('[data-area-label]');
+        if (label) { label.textContent = area.label || 'Area'; }
+        const notes = area.element.querySelector('[data-area-notes]');
+        if (notes) {
+            notes.textContent = area.notes || '';
+            notes.hidden = !area.notes;
+        }
+        area.element.setAttribute('aria-label', `${area.label || 'Area'} visual area box`);
+        applyAreaPosition(area);
+    }
+
+    function createAreaElement(area) {
+        const element = document.createElement('div');
+        element.className = 'diagram-area';
+        element.tabIndex = 0;
+        element.setAttribute('role', 'button');
+        element.dataset.areaId = area.id;
+        element.dataset.selected = 'false';
+        const header = document.createElement('div');
+        header.className = 'diagram-area-header';
+        header.dataset.areaDragHandle = 'true';
+        header.innerHTML = '<span data-area-label></span>';
+        const notes = document.createElement('div');
+        notes.className = 'diagram-area-notes';
+        notes.dataset.areaNotes = 'true';
+        const resize = document.createElement('span');
+        resize.className = 'diagram-area-resize-handle';
+        resize.dataset.areaResizeHandle = 'true';
+        resize.setAttribute('aria-hidden', 'true');
+        element.append(header, notes, resize);
+        return element;
+    }
+
+    function addArea() {
+        const position = getNextAreaPosition();
+        const area = { id: position.id, label: 'New area', notes: '', x: position.x, y: position.y, width: position.width, height: position.height, styleKey: 'neutral', sortOrder: state.areas.length, element: null };
+        area.element = createAreaElement(area);
+        areaLayer.appendChild(area.element);
+        state.areas.push(area);
+        updateAreaElement(area);
+        selectArea(area.id);
+        markDirty();
+    }
+
     function findNodeByElement(element) {
         return state.nodes.find(node => node.element === element);
     }
@@ -508,17 +583,28 @@
         return state.links.find(link => link.id === linkId) || null;
     }
 
+    function findAreaById(areaId) {
+        return state.areas.find(area => area.id === areaId) || null;
+    }
+
+    function selectedArea() {
+        return state.selectedAreaId ? findAreaById(state.selectedAreaId) : null;
+    }
+
     function selectedNodes() {
         return state.selectedNodeIds.map(findNodeById).filter(Boolean);
     }
 
     function hasSelection() {
-        return state.selectedNodeIds.length > 0 || Boolean(state.selectedLinkId);
+        return state.selectedNodeIds.length > 0 || Boolean(state.selectedLinkId) || Boolean(state.selectedAreaId);
     }
 
     function syncSelectionDom() {
         state.nodes.forEach(node => {
             node.element.dataset.selected = state.selectedNodeIds.includes(node.id) ? 'true' : 'false';
+        });
+        state.areas.forEach(area => {
+            area.element.dataset.selected = state.selectedAreaId === area.id ? 'true' : 'false';
         });
         renderLinks();
         updatePropertiesPanel();
@@ -545,12 +631,14 @@
     function selectOnlyNode(nodeId) {
         state.selectedNodeIds = [nodeId];
         state.selectedLinkId = null;
+        state.selectedAreaId = null;
         state.activeSelectionType = 'nodes';
         syncSelectionDom();
     }
 
     function toggleNodeSelection(nodeId) {
         state.selectedLinkId = null;
+        state.selectedAreaId = null;
         if (state.selectedNodeIds.includes(nodeId)) {
             state.selectedNodeIds = state.selectedNodeIds.filter(id => id !== nodeId);
         } else {
@@ -564,6 +652,7 @@
     function selectAllNodes() {
         state.selectedNodeIds = state.nodes.map(node => node.id);
         state.selectedLinkId = null;
+        state.selectedAreaId = null;
         state.activeSelectionType = state.selectedNodeIds.length > 0 ? 'nodes' : 'none';
         syncSelectionDom();
     }
@@ -571,6 +660,7 @@
     function clearSelection() {
         state.selectedNodeIds = [];
         state.selectedLinkId = null;
+        state.selectedAreaId = null;
         state.activeSelectionType = 'none';
         syncSelectionDom();
     }
@@ -578,7 +668,16 @@
     function selectLink(linkId) {
         state.selectedLinkId = linkId;
         state.selectedNodeIds = [];
+        state.selectedAreaId = null;
         state.activeSelectionType = 'link';
+        syncSelectionDom();
+    }
+
+    function selectArea(areaId) {
+        state.selectedAreaId = areaId;
+        state.selectedLinkId = null;
+        state.selectedNodeIds = [];
+        state.activeSelectionType = 'area';
         syncSelectionDom();
     }
 
@@ -730,6 +829,37 @@
         };
     }
 
+
+    function handleAreaPointerDown(event) {
+        const target = event.target instanceof Element ? event.target : null;
+        const areaElement = target?.closest('.diagram-area');
+        if (!areaElement || event.button !== 0 || state.currentTool !== 'select') {
+            return;
+        }
+
+        const area = findAreaById(areaElement.dataset.areaId);
+        if (!area) {
+            return;
+        }
+
+        selectArea(area.id);
+        const pointer = screenToWorld(event.clientX, event.clientY);
+        const isResize = Boolean(target?.closest('[data-area-resize-handle]'));
+        dragState = {
+            pointerId: event.pointerId,
+            area,
+            mode: isResize ? 'resize-area' : 'move-area',
+            startPointer: pointer,
+            startArea: { x: area.x, y: area.y, width: area.width, height: area.height },
+            moved: false
+        };
+        area.element.dataset.dragging = 'true';
+        area.element.setPointerCapture(event.pointerId);
+        area.element.focus({ preventScroll: true });
+        event.preventDefault();
+        event.stopPropagation();
+    }
+
     function handleNodePointerDown(event) {
         const target = event.target.closest('.diagram-node');
         if (!target || !nodeLayer.contains(target)) {
@@ -791,6 +921,25 @@
         const pointer = screenToWorld(event.clientX, event.clientY);
         const requestedDeltaX = pointer.x - dragState.startPointer.x;
         const requestedDeltaY = pointer.y - dragState.startPointer.y;
+
+        if (dragState.area) {
+            const area = dragState.area;
+            if (dragState.mode === 'resize-area') {
+                area.width = clamp(dragState.startArea.width + requestedDeltaX, 80, 20000);
+                area.height = clamp(dragState.startArea.height + requestedDeltaY, 60, 20000);
+            } else {
+                area.x = clamp(dragState.startArea.x + requestedDeltaX, -1000, state.virtualCanvasWidth - 80);
+                area.y = clamp(dragState.startArea.y + requestedDeltaY, -1000, state.virtualCanvasHeight - 60);
+            }
+
+            dragState.moved = dragState.moved || Math.abs(requestedDeltaX) > 1 || Math.abs(requestedDeltaY) > 1;
+            updateAreaElement(area);
+            markDirty();
+            updatePropertiesPanel();
+            event.preventDefault();
+            return;
+        }
+
         const { deltaX, deltaY } = clampGroupDelta(dragState.nodes, requestedDeltaX, requestedDeltaY, dragState.startPositions);
         dragState.moved = dragState.moved || Math.abs(deltaX) > 1 || Math.abs(deltaY) > 1;
 
@@ -812,6 +961,19 @@
 
     function endDrag(event) {
         if (!dragState || dragState.pointerId !== event.pointerId) {
+            return;
+        }
+
+        if (dragState.area) {
+            const area = dragState.area;
+            area.element.dataset.dragging = 'false';
+            if (area.element.hasPointerCapture(event.pointerId)) {
+                area.element.releasePointerCapture(event.pointerId);
+            }
+            const moved = dragState.moved;
+            dragState = null;
+            if (moved) { markDirty(); }
+            updatePropertiesPanel();
             return;
         }
 
@@ -1102,12 +1264,17 @@
 
     function updatePropertiesPanel() {
         const selectedLink = state.selectedLinkId ? findLinkById(state.selectedLinkId) : null;
+        const area = selectedArea();
         const nodes = selectedNodes();
         const singleNode = nodes.length === 1 ? nodes[0] : null;
         const multipleNodes = nodes.length > 1;
 
         if (noSelectionPanel) {
-            noSelectionPanel.hidden = Boolean(selectedLink) || Boolean(singleNode) || multipleNodes;
+            noSelectionPanel.hidden = Boolean(selectedLink) || Boolean(area) || Boolean(singleNode) || multipleNodes;
+        }
+
+        if (areaProperties) {
+            areaProperties.hidden = !area;
         }
 
         if (nodeProperties) {
@@ -1157,6 +1324,15 @@
         if (selectedNodeCount) {
             selectedNodeCount.textContent = String(nodes.length);
         }
+
+        areaFields.forEach(field => {
+            const propertyName = field.dataset.areaField;
+            if (!area || !propertyName) {
+                field.value = '';
+            } else {
+                field.value = area[propertyName] ?? '';
+            }
+        });
 
         nodeFields.forEach(field => {
             const propertyName = field.dataset.nodeField;
@@ -1272,6 +1448,30 @@
             inputs[3].addEventListener('input', event => { vlan.notes = event.currentTarget.value; markDirty(); });
             linkVlanList.appendChild(card);
         });
+    }
+
+
+    function updateSelectedAreaField(event) {
+        const area = selectedArea();
+        const field = event.currentTarget;
+        const propertyName = field.dataset.areaField;
+        if (!area || !propertyName) {
+            return;
+        }
+
+        if (['x', 'y', 'width', 'height'].includes(propertyName)) {
+            const min = propertyName === 'width' ? 80 : propertyName === 'height' ? 60 : -1000;
+            const max = propertyName === 'x' || propertyName === 'y' ? 21000 : 20000;
+            area[propertyName] = clamp(Number(field.value) || 0, min, max);
+        } else if (propertyName === 'styleKey') {
+            area.styleKey = normalizeAreaStyleKey(field.value);
+        } else {
+            area[propertyName] = field.value;
+        }
+
+        updateAreaElement(area);
+        markDirty();
+        updatePropertiesPanel();
     }
 
     function updateSelectedNodeField(event) {
@@ -1394,6 +1594,21 @@
     }
 
     function deleteSelection() {
+        if (state.selectedAreaId) {
+            const confirmed = window.confirm('Remove selected area box from this draft diagram only? Nodes, links, endpoints, monitoring data, dependencies, alerts, and agents will not be changed.');
+            if (!confirmed) {
+                return;
+            }
+
+            const area = selectedArea();
+            area?.element.remove();
+            state.areas = state.areas.filter(existing => existing.id !== state.selectedAreaId);
+            state.selectedAreaId = null;
+            markDirty();
+            syncSelectionDom();
+            return;
+        }
+
         if (state.selectedNodeIds.length > 0) {
             const confirmed = window.confirm('Remove selected item(s) from this draft diagram only? Monitored endpoints and monitoring data will not be deleted.');
             if (!confirmed) {
@@ -1463,17 +1678,21 @@
     }
 
     function fitContent() {
-        if (state.nodes.length === 0) {
+        if (state.nodes.length === 0 && state.areas.length === 0) {
             resetView();
             return;
         }
 
         const padding = 96;
         const rect = getCanvasRect();
-        const minX = Math.min(...state.nodes.map(node => node.x));
-        const minY = Math.min(...state.nodes.map(node => node.y));
-        const maxX = Math.max(...state.nodes.map(node => node.x + getNodeWidth(node)));
-        const maxY = Math.max(...state.nodes.map(node => node.y + getNodeHeight(node)));
+        const items = [
+            ...state.areas.map(area => ({ x: area.x, y: area.y, width: area.width, height: area.height })),
+            ...state.nodes.map(node => ({ x: node.x, y: node.y, width: getNodeWidth(node), height: getNodeHeight(node) }))
+        ];
+        const minX = Math.min(...items.map(item => item.x));
+        const minY = Math.min(...items.map(item => item.y));
+        const maxX = Math.max(...items.map(item => item.x + item.width));
+        const maxY = Math.max(...items.map(item => item.y + item.height));
         const contentWidth = Math.max(1, maxX - minX);
         const contentHeight = Math.max(1, maxY - minY);
         const nextZoom = clamp(Math.min(
@@ -1489,7 +1708,7 @@
     }
 
     function beginPan(event) {
-        if (event.button !== 0 || event.target.closest('.diagram-node') || event.target.closest('.diagram-link-group')) {
+        if (event.button !== 0 || event.target.closest('.diagram-node') || event.target.closest('.diagram-area') || event.target.closest('.diagram-link-group')) {
             return;
         }
 
@@ -1607,6 +1826,26 @@
         return { nodeType: 'generic-device', nodeKind: 'custom-device' };
     }
 
+
+    function addLoadedArea(savedArea) {
+        const area = {
+            id: savedArea.areaId,
+            label: savedArea.label || 'Area',
+            notes: savedArea.notes || '',
+            x: Number(savedArea.x) || 0,
+            y: Number(savedArea.y) || 0,
+            width: Math.max(80, Number(savedArea.width) || 600),
+            height: Math.max(60, Number(savedArea.height) || 350),
+            styleKey: normalizeAreaStyleKey(savedArea.styleKey),
+            sortOrder: Number(savedArea.sortOrder) || state.areas.length,
+            element: null
+        };
+        area.element = createAreaElement(area);
+        areaLayer.appendChild(area.element);
+        state.areas.push(area);
+        updateAreaElement(area);
+    }
+
     function addLoadedNode(savedNode) {
         const normalized = normalizeNodeType(savedNode.nodeType);
         const node = {
@@ -1668,8 +1907,11 @@
         state.panY = diagram.viewportPanY || 0;
         state.zoom = diagram.viewportZoom || 1;
         nodeLayer.replaceChildren();
+        areaLayer.replaceChildren();
         state.nodes = [];
         state.links = [];
+        state.areas = [];
+        (diagram.areas || []).forEach(addLoadedArea);
         (diagram.nodes || []).forEach(addLoadedNode);
         updateEndpointToolboxFilters();
         state.links = (diagram.links || []).map(link => ({
@@ -1719,6 +1961,17 @@
             viewportPanX: state.panX,
             viewportPanY: state.panY,
             viewportZoom: state.zoom,
+            areas: state.areas.map((area, index) => ({
+                areaId: area.id,
+                label: area.label || 'Area',
+                notes: area.notes || null,
+                x: Number(area.x) || 0,
+                y: Number(area.y) || 0,
+                width: Math.max(80, Number(area.width) || 600),
+                height: Math.max(60, Number(area.height) || 350),
+                styleKey: normalizeAreaStyleKey(area.styleKey),
+                sortOrder: index
+            })),
             nodes: state.nodes.map(node => ({
                 nodeId: node.id,
                 nodeType: toServerNodeType(node),
@@ -1837,6 +2090,8 @@
         button.addEventListener('click', () => addEndpointNode(button));
     });
 
+    addAreaButton?.addEventListener('click', addArea);
+
     endpointSearchInput?.addEventListener('input', updateEndpointToolboxFilters);
     endpointSearchInput?.addEventListener('keydown', event => {
         event.stopPropagation();
@@ -1876,6 +2131,10 @@
             drawLinkTypeSelect.value = state.selectedDrawLinkType;
         });
     }
+
+    areaFields.forEach(field => {
+        field.addEventListener('input', updateSelectedAreaField);
+    });
 
     nodeFields.forEach(field => {
         field.addEventListener('input', updateSelectedNodeField);
@@ -1944,6 +2203,7 @@
         event.returnValue = '';
     });
 
+    areaLayer?.addEventListener('pointerdown', handleAreaPointerDown);
     nodeLayer.addEventListener('pointerdown', handleNodePointerDown);
     nodeLayer.addEventListener('pointermove', moveDrag);
     nodeLayer.addEventListener('pointerup', endDrag);

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
@@ -117,6 +117,10 @@
         { value: 'large', label: 'Large', width: 8000, height: 5657 },
         { value: 'extra-large', label: 'Extra large', width: 11314, height: 8000 }
     ];
+    const minimumAreaWidth = 80;
+    const minimumAreaHeight = 60;
+    const maximumAreaSize = 20000;
+
 
     const state = {
         nodes: [],
@@ -163,6 +167,15 @@
         }
 
         return Math.min(Math.max(value, min), max);
+    }
+
+    function formatDiagramNumber(value) {
+        const number = Number(value);
+        if (!Number.isFinite(number)) {
+            return '0';
+        }
+
+        return String(Math.round(number * 100) / 100);
     }
 
     function getNodeWidth(node) {
@@ -308,7 +321,7 @@
         const width = 600;
         const height = 350;
         const offset = ((areaSequence - 1) % 6) * 34;
-        return { id: makeClientId('diagram-area'), x: clamp(center.x - width / 2 + offset, -1000, state.virtualCanvasWidth - 80), y: clamp(center.y - height / 2 + offset, -1000, state.virtualCanvasHeight - 60), width, height };
+        return { id: makeClientId('diagram-area'), x: clamp(center.x - width / 2 + offset, -1000, state.virtualCanvasWidth - minimumAreaWidth), y: clamp(center.y - height / 2 + offset, -1000, state.virtualCanvasHeight - minimumAreaHeight), width, height };
     }
 
     function getNextNodePosition() {
@@ -552,11 +565,30 @@
         const notes = document.createElement('div');
         notes.className = 'diagram-area-notes';
         notes.dataset.areaNotes = 'true';
-        const resize = document.createElement('span');
-        resize.className = 'diagram-area-resize-handle';
-        resize.dataset.areaResizeHandle = 'true';
-        resize.setAttribute('aria-hidden', 'true');
-        element.append(header, notes, resize);
+        const hitTop = document.createElement('span');
+        hitTop.className = 'diagram-area-hit diagram-area-hit-top';
+        hitTop.dataset.areaDragHandle = 'true';
+        hitTop.setAttribute('aria-hidden', 'true');
+        const hitRight = document.createElement('span');
+        hitRight.className = 'diagram-area-hit diagram-area-hit-right';
+        hitRight.dataset.areaDragHandle = 'true';
+        hitRight.setAttribute('aria-hidden', 'true');
+        const hitBottom = document.createElement('span');
+        hitBottom.className = 'diagram-area-hit diagram-area-hit-bottom';
+        hitBottom.dataset.areaDragHandle = 'true';
+        hitBottom.setAttribute('aria-hidden', 'true');
+        const hitLeft = document.createElement('span');
+        hitLeft.className = 'diagram-area-hit diagram-area-hit-left';
+        hitLeft.dataset.areaDragHandle = 'true';
+        hitLeft.setAttribute('aria-hidden', 'true');
+        const resizeHandles = ['nw', 'ne', 'sw', 'se'].map(position => {
+            const resize = document.createElement('span');
+            resize.className = `diagram-area-resize-handle diagram-area-resize-handle-${position}`;
+            resize.dataset.areaResizeHandle = position;
+            resize.setAttribute('aria-label', `Resize area ${position}`);
+            return resize;
+        });
+        element.append(header, notes, hitTop, hitRight, hitBottom, hitLeft, ...resizeHandles);
         return element;
     }
 
@@ -844,11 +876,12 @@
 
         selectArea(area.id);
         const pointer = screenToWorld(event.clientX, event.clientY);
-        const isResize = Boolean(target?.closest('[data-area-resize-handle]'));
+        const resizeHandle = target?.closest('[data-area-resize-handle]');
         dragState = {
             pointerId: event.pointerId,
             area,
-            mode: isResize ? 'resize-area' : 'move-area',
+            mode: resizeHandle ? 'resize-area' : 'move-area',
+            resizeHandle: resizeHandle?.dataset.areaResizeHandle || 'se',
             startPointer: pointer,
             startArea: { x: area.x, y: area.y, width: area.width, height: area.height },
             moved: false
@@ -913,6 +946,36 @@
         event.stopPropagation();
     }
 
+    function resizeAreaFromDrag(area, drag, requestedDeltaX, requestedDeltaY) {
+        const start = drag.startArea;
+        const handle = drag.resizeHandle || 'se';
+        let left = start.x;
+        let top = start.y;
+        let right = start.x + start.width;
+        let bottom = start.y + start.height;
+
+        if (handle.includes('e')) {
+            right = clamp(right + requestedDeltaX, left + minimumAreaWidth, left + maximumAreaSize);
+        }
+
+        if (handle.includes('s')) {
+            bottom = clamp(bottom + requestedDeltaY, top + minimumAreaHeight, top + maximumAreaSize);
+        }
+
+        if (handle.includes('w')) {
+            left = clamp(left + requestedDeltaX, right - maximumAreaSize, right - minimumAreaWidth);
+        }
+
+        if (handle.includes('n')) {
+            top = clamp(top + requestedDeltaY, bottom - maximumAreaSize, bottom - minimumAreaHeight);
+        }
+
+        area.x = left;
+        area.y = top;
+        area.width = right - left;
+        area.height = bottom - top;
+    }
+
     function moveDrag(event) {
         if (!dragState || dragState.pointerId !== event.pointerId) {
             return;
@@ -925,11 +988,10 @@
         if (dragState.area) {
             const area = dragState.area;
             if (dragState.mode === 'resize-area') {
-                area.width = clamp(dragState.startArea.width + requestedDeltaX, 80, 20000);
-                area.height = clamp(dragState.startArea.height + requestedDeltaY, 60, 20000);
+                resizeAreaFromDrag(area, dragState, requestedDeltaX, requestedDeltaY);
             } else {
-                area.x = clamp(dragState.startArea.x + requestedDeltaX, -1000, state.virtualCanvasWidth - 80);
-                area.y = clamp(dragState.startArea.y + requestedDeltaY, -1000, state.virtualCanvasHeight - 60);
+                area.x = clamp(dragState.startArea.x + requestedDeltaX, -1000, state.virtualCanvasWidth - minimumAreaWidth);
+                area.y = clamp(dragState.startArea.y + requestedDeltaY, -1000, state.virtualCanvasHeight - minimumAreaHeight);
             }
 
             dragState.moved = dragState.moved || Math.abs(requestedDeltaX) > 1 || Math.abs(requestedDeltaY) > 1;
@@ -1329,6 +1391,8 @@
             const propertyName = field.dataset.areaField;
             if (!area || !propertyName) {
                 field.value = '';
+            } else if (['x', 'y', 'width', 'height'].includes(propertyName)) {
+                field.value = formatDiagramNumber(area[propertyName]);
             } else {
                 field.value = area[propertyName] ?? '';
             }
@@ -1460,8 +1524,8 @@
         }
 
         if (['x', 'y', 'width', 'height'].includes(propertyName)) {
-            const min = propertyName === 'width' ? 80 : propertyName === 'height' ? 60 : -1000;
-            const max = propertyName === 'x' || propertyName === 'y' ? 21000 : 20000;
+            const min = propertyName === 'width' ? minimumAreaWidth : propertyName === 'height' ? minimumAreaHeight : -1000;
+            const max = propertyName === 'x' || propertyName === 'y' ? 21000 : maximumAreaSize;
             area[propertyName] = clamp(Number(field.value) || 0, min, max);
         } else if (propertyName === 'styleKey') {
             area.styleKey = normalizeAreaStyleKey(field.value);
@@ -1834,8 +1898,8 @@
             notes: savedArea.notes || '',
             x: Number(savedArea.x) || 0,
             y: Number(savedArea.y) || 0,
-            width: Math.max(80, Number(savedArea.width) || 600),
-            height: Math.max(60, Number(savedArea.height) || 350),
+            width: Math.max(minimumAreaWidth, Number(savedArea.width) || 600),
+            height: Math.max(minimumAreaHeight, Number(savedArea.height) || 350),
             styleKey: normalizeAreaStyleKey(savedArea.styleKey),
             sortOrder: Number(savedArea.sortOrder) || state.areas.length,
             element: null
@@ -1967,8 +2031,8 @@
                 notes: area.notes || null,
                 x: Number(area.x) || 0,
                 y: Number(area.y) || 0,
-                width: Math.max(80, Number(area.width) || 600),
-                height: Math.max(60, Number(area.height) || 350),
+                width: Math.max(minimumAreaWidth, Number(area.width) || 600),
+                height: Math.max(minimumAreaHeight, Number(area.height) || 350),
                 styleKey: normalizeAreaStyleKey(area.styleKey),
                 sortOrder: index
             })),
@@ -2204,6 +2268,9 @@
     });
 
     areaLayer?.addEventListener('pointerdown', handleAreaPointerDown);
+    areaLayer?.addEventListener('pointermove', moveDrag);
+    areaLayer?.addEventListener('pointerup', endDrag);
+    areaLayer?.addEventListener('pointercancel', endDrag);
     nodeLayer.addEventListener('pointerdown', handleNodePointerDown);
     nodeLayer.addEventListener('pointermove', moveDrag);
     nodeLayer.addEventListener('pointerup', endDrag);

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
@@ -11,6 +11,7 @@
     const canvas = viewer.querySelector('[data-diagram-canvas]');
     const world = viewer.querySelector('[data-diagram-world]');
     const nodeLayer = viewer.querySelector('[data-node-layer]');
+    const areaLayer = viewer.querySelector('[data-area-layer]');
     const linkLayer = viewer.querySelector('[data-link-layer]');
     const emptyState = viewer.querySelector('[data-empty-state]');
     const zoomLabel = viewer.querySelector('[data-zoom-label]');
@@ -34,6 +35,7 @@
     const state = {
         nodes: [],
         links: [],
+        areas: [],
         overlayByNodeId: new Map(),
         lastOverlayRefreshUtc: null,
         summaryMessage: '',
@@ -91,6 +93,41 @@
         if (serverType === 'MonitoredEndpoint') { return { nodeType: 'monitored-endpoint', nodeKind: 'monitored-endpoint' }; }
         if (serverType === 'Note') { return { nodeType: 'note', nodeKind: 'custom-device' }; }
         return { nodeType: 'generic-device', nodeKind: 'custom-device' };
+    }
+
+    function normalizeAreaStyleKey(value) {
+        const requested = String(value || 'neutral').trim().toLowerCase();
+        return ['neutral', 'blue', 'green', 'amber', 'red', 'purple'].includes(requested) ? requested : 'neutral';
+    }
+
+    function createAreaElement(area) {
+        const element = document.createElement('div');
+        element.className = 'diagram-area diagram-viewer-area';
+        element.dataset.areaId = area.id;
+        element.dataset.styleKey = normalizeAreaStyleKey(area.styleKey);
+        element.setAttribute('aria-label', `${area.label} visual area box`);
+        element.innerHTML = `<div class="diagram-area-header"><span>${escapeHtml(area.label)}</span></div>${area.notes ? `<div class="diagram-area-notes">${escapeHtml(area.notes)}</div>` : ''}`;
+        element.style.transform = `translate(${Math.round(area.x)}px, ${Math.round(area.y)}px)`;
+        element.style.width = `${Math.round(area.width)}px`;
+        element.style.height = `${Math.round(area.height)}px`;
+        return element;
+    }
+
+    function addLoadedArea(savedArea) {
+        const area = {
+            id: savedArea.areaId,
+            label: savedArea.label || 'Area',
+            notes: savedArea.notes || '',
+            x: Number(savedArea.x) || 0,
+            y: Number(savedArea.y) || 0,
+            width: Math.max(80, Number(savedArea.width) || 600),
+            height: Math.max(60, Number(savedArea.height) || 350),
+            styleKey: normalizeAreaStyleKey(savedArea.styleKey),
+            sortOrder: Number(savedArea.sortOrder) || state.areas.length
+        };
+        area.element = createAreaElement(area);
+        areaLayer.appendChild(area.element);
+        state.areas.push(area);
     }
 
     function formatNodeType(type) {
@@ -253,7 +290,7 @@
         });
     }
 
-    function setEmptyState() { emptyState.hidden = state.nodes.length > 0; }
+    function setEmptyState() { emptyState.hidden = state.nodes.length > 0 || state.areas.length > 0; }
     function formatRtt(value) { return value == null ? '—' : `${Number(value).toFixed(1)} ms`; }
     function formatDate(value) { return value ? new Date(value).toLocaleString() : '—'; }
     function stateLabel(value) { return value || 'Unknown'; }
@@ -440,8 +477,9 @@
 
     function resetView() { state.zoom = 1; state.panX = 0; state.panY = 0; updateCanvasSize(); }
     function fitContent() {
-        if (state.nodes.length === 0) { resetView(); return; }
-        const bounds = state.nodes.reduce((acc, node) => ({ minX: Math.min(acc.minX, node.x), minY: Math.min(acc.minY, node.y), maxX: Math.max(acc.maxX, node.x + getNodeWidth(node)), maxY: Math.max(acc.maxY, node.y + getNodeHeight(node)) }), { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity });
+        if (state.nodes.length === 0 && state.areas.length === 0) { resetView(); return; }
+        const items = [...state.areas.map(area => ({ x: area.x, y: area.y, width: area.width, height: area.height })), ...state.nodes.map(node => ({ x: node.x, y: node.y, width: getNodeWidth(node), height: getNodeHeight(node) }))];
+        const bounds = items.reduce((acc, item) => ({ minX: Math.min(acc.minX, item.x), minY: Math.min(acc.minY, item.y), maxX: Math.max(acc.maxX, item.x + item.width), maxY: Math.max(acc.maxY, item.y + item.height) }), { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity });
         const rect = canvas.getBoundingClientRect();
         const padding = 80;
         state.zoom = Math.min(Math.max(Math.min((rect.width - padding) / Math.max(bounds.maxX - bounds.minX, 1), (rect.height - padding) / Math.max(bounds.maxY - bounds.minY, 1)), minZoom), maxZoom);
@@ -485,7 +523,10 @@
         state.panY = diagram.viewportPanY || 0;
         state.zoom = diagram.viewportZoom || 1;
         nodeLayer.replaceChildren();
+        areaLayer.replaceChildren();
         state.nodes = [];
+        state.areas = [];
+        (diagram.areas || []).forEach(addLoadedArea);
         (diagram.nodes || []).forEach(addLoadedNode);
         state.links = (diagram.links || []).map(link => ({ id: link.linkId, sourceNodeId: link.sourceNodeId, targetNodeId: link.targetNodeId, label: link.label || '', sourcePort: link.sourcePortLabel || '', targetPort: link.targetPortLabel || '', notes: link.notes || '', mediaType: normalizeMediaType(link.mediaType, link.linkType), linkType: normalizeLinkType(link.linkType), linkSpeedValue: link.linkSpeedValue, linkSpeedUnit: link.linkSpeedUnit, vlans: normalizeVlans(link.vlans) }));
         setEmptyState();


### PR DESCRIPTION
### Motivation
- Provide a simple, persistent visual grouping primitive for Network Diagrams so operators can annotate diagrams by physical/logical location without affecting monitoring, dependencies, agents, or alerts.

### Description
- Add a new persistent entity `NetworkDiagramArea` and EF configuration and `DbSet` so area boxes are stored with diagrams and cascaded when a diagram is deleted. 
- Extend diagram DTOs and `INetworkDiagramService` save/load paths to validate, persist, and return area box payloads alongside existing nodes and links. 
- Wire editor UI to create/select/move/resize/edit/delete area boxes and show area properties (label, notes, geometry, style) in the Properties panel; editor changes mark the diagram dirty and are included in the existing save payload. 
- Render area boxes in the read-only viewer and include them in native exports (SVG/PNG/PDF) by adding them to the native export layout so they draw behind links/nodes and show labels; include areas in configuration backup and restore flows. 
- Add simple theme-compatible styling for translucent fills, borders, selection outlines, and ensure pointer events keep areas behind nodes/links so node/link interaction remains unchanged. 
- Increment `StartupGate.RequiredSchemaVersion` and add the schema creation/check for the new areas table in startup schema service, and create GitHub issue tracking this work `#533` as required by repository automation rules.

### Testing
- Added unit tests covering area persistence, payload validation, deletion semantics, and backup/restore preview/restore paths and ran the WebApp unit test suite (`dotnet test src/WebApp/PingMonitor.Web.Tests`), which passed.
- Exercised export paths for SVG/PNG/PDF generation in unit tests to confirm area boxes appear in exports and that export pixel budget/limits remain enforced.
- Verified configuration backup preview and replace-restore logic includes area counts and restores area records without touching endpoints, assignments, dependencies, alerts, or agents.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2717cbdcb0832aa802428e70321e51)