### PR TITLE
Fix collapsed network diagram viewer canvas height

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs
@@ -758,6 +758,7 @@ public sealed class NetworkDiagramsFeatureTests
         var repoRoot = FindRepositoryRoot();
         var viewMarkup = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "Views", "NetworkDiagrams", "View.cshtml"));
         var script = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "wwwroot", "js", "network-diagrams-viewer.js"));
+        var stylesheet = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "wwwroot", "css", "network-diagrams.css"));
 
         Assert.Contains("data-network-diagram-viewer", viewMarkup);
         Assert.Contains("data-live-data-url", viewMarkup);
@@ -796,6 +797,8 @@ public sealed class NetworkDiagramsFeatureTests
         Assert.Contains("bindCollapseToggle('[data-show-toolbar]'", script);
         Assert.Contains("bindCollapseToggle('[data-hide-details]'", script);
         Assert.Contains("bindCollapseToggle('[data-show-details]'", script);
+        Assert.Contains("grid-template-rows: auto minmax(0, 1fr) auto;", stylesheet);
+        Assert.Contains(".diagram-viewer-toolbar-show {\n    position: absolute;", stylesheet);
         Assert.DoesNotContain("diagram-editor-heading", viewMarkup);
         Assert.Contains("Diagram live summary", script);
         Assert.Contains("Total nodes", script);

--- a/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
+++ b/src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css
@@ -1609,7 +1609,7 @@ html[data-theme="dark"] .diagram-area[data-style-key="purple"] { border-color: r
 
 /* Read-only viewer layout compaction controls. Keep scoped to the viewer shell. */
 .diagram-viewer-shell {
-    grid-template-rows: minmax(0, 1fr) auto;
+    grid-template-rows: auto minmax(0, 1fr) auto;
 }
 
 .diagram-viewer-shell .diagram-workspace {


### PR DESCRIPTION
### Motivation
- Restore the Network Diagram viewer after a regression that left the visible canvas as a tiny strip and made the collapsed "Show toolbar" overlay appear muted/unusable by ensuring the viewer shell reserves the expected flexible middle row.

### Description
- Revert the viewer shell grid rows so the hidden title does not consume the flexible row by setting `.diagram-viewer-shell { grid-template-rows: auto minmax(0, 1fr) auto; }` in `src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css`. 
- Keep the collapsed toolbar restore control as an absolute-positioned overlay inside the canvas viewport and add assertions to `src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs` to validate the grid layout and overlay positioning. 
- Files changed: `src/WebApp/PingMonitor.Web/wwwroot/css/network-diagrams.css` and `src/WebApp/PingMonitor.Web.Tests/NetworkDiagramsFeatureTests.cs`.

### Testing
- Built the solution with `PATH=/tmp/dotnet10:$PATH dotnet build src/WebApp/PingMonitor.WebApp.slnx` and the build succeeded. 
- Ran unit tests with `PATH=/tmp/dotnet10:$PATH dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and `PATH=/tmp/dotnet10:$PATH dotnet test src/WebApp/PingMonitor.WebApp.slnx`, both completed successfully (tests passed). 
- Performed static verification that the viewer shell now reserves a flexible middle row and that the Show toolbar overlay remains absolute and styled with the normal `diagram-tool-button` class; interactive browser verification was not executed in this non-interactive environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ee0200b20832a8ccff4e5c49194d7)