### PR TITLE
Fix network diagram viewer collapse controls and top-nav spacing

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -787,9 +787,12 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("setToolbarCollapsed", script);
         Assert.Contains("setDetailsCollapsed", script);
         Assert.Contains("scheduleCanvasResize", script);
-        Assert.Contains("toolbar.hidden = collapsed", script);
-        Assert.Contains("detailsPanel.hidden = collapsed", script);
-        Assert.Contains("[data-hide-toolbar], [data-show-toolbar], [data-hide-details], [data-show-details]", script);
+        Assert.Contains("diagram-viewer--toolbar-collapsed", script);
+        Assert.Contains("diagram-viewer--details-collapsed", script);
+        Assert.Contains("bindCollapseToggle('[data-hide-toolbar]'", script);
+        Assert.Contains("bindCollapseToggle('[data-show-toolbar]'", script);
+        Assert.Contains("bindCollapseToggle('[data-hide-details]'", script);
+        Assert.Contains("bindCollapseToggle('[data-show-details]'", script);
         Assert.DoesNotContain("diagram-editor-heading", viewMarkup);
         Assert.Contains("Diagram live summary", script);
         Assert.Contains("Total nodes", script);

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
@@ -16,7 +16,7 @@
 
         <div class="diagram-viewer-layout">
             <section class="diagram-workspace" aria-label="Read-only network diagram viewer">
-                <button type="button" class="diagram-tool-button diagram-viewer-toolbar-show" data-show-toolbar hidden aria-controls="diagram-viewer-toolbar">Show toolbar</button>
+                <button type="button" class="diagram-tool-button diagram-viewer-toolbar-show" data-show-toolbar aria-controls="diagram-viewer-toolbar">Show toolbar</button>
                 <div class="diagram-workspace-toolbar diagram-viewer-toolbar" id="diagram-viewer-toolbar" data-viewer-toolbar>
                     <button type="button" class="diagram-tool-button" data-hide-toolbar aria-controls="diagram-viewer-toolbar">Hide toolbar</button>
                     <button type="button" class="diagram-tool-button" data-zoom-out>Zoom out</button>
@@ -64,7 +64,7 @@
                                 <span>@Model.DiagramDescription</span>
                             }
                         </div>
