### PR TITLE
Move collapsed diagram toolbar control into canvas

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -780,6 +780,9 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("Visual links are documentation-only.", viewMarkup);
         Assert.Contains("data-hide-toolbar", viewMarkup);
         Assert.Contains("data-show-toolbar", viewMarkup);
+        Assert.True(
+            viewMarkup.IndexOf("data-diagram-canvas role=", StringComparison.Ordinal) < viewMarkup.IndexOf("data-show-toolbar", StringComparison.Ordinal),
+            "The collapsed toolbar restore button must render inside the canvas viewport so it does not reserve a separate row above the canvas.");
         Assert.Contains("data-hide-details", viewMarkup);
         Assert.Contains("data-show-details", viewMarkup);
         Assert.Contains("pingMonitor.diagramViewer.toolbarCollapsed", script);

--- a/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml
@@ -16,7 +16,6 @@
 
         <div class="diagram-viewer-layout">
             <section class="diagram-workspace" aria-label="Read-only network diagram viewer">
-                <button type="button" class="diagram-tool-button diagram-viewer-toolbar-show" data-show-toolbar aria-controls="diagram-viewer-toolbar">Show toolbar</button>
                 <div class="diagram-workspace-toolbar diagram-viewer-toolbar" id="diagram-viewer-toolbar" data-viewer-toolbar>
                     <button type="button" class="diagram-tool-button" data-hide-toolbar aria-controls="diagram-viewer-toolbar">Hide toolbar</button>
                     <button type="button" class="diagram-tool-button" data-zoom-out>Zoom out</button>
@@ -56,6 +55,7 @@
                 </div>
                 <div class="diagram-canvas-host" data-diagram-canvas-host>
                     <div class="diagram-canvas" data-diagram-canvas role="application" aria-label="Read-only network diagram canvas" tabindex="0">
+                        <button type="button" class="diagram-tool-button diagram-viewer-toolbar-show" data-show-toolbar aria-controls="diagram-viewer-toolbar">Show toolbar</button>
                         <div class="diagram-viewer-canvas-overlay" aria-hidden="true">
                             <strong>@Model.DiagramName</strong>
                             <span>Visual links are documentation-only.</span>

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -1658,8 +1658,13 @@ html[data-theme="dark"] .diagram-area[data-style-key="purple"] { border-color: r
 .diagram-viewer-toolbar-show,
 .diagram-viewer-details-show {
     display: none;
-    justify-self: start;
     z-index: 6;
+}
+
+.diagram-viewer-toolbar-show {
+    position: absolute;
+    top: .75rem;
+    left: .75rem;
 }
 
 .diagram-viewer-details-show {
@@ -1714,6 +1719,11 @@ html[data-theme="dark"] .diagram-viewer-canvas-overlay {
 }
 
 @media (max-width: 980px) {
+    .diagram-viewer-toolbar-show {
+        top: .5rem;
+        left: .5rem;
+    }
+
     .diagram-viewer-details-show {
         top: .5rem;
         right: .5rem;


### PR DESCRIPTION
### Motivation
- The `Show toolbar` control for the Network Diagram viewer currently reserves a full row above the canvas when the toolbar is hidden, wasting vertical space.  
- The goal is to render the collapsed toolbar restore control as a viewport-pinned overlay inside the canvas, matching the existing `Show details` behavior and allowing the canvas to grow into the freed space.  

### Description
- Moved the collapsed `Show toolbar` button from the toolbar row into the canvas markup in `src/WebApp/PingMonitor.Web/Views/NetworkDiagrams/View.cshtml` so it is rendered inside the canvas viewport.  
- Added CSS rules in `src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css` to position `.diagram-viewer-toolbar-show` as a top-left absolute overlay inside the canvas and to maintain responsive positioning.  
- Kept the existing collapsed/expanded toggle logic (data attributes and JS collapse handlers) unchanged so runtime behavior and bindings remain intact.  
- Added a regression assertion to `src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs` ensuring the `data-show-toolbar` markup appears inside the canvas portion of the view to prevent future regressions.  

### Testing
- Ran `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj` which completed successfully.  
- Ran `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and all tests passed (`Passed: 154, Failed: 0, Skipped: 0`).  
- The new markup assertion in `NetworkDiagramsFeatureTests` is present and included in the test run and passed.  

Fixes #546

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2edcef3800832a8f588d7852768862)