### PR TITLE
Fix network diagram area box interactions

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -164,6 +164,35 @@ public sealed class NetworkDiagramsFeatureTests
     }
 
 
+
+    [Fact]
+    public void NetworkDiagramEditor_AreaBoxesUseCanvasObjectInteractionGuards()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var viewMarkup = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "Views", "NetworkDiagrams", "Edit.cshtml"));
+        var script = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "wwwroot", "js", "network-diagrams-editor.js"));
+        var styles = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "wwwroot", "css", "network-diagrams.css"));
+
+        Assert.Contains("Advanced coordinates", viewMarkup);
+        Assert.Contains("Drag the area border/header to move it", viewMarkup);
+        Assert.Contains("diagram-area-hit", script);
+        Assert.Contains("resize.dataset.areaResizeHandle = position", script);
+        Assert.Contains("['nw', 'ne', 'sw', 'se']", script);
+        Assert.Contains("resizeAreaFromDrag", script);
+        Assert.Contains("screenToWorld(event.clientX, event.clientY)", script);
+        Assert.Contains("areaLayer?.addEventListener('pointermove', moveDrag)", script);
+        Assert.Contains("areaLayer?.addEventListener('pointerup', endDrag)", script);
+        Assert.Contains("formatDiagramNumber(area[propertyName])", script);
+        Assert.Contains(".diagram-area {", styles);
+        Assert.Contains("pointer-events: none;", styles);
+        Assert.Contains(".diagram-area-hit", styles);
+        Assert.Contains("pointer-events: auto;", styles);
+        Assert.Contains(".diagram-area-resize-handle-nw", styles);
+        Assert.Contains(".diagram-area-resize-handle-se", styles);
+        Assert.Contains(@"html[data-theme=""dark""] .diagram-area[data-style-key=""blue""]", styles);
+        Assert.Contains(@"html[data-theme=""dark""] .diagram-area[data-style-key=""purple""]", styles);
+    }
+
     [Fact]
     public void NetworkDiagramEditor_ViewIncludesEndpointToolboxFilters()
     {

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/Edit.cshtml
@@ -242,12 +242,16 @@
                             <option value="purple">Purple</option>
                         </select>
                     </label>
-                    <div class="area-geometry-fields">
-                        <label>X<input type="number" data-area-field="x" step="1" /></label>
-                        <label>Y<input type="number" data-area-field="y" step="1" /></label>
-                        <label>Width<input type="number" data-area-field="width" min="80" step="1" /></label>
-                        <label>Height<input type="number" data-area-field="height" min="60" step="1" /></label>
-                    </div>
+                    <details class="area-geometry-details">
+                        <summary>Advanced coordinates</summary>
+                        <p class="toolbox-help">Drag the area border/header to move it and drag a visible corner handle to resize it. These fields are for precision adjustments only.</p>
+                        <div class="area-geometry-fields">
+                            <label>X<input type="number" data-area-field="x" step="1" /></label>
+                            <label>Y<input type="number" data-area-field="y" step="1" /></label>
+                            <label>Width<input type="number" data-area-field="width" min="80" step="1" /></label>
+                            <label>Height<input type="number" data-area-field="height" min="60" step="1" /></label>
+                        </div>
+                    </details>
                     <button type="button" class="danger-button" data-delete-selection>Delete selected area</button>
                 </form>
                 <form class="node-properties" data-node-properties hidden>

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -1499,10 +1499,42 @@ html[data-theme="dark"] .diagram-link-port-label {
     pointer-events: none;
 }
 
+.diagram-area-hit {
+    position: absolute;
+    pointer-events: auto;
+    cursor: grab;
+}
+
+.diagram-area-hit-top {
+    top: -9px;
+    left: 18px;
+    right: 18px;
+    height: 18px;
+}
+
+.diagram-area-hit-right {
+    top: 18px;
+    right: -9px;
+    bottom: 18px;
+    width: 18px;
+}
+
+.diagram-area-hit-bottom {
+    right: 18px;
+    bottom: -9px;
+    left: 18px;
+    height: 18px;
+}
+
+.diagram-area-hit-left {
+    top: 18px;
+    bottom: 18px;
+    left: -9px;
+    width: 18px;
+}
+
 .diagram-area-resize-handle {
     position: absolute;
-    right: -9px;
-    bottom: -9px;
     width: 24px;
     height: 24px;
     border-radius: 999px;
@@ -1510,6 +1542,29 @@ html[data-theme="dark"] .diagram-link-port-label {
     background: var(--diagram-panel);
     box-shadow: 0 2px 8px rgba(16, 24, 40, .24);
     pointer-events: auto;
+}
+
+.diagram-area-resize-handle-nw {
+    top: -11px;
+    left: -11px;
+    cursor: nwse-resize;
+}
+
+.diagram-area-resize-handle-ne {
+    top: -11px;
+    right: -11px;
+    cursor: nesw-resize;
+}
+
+.diagram-area-resize-handle-sw {
+    bottom: -11px;
+    left: -11px;
+    cursor: nesw-resize;
+}
+
+.diagram-area-resize-handle-se {
+    right: -11px;
+    bottom: -11px;
     cursor: nwse-resize;
 }
 
@@ -1521,6 +1576,11 @@ html[data-theme="dark"] .diagram-link-port-label {
 
 .diagram-area[data-selected="false"] .diagram-area-resize-handle {
     display: none;
+}
+
+.diagram-area[data-dragging="true"] .diagram-area-header,
+.diagram-area[data-dragging="true"] .diagram-area-hit {
+    cursor: grabbing;
 }
 
 .area-geometry-fields {
@@ -1539,3 +1599,9 @@ html[data-theme="dark"] .diagram-area-header {
     background: rgba(15, 23, 42, .86);
     border-color: rgba(148, 163, 184, .32);
 }
+
+html[data-theme="dark"] .diagram-area[data-style-key="blue"] { border-color: rgba(96, 165, 250, .84); background: rgba(37, 99, 235, .22); }
+html[data-theme="dark"] .diagram-area[data-style-key="green"] { border-color: rgba(52, 211, 153, .84); background: rgba(5, 150, 105, .22); }
+html[data-theme="dark"] .diagram-area[data-style-key="amber"] { border-color: rgba(251, 191, 36, .88); background: rgba(217, 119, 6, .24); }
+html[data-theme="dark"] .diagram-area[data-style-key="red"] { border-color: rgba(248, 113, 113, .84); background: rgba(220, 38, 38, .2); }
+html[data-theme="dark"] .diagram-area[data-style-key="purple"] { border-color: rgba(196, 181, 253, .84); background: rgba(124, 58, 237, .24); }

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-editor.js
@@ -117,6 +117,10 @@
         { value: 'large', label: 'Large', width: 8000, height: 5657 },
         { value: 'extra-large', label: 'Extra large', width: 11314, height: 8000 }
     ];
+    const minimumAreaWidth = 80;
+    const minimumAreaHeight = 60;
+    const maximumAreaSize = 20000;
+
 
     const state = {
         nodes: [],
@@ -163,6 +167,15 @@
         }
 
         return Math.min(Math.max(value, min), max);
+    }
+
+    function formatDiagramNumber(value) {
+        const number = Number(value);
+        if (!Number.isFinite(number)) {
+            return '0';
+        }
+
+        return String(Math.round(number * 100) / 100);
     }
 
     function getNodeWidth(node) {
@@ -308,7 +321,7 @@
         const width = 600;
         const height = 350;
         const offset = ((areaSequence - 1) % 6) * 34;
-        return { id: makeClientId('diagram-area'), x: clamp(center.x - width / 2 + offset, -1000, state.virtualCanvasWidth - 80), y: clamp(center.y - height / 2 + offset, -1000, state.virtualCanvasHeight - 60), width, height };
+        return { id: makeClientId('diagram-area'), x: clamp(center.x - width / 2 + offset, -1000, state.virtualCanvasWidth - minimumAreaWidth), y: clamp(center.y - height / 2 + offset, -1000, state.virtualCanvasHeight - minimumAreaHeight), width, height };
     }
 
     function getNextNodePosition() {
@@ -552,11 +565,30 @@
         const notes = document.createElement('div');
         notes.className = 'diagram-area-notes';
         notes.dataset.areaNotes = 'true';
-        const resize = document.createElement('span');
-        resize.className = 'diagram-area-resize-handle';
-        resize.dataset.areaResizeHandle = 'true';
-        resize.setAttribute('aria-hidden', 'true');
-        element.append(header, notes, resize);
+        const hitTop = document.createElement('span');
+        hitTop.className = 'diagram-area-hit diagram-area-hit-top';
+        hitTop.dataset.areaDragHandle = 'true';
+        hitTop.setAttribute('aria-hidden', 'true');
+        const hitRight = document.createElement('span');
+        hitRight.className = 'diagram-area-hit diagram-area-hit-right';
+        hitRight.dataset.areaDragHandle = 'true';
+        hitRight.setAttribute('aria-hidden', 'true');
+        const hitBottom = document.createElement('span');
+        hitBottom.className = 'diagram-area-hit diagram-area-hit-bottom';
+        hitBottom.dataset.areaDragHandle = 'true';
+        hitBottom.setAttribute('aria-hidden', 'true');
+        const hitLeft = document.createElement('span');
+        hitLeft.className = 'diagram-area-hit diagram-area-hit-left';
+        hitLeft.dataset.areaDragHandle = 'true';
+        hitLeft.setAttribute('aria-hidden', 'true');
+        const resizeHandles = ['nw', 'ne', 'sw', 'se'].map(position => {
+            const resize = document.createElement('span');
+            resize.className = `diagram-area-resize-handle diagram-area-resize-handle-${position}`;
+            resize.dataset.areaResizeHandle = position;
+            resize.setAttribute('aria-label', `Resize area ${position}`);
+            return resize;
+        });
+        element.append(header, notes, hitTop, hitRight, hitBottom, hitLeft, ...resizeHandles);
         return element;
     }
 
@@ -844,11 +876,12 @@
 
         selectArea(area.id);
         const pointer = screenToWorld(event.clientX, event.clientY);
-        const isResize = Boolean(target?.closest('[data-area-resize-handle]'));
+        const resizeHandle = target?.closest('[data-area-resize-handle]');
         dragState = {
             pointerId: event.pointerId,
             area,
-            mode: isResize ? 'resize-area' : 'move-area',
+            mode: resizeHandle ? 'resize-area' : 'move-area',
+            resizeHandle: resizeHandle?.dataset.areaResizeHandle || 'se',
             startPointer: pointer,
             startArea: { x: area.x, y: area.y, width: area.width, height: area.height },
             moved: false
@@ -913,6 +946,36 @@
         event.stopPropagation();
     }
 
+    function resizeAreaFromDrag(area, drag, requestedDeltaX, requestedDeltaY) {
+        const start = drag.startArea;
+        const handle = drag.resizeHandle || 'se';
+        let left = start.x;
+        let top = start.y;
+        let right = start.x + start.width;
+        let bottom = start.y + start.height;
+
+        if (handle.includes('e')) {
+            right = clamp(right + requestedDeltaX, left + minimumAreaWidth, left + maximumAreaSize);
+        }
+
+        if (handle.includes('s')) {
+            bottom = clamp(bottom + requestedDeltaY, top + minimumAreaHeight, top + maximumAreaSize);
+        }
+
+        if (handle.includes('w')) {
+            left = clamp(left + requestedDeltaX, right - maximumAreaSize, right - minimumAreaWidth);
+        }
+
+        if (handle.includes('n')) {
+            top = clamp(top + requestedDeltaY, bottom - maximumAreaSize, bottom - minimumAreaHeight);
+        }
+
+        area.x = left;
+        area.y = top;
+        area.width = right - left;
+        area.height = bottom - top;
+    }
+
     function moveDrag(event) {
         if (!dragState || dragState.pointerId !== event.pointerId) {
             return;
@@ -925,11 +988,10 @@
         if (dragState.area) {
             const area = dragState.area;
             if (dragState.mode === 'resize-area') {
-                area.width = clamp(dragState.startArea.width + requestedDeltaX, 80, 20000);
-                area.height = clamp(dragState.startArea.height + requestedDeltaY, 60, 20000);
+                resizeAreaFromDrag(area, dragState, requestedDeltaX, requestedDeltaY);
             } else {
-                area.x = clamp(dragState.startArea.x + requestedDeltaX, -1000, state.virtualCanvasWidth - 80);
-                area.y = clamp(dragState.startArea.y + requestedDeltaY, -1000, state.virtualCanvasHeight - 60);
+                area.x = clamp(dragState.startArea.x + requestedDeltaX, -1000, state.virtualCanvasWidth - minimumAreaWidth);
+                area.y = clamp(dragState.startArea.y + requestedDeltaY, -1000, state.virtualCanvasHeight - minimumAreaHeight);
             }
 
             dragState.moved = dragState.moved || Math.abs(requestedDeltaX) > 1 || Math.abs(requestedDeltaY) > 1;
@@ -1329,6 +1391,8 @@
             const propertyName = field.dataset.areaField;
             if (!area || !propertyName) {
                 field.value = '';
+            } else if (['x', 'y', 'width', 'height'].includes(propertyName)) {
+                field.value = formatDiagramNumber(area[propertyName]);
             } else {
                 field.value = area[propertyName] ?? '';
             }
@@ -1460,8 +1524,8 @@
         }
 
         if (['x', 'y', 'width', 'height'].includes(propertyName)) {
-            const min = propertyName === 'width' ? 80 : propertyName === 'height' ? 60 : -1000;
-            const max = propertyName === 'x' || propertyName === 'y' ? 21000 : 20000;
+            const min = propertyName === 'width' ? minimumAreaWidth : propertyName === 'height' ? minimumAreaHeight : -1000;
+            const max = propertyName === 'x' || propertyName === 'y' ? 21000 : maximumAreaSize;
             area[propertyName] = clamp(Number(field.value) || 0, min, max);
         } else if (propertyName === 'styleKey') {
             area.styleKey = normalizeAreaStyleKey(field.value);
@@ -1834,8 +1898,8 @@
             notes: savedArea.notes || '',
             x: Number(savedArea.x) || 0,
             y: Number(savedArea.y) || 0,
-            width: Math.max(80, Number(savedArea.width) || 600),
-            height: Math.max(60, Number(savedArea.height) || 350),
+            width: Math.max(minimumAreaWidth, Number(savedArea.width) || 600),
+            height: Math.max(minimumAreaHeight, Number(savedArea.height) || 350),
             styleKey: normalizeAreaStyleKey(savedArea.styleKey),
             sortOrder: Number(savedArea.sortOrder) || state.areas.length,
             element: null
@@ -1967,8 +2031,8 @@
                 notes: area.notes || null,
                 x: Number(area.x) || 0,
                 y: Number(area.y) || 0,
-                width: Math.max(80, Number(area.width) || 600),
-                height: Math.max(60, Number(area.height) || 350),
+                width: Math.max(minimumAreaWidth, Number(area.width) || 600),
+                height: Math.max(minimumAreaHeight, Number(area.height) || 350),
                 styleKey: normalizeAreaStyleKey(area.styleKey),
                 sortOrder: index
             })),
@@ -2204,6 +2268,9 @@
     });
 
     areaLayer?.addEventListener('pointerdown', handleAreaPointerDown);
