### PR TITLE
Fix network diagram area box hit testing

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -186,6 +186,9 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains(".diagram-area {", styles);
         Assert.Contains("pointer-events: none;", styles);
         Assert.Contains(".diagram-area-hit", styles);
+        Assert.Contains("Allow area border/header hit targets below the SVG layer to receive clicks.", styles);
+        Assert.Contains(".diagram-link-layer", styles);
+        Assert.Contains("pointer-events: none;", styles);
         Assert.Contains("pointer-events: auto;", styles);
         Assert.Contains(".diagram-area-resize-handle-nw", styles);
         Assert.Contains(".diagram-area-resize-handle-se", styles);

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -693,7 +693,8 @@ body {
     width: 100%;
     height: 100%;
     overflow: visible;
-    pointer-events: auto;
+    /* Allow area border/header hit targets below the SVG layer to receive clicks. */
+    pointer-events: none;
     z-index: 1;
 }
 


### PR DESCRIPTION
### Motivation
- Area boxes rendered correctly but could not be selected, dragged, or resized because the full SVG link overlay intercepted pointer events and prevented area hit targets from receiving mouse input.
- The fix must enable clicks on area borders/headers and resize handles while keeping existing node/link interaction semantics intact and without changing area data model or monitoring behaviour.

### Description
- Update CSS so the SVG link layer does not block pointer events by setting `.diagram-link-layer { pointer-events: none; }` while preserving explicit link hit-paths that keep `pointer-events: all`; this allows area border/header and resize hit targets to receive pointer events (file: `src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css`).
- Add a regression assertion to `NetworkDiagramsFeatureTests` to ensure the non-blocking SVG layer rule remains present in the shipped CSS (file: `src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs`).
- No changes were made to the area data model, diagram semantics, node/link logic, or export behaviour; link hit elements remain interactive so link selection still works.

### Testing
- Ran `dotnet build src/WebApp/PingMonitor.WebApp.slnx` and the build succeeded without errors.
- Ran `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and the test suite passed (153 tests passed).
- Ran the dev packaging script `pwsh -NoLogo -NoProfile -File scripts/build-dev.ps1` and the dev package build completed successfully.
- The updated feature test now asserts the presence of the non-blocking SVG layer rule as a regression barrier and it passes as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cb6bf51f8832a93a9c6585e28c93f)