### PR TITLE
Improve network diagram viewer canvas space

### DIFF
--- a/docs/network-diagrams-v0.1.1.md
+++ b/docs/network-diagrams-v0.1.1.md
@@ -505,3 +505,24 @@ Area boxes use saved diagram world coordinates and are rendered behind visual li
 - Export PNG and confirm boxes appear in the export.
 - Run configuration backup/restore when practical and confirm area boxes round-trip.
 - Confirm no monitoring, dependency, alert, endpoint, or agent behaviour changed.
+
+### Manual Regression Checklist - Viewer Canvas Space Controls
+
+Issue: #540
+
+- Open the read-only diagram viewer.
+- Confirm the large viewer title/header no longer consumes top space.
+- Confirm the diagram name and documentation-only note appear as small lower-left canvas overlay text.
+- Confirm the Edit diagram link appears in the viewer toolbar for admins/editors and is absent for read-only users.
+- Hide the toolbar and confirm canvas height increases.
+- Show the toolbar and confirm zoom, fit, export, live status text, and Edit diagram controls return.
+- Hide the right details panel and confirm canvas width increases.
+- Show the right details panel and confirm current summary/details return.
+- Select a node, hide/show details, and confirm the selected node details remain correct.
+- Wait for a live overlay poll with details hidden, show details, and confirm summary data is current.
+- Confirm pan, zoom, and fit content still work after hiding/showing toolbar and details.
+- Confirm PNG, SVG, and PDF exports still use the saved diagram layout rather than viewer chrome.
+- Confirm the dark mode control appears next to the Profile dropdown globally.
+- Confirm the endpoint status dashboard still renders with the global dark mode control in the nav row.
+- Test at 1366x768 in dark and light mode with toolbar visible/hidden, details visible/hidden, and both hidden.
+- Confirm no monitoring, dependency, agent, state-evaluation, alerting, schema, backup/restore, or export-behaviour changes were made.

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -787,6 +787,9 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("setToolbarCollapsed", script);
         Assert.Contains("setDetailsCollapsed", script);
         Assert.Contains("scheduleCanvasResize", script);
+        Assert.Contains("toolbar.hidden = collapsed", script);
+        Assert.Contains("detailsPanel.hidden = collapsed", script);
+        Assert.Contains("[data-hide-toolbar], [data-show-toolbar], [data-hide-details], [data-show-details]", script);
         Assert.DoesNotContain("diagram-editor-heading", viewMarkup);
         Assert.Contains("Diagram live summary", script);
         Assert.Contains("Total nodes", script);
@@ -818,8 +821,11 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("site-nav-account", navMarkup);
         Assert.Contains("site-nav-theme", navMarkup);
         Assert.Contains("_ThemeSelector", navMarkup);
+        Assert.Contains("width: 100%;", navMarkup);
+        Assert.Contains("flex-wrap: nowrap;", navMarkup);
+        Assert.Contains("min-width: 140px;", navMarkup);
         Assert.Contains(@"Profile <span aria-hidden=""true"">▾</span>", navMarkup);
