### PR TITLE
Improve Network Diagram viewer layout to maximise canvas space

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -794,7 +794,29 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("centreOnNode", script);
         Assert.Contains("data-summary-node-id", script);
         Assert.Contains("selectNode(node.id)", script);
-        Assert.Contains("Viewer overlays existing monitoring status only. Visual links remain documentation-only.", script);
+        Assert.Contains("diagram-viewer-canvas-overlay", viewMarkup);
+        Assert.Contains("Visual links are documentation-only.", viewMarkup);
+        Assert.DoesNotContain("<header class=\"diagram-editor-toolbar\">", viewMarkup);
+        Assert.Contains("data-hide-toolbar", viewMarkup);
+        Assert.Contains("data-show-toolbar", viewMarkup);
+        Assert.Contains("data-hide-details", viewMarkup);
+        Assert.Contains("data-show-details", viewMarkup);
+        Assert.Contains("pingMonitor.diagramViewer.toolbarCollapsed", script);
+        Assert.Contains("pingMonitor.diagramViewer.detailsCollapsed", script);
+        Assert.Contains("data-viewer-layout", viewMarkup);
+        Assert.Contains("diagram-viewer-edit-link", viewMarkup);
+    }
+
+    [Fact]
+    public void AuthenticatedNav_PlacesDarkModeSelectorWithProfileMenu()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var navMarkup = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "Views", "Shared", "_AuthenticatedNav.cshtml"));
+
+        Assert.Contains("site-nav-account", navMarkup);
+        Assert.Contains("nav-menu-profile", navMarkup);
+        Assert.Contains("_ThemeSelector", navMarkup);
+        Assert.True(navMarkup.IndexOf("site-nav-account", StringComparison.Ordinal) < navMarkup.IndexOf("_ThemeSelector", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
@@ -11,27 +11,13 @@
 <body>
 @await Html.PartialAsync("_AuthenticatedNav")
 <main class="network-diagrams-main">
-    <section class="diagram-editor-shell diagram-viewer-shell" data-network-diagram-viewer data-load-url="@Model.LoadUrl" data-live-data-url="@Model.LiveDataUrl" aria-labelledby="network-diagram-viewer-title">
-        <header class="diagram-editor-toolbar">
-            <div class="diagram-editor-heading">
-                <h1 id="network-diagram-viewer-title">@Model.DiagramName</h1>
-                @if (!string.IsNullOrWhiteSpace(Model.DiagramDescription))
-                {
-                    <p>@Model.DiagramDescription</p>
-                }
-                <p class="diagram-viewer-note">@Model.Notice</p>
-            </div>
-            <div class="diagram-viewer-actions">
-                @if (Model.IsAdmin && !string.IsNullOrWhiteSpace(Model.EditUrl))
-                {
-                    <a class="diagram-tool-button" href="@Model.EditUrl">Edit diagram</a>
-                }
-            </div>
-        </header>
+    <section class="diagram-editor-shell diagram-viewer-shell" data-network-diagram-viewer data-load-url="@Model.LoadUrl" data-live-data-url="@Model.LiveDataUrl" aria-label="Read-only network diagram viewer">
+        <button type="button" class="diagram-tool-button diagram-viewer-restore-toolbar" data-show-toolbar hidden title="Show toolbar">Show toolbar</button>
+        <button type="button" class="diagram-tool-button diagram-viewer-restore-details" data-show-details hidden title="Show details">Show details</button>
 
-        <div class="diagram-viewer-layout">
+        <div class="diagram-viewer-layout" data-viewer-layout>
             <section class="diagram-workspace" aria-label="Read-only network diagram viewer">
-                <div class="diagram-workspace-toolbar diagram-viewer-toolbar">
+                <div class="diagram-workspace-toolbar diagram-viewer-toolbar" data-viewer-toolbar>
                     <button type="button" class="diagram-tool-button" data-zoom-out>Zoom out</button>
                     <span class="diagram-zoom-label" data-zoom-label>100%</span>
                     <button type="button" class="diagram-tool-button" data-zoom-in>Zoom in</button>
@@ -61,9 +47,18 @@
                         <button type="button" class="diagram-tool-button" data-export-pdf data-export-pdf-url="@Model.ExportPdfUrl">Export PDF</button>
                     }
                     <span class="diagram-tool-hint" data-refresh-status>Live overlay pending</span>
+                    @if (Model.IsAdmin && !string.IsNullOrWhiteSpace(Model.EditUrl))
+                    {
+                        <a class="diagram-tool-button diagram-viewer-edit-link" href="@Model.EditUrl">Edit diagram</a>
+                    }
+                    <button type="button" class="diagram-tool-button" data-hide-toolbar title="Hide toolbar">Hide toolbar</button>
                 </div>
                 <div class="diagram-canvas-host" data-diagram-canvas-host>
                     <div class="diagram-canvas" data-diagram-canvas role="application" aria-label="Read-only network diagram canvas" tabindex="0">
+                        <div class="diagram-viewer-canvas-overlay" aria-hidden="true">
+                            <strong>@Model.DiagramName</strong>
+                            <span>Visual links are documentation-only.</span>
+                        </div>
                         <div class="diagram-empty-state" data-empty-state>Loading saved diagram…</div>
                         <div class="diagram-world" data-diagram-world>
                             <div class="diagram-area-layer" data-area-layer></div>
@@ -74,8 +69,11 @@
                 </div>
             </section>
 
-            <aside class="diagram-properties diagram-viewer-details" aria-label="Read-only diagram details">
-                <h2>Details</h2>
+            <aside class="diagram-properties diagram-viewer-details" data-viewer-details aria-label="Read-only diagram details">
+                <div class="diagram-viewer-details-header">
+                    <h2>Details</h2>
+                    <button type="button" class="diagram-tool-button" data-hide-details title="Hide details">Hide details</button>
+                </div>
                 <div class="diagram-summary-panel" data-no-selection-panel data-summary-panel>
                     <p class="toolbox-help">Loading diagram summary…</p>
                 </div>

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -47,8 +47,15 @@
         align-items: stretch;
     }
 
