### PR TITLE
Move collapsed diagram toolbar control into canvas

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -777,6 +777,7 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("data-export-scale", viewMarkup);
         Assert.Contains("Exports saved diagram layout", viewMarkup);
         Assert.Contains("diagram-viewer-canvas-overlay", viewMarkup);
+        Assert.Matches("diagram-canvas[\\s\\S]*data-show-toolbar", viewMarkup);
         Assert.Contains("Visual links are documentation-only.", viewMarkup);
         Assert.Contains("data-hide-toolbar", viewMarkup);
         Assert.Contains("data-show-toolbar", viewMarkup);

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
@@ -16,7 +16,6 @@
 
         <div class="diagram-viewer-layout">
             <section class="diagram-workspace" aria-label="Read-only network diagram viewer">
-                <button type="button" class="diagram-tool-button diagram-viewer-toolbar-show" data-show-toolbar aria-controls="diagram-viewer-toolbar">Show toolbar</button>
                 <div class="diagram-workspace-toolbar diagram-viewer-toolbar" id="diagram-viewer-toolbar" data-viewer-toolbar>
                     <button type="button" class="diagram-tool-button" data-hide-toolbar aria-controls="diagram-viewer-toolbar">Hide toolbar</button>
                     <button type="button" class="diagram-tool-button" data-zoom-out>Zoom out</button>
@@ -64,6 +63,7 @@
                                 <span>@Model.DiagramDescription</span>
                             }
                         </div>
+                        <button type="button" class="diagram-tool-button diagram-viewer-toolbar-show" data-show-toolbar aria-controls="diagram-viewer-toolbar">Show toolbar</button>
                         <button type="button" class="diagram-tool-button diagram-viewer-details-show" data-show-details aria-controls="diagram-viewer-details">Show details</button>
                         <div class="diagram-empty-state" data-empty-state>Loading saved diagram…</div>
                         <div class="diagram-world" data-diagram-world>

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -1658,8 +1658,13 @@ html[data-theme="dark"] .diagram-area[data-style-key="purple"] { border-color: r
 .diagram-viewer-toolbar-show,
 .diagram-viewer-details-show {
     display: none;
-    justify-self: start;
     z-index: 6;
+}
+
+.diagram-viewer-toolbar-show {
+    position: absolute;
+    top: .75rem;
+    left: .75rem;
 }
 
 .diagram-viewer-details-show {
@@ -1684,6 +1689,11 @@ html[data-theme="dark"] .diagram-area[data-style-key="purple"] { border-color: r
 .diagram-viewer-shell[data-toolbar-collapsed="true"] .diagram-viewer-toolbar,
 .diagram-viewer-shell .diagram-viewer-toolbar[hidden] {
     display: none;
+}
+
+.diagram-viewer-shell.diagram-viewer--toolbar-collapsed .diagram-workspace,
+.diagram-viewer-shell[data-toolbar-collapsed="true"] .diagram-workspace {
+    grid-template-rows: minmax(0, 1fr);
 }
 
 .diagram-viewer-shell.diagram-viewer--toolbar-collapsed .diagram-viewer-toolbar-show,
@@ -1714,6 +1724,11 @@ html[data-theme="dark"] .diagram-viewer-canvas-overlay {
 }
 
 @media (max-width: 980px) {
+    .diagram-viewer-toolbar-show {
+        top: .5rem;
+        left: .5rem;
+    }
+
     .diagram-viewer-details-show {
         top: .5rem;
         right: .5rem;


### PR DESCRIPTION
### Motivation
- Reduce wasted vertical space when the Network Diagram toolbar is collapsed by placing the collapsed `Show toolbar` control inside the diagram canvas overlay like the existing `Show details` control.
- Keep viewer behaviour predictable: overlay remains pinned to the viewport, does not reserve its own workspace row, and preserves existing toolbar/details toggles.

### Description
- Moved the `Show toolbar` button from above the workspace into the canvas overlay markup so it is rendered inside the `.diagram-canvas` container (`View.cshtml`).
- Added viewer-scoped CSS to absolutely position the collapsed-toolbar overlay at the top-left of the canvas and to make the workspace use a single canvas row when the toolbar is collapsed (`network-diagrams.css`).
- Kept the existing top-right `Show details` overlay and preserved responsive offsets for smaller viewports (`network-diagrams.css`).
- Added a regression assertion in the viewer markup unit test to ensure `data-show-toolbar` is rendered within the `diagram-canvas` block (`NetworkDiagramsFeatureTests.cs`).

### Testing
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` and the project build succeeded.
- Ran `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and the test suite passed (`154 passed, 0 failed`).
- Noted that `dotnet build`/`dotnet test` executed from the repository root fail as expected because the repo root contains no solution/project file, which is the same environment behaviour before this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ed59d6450832ab2529b48a34964d3)