-        Assert.True(navMarkup.IndexOf("site-nav-account", StringComparison.Ordinal) < navMarkup.IndexOf("site-nav-theme", StringComparison.Ordinal));
+        Assert.True(navMarkup.IndexOf(@"<div class=""site-nav-account"">", StringComparison.Ordinal) < navMarkup.IndexOf(@"<div class=""site-nav-theme""", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -787,9 +787,12 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("setToolbarCollapsed", script);
         Assert.Contains("setDetailsCollapsed", script);
         Assert.Contains("scheduleCanvasResize", script);
-        Assert.Contains("toolbar.hidden = collapsed", script);
-        Assert.Contains("detailsPanel.hidden = collapsed", script);
-        Assert.Contains("[data-hide-toolbar], [data-show-toolbar], [data-hide-details], [data-show-details]", script);
+        Assert.Contains("diagram-viewer--toolbar-collapsed", script);
+        Assert.Contains("diagram-viewer--details-collapsed", script);
+        Assert.Contains("bindCollapseToggle('[data-hide-toolbar]'", script);
+        Assert.Contains("bindCollapseToggle('[data-show-toolbar]'", script);
+        Assert.Contains("bindCollapseToggle('[data-hide-details]'", script);
+        Assert.Contains("bindCollapseToggle('[data-show-details]'", script);
         Assert.DoesNotContain("diagram-editor-heading", viewMarkup);
         Assert.Contains("Diagram live summary", script);
         Assert.Contains("Total nodes", script);

--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -776,6 +776,18 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("data-export-svg", viewMarkup);
         Assert.Contains("data-export-scale", viewMarkup);
         Assert.Contains("Exports saved diagram layout", viewMarkup);
+        Assert.Contains("diagram-viewer-canvas-overlay", viewMarkup);
+        Assert.Contains("Visual links are documentation-only.", viewMarkup);
+        Assert.Contains("data-hide-toolbar", viewMarkup);
+        Assert.Contains("data-show-toolbar", viewMarkup);
+        Assert.Contains("data-hide-details", viewMarkup);
+        Assert.Contains("data-show-details", viewMarkup);
+        Assert.Contains("pingMonitor.diagramViewer.toolbarCollapsed", script);
+        Assert.Contains("pingMonitor.diagramViewer.detailsCollapsed", script);
+        Assert.Contains("setToolbarCollapsed", script);
+        Assert.Contains("setDetailsCollapsed", script);
+        Assert.Contains("scheduleCanvasResize", script);
+        Assert.DoesNotContain("diagram-editor-heading", viewMarkup);
         Assert.Contains("Diagram live summary", script);
         Assert.Contains("Total nodes", script);
         Assert.Contains("Monitored", script);
@@ -795,6 +807,19 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("data-summary-node-id", script);
         Assert.Contains("selectNode(node.id)", script);
         Assert.Contains("Viewer overlays existing monitoring status only. Visual links remain documentation-only.", script);
+    }
+
+    [Fact]
+    public void AuthenticatedNav_PlacesThemeSelectorBesideProfileMenu()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var navMarkup = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "Views", "Shared", "_AuthenticatedNav.cshtml"));
+
+        Assert.Contains("site-nav-account", navMarkup);
+        Assert.Contains("site-nav-theme", navMarkup);
+        Assert.Contains("_ThemeSelector", navMarkup);
+        Assert.Contains(@"Profile <span aria-hidden=""true"">▾</span>", navMarkup);
+        Assert.True(navMarkup.IndexOf("site-nav-account", StringComparison.Ordinal) < navMarkup.IndexOf("site-nav-theme", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
@@ -16,7 +16,7 @@
 
         <div class="diagram-viewer-layout">
             <section class="diagram-workspace" aria-label="Read-only network diagram viewer">
-                <button type="button" class="diagram-tool-button diagram-viewer-toolbar-show" data-show-toolbar hidden aria-controls="diagram-viewer-toolbar">Show toolbar</button>
+                <button type="button" class="diagram-tool-button diagram-viewer-toolbar-show" data-show-toolbar aria-controls="diagram-viewer-toolbar">Show toolbar</button>
                 <div class="diagram-workspace-toolbar diagram-viewer-toolbar" id="diagram-viewer-toolbar" data-viewer-toolbar>
                     <button type="button" class="diagram-tool-button" data-hide-toolbar aria-controls="diagram-viewer-toolbar">Hide toolbar</button>
                     <button type="button" class="diagram-tool-button" data-zoom-out>Zoom out</button>
@@ -64,7 +64,7 @@
                                 <span>@Model.DiagramDescription</span>
                             }
                         </div>
-                        <button type="button" class="diagram-tool-button diagram-viewer-details-show" data-show-details hidden aria-controls="diagram-viewer-details">Show details</button>
+                        <button type="button" class="diagram-tool-button diagram-viewer-details-show" data-show-details aria-controls="diagram-viewer-details">Show details</button>
                         <div class="diagram-empty-state" data-empty-state>Loading saved diagram…</div>
                         <div class="diagram-world" data-diagram-world>
                             <div class="diagram-area-layer" data-area-layer></div>

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
@@ -12,26 +12,13 @@
 @await Html.PartialAsync("_AuthenticatedNav")
 <main class="network-diagrams-main">
     <section class="diagram-editor-shell diagram-viewer-shell" data-network-diagram-viewer data-load-url="@Model.LoadUrl" data-live-data-url="@Model.LiveDataUrl" aria-labelledby="network-diagram-viewer-title">
-        <header class="diagram-editor-toolbar">
-            <div class="diagram-editor-heading">
-                <h1 id="network-diagram-viewer-title">@Model.DiagramName</h1>
-                @if (!string.IsNullOrWhiteSpace(Model.DiagramDescription))
-                {
-                    <p>@Model.DiagramDescription</p>
-                }
-                <p class="diagram-viewer-note">@Model.Notice</p>
-            </div>
-            <div class="diagram-viewer-actions">
-                @if (Model.IsAdmin && !string.IsNullOrWhiteSpace(Model.EditUrl))
-                {
-                    <a class="diagram-tool-button" href="@Model.EditUrl">Edit diagram</a>
-                }
-            </div>
-        </header>
+        <h1 id="network-diagram-viewer-title" class="sr-only">@Model.DiagramName</h1>
 
         <div class="diagram-viewer-layout">
             <section class="diagram-workspace" aria-label="Read-only network diagram viewer">
-                <div class="diagram-workspace-toolbar diagram-viewer-toolbar">
+                <button type="button" class="diagram-tool-button diagram-viewer-toolbar-show" data-show-toolbar hidden aria-controls="diagram-viewer-toolbar">Show toolbar</button>
+                <div class="diagram-workspace-toolbar diagram-viewer-toolbar" id="diagram-viewer-toolbar" data-viewer-toolbar>
+                    <button type="button" class="diagram-tool-button" data-hide-toolbar aria-controls="diagram-viewer-toolbar">Hide toolbar</button>
                     <button type="button" class="diagram-tool-button" data-zoom-out>Zoom out</button>
                     <span class="diagram-zoom-label" data-zoom-label>100%</span>
                     <button type="button" class="diagram-tool-button" data-zoom-in>Zoom in</button>
@@ -60,10 +47,24 @@
                         </label>
                         <button type="button" class="diagram-tool-button" data-export-pdf data-export-pdf-url="@Model.ExportPdfUrl">Export PDF</button>
                     }
