### PR TITLE
Center global navigation row in header

### DIFF
--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -42,16 +42,17 @@
         width: 100%;
         margin: 0 auto;
         display: flex;
+        justify-content: center;
+        align-items: center;
         gap: .5rem;
         flex-wrap: wrap;
-        align-items: stretch;
     }
 
     .site-nav-account {
         display: flex;
         flex-wrap: wrap;
         gap: .5rem;
-        align-items: stretch;
+        align-items: center;
     }
 
     .site-nav-account details {


### PR DESCRIPTION
### Motivation
- The top navigation row was pinned to the left edge of the header; the layout should be horizontally centred while keeping all items (logo, Monitoring, Agents, Events/Logs, Admin, Info, Profile, Dark mode) on a single row with normal spacing.

### Description
- Update shared nav CSS in `src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml` to set `.site-nav` to `justify-content: center; align-items: center;` and change `.site-nav-account` to `align-items: center;` to keep the account and theme controls inline without using split groups or auto margins (Fixes #544).

### Testing
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which succeeded; ran `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` which succeeded with all tests passing (154 passed); a root `dotnet build` is not applicable because there is no solution/project at the repository root.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2df7565508832a9175d4f2ef2ada99)