+    areaLayer?.addEventListener('pointermove', moveDrag);
+    areaLayer?.addEventListener('pointerup', endDrag);
+    areaLayer?.addEventListener('pointercancel', endDrag);
     nodeLayer.addEventListener('pointerdown', handleNodePointerDown);
     nodeLayer.addEventListener('pointermove', moveDrag);
     nodeLayer.addEventListener('pointerup', endDrag);


### PR DESCRIPTION
### Motivation

- Area/location boxes in the network diagram editor were not behaving like canvas objects: they could not be re-selected after placement, did not support mouse drag/resize, and style changes were not visually applied.  
- The goal is to make area boxes selectable, draggable, resizable in world coordinates, and for style/colour changes to render reliably while preserving existing node/link interaction semantics.

### Description

- Add dedicated hit zones and resize handles to area elements and wire pointer events so clicking the header/border/handles selects the area without bubbling to the canvas pan handler, and selection persists after reload; key editor logic lives in `wwwroot/js/network-diagrams-editor.js`.  
- Implement pointer-based move and resize using existing `screenToWorld` conversion and `dragState` so moves/resizes operate in world coordinates, honor zoom/pan, enforce minimum sizes, mark the diagram dirty, and update properties; added helper `resizeAreaFromDrag`.  
- Render visible corner resize handles and non-blocking border hit zones in `wwwroot/css/network-diagrams.css` and ensure `.diagram-area` fill remains non-interactive so nodes/links inside remain selectable.  
- Make area styles render correctly in light and dark modes by extending style rules for `data-style-key` and ensure the `styleKey` property updates the DOM via `updateAreaElement`.  
- Move numeric geometry fields into an `Advanced coordinates` disclosure and round displayed numbers with `formatDiagramNumber` to avoid long floating decimal strings; fields remain for precision adjustments and still update area geometry.  
- Add a regression test that verifies editor/view/CSS wiring for area hit zones, resize handles, world-coordinate pointer movement, and style rules in `src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs`.

### Testing

- Built the web project with `PATH=/tmp/dotnet10:$PATH dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the build succeeded.  
- Ran unit tests with `PATH=/tmp/dotnet10:$PATH dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj --no-restore`, and the test suite passed (153 tests passed, 0 failed).  
- Executed the repository packaging script `PATH=/tmp/dotnet10:$PATH pwsh -NoProfile -File scripts/build.ps1 -Version V0.0.0` as a smoke check and it completed successfully for release packaging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ca4c4a364832abd26b02fe3219a54)