+                    @if (Model.IsAdmin && !string.IsNullOrWhiteSpace(Model.EditUrl))
+                    {
+                        <span class="diagram-toolbar-spacer" aria-hidden="true"></span>
+                        <a class="diagram-tool-button" href="@Model.EditUrl">Edit diagram</a>
+                    }
                     <span class="diagram-tool-hint" data-refresh-status>Live overlay pending</span>
                 </div>
                 <div class="diagram-canvas-host" data-diagram-canvas-host>
                     <div class="diagram-canvas" data-diagram-canvas role="application" aria-label="Read-only network diagram canvas" tabindex="0">
+                        <div class="diagram-viewer-canvas-overlay" aria-hidden="true">
+                            <strong>@Model.DiagramName</strong>
+                            <span>Visual links are documentation-only.</span>
+                            @if (!string.IsNullOrWhiteSpace(Model.DiagramDescription))
+                            {
+                                <span>@Model.DiagramDescription</span>
+                            }
+                        </div>
+                        <button type="button" class="diagram-tool-button diagram-viewer-details-show" data-show-details hidden aria-controls="diagram-viewer-details">Show details</button>
                         <div class="diagram-empty-state" data-empty-state>Loading saved diagram…</div>
                         <div class="diagram-world" data-diagram-world>
                             <div class="diagram-area-layer" data-area-layer></div>
@@ -74,8 +75,11 @@
                 </div>
             </section>
 
-            <aside class="diagram-properties diagram-viewer-details" aria-label="Read-only diagram details">
-                <h2>Details</h2>
+            <aside class="diagram-properties diagram-viewer-details" id="diagram-viewer-details" data-viewer-details aria-label="Read-only diagram details">
+                <div class="diagram-viewer-details-header">
+                    <h2>Details</h2>
+                    <button type="button" class="diagram-tool-button" data-hide-details aria-controls="diagram-viewer-details">Hide details</button>
+                </div>
                 <div class="diagram-summary-panel" data-no-selection-panel data-summary-panel>
                     <p class="toolbox-help">Loading diagram summary…</p>
                 </div>
@@ -85,7 +89,7 @@
         </div>
 
         <footer class="diagram-status-bar">