-                        <button type="button" class="diagram-tool-button diagram-viewer-details-show" data-show-details hidden aria-controls="diagram-viewer-details">Show details</button>
+                        <button type="button" class="diagram-tool-button diagram-viewer-details-show" data-show-details aria-controls="diagram-viewer-details">Show details</button>
                         <div class="diagram-empty-state" data-empty-state>Loading saved diagram…</div>
                         <div class="diagram-world" data-diagram-world>
                             <div class="diagram-area-layer" data-area-layer></div>

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -48,7 +48,6 @@
     }
 
     .site-nav-account {
-        margin-left: auto;
         display: flex;
         flex-wrap: wrap;
         gap: .5rem;

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -42,16 +42,17 @@
         width: 100%;
         margin: 0 auto;
         display: flex;
+        justify-content: center;
+        align-items: center;
         gap: .5rem;
         flex-wrap: wrap;
-        align-items: stretch;
     }
 
     .site-nav-account {
         display: flex;
         flex-wrap: wrap;
         gap: .5rem;
-        align-items: stretch;
+        align-items: center;
     }
 
     .site-nav-account details {

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -1657,6 +1657,7 @@ html[data-theme="dark"] .diagram-area[data-style-key="purple"] { border-color: r
 
 .diagram-viewer-toolbar-show,
 .diagram-viewer-details-show {
+    display: none;
     justify-self: start;
     z-index: 6;
 }
@@ -1679,24 +1680,29 @@ html[data-theme="dark"] .diagram-area[data-style-key="purple"] { border-color: r
     margin: 0;
 }
 
+.diagram-viewer-shell.diagram-viewer--toolbar-collapsed .diagram-viewer-toolbar,
 .diagram-viewer-shell[data-toolbar-collapsed="true"] .diagram-viewer-toolbar,
 .diagram-viewer-shell .diagram-viewer-toolbar[hidden] {
     display: none;
 }
 
+.diagram-viewer-shell.diagram-viewer--toolbar-collapsed .diagram-viewer-toolbar-show,
 .diagram-viewer-shell[data-toolbar-collapsed="true"] .diagram-viewer-toolbar-show {
     display: inline-flex;
 }
 
+.diagram-viewer-shell.diagram-viewer--details-collapsed .diagram-viewer-layout,
 .diagram-viewer-shell[data-details-collapsed="true"] .diagram-viewer-layout {
     grid-template-columns: minmax(0, 1fr);
 }
 
+.diagram-viewer-shell.diagram-viewer--details-collapsed .diagram-viewer-details,
 .diagram-viewer-shell[data-details-collapsed="true"] .diagram-viewer-details,
 .diagram-viewer-shell .diagram-viewer-details[hidden] {
     display: none;
 }
 
+.diagram-viewer-shell.diagram-viewer--details-collapsed .diagram-viewer-details-show,
 .diagram-viewer-shell[data-details-collapsed="true"] .diagram-viewer-details-show {
     display: inline-flex;
 }

--- a/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
+++ b/src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js
@@ -100,11 +100,11 @@
 
     function setToolbarCollapsed(collapsed) {
         viewer.dataset.toolbarCollapsed = collapsed ? 'true' : 'false';
+        viewer.classList.toggle('diagram-viewer--toolbar-collapsed', collapsed);
         if (toolbarShowButton) {
-            toolbarShowButton.hidden = !collapsed;
+            toolbarShowButton.setAttribute('aria-hidden', collapsed ? 'false' : 'true');
         }
         if (toolbar) {
-            toolbar.hidden = collapsed;
             toolbar.setAttribute('aria-hidden', collapsed ? 'true' : 'false');
         }
         writeStoredBoolean(toolbarCollapsedStorageKey, collapsed);
@@ -113,11 +113,11 @@
 
     function setDetailsCollapsed(collapsed) {
         viewer.dataset.detailsCollapsed = collapsed ? 'true' : 'false';
+        viewer.classList.toggle('diagram-viewer--details-collapsed', collapsed);
         if (detailsShowButton) {
-            detailsShowButton.hidden = !collapsed;
+            detailsShowButton.setAttribute('aria-hidden', collapsed ? 'false' : 'true');
         }
         if (detailsPanel) {
-            detailsPanel.hidden = collapsed;
             detailsPanel.setAttribute('aria-hidden', collapsed ? 'true' : 'false');
         }
         writeStoredBoolean(detailsCollapsedStorageKey, collapsed);
@@ -591,28 +591,25 @@
         refreshTimer = window.setInterval(refreshLiveData, refreshIntervalMs);
     }
 
+    function bindCollapseToggle(selector, collapsed) {
+        const button = viewer.querySelector(selector);
+        if (!button) { return; }
+        button.addEventListener('click', event => {
+            event.preventDefault();
+            event.stopPropagation();
+            collapsed();
+        });
+        button.addEventListener('pointerdown', event => event.stopPropagation());
+    }
+
+    bindCollapseToggle('[data-hide-toolbar]', () => setToolbarCollapsed(true));
+    bindCollapseToggle('[data-show-toolbar]', () => setToolbarCollapsed(false));
+    bindCollapseToggle('[data-hide-details]', () => setDetailsCollapsed(true));
+    bindCollapseToggle('[data-show-details]', () => setDetailsCollapsed(false));
     viewer.querySelector('[data-zoom-in]')?.addEventListener('click', () => zoomAt(canvas.getBoundingClientRect().left + canvas.clientWidth / 2, canvas.getBoundingClientRect().top + canvas.clientHeight / 2, state.zoom * zoomStep));
     viewer.querySelector('[data-zoom-out]')?.addEventListener('click', () => zoomAt(canvas.getBoundingClientRect().left + canvas.clientWidth / 2, canvas.getBoundingClientRect().top + canvas.clientHeight / 2, state.zoom / zoomStep));
     viewer.querySelector('[data-reset-view]')?.addEventListener('click', resetView);
     viewer.querySelector('[data-fit-content]')?.addEventListener('click', fitContent);
-    viewer.addEventListener('click', event => {
-        const target = event.target instanceof Element ? event.target : event.target?.parentElement;
-        const toggle = target?.closest('[data-hide-toolbar], [data-show-toolbar], [data-hide-details], [data-show-details]');
-        if (!toggle || !viewer.contains(toggle)) {
-            return;
-        }
-
-        event.preventDefault();
-        if (toggle.matches('[data-hide-toolbar]')) {
-            setToolbarCollapsed(true);
-        } else if (toggle.matches('[data-show-toolbar]')) {
-            setToolbarCollapsed(false);
-        } else if (toggle.matches('[data-hide-details]')) {
-            setDetailsCollapsed(true);
-        } else if (toggle.matches('[data-show-details]')) {
-            setDetailsCollapsed(false);
-        }
-    });
     exportPdfButton?.addEventListener('click', () => { const base = exportPdfButton.dataset.exportPdfUrl; if (base) { window.location.href = `${base}?paper=${encodeURIComponent(exportPaperSelect?.value || 'A4')}`; } });
     const exportImage = button => { const base = button?.dataset.exportImageUrl; if (base) { const separator = base.includes('?') ? '&' : '?'; window.location.href = `${base}${separator}scale=${encodeURIComponent(exportScaleSelect?.value || '1')}&background=light`; } };
     exportPngButton?.addEventListener('click', () => exportImage(exportPngButton));


### PR DESCRIPTION
### Motivation
- Remove the large gap in the authenticated global nav so Profile and Dark mode sit inline with other top navigation items.
- Restore functioning collapse/expand behaviour for the Network Diagram viewer toolbar and details panel so the canvas reflows and gains space when panels are hidden.
- Keep changes limited to UI wiring/CSS/JS and maintain platform constraints (no schema, agent, or monitoring logic changes).
- Link the fix to the related issue: Fixes #540.

### Description
- Removed the account-group auto-right-margin so Profile and the theme selector remain adjacent to the other nav items by default (edit: `_AuthenticatedNav.cshtml`).
- Ensured the viewer "Show" buttons render outside the panels they reveal and removed the hidden attribute so they can be bound directly (`View.cshtml`).
- Replaced delegated click logic with explicit button bindings and a small `bindCollapseToggle` helper which prevents propagation, toggles viewer root classes, and updates ARIA attributes (`network-diagrams-viewer.js`).
- Added viewer-root collapse CSS classes and updated rules so collapsing the toolbar/details removes their layout space (allowing the canvas to expand) while keeping the small Show controls visible (`network-diagrams.css`).
- Updated an existing feature test to assert the presence of the collapse selectors and new state classes to prevent regression (`NetworkDiagramsFeatureTests.cs`).
- No changes to database schema, startup, monitoring logic, agents, exports semantics, or persistence behaviour.

### Testing
- Ran `node --check src/WebApp/PingMonitor.Web/wwwroot/js/network-diagrams-viewer.js` and it succeeded.
- Built the web project with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the build succeeded.
- Ran automated tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and the test suite passed (154 passed, 0 failed).
- Performed a static wiring check to verify viewer hide/show selectors and collapse CSS classes are present and bound, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dedfa7d68832ab1c4bb9651ae716e)