-    .site-nav-theme {
+    .site-nav-account {
         margin-left: auto;
+        display: flex;
+        align-items: stretch;
+        gap: .5rem;
+        flex-wrap: wrap;
+    }
+
+    .site-nav-account .site-nav-theme {
         display: flex;
         align-items: center;
     }
@@ -256,21 +263,23 @@
             </div>
         </details>
 
-        <details data-active="@profileOpen">
-            <summary aria-controls="nav-menu-profile" aria-expanded="false">Profile <span aria-hidden="true">▾</span></summary>
-            <div class="site-nav-dropdown" id="nav-menu-profile">
-                <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile">My profile</a>
-                <a class="site-nav-link" data-current="@IsCurrent(path, "/profile/notification-settings")" href="/profile/notification-settings">Notification settings</a>
-                <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile#change-password">Change password</a>
-                <form method="post" action="/account/logout">
-                    @Html.AntiForgeryToken()
-                    <button class="site-nav-logout" type="submit">Logout</button>
-                </form>
-            </div>
-        </details>
+        <div class="site-nav-account">
+            <details data-active="@profileOpen">
+                <summary aria-controls="nav-menu-profile" aria-expanded="false">Profile <span aria-hidden="true">▾</span></summary>
+                <div class="site-nav-dropdown" id="nav-menu-profile">
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile">My profile</a>
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/profile/notification-settings")" href="/profile/notification-settings">Notification settings</a>
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile#change-password">Change password</a>
+                    <form method="post" action="/account/logout">
+                        @Html.AntiForgeryToken()
+                        <button class="site-nav-logout" type="submit">Logout</button>
+                    </form>
+                </div>
+            </details>
 
-        <div class="site-nav-theme" aria-label="Dark mode selector">
-            @await Html.PartialAsync("_ThemeSelector")
+            <div class="site-nav-theme" aria-label="Dark mode selector">
+                @await Html.PartialAsync("_ThemeSelector")
+            </div>
         </div>
     </div>
 </nav>

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -1606,3 +1606,123 @@ html[data-theme="dark"] .diagram-area[data-style-key="green"] { border-color: rg
 html[data-theme="dark"] .diagram-area[data-style-key="amber"] { border-color: rgba(251, 191, 36, .88); background: rgba(217, 119, 6, .24); }
 html[data-theme="dark"] .diagram-area[data-style-key="red"] { border-color: rgba(248, 113, 113, .84); background: rgba(220, 38, 38, .2); }
 html[data-theme="dark"] .diagram-area[data-style-key="purple"] { border-color: rgba(196, 181, 253, .84); background: rgba(124, 58, 237, .24); }
+
+/* Viewer-only chrome reduction and wallboard controls. */
+.diagram-viewer-shell {
+    position: relative;
+    grid-template-rows: minmax(0, 1fr) auto;
+}
+
+.diagram-viewer-shell .diagram-workspace {
+    padding: .5rem;
+    gap: .45rem;
+}
+
+.diagram-viewer-toolbar {
+    align-items: center;
+}
+
+.diagram-viewer-edit-link {
+    margin-left: auto;
+}
+
+.diagram-viewer-canvas-overlay {
+    position: absolute;
+    left: .65rem;
+    bottom: .65rem;
+    z-index: 5;
+    display: grid;
+    gap: .15rem;
+    max-width: min(24rem, calc(100% - 1.3rem));
+    padding: .45rem .55rem;
+    border: 1px solid rgba(217, 226, 236, .72);
+    border-radius: 10px;
+    background: rgba(255, 255, 255, .78);
+    color: var(--diagram-text);
+    box-shadow: 0 6px 18px rgba(16, 24, 40, .14);
+    font-size: .78rem;
+    line-height: 1.25;
+    pointer-events: none;
+    backdrop-filter: blur(4px);
+}
+
+.diagram-viewer-canvas-overlay strong {
+    font-size: .88rem;
+    line-height: 1.15;
+}
+
+.diagram-viewer-canvas-overlay span {
+    color: var(--diagram-muted);
+    font-weight: 700;
+}
+
+.diagram-viewer-details-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .5rem;
+    margin-bottom: .65rem;
+}
+
+.diagram-viewer-details-header h2 {
+    margin: 0;
+}
+
+.diagram-viewer-details-header .diagram-tool-button {
+    min-height: 34px;
+    padding: .35rem .55rem;
+    font-size: .82rem;
+}
+
+.diagram-viewer-layout[data-details-collapsed="true"] {
+    grid-template-columns: minmax(0, 1fr);
+}
+
+.diagram-viewer-layout[data-details-collapsed="true"] .diagram-viewer-details {
+    display: none;
+}
+
+.diagram-viewer-toolbar[hidden] {
+    display: none;
+}
+
+.diagram-viewer-restore-toolbar,
+.diagram-viewer-restore-details {
+    position: absolute;
+    z-index: 10;
+    min-height: 34px;
+    padding: .35rem .55rem;
+    font-size: .82rem;
+    box-shadow: 0 4px 14px rgba(16, 24, 40, .18);
+}
+
+.diagram-viewer-restore-toolbar {
+    top: .5rem;
+    left: .5rem;
+}
+
+.diagram-viewer-restore-details {
+    top: .5rem;
+    right: .5rem;
+}
+
+.diagram-viewer-shell > .diagram-viewer-restore-toolbar[hidden],
+.diagram-viewer-shell > .diagram-viewer-restore-details[hidden] {
+    display: none;
+}
+
+html[data-theme="dark"] .diagram-viewer-canvas-overlay {
+    border-color: rgba(49, 65, 86, .82);
+    background: rgba(15, 23, 42, .78);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, .36);
+}
+
+@media (max-width: 980px) {
+    .diagram-viewer-layout[data-details-collapsed="true"] {
+        grid-template-rows: minmax(60vh, 1fr);
+    }
+
+    .diagram-viewer-edit-link {
+        margin-left: 0;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
@@ -25,6 +25,15 @@
     const exportSvgButton = viewer.querySelector('[data-export-svg]');
     const exportPaperSelect = viewer.querySelector('[data-export-paper]');
     const exportScaleSelect = viewer.querySelector('[data-export-scale]');
+    const viewerLayout = viewer.querySelector('[data-viewer-layout]');
+    const viewerToolbar = viewer.querySelector('[data-viewer-toolbar]');
+    const hideToolbarButton = viewer.querySelector('[data-hide-toolbar]');
+    const showToolbarButton = viewer.querySelector('[data-show-toolbar]');
+    const hideDetailsButton = viewer.querySelector('[data-hide-details]');
+    const showDetailsButton = viewer.querySelector('[data-show-details]');
+
+    const toolbarCollapsedStorageKey = 'pingMonitor.diagramViewer.toolbarCollapsed';
+    const detailsCollapsedStorageKey = 'pingMonitor.diagramViewer.detailsCollapsed';
 
     const zoomStep = 1.15;
     const minZoom = 0.15;
@@ -53,6 +62,64 @@
     function updateNavHeight() {
         const height = nav ? nav.getBoundingClientRect().height : 0;
         document.documentElement.style.setProperty('--network-diagrams-nav-height', `${height}px`);
+    }
+
+
+    function readCollapsedPreference(key) {
+        try {
+            return window.localStorage.getItem(key) === 'true';
+        } catch (error) {
+            return false;
+        }
+    }
+
+    function writeCollapsedPreference(key, value) {
+        try {
+            window.localStorage.setItem(key, value ? 'true' : 'false');
+        } catch (error) {
+            // Keep collapse state in memory only when storage is unavailable.
+        }
+    }
+
+    function scheduleCanvasResize() {
+        window.requestAnimationFrame(() => {
+            updateCanvasSize();
+            window.requestAnimationFrame(updateCanvasSize);
+        });
+    }
+
+    function setToolbarCollapsed(collapsed, persist = true) {
+        if (viewerToolbar) {
+            viewerToolbar.hidden = collapsed;
+        }
+        if (showToolbarButton) {
+            showToolbarButton.hidden = !collapsed;
+            showToolbarButton.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+        }
+        if (hideToolbarButton) {
+            hideToolbarButton.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+        }
+        if (persist) {
+            writeCollapsedPreference(toolbarCollapsedStorageKey, collapsed);
+        }
+        scheduleCanvasResize();
+    }
+
+    function setDetailsCollapsed(collapsed, persist = true) {
+        if (viewerLayout) {
+            viewerLayout.dataset.detailsCollapsed = collapsed ? 'true' : 'false';
+        }
+        if (showDetailsButton) {
+            showDetailsButton.hidden = !collapsed;
+            showDetailsButton.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+        }
+        if (hideDetailsButton) {
+            hideDetailsButton.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+        }
+        if (persist) {
+            writeCollapsedPreference(detailsCollapsedStorageKey, collapsed);
+        }
+        scheduleCanvasResize();
     }
 
     function applyViewTransform() {
@@ -540,6 +607,10 @@
     viewer.querySelector('[data-zoom-out]')?.addEventListener('click', () => zoomAt(canvas.getBoundingClientRect().left + canvas.clientWidth / 2, canvas.getBoundingClientRect().top + canvas.clientHeight / 2, state.zoom / zoomStep));
     viewer.querySelector('[data-reset-view]')?.addEventListener('click', resetView);
     viewer.querySelector('[data-fit-content]')?.addEventListener('click', fitContent);
+    hideToolbarButton?.addEventListener('click', () => setToolbarCollapsed(true));
+    showToolbarButton?.addEventListener('click', () => setToolbarCollapsed(false));
+    hideDetailsButton?.addEventListener('click', () => setDetailsCollapsed(true));
+    showDetailsButton?.addEventListener('click', () => setDetailsCollapsed(false));
     exportPdfButton?.addEventListener('click', () => { const base = exportPdfButton.dataset.exportPdfUrl; if (base) { window.location.href = `${base}?paper=${encodeURIComponent(exportPaperSelect?.value || 'A4')}`; } });
     const exportImage = button => { const base = button?.dataset.exportImageUrl; if (base) { const separator = base.includes('?') ? '&' : '?'; window.location.href = `${base}${separator}scale=${encodeURIComponent(exportScaleSelect?.value || '1')}&background=light`; } };
     exportPngButton?.addEventListener('click', () => exportImage(exportPngButton));
@@ -558,6 +629,8 @@
     window.addEventListener('resize', updateCanvasSize);
     if ('ResizeObserver' in window) { new ResizeObserver(updateCanvasSize).observe(canvasHost); }
     window.addEventListener('beforeunload', () => { if (refreshTimer) { window.clearInterval(refreshTimer); } });
+    setToolbarCollapsed(readCollapsedPreference(toolbarCollapsedStorageKey), false);
+    setDetailsCollapsed(readCollapsedPreference(detailsCollapsedStorageKey), false);
     applyViewTransform();
     updateCanvasSize();
     loadDiagram();


### PR DESCRIPTION
### Motivation
- The read-only Network Diagram viewer used excessive header and panel chrome, reducing usable canvas area for operational wallboard use. This change reduces top/both-side chrome and groups controls to maximise visible diagram space.\
- Keep behavior and permissions identical: no monitoring, storage, agent, schema, or state/evaluation changes are introduced.\
- Fixes #538 (created to track this UI improvement).\

### Description
- Removed the large viewer header and moved the diagram name + documentation-only note into a small, semi-transparent lower-left canvas overlay that is pointer-events-free and supports dark/light themes (`View.cshtml`, `network-diagrams.css`).\
- Moved the admin-only `Edit diagram` action into the viewer toolbar, preserving the existing admin/url guard so it remains visible only to authorized users (`View.cshtml`).\
- Added hide/show (collapse) controls for the viewer toolbar and the right-hand details panel with in-memory + `localStorage` persistence using keys `pingMonitor.diagramViewer.toolbarCollapsed` and `pingMonitor.diagramViewer.detailsCollapsed`, and ensured canvas resize/recalculation hooks run after collapse/expand so pan/zoom/fit continue to work (`network-diagrams-viewer.js`, `network-diagrams.css`, `View.cshtml`).\
- Moved the global Dark mode selector into the authenticated nav grouped with the Profile dropdown to save header vertical space and keep it on the top navigation row (`_AuthenticatedNav.cshtml`).\
- Scoped CSS changes to viewer-only selectors to avoid regressions in the editor and other pages, and added small restore buttons that are unobtrusive and reachable when toolbars/panels are hidden (`network-diagrams.css`).\
- Added markup/regression assertions to `NetworkDiagramsFeatureTests` to validate the presence/absence of the old header and presence of the overlay/collapse controls and theme selector placement.\

### Testing
- Ran `PATH=/tmp/dotnet10:$PATH dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj`; build succeeded.\
- Ran `PATH=/tmp/dotnet10:$PATH dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj`; unit tests passed (154 passed, 0 failed).\
- Ran the dev packaging script `PATH=/tmp/dotnet10:$PATH pwsh -NoLogo -NoProfile -File scripts/build-dev.ps1`; dev package build completed successfully.\
- Verified `git diff --check` and ensured no unintended whitespace/errors; local commit created for the change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dd54e1f88832ab94a66c1f075f9d6)