-            <span>Read-only viewer. Visual links do not create monitoring dependencies.</span>
+            <span>Read-only viewer.</span>
             <span data-canvas-size>Canvas size pending</span>
         </footer>
     </section>

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -48,7 +48,6 @@
     }
 
     .site-nav-account {
-        margin-left: auto;
         display: flex;
         flex-wrap: wrap;
         gap: .5rem;

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -39,7 +39,7 @@
     }
 
     .site-nav {
-        max-width: 1180px;
+        width: 100%;
         margin: 0 auto;
         display: flex;
         gap: .5rem;
@@ -56,7 +56,7 @@
     }
 
     .site-nav-account details {
-        min-width: 160px;
+        min-width: 140px;
     }
 
     .site-nav-theme {
@@ -186,8 +186,17 @@
     }
 
     @@media (min-width: 860px) {
+        .site-nav {
+            flex-wrap: nowrap;
+        }
+
         .site-nav details {
-            min-width: 180px;
+            min-width: 140px;
+        }
+
+        .site-nav-account {
+            flex: 0 0 auto;
+            flex-wrap: nowrap;
         }
 
         .site-nav details[open] .site-nav-dropdown {

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -47,10 +47,25 @@
         align-items: stretch;
     }
 
-    .site-nav-theme {
+    .site-nav-account {
         margin-left: auto;
         display: flex;
+        flex-wrap: wrap;
+        gap: .5rem;
+        align-items: stretch;
+    }
+
+    .site-nav-account details {
+        min-width: 160px;
+    }
+
+    .site-nav-theme {
+        display: flex;
         align-items: center;
+    }
+
+    .site-nav-theme .theme-selector {
+        height: 100%;
     }
 
     .site-nav details {
@@ -256,21 +271,23 @@
             </div>
         </details>
 
-        <details data-active="@profileOpen">
-            <summary aria-controls="nav-menu-profile" aria-expanded="false">Profile <span aria-hidden="true">▾</span></summary>
-            <div class="site-nav-dropdown" id="nav-menu-profile">
-                <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile">My profile</a>
-                <a class="site-nav-link" data-current="@IsCurrent(path, "/profile/notification-settings")" href="/profile/notification-settings">Notification settings</a>
-                <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile#change-password">Change password</a>
-                <form method="post" action="/account/logout">
-                    @Html.AntiForgeryToken()
-                    <button class="site-nav-logout" type="submit">Logout</button>
-                </form>
-            </div>
-        </details>
+        <div class="site-nav-account">
+            <details data-active="@profileOpen">
+                <summary aria-controls="nav-menu-profile" aria-expanded="false">Profile <span aria-hidden="true">▾</span></summary>
+                <div class="site-nav-dropdown" id="nav-menu-profile">
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile">My profile</a>
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/profile/notification-settings")" href="/profile/notification-settings">Notification settings</a>
+                    <a class="site-nav-link" data-current="@IsCurrent(path, "/profile")" href="/profile#change-password">Change password</a>
+                    <form method="post" action="/account/logout">
+                        @Html.AntiForgeryToken()
+                        <button class="site-nav-logout" type="submit">Logout</button>
+                    </form>
+                </div>
+            </details>
 
-        <div class="site-nav-theme" aria-label="Dark mode selector">
-            @await Html.PartialAsync("_ThemeSelector")
+            <div class="site-nav-theme" aria-label="Dark mode selector">
+                @await Html.PartialAsync("_ThemeSelector")
+            </div>
         </div>
     </div>
 </nav>

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -42,16 +42,17 @@
         width: 100%;
         margin: 0 auto;
         display: flex;
+        justify-content: center;
+        align-items: center;
         gap: .5rem;
         flex-wrap: wrap;
-        align-items: stretch;
     }
 
     .site-nav-account {
         display: flex;
         flex-wrap: wrap;
         gap: .5rem;
-        align-items: stretch;
+        align-items: center;
     }
 
     .site-nav-account details {

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -1657,6 +1657,7 @@ html[data-theme="dark"] .diagram-area[data-style-key="purple"] { border-color: r
 
 .diagram-viewer-toolbar-show,
 .diagram-viewer-details-show {
+    display: none;
     justify-self: start;
     z-index: 6;
 }
@@ -1679,24 +1680,29 @@ html[data-theme="dark"] .diagram-area[data-style-key="purple"] { border-color: r
     margin: 0;
 }
 
+.diagram-viewer-shell.diagram-viewer--toolbar-collapsed .diagram-viewer-toolbar,
 .diagram-viewer-shell[data-toolbar-collapsed="true"] .diagram-viewer-toolbar,
 .diagram-viewer-shell .diagram-viewer-toolbar[hidden] {
     display: none;
 }
 
+.diagram-viewer-shell.diagram-viewer--toolbar-collapsed .diagram-viewer-toolbar-show,
 .diagram-viewer-shell[data-toolbar-collapsed="true"] .diagram-viewer-toolbar-show {
     display: inline-flex;
 }
 
+.diagram-viewer-shell.diagram-viewer--details-collapsed .diagram-viewer-layout,
 .diagram-viewer-shell[data-details-collapsed="true"] .diagram-viewer-layout {
     grid-template-columns: minmax(0, 1fr);
 }
 
+.diagram-viewer-shell.diagram-viewer--details-collapsed .diagram-viewer-details,
 .diagram-viewer-shell[data-details-collapsed="true"] .diagram-viewer-details,
 .diagram-viewer-shell .diagram-viewer-details[hidden] {
     display: none;
 }
 
+.diagram-viewer-shell.diagram-viewer--details-collapsed .diagram-viewer-details-show,
 .diagram-viewer-shell[data-details-collapsed="true"] .diagram-viewer-details-show {
     display: inline-flex;
 }

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -1606,3 +1606,108 @@ html[data-theme="dark"] .diagram-area[data-style-key="green"] { border-color: rg
 html[data-theme="dark"] .diagram-area[data-style-key="amber"] { border-color: rgba(251, 191, 36, .88); background: rgba(217, 119, 6, .24); }
 html[data-theme="dark"] .diagram-area[data-style-key="red"] { border-color: rgba(248, 113, 113, .84); background: rgba(220, 38, 38, .2); }
 html[data-theme="dark"] .diagram-area[data-style-key="purple"] { border-color: rgba(196, 181, 253, .84); background: rgba(124, 58, 237, .24); }
+
+/* Read-only viewer layout compaction controls. Keep scoped to the viewer shell. */
+.diagram-viewer-shell {
+    grid-template-rows: minmax(0, 1fr) auto;
+}
+
+.diagram-viewer-shell .diagram-workspace {
+    padding: .55rem;
+    gap: .45rem;
+}
+
+.diagram-viewer-shell .diagram-viewer-toolbar {
+    padding-right: .15rem;
+}
+
+.diagram-toolbar-spacer {
+    flex: 1 1 auto;
+    min-width: .5rem;
+}
+
+.diagram-viewer-canvas-overlay {
+    position: absolute;
+    left: .75rem;
+    bottom: .75rem;
+    z-index: 5;
+    display: grid;
+    gap: .12rem;
+    max-width: min(24rem, calc(100% - 1.5rem));
+    padding: .45rem .55rem;
+    border: 1px solid rgba(148, 163, 184, .28);
+    border-radius: .55rem;
+    background: rgba(255, 255, 255, .78);
+    color: var(--diagram-text);
+    box-shadow: 0 6px 18px rgba(15, 23, 42, .10);
+    font-size: .78rem;
+    line-height: 1.25;
+    pointer-events: none;
+    backdrop-filter: blur(6px);
+}
+
+.diagram-viewer-canvas-overlay strong {
+    font-size: .86rem;
+    line-height: 1.2;
+}
+
+.diagram-viewer-canvas-overlay span {
+    color: var(--diagram-muted);
+}
+
+.diagram-viewer-toolbar-show,
+.diagram-viewer-details-show {
+    justify-self: start;
+    z-index: 6;
+}
+
+.diagram-viewer-details-show {
+    position: absolute;
+    top: .75rem;
+    right: .75rem;
+}
+
+.diagram-viewer-details-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .5rem;
+    margin-bottom: .65rem;
+}
+
+.diagram-viewer-details-header h2 {
+    margin: 0;
+}
+
+.diagram-viewer-shell[data-toolbar-collapsed="true"] .diagram-viewer-toolbar {
+    display: none;
+}
+
+.diagram-viewer-shell[data-toolbar-collapsed="true"] .diagram-viewer-toolbar-show {
+    display: inline-flex;
+}
+
+.diagram-viewer-shell[data-details-collapsed="true"] .diagram-viewer-layout {
+    grid-template-columns: minmax(0, 1fr);
+}
+
+.diagram-viewer-shell[data-details-collapsed="true"] .diagram-viewer-details {
+    display: none;
+}
+
+.diagram-viewer-shell[data-details-collapsed="true"] .diagram-viewer-details-show {
+    display: inline-flex;
+}
+
+html[data-theme="dark"] .diagram-viewer-canvas-overlay {
+    border-color: rgba(148, 163, 184, .35);
+    background: rgba(15, 23, 42, .78);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, .28);
+}
+
+@media (max-width: 980px) {
+    .diagram-viewer-details-show {
+        top: .5rem;
+        right: .5rem;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -1679,7 +1679,8 @@ html[data-theme="dark"] .diagram-area[data-style-key="purple"] { border-color: r
     margin: 0;
 }
 
-.diagram-viewer-shell[data-toolbar-collapsed="true"] .diagram-viewer-toolbar {
+.diagram-viewer-shell[data-toolbar-collapsed="true"] .diagram-viewer-toolbar,
+.diagram-viewer-shell .diagram-viewer-toolbar[hidden] {
     display: none;
 }
 
@@ -1691,7 +1692,8 @@ html[data-theme="dark"] .diagram-area[data-style-key="purple"] { border-color: r
     grid-template-columns: minmax(0, 1fr);
 }
 
-.diagram-viewer-shell[data-details-collapsed="true"] .diagram-viewer-details {
+.diagram-viewer-shell[data-details-collapsed="true"] .diagram-viewer-details,
+.diagram-viewer-shell .diagram-viewer-details[hidden] {
     display: none;
 }
 

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
@@ -100,11 +100,11 @@
 
     function setToolbarCollapsed(collapsed) {
         viewer.dataset.toolbarCollapsed = collapsed ? 'true' : 'false';
+        viewer.classList.toggle('diagram-viewer--toolbar-collapsed', collapsed);
         if (toolbarShowButton) {
-            toolbarShowButton.hidden = !collapsed;
+            toolbarShowButton.setAttribute('aria-hidden', collapsed ? 'false' : 'true');
         }
         if (toolbar) {
-            toolbar.hidden = collapsed;
             toolbar.setAttribute('aria-hidden', collapsed ? 'true' : 'false');
         }
         writeStoredBoolean(toolbarCollapsedStorageKey, collapsed);
@@ -113,11 +113,11 @@
 
     function setDetailsCollapsed(collapsed) {
         viewer.dataset.detailsCollapsed = collapsed ? 'true' : 'false';
+        viewer.classList.toggle('diagram-viewer--details-collapsed', collapsed);
         if (detailsShowButton) {
-            detailsShowButton.hidden = !collapsed;
+            detailsShowButton.setAttribute('aria-hidden', collapsed ? 'false' : 'true');
         }
         if (detailsPanel) {
-            detailsPanel.hidden = collapsed;
             detailsPanel.setAttribute('aria-hidden', collapsed ? 'true' : 'false');
         }
         writeStoredBoolean(detailsCollapsedStorageKey, collapsed);
@@ -591,28 +591,25 @@
         refreshTimer = window.setInterval(refreshLiveData, refreshIntervalMs);
     }
 
+    function bindCollapseToggle(selector, collapsed) {
+        const button = viewer.querySelector(selector);
+        if (!button) { return; }
+        button.addEventListener('click', event => {
+            event.preventDefault();
+            event.stopPropagation();
+            collapsed();
+        });
+        button.addEventListener('pointerdown', event => event.stopPropagation());
+    }
+
+    bindCollapseToggle('[data-hide-toolbar]', () => setToolbarCollapsed(true));
+    bindCollapseToggle('[data-show-toolbar]', () => setToolbarCollapsed(false));
+    bindCollapseToggle('[data-hide-details]', () => setDetailsCollapsed(true));
+    bindCollapseToggle('[data-show-details]', () => setDetailsCollapsed(false));
     viewer.querySelector('[data-zoom-in]')?.addEventListener('click', () => zoomAt(canvas.getBoundingClientRect().left + canvas.clientWidth / 2, canvas.getBoundingClientRect().top + canvas.clientHeight / 2, state.zoom * zoomStep));
     viewer.querySelector('[data-zoom-out]')?.addEventListener('click', () => zoomAt(canvas.getBoundingClientRect().left + canvas.clientWidth / 2, canvas.getBoundingClientRect().top + canvas.clientHeight / 2, state.zoom / zoomStep));
     viewer.querySelector('[data-reset-view]')?.addEventListener('click', resetView);
     viewer.querySelector('[data-fit-content]')?.addEventListener('click', fitContent);
-    viewer.addEventListener('click', event => {
-        const target = event.target instanceof Element ? event.target : event.target?.parentElement;
-        const toggle = target?.closest('[data-hide-toolbar], [data-show-toolbar], [data-hide-details], [data-show-details]');
-        if (!toggle || !viewer.contains(toggle)) {
-            return;
-        }
-
-        event.preventDefault();
-        if (toggle.matches('[data-hide-toolbar]')) {
-            setToolbarCollapsed(true);
-        } else if (toggle.matches('[data-show-toolbar]')) {
-            setToolbarCollapsed(false);
-        } else if (toggle.matches('[data-hide-details]')) {
-            setDetailsCollapsed(true);
-        } else if (toggle.matches('[data-show-details]')) {
-            setDetailsCollapsed(false);
-        }
-    });
     exportPdfButton?.addEventListener('click', () => { const base = exportPdfButton.dataset.exportPdfUrl; if (base) { window.location.href = `${base}?paper=${encodeURIComponent(exportPaperSelect?.value || 'A4')}`; } });
     const exportImage = button => { const base = button?.dataset.exportImageUrl; if (base) { const separator = base.includes('?') ? '&' : '?'; window.location.href = `${base}${separator}scale=${encodeURIComponent(exportScaleSelect?.value || '1')}&background=light`; } };
     exportPngButton?.addEventListener('click', () => exportImage(exportPngButton));

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
@@ -25,6 +25,12 @@
     const exportSvgButton = viewer.querySelector('[data-export-svg]');
     const exportPaperSelect = viewer.querySelector('[data-export-paper]');
     const exportScaleSelect = viewer.querySelector('[data-export-scale]');
+    const toolbar = viewer.querySelector('[data-viewer-toolbar]');
+    const toolbarShowButton = viewer.querySelector('[data-show-toolbar]');
+    const detailsPanel = viewer.querySelector('[data-viewer-details]');
+    const detailsShowButton = viewer.querySelector('[data-show-details]');
+    const toolbarCollapsedStorageKey = 'pingMonitor.diagramViewer.toolbarCollapsed';
+    const detailsCollapsedStorageKey = 'pingMonitor.diagramViewer.detailsCollapsed';
 
     const zoomStep = 1.15;
     const minZoom = 0.15;
@@ -67,6 +73,45 @@
         if (zoomLabel) {
             zoomLabel.textContent = `${Math.round(state.zoom * 100)}%`;
         }
+    }
+
+    function scheduleCanvasResize() {
+        window.requestAnimationFrame(() => {
+            updateCanvasSize();
+            window.requestAnimationFrame(updateCanvasSize);
+        });
+    }
+
+    function readStoredBoolean(key) {
+        try {
+            return window.localStorage?.getItem(key) === 'true';
+        } catch {
+            return false;
+        }
+    }
+
+    function writeStoredBoolean(key, value) {
+        try {
+            window.localStorage?.setItem(key, value ? 'true' : 'false');
+        } catch {
+            // Collapse state is an optional per-browser preference only.
+        }
+    }
+
+    function setToolbarCollapsed(collapsed) {
+        viewer.dataset.toolbarCollapsed = collapsed ? 'true' : 'false';
+        toolbarShowButton?.toggleAttribute('hidden', !collapsed);
+        toolbar?.setAttribute('aria-hidden', collapsed ? 'true' : 'false');
+        writeStoredBoolean(toolbarCollapsedStorageKey, collapsed);
+        scheduleCanvasResize();
+    }
+
+    function setDetailsCollapsed(collapsed) {
+        viewer.dataset.detailsCollapsed = collapsed ? 'true' : 'false';
+        detailsShowButton?.toggleAttribute('hidden', !collapsed);
+        detailsPanel?.setAttribute('aria-hidden', collapsed ? 'true' : 'false');
+        writeStoredBoolean(detailsCollapsedStorageKey, collapsed);
+        scheduleCanvasResize();
     }
 
     function updateCanvasSize() {
@@ -540,6 +585,10 @@
     viewer.querySelector('[data-zoom-out]')?.addEventListener('click', () => zoomAt(canvas.getBoundingClientRect().left + canvas.clientWidth / 2, canvas.getBoundingClientRect().top + canvas.clientHeight / 2, state.zoom / zoomStep));
     viewer.querySelector('[data-reset-view]')?.addEventListener('click', resetView);
     viewer.querySelector('[data-fit-content]')?.addEventListener('click', fitContent);
+    viewer.querySelector('[data-hide-toolbar]')?.addEventListener('click', () => setToolbarCollapsed(true));
+    toolbarShowButton?.addEventListener('click', () => setToolbarCollapsed(false));
+    viewer.querySelector('[data-hide-details]')?.addEventListener('click', () => setDetailsCollapsed(true));
+    detailsShowButton?.addEventListener('click', () => setDetailsCollapsed(false));
     exportPdfButton?.addEventListener('click', () => { const base = exportPdfButton.dataset.exportPdfUrl; if (base) { window.location.href = `${base}?paper=${encodeURIComponent(exportPaperSelect?.value || 'A4')}`; } });
     const exportImage = button => { const base = button?.dataset.exportImageUrl; if (base) { const separator = base.includes('?') ? '&' : '?'; window.location.href = `${base}${separator}scale=${encodeURIComponent(exportScaleSelect?.value || '1')}&background=light`; } };
     exportPngButton?.addEventListener('click', () => exportImage(exportPngButton));
@@ -558,6 +607,8 @@
     window.addEventListener('resize', updateCanvasSize);
     if ('ResizeObserver' in window) { new ResizeObserver(updateCanvasSize).observe(canvasHost); }
     window.addEventListener('beforeunload', () => { if (refreshTimer) { window.clearInterval(refreshTimer); } });
+    setToolbarCollapsed(readStoredBoolean(toolbarCollapsedStorageKey));
+    setDetailsCollapsed(readStoredBoolean(detailsCollapsedStorageKey));
     applyViewTransform();
     updateCanvasSize();
     loadDiagram();

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
@@ -100,16 +100,26 @@
 
     function setToolbarCollapsed(collapsed) {
         viewer.dataset.toolbarCollapsed = collapsed ? 'true' : 'false';
-        toolbarShowButton?.toggleAttribute('hidden', !collapsed);
-        toolbar?.setAttribute('aria-hidden', collapsed ? 'true' : 'false');
+        if (toolbarShowButton) {
+            toolbarShowButton.hidden = !collapsed;
+        }
+        if (toolbar) {
+            toolbar.hidden = collapsed;
+            toolbar.setAttribute('aria-hidden', collapsed ? 'true' : 'false');
+        }
         writeStoredBoolean(toolbarCollapsedStorageKey, collapsed);
         scheduleCanvasResize();
     }
 
     function setDetailsCollapsed(collapsed) {
         viewer.dataset.detailsCollapsed = collapsed ? 'true' : 'false';
-        detailsShowButton?.toggleAttribute('hidden', !collapsed);
-        detailsPanel?.setAttribute('aria-hidden', collapsed ? 'true' : 'false');
+        if (detailsShowButton) {
+            detailsShowButton.hidden = !collapsed;
+        }
+        if (detailsPanel) {
+            detailsPanel.hidden = collapsed;
+            detailsPanel.setAttribute('aria-hidden', collapsed ? 'true' : 'false');
+        }
         writeStoredBoolean(detailsCollapsedStorageKey, collapsed);
         scheduleCanvasResize();
     }
@@ -585,10 +595,24 @@
     viewer.querySelector('[data-zoom-out]')?.addEventListener('click', () => zoomAt(canvas.getBoundingClientRect().left + canvas.clientWidth / 2, canvas.getBoundingClientRect().top + canvas.clientHeight / 2, state.zoom / zoomStep));
     viewer.querySelector('[data-reset-view]')?.addEventListener('click', resetView);
     viewer.querySelector('[data-fit-content]')?.addEventListener('click', fitContent);
-    viewer.querySelector('[data-hide-toolbar]')?.addEventListener('click', () => setToolbarCollapsed(true));
-    toolbarShowButton?.addEventListener('click', () => setToolbarCollapsed(false));
-    viewer.querySelector('[data-hide-details]')?.addEventListener('click', () => setDetailsCollapsed(true));
-    detailsShowButton?.addEventListener('click', () => setDetailsCollapsed(false));
+    viewer.addEventListener('click', event => {
+        const target = event.target instanceof Element ? event.target : event.target?.parentElement;
+        const toggle = target?.closest('[data-hide-toolbar], [data-show-toolbar], [data-hide-details], [data-show-details]');
+        if (!toggle || !viewer.contains(toggle)) {
+            return;
+        }
+
+        event.preventDefault();
+        if (toggle.matches('[data-hide-toolbar]')) {
+            setToolbarCollapsed(true);
+        } else if (toggle.matches('[data-show-toolbar]')) {
+            setToolbarCollapsed(false);
+        } else if (toggle.matches('[data-hide-details]')) {
+            setDetailsCollapsed(true);
+        } else if (toggle.matches('[data-show-details]')) {
+            setDetailsCollapsed(false);
+        }
+    });
     exportPdfButton?.addEventListener('click', () => { const base = exportPdfButton.dataset.exportPdfUrl; if (base) { window.location.href = `${base}?paper=${encodeURIComponent(exportPaperSelect?.value || 'A4')}`; } });
     const exportImage = button => { const base = button?.dataset.exportImageUrl; if (base) { const separator = base.includes('?') ? '&' : '?'; window.location.href = `${base}${separator}scale=${encodeURIComponent(exportScaleSelect?.value || '1')}&background=light`; } };
     exportPngButton?.addEventListener('click', () => exportImage(exportPngButton));


### PR DESCRIPTION
### Motivation

- Reduce viewer chrome so the read-only Network Diagram canvas has more usable vertical and horizontal space for wallboard/operational use. 
- Surface the diagram name/note as a subtle in-canvas overlay and relocate tooling to the viewer toolbar to avoid wasting header area. 
- Provide quick hide/show controls for the toolbar and right-hand details panel and move the global Dark mode control into the primary nav to save vertical space.

### Description

- Reworked the read-only viewer markup to remove the large header and keep the page title as screen-reader-only by moving `diagram` title/description into a small bottom-left in-canvas overlay (`View.cshtml` and `network-diagrams.css`).
- Moved the admin-only `Edit diagram` link from the header into the viewer toolbar and kept the same permission checks so read-only users do not see edit controls (`View.cshtml`).
- Added toolbar and details-panel hide/show controls including minimal viewer-scoped CSS and unobtrusive `Show` buttons, with localStorage keys `pingMonitor.diagramViewer.toolbarCollapsed` and `pingMonitor.diagramViewer.detailsCollapsed` and a `scheduleCanvasResize()` helper to trigger layout recalculation after toggles (`network-diagrams.css`, `network-diagrams-viewer.js`).
- Kept overlay non-interactive (`pointer-events: none`) and added dark/light styling for the overlay so it works in both themes (`network-diagrams.css`).
- Hooked the collapse/restore buttons into the existing viewer script and ensured `ResizeObserver` / `updateCanvasSize()` runs after state changes so pan/zoom/fit/export continue to work correctly (`network-diagrams-viewer.js`).
- Moved the global dark mode selector into the account/profile group in the global navigation so it sits next to the Profile dropdown and adjusted nav styles to avoid duplication (`_AuthenticatedNav.cshtml`, `_ThemeSelector.cshtml`).
- Added/updated automated feature assertions to cover the new markup/script symbols and added a manual regression checklist in the network diagrams docs; created GitHub issue `#540` for traceability (`NetworkDiagramsFeatureTests.cs`, `docs/network-diagrams-v0.1.1.md`).

### Testing

- Ran `dotnet build src/WebApp/PingMonitor.WebApp.slnx` which completed successfully.
- Ran `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj -v minimal` and the test suite passed (154 tests passed, 0 failed).
- Ran the repository dev packaging script `pwsh ./scripts/build-dev.ps1` which completed successfully and produced the dev package; this confirms the web project builds in dev packaging flow.
- Verified no agent files or agent version metadata were modified and added a manual regression checklist to `docs/network-diagrams-v0.1.1.md` for interactive verification steps (toolbar/details hide-show, overlay visibility, pan/zoom/fit, and exports).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dd9baf8e8832a8310b8f17400fdc4)