### PR TITLE
Add admin AI assistant settings page

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AiAssistantSettingsTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiAssistantSettingsTests.cs
@@ -116,6 +116,7 @@ public sealed class AiAssistantSettingsTests
         Assert.Contains("AiAssistantSettings", source);
         Assert.Contains("ApiKeyProtected", source);
         Assert.Contains("GlobalSystemPrompt", source);
+        Assert.Contains("`GlobalSystemPrompt` longtext NOT NULL", source);
     }
 
     private sealed class FakeAiAssistantSettingsService : IAiAssistantSettingsService

--- a/src/WebApp/PingMonitor.Web.Tests/AiAssistantSettingsTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiAssistantSettingsTests.cs
@@ -1,0 +1,158 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using PingMonitor.Web.Controllers;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.Identity;
+using PingMonitor.Web.ViewModels.Admin;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class AiAssistantSettingsTests
+{
+    [Fact]
+    public void Controller_IsAdminOnly()
+    {
+        var authorize = Assert.Single(typeof(AdminAiAssistantSettingsController).GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true).Cast<AuthorizeAttribute>());
+        Assert.Equal(ApplicationRoles.Admin, authorize.Roles);
+    }
+
+    [Fact]
+    public async Task AdminCanAccessSettingsPage()
+    {
+        var controller = new AdminAiAssistantSettingsController(new FakeAiAssistantSettingsService(new AiAssistantSettingsDto()));
+        var result = Assert.IsType<ViewResult>(await controller.Index(CancellationToken.None));
+        Assert.Equal("Index", result.ViewName);
+        Assert.IsType<AiAssistantSettingsPageViewModel>(result.Model);
+    }
+
+    [Fact]
+    public async Task AdminCanSaveValidSettings_AndApiKeyIsNotEchoed()
+    {
+        var service = new FakeAiAssistantSettingsService(new AiAssistantSettingsDto());
+        var controller = new AdminAiAssistantSettingsController(service);
+
+        var result = Assert.IsType<ViewResult>(await controller.Save(new AiAssistantSettingsPageViewModel
+        {
+            AssistantEnabled = true,
+            BaseUrl = "https://ai.example.test/v1",
+            ModelName = "ops-model",
+            ProviderType = AiAssistantSettings.OpenAICompatibleProviderType,
+            ProviderDisplayName = "Ops AI",
+            ApiKey = "secret",
+            RequestTimeoutSeconds = 60,
+            MaxOutputTokens = 2048,
+            Temperature = 0.2,
+            ToolCallingEnabled = true
+        }, CancellationToken.None));
+
+        var model = Assert.IsType<AiAssistantSettingsPageViewModel>(result.Model);
+        Assert.True(model.Saved);
+        Assert.Null(model.ApiKey);
+        Assert.Equal("secret", service.LastCommand?.ApiKey);
+    }
+
+    [Theory]
+    [InlineData(true, "not-a-url", "model", 60, 2048, 0.2)]
+    [InlineData(true, "ftp://example.test", "model", 60, 2048, 0.2)]
+    [InlineData(true, "https://example.test/v1", "", 60, 2048, 0.2)]
+    [InlineData(true, "https://example.test/v1", "model", 0, 2048, 0.2)]
+    [InlineData(true, "https://example.test/v1", "model", 60, 63, 0.2)]
+    [InlineData(true, "https://example.test/v1", "model", 60, 2048, 2.1)]
+    public async Task InvalidSettingsAreRejected(bool enabled, string baseUrl, string modelName, int timeout, int tokens, double temperature)
+    {
+        var service = new FakeAiAssistantSettingsService(new AiAssistantSettingsDto());
+        var controller = new AdminAiAssistantSettingsController(service);
+        controller.ModelState.Clear();
+        if (timeout is < 1 or > 300) controller.ModelState.AddModelError(nameof(AiAssistantSettingsPageViewModel.RequestTimeoutSeconds), "range");
+        if (tokens is < 64 or > 32768) controller.ModelState.AddModelError(nameof(AiAssistantSettingsPageViewModel.MaxOutputTokens), "range");
+        if (temperature is < 0 or > 2) controller.ModelState.AddModelError(nameof(AiAssistantSettingsPageViewModel.Temperature), "range");
+
+        var result = Assert.IsType<ViewResult>(await controller.Save(new AiAssistantSettingsPageViewModel
+        {
+            AssistantEnabled = enabled,
+            BaseUrl = baseUrl,
+            ModelName = modelName,
+            ProviderType = AiAssistantSettings.OpenAICompatibleProviderType,
+            ProviderDisplayName = "Ops AI",
+            RequestTimeoutSeconds = timeout,
+            MaxOutputTokens = tokens,
+            Temperature = temperature
+        }, CancellationToken.None));
+
+        Assert.False(controller.ModelState.IsValid);
+        Assert.Null(service.LastCommand);
+        Assert.IsType<AiAssistantSettingsPageViewModel>(result.Model);
+    }
+
+    [Fact]
+    public void ExistingApiKeyIsPreservedWhenSecretFieldBlank_AndClearRemovesIt()
+    {
+        var preserve = new UpdateAiAssistantSettingsCommand { ApiKey = "   ", ClearApiKey = false };
+        var clear = new UpdateAiAssistantSettingsCommand { ApiKey = null, ClearApiKey = true };
+
+        Assert.False(clear.ApiKey is not null);
+        Assert.False(preserve.ClearApiKey);
+        Assert.True(clear.ClearApiKey);
+    }
+
+    [Fact]
+    public void DefaultsAndStartupGateSchemaAreDeclared()
+    {
+        var settings = new AiAssistantSettings();
+        Assert.False(settings.AssistantEnabled);
+        Assert.Equal("Local Ollama", settings.ProviderDisplayName);
+        Assert.Equal("OpenAICompatible", settings.ProviderType);
+        Assert.Equal("http://localhost:11434/v1", settings.BaseUrl);
+        Assert.Equal(60, settings.RequestTimeoutSeconds);
+        Assert.Equal(2048, settings.MaxOutputTokens);
+        Assert.Equal(0.2, settings.Temperature);
+        Assert.True(settings.ToolCallingEnabled);
+
+        var repoRoot = FindRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(repoRoot, "src", "WebApp", "PingMonitor.Web", "Services", "StartupGate", "StartupSchemaService.cs"));
+        Assert.Contains("AiAssistantSettings", source);
+        Assert.Contains("ApiKeyProtected", source);
+        Assert.Contains("GlobalSystemPrompt", source);
+    }
+
+    private sealed class FakeAiAssistantSettingsService : IAiAssistantSettingsService
+    {
+        private AiAssistantSettingsDto _current;
+        public UpdateAiAssistantSettingsCommand? LastCommand { get; private set; }
+
+        public FakeAiAssistantSettingsService(AiAssistantSettingsDto current) => _current = current;
+        public Task<AiAssistantSettingsDto> GetCurrentAsync(CancellationToken cancellationToken) => Task.FromResult(_current);
+        public Task<AiAssistantSettingsDto> UpdateAsync(UpdateAiAssistantSettingsCommand command, CancellationToken cancellationToken)
+        {
+            LastCommand = command;
+            _current = new AiAssistantSettingsDto
+            {
+                AssistantEnabled = command.AssistantEnabled,
+                BaseUrl = command.BaseUrl ?? string.Empty,
+                ModelName = command.ModelName ?? string.Empty,
+                ProviderType = command.ProviderType ?? string.Empty,
+                ProviderDisplayName = command.ProviderDisplayName ?? string.Empty,
+                ApiKeyConfigured = !command.ClearApiKey && !string.IsNullOrWhiteSpace(command.ApiKey),
+                RequestTimeoutSeconds = command.RequestTimeoutSeconds,
+                MaxOutputTokens = command.MaxOutputTokens,
+                Temperature = command.Temperature,
+                ToolCallingEnabled = command.ToolCallingEnabled
+            };
+            return Task.FromResult(_current);
+        }
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "global.json"))) return directory.FullName;
+            directory = directory.Parent;
+        }
+        throw new InvalidOperationException("Could not locate repository root.");
+    }
+}

--- a/src/WebApp/PingMonitor.Web.Tests/StartupSchemaServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/StartupSchemaServiceTests.cs
@@ -60,7 +60,9 @@ public sealed class StartupSchemaServiceTests
 
         Assert.Contains("\"NetworkDiagramAreas\"", source);
         Assert.Contains("\"NetworkDiagramLinkVlans\"", source);
-        Assert.Equal(19, appRequiredSchemaVersion);
+        Assert.Equal(20, appRequiredSchemaVersion);
+        Assert.Contains("AiAssistantSettings", source);
+        Assert.Contains("RequiredAiAssistantSettingsColumns", source);
         Assert.Equal(appRequiredSchemaVersion, developmentRequiredSchemaVersion);
     }
 

--- a/src/WebApp/PingMonitor.Web.Tests/StartupSchemaServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/StartupSchemaServiceTests.cs
@@ -60,7 +60,7 @@ public sealed class StartupSchemaServiceTests
 
         Assert.Contains("\"NetworkDiagramAreas\"", source);
         Assert.Contains("\"NetworkDiagramLinkVlans\"", source);
-        Assert.Equal(20, appRequiredSchemaVersion);
+        Assert.Equal(21, appRequiredSchemaVersion);
         Assert.Contains("AiAssistantSettings", source);
         Assert.Contains("RequiredAiAssistantSettingsColumns", source);
         Assert.Equal(appRequiredSchemaVersion, developmentRequiredSchemaVersion);

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminAiAssistantSettingsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminAiAssistantSettingsController.cs
@@ -1,0 +1,113 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.Identity;
+using PingMonitor.Web.ViewModels.Admin;
+
+namespace PingMonitor.Web.Controllers;
+
+[Authorize(Roles = ApplicationRoles.Admin)]
+[Route("admin/ai-assistant-settings")]
+public sealed class AdminAiAssistantSettingsController : Controller
+{
+    private readonly IAiAssistantSettingsService _settingsService;
+
+    public AdminAiAssistantSettingsController(IAiAssistantSettingsService settingsService)
+    {
+        _settingsService = settingsService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Index(CancellationToken cancellationToken)
+    {
+        var settings = await _settingsService.GetCurrentAsync(cancellationToken);
+        return View("Index", ToViewModel(settings, saved: false));
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Save([FromForm] AiAssistantSettingsPageViewModel model, CancellationToken cancellationToken)
+    {
+        ValidateSettings(model);
+        if (!ModelState.IsValid)
+        {
+            model.ApiKey = null;
+            return View("Index", model);
+        }
+
+        var updated = await _settingsService.UpdateAsync(new UpdateAiAssistantSettingsCommand
+        {
+            AssistantEnabled = model.AssistantEnabled,
+            WebChatEnabled = model.WebChatEnabled,
+            TelegramChatEnabled = model.TelegramChatEnabled,
+            MemoryEnabled = model.MemoryEnabled,
+            DebugLoggingEnabled = model.DebugLoggingEnabled,
+            ProviderDisplayName = model.ProviderDisplayName,
+            ProviderType = model.ProviderType,
+            BaseUrl = model.BaseUrl,
+            ModelName = model.ModelName,
+            ApiKey = model.ApiKey,
+            ClearApiKey = model.ClearApiKey,
+            RequestTimeoutSeconds = model.RequestTimeoutSeconds,
+            MaxOutputTokens = model.MaxOutputTokens,
+            Temperature = model.Temperature,
+            ToolCallingEnabled = model.ToolCallingEnabled,
+            GlobalSystemPrompt = model.GlobalSystemPrompt,
+            UpdatedByUserId = User?.Identity?.Name
+        }, cancellationToken);
+
+        return View("Index", ToViewModel(updated, saved: true));
+    }
+
+    private void ValidateSettings(AiAssistantSettingsPageViewModel model)
+    {
+        if (!string.Equals(model.ProviderType?.Trim(), AiAssistantSettings.OpenAICompatibleProviderType, StringComparison.Ordinal))
+        {
+            ModelState.AddModelError(nameof(model.ProviderType), "Provider type must be OpenAICompatible.");
+        }
+
+        if (model.AssistantEnabled && string.IsNullOrWhiteSpace(model.ModelName))
+        {
+            ModelState.AddModelError(nameof(model.ModelName), "Model name is required when the AI assistant is enabled.");
+        }
+
+        if (model.AssistantEnabled && string.IsNullOrWhiteSpace(model.BaseUrl))
+        {
+            ModelState.AddModelError(nameof(model.BaseUrl), "Base URL is required when the AI assistant is enabled.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(model.BaseUrl)
+            && (!Uri.TryCreate(model.BaseUrl.Trim(), UriKind.Absolute, out var uri)
+                || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)))
+        {
+            ModelState.AddModelError(nameof(model.BaseUrl), "Base URL must be an absolute http or https URL.");
+        }
+    }
+
+    private static AiAssistantSettingsPageViewModel ToViewModel(AiAssistantSettingsDto settings, bool saved)
+    {
+        return new AiAssistantSettingsPageViewModel
+        {
+            AssistantEnabled = settings.AssistantEnabled,
+            WebChatEnabled = settings.WebChatEnabled,
+            TelegramChatEnabled = settings.TelegramChatEnabled,
+            MemoryEnabled = settings.MemoryEnabled,
+            DebugLoggingEnabled = settings.DebugLoggingEnabled,
+            ProviderDisplayName = settings.ProviderDisplayName,
+            ProviderType = settings.ProviderType,
+            BaseUrl = settings.BaseUrl,
+            ModelName = settings.ModelName,
+            ApiKey = null,
+            ApiKeyConfigured = settings.ApiKeyConfigured,
+            RequestTimeoutSeconds = settings.RequestTimeoutSeconds,
+            MaxOutputTokens = settings.MaxOutputTokens,
+            Temperature = settings.Temperature,
+            ToolCallingEnabled = settings.ToolCallingEnabled,
+            GlobalSystemPrompt = settings.GlobalSystemPrompt,
+            UpdatedAtUtc = settings.UpdatedAtUtc,
+            UpdatedByUserId = settings.UpdatedByUserId,
+            Saved = saved
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -346,7 +346,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         aiAssistantSettings.Property(x => x.MaxOutputTokens).IsRequired();
         aiAssistantSettings.Property(x => x.Temperature).IsRequired();
         aiAssistantSettings.Property(x => x.ToolCallingEnabled).IsRequired();
-        aiAssistantSettings.Property(x => x.GlobalSystemPrompt).HasMaxLength(20000).IsRequired();
+        aiAssistantSettings.Property(x => x.GlobalSystemPrompt).HasColumnType("longtext").IsRequired();
         aiAssistantSettings.Property(x => x.UpdatedAtUtc).IsRequired();
         aiAssistantSettings.Property(x => x.UpdatedByUserId).HasMaxLength(255);
 

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -39,6 +39,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
     public DbSet<SecuritySettings> SecuritySettings => Set<SecuritySettings>();
     public DbSet<SecurityIpBlock> SecurityIpBlocks => Set<SecurityIpBlock>();
     public DbSet<NotificationSettings> NotificationSettings => Set<NotificationSettings>();
+    public DbSet<AiAssistantSettings> AiAssistantSettings => Set<AiAssistantSettings>();
     public DbSet<UserNotificationSettings> UserNotificationSettings => Set<UserNotificationSettings>();
     public DbSet<PendingTelegramLink> PendingTelegramLinks => Set<PendingTelegramLink>();
     public DbSet<TelegramAccount> TelegramAccounts => Set<TelegramAccount>();
@@ -326,6 +327,28 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         appSettings.Property(x => x.DegradedMinimumSamples).IsRequired();
         appSettings.Property(x => x.NetworkDiagramsEnabled).IsRequired();
         appSettings.Property(x => x.UpdatedAtUtc).IsRequired();
+
+        var aiAssistantSettings = modelBuilder.Entity<AiAssistantSettings>();
+        aiAssistantSettings.ToTable("AiAssistantSettings");
+        aiAssistantSettings.HasKey(x => x.AiAssistantSettingsId);
+        aiAssistantSettings.Property(x => x.AiAssistantSettingsId).ValueGeneratedNever();
+        aiAssistantSettings.Property(x => x.AssistantEnabled).IsRequired();
+        aiAssistantSettings.Property(x => x.WebChatEnabled).IsRequired();
+        aiAssistantSettings.Property(x => x.TelegramChatEnabled).IsRequired();
+        aiAssistantSettings.Property(x => x.MemoryEnabled).IsRequired();
+        aiAssistantSettings.Property(x => x.DebugLoggingEnabled).IsRequired();
+        aiAssistantSettings.Property(x => x.ProviderDisplayName).HasMaxLength(128).IsRequired();
+        aiAssistantSettings.Property(x => x.ProviderType).HasMaxLength(64).IsRequired();
+        aiAssistantSettings.Property(x => x.BaseUrl).HasMaxLength(2048).IsRequired();
+        aiAssistantSettings.Property(x => x.ModelName).HasMaxLength(255).IsRequired();
+        aiAssistantSettings.Property(x => x.ApiKeyProtected).HasMaxLength(4096);
+        aiAssistantSettings.Property(x => x.RequestTimeoutSeconds).IsRequired();
+        aiAssistantSettings.Property(x => x.MaxOutputTokens).IsRequired();
+        aiAssistantSettings.Property(x => x.Temperature).IsRequired();
+        aiAssistantSettings.Property(x => x.ToolCallingEnabled).IsRequired();
+        aiAssistantSettings.Property(x => x.GlobalSystemPrompt).HasMaxLength(20000).IsRequired();
+        aiAssistantSettings.Property(x => x.UpdatedAtUtc).IsRequired();
+        aiAssistantSettings.Property(x => x.UpdatedByUserId).HasMaxLength(255);
 
         var notificationSettings = modelBuilder.Entity<NotificationSettings>();
         notificationSettings.ToTable("NotificationSettings");

--- a/src/WebApp/PingMonitor.Web/Models/AiAssistantSettings.cs
+++ b/src/WebApp/PingMonitor.Web/Models/AiAssistantSettings.cs
@@ -1,0 +1,26 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class AiAssistantSettings
+{
+    public const int SingletonId = 1;
+    public const string OpenAICompatibleProviderType = "OpenAICompatible";
+
+    public int AiAssistantSettingsId { get; set; } = SingletonId;
+    public bool AssistantEnabled { get; set; }
+    public bool WebChatEnabled { get; set; }
+    public bool TelegramChatEnabled { get; set; }
+    public bool MemoryEnabled { get; set; }
+    public bool DebugLoggingEnabled { get; set; }
+    public string ProviderDisplayName { get; set; } = "Local Ollama";
+    public string ProviderType { get; set; } = OpenAICompatibleProviderType;
+    public string BaseUrl { get; set; } = "http://localhost:11434/v1";
+    public string ModelName { get; set; } = string.Empty;
+    public string? ApiKeyProtected { get; set; }
+    public int RequestTimeoutSeconds { get; set; } = 60;
+    public int MaxOutputTokens { get; set; } = 2048;
+    public double Temperature { get; set; } = 0.2;
+    public bool ToolCallingEnabled { get; set; } = true;
+    public string GlobalSystemPrompt { get; set; } = string.Empty;
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+    public string? UpdatedByUserId { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs
@@ -5,6 +5,6 @@ public sealed class StartupGateOptions
     public const string SectionName = "StartupGate";
 
     public string StorageDirectory { get; set; } = "App_Data/StartupGate";
-    public int RequiredSchemaVersion { get; set; } = 19;
+    public int RequiredSchemaVersion { get; set; } = 20;
     public int DefaultMySqlPort { get; set; } = 3306;
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -197,6 +197,7 @@ builder.Services.AddScoped<IAgentPackageBuilder, AgentPackageBuilder>();
 builder.Services.AddScoped<IAgentTemplateVersionProvider, AgentTemplateVersionProvider>();
 builder.Services.AddScoped<IAgentProvisioningService, AgentProvisioningService>();
 builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsService>();
+builder.Services.AddScoped<IAiAssistantSettingsService, AiAssistantSettingsService>();
 builder.Services.AddSingleton<IApplicationMetadataProvider, ApplicationMetadataProvider>();
 builder.Services.AddHttpClient(nameof(GitHubReleaseLookupService));
 builder.Services.AddHttpClient(nameof(ApplicationUpdateStagingService));

--- a/src/WebApp/PingMonitor.Web/Services/AiAssistantSettingsDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiAssistantSettingsDto.cs
@@ -1,0 +1,22 @@
+namespace PingMonitor.Web.Services;
+
+public sealed class AiAssistantSettingsDto
+{
+    public bool AssistantEnabled { get; set; }
+    public bool WebChatEnabled { get; set; }
+    public bool TelegramChatEnabled { get; set; }
+    public bool MemoryEnabled { get; set; }
+    public bool DebugLoggingEnabled { get; set; }
+    public string ProviderDisplayName { get; set; } = "Local Ollama";
+    public string ProviderType { get; set; } = "OpenAICompatible";
+    public string BaseUrl { get; set; } = "http://localhost:11434/v1";
+    public string ModelName { get; set; } = string.Empty;
+    public bool ApiKeyConfigured { get; set; }
+    public int RequestTimeoutSeconds { get; set; } = 60;
+    public int MaxOutputTokens { get; set; } = 2048;
+    public double Temperature { get; set; } = 0.2;
+    public bool ToolCallingEnabled { get; set; } = true;
+    public string GlobalSystemPrompt { get; set; } = string.Empty;
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+    public string? UpdatedByUserId { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/AiAssistantSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiAssistantSettingsService.cs
@@ -1,0 +1,153 @@
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace PingMonitor.Web.Services;
+
+internal sealed class AiAssistantSettingsService : IAiAssistantSettingsService
+{
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly ILogger<AiAssistantSettingsService> _logger;
+
+    public AiAssistantSettingsService(PingMonitorDbContext dbContext, ILogger<AiAssistantSettingsService> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<AiAssistantSettingsDto> GetCurrentAsync(CancellationToken cancellationToken)
+    {
+        var settings = await GetOrCreateEntityAsync(cancellationToken);
+        return ToDto(settings);
+    }
+
+    public async Task<AiAssistantSettingsDto> UpdateAsync(UpdateAiAssistantSettingsCommand command, CancellationToken cancellationToken)
+    {
+        var settings = await GetOrCreateEntityAsync(cancellationToken);
+
+        settings.AssistantEnabled = command.AssistantEnabled;
+        settings.WebChatEnabled = command.WebChatEnabled;
+        settings.TelegramChatEnabled = command.TelegramChatEnabled;
+        settings.MemoryEnabled = command.MemoryEnabled;
+        settings.DebugLoggingEnabled = command.DebugLoggingEnabled;
+        settings.ProviderDisplayName = NormalizeString(command.ProviderDisplayName) ?? "Local Ollama";
+        settings.ProviderType = NormalizeProviderType(command.ProviderType);
+        settings.BaseUrl = NormalizeString(command.BaseUrl) ?? string.Empty;
+        settings.ModelName = NormalizeString(command.ModelName) ?? string.Empty;
+        settings.RequestTimeoutSeconds = command.RequestTimeoutSeconds;
+        settings.MaxOutputTokens = command.MaxOutputTokens;
+        settings.Temperature = command.Temperature;
+        settings.ToolCallingEnabled = command.ToolCallingEnabled;
+        settings.GlobalSystemPrompt = command.GlobalSystemPrompt?.Trim() ?? string.Empty;
+
+        if (command.ClearApiKey)
+        {
+            settings.ApiKeyProtected = null;
+        }
+        else if (!string.IsNullOrWhiteSpace(command.ApiKey))
+        {
+            settings.ApiKeyProtected = ProtectSecret(command.ApiKey.Trim());
+        }
+
+        settings.UpdatedAtUtc = DateTimeOffset.UtcNow;
+        settings.UpdatedByUserId = NormalizeString(command.UpdatedByUserId);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("AI assistant settings updated by {UpdatedByUserId}. AssistantEnabled={AssistantEnabled} WebChatEnabled={WebChatEnabled} TelegramChatEnabled={TelegramChatEnabled} MemoryEnabled={MemoryEnabled} DebugLoggingEnabled={DebugLoggingEnabled} ProviderType={ProviderType}",
+            settings.UpdatedByUserId ?? "(unknown)",
+            settings.AssistantEnabled,
+            settings.WebChatEnabled,
+            settings.TelegramChatEnabled,
+            settings.MemoryEnabled,
+            settings.DebugLoggingEnabled,
+            settings.ProviderType);
+
+        return ToDto(settings);
+    }
+
+    private async Task<AiAssistantSettings> GetOrCreateEntityAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _dbContext.AiAssistantSettings
+            .SingleOrDefaultAsync(x => x.AiAssistantSettingsId == AiAssistantSettings.SingletonId, cancellationToken);
+
+        if (settings is not null)
+        {
+            return settings;
+        }
+
+        settings = new AiAssistantSettings
+        {
+            AiAssistantSettingsId = AiAssistantSettings.SingletonId,
+            AssistantEnabled = false,
+            WebChatEnabled = false,
+            TelegramChatEnabled = false,
+            MemoryEnabled = false,
+            DebugLoggingEnabled = false,
+            ProviderDisplayName = "Local Ollama",
+            ProviderType = AiAssistantSettings.OpenAICompatibleProviderType,
+            BaseUrl = "http://localhost:11434/v1",
+            ModelName = string.Empty,
+            RequestTimeoutSeconds = 60,
+            MaxOutputTokens = 2048,
+            Temperature = 0.2,
+            ToolCallingEnabled = true,
+            GlobalSystemPrompt = string.Empty,
+            UpdatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        _dbContext.AiAssistantSettings.Add(settings);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return settings;
+    }
+
+    private string ProtectSecret(string secret)
+    {
+        var payload = Encoding.UTF8.GetBytes(secret);
+        if (OperatingSystem.IsWindows())
+        {
+            payload = ProtectedData.Protect(payload, optionalEntropy: null, DataProtectionScope.LocalMachine);
+        }
+        else
+        {
+            _logger.LogWarning("AI assistant API key fallback storage is in use because DPAPI is only available on Windows.");
+        }
+
+        return Convert.ToBase64String(payload);
+    }
+
+    private static string? NormalizeString(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string NormalizeProviderType(string? value)
+    {
+        var normalized = NormalizeString(value);
+        return string.Equals(normalized, AiAssistantSettings.OpenAICompatibleProviderType, StringComparison.Ordinal)
+            ? AiAssistantSettings.OpenAICompatibleProviderType
+            : AiAssistantSettings.OpenAICompatibleProviderType;
+    }
+
+    private static AiAssistantSettingsDto ToDto(AiAssistantSettings settings)
+    {
+        return new AiAssistantSettingsDto
+        {
+            AssistantEnabled = settings.AssistantEnabled,
+            WebChatEnabled = settings.WebChatEnabled,
+            TelegramChatEnabled = settings.TelegramChatEnabled,
+            MemoryEnabled = settings.MemoryEnabled,
+            DebugLoggingEnabled = settings.DebugLoggingEnabled,
+            ProviderDisplayName = settings.ProviderDisplayName,
+            ProviderType = settings.ProviderType,
+            BaseUrl = settings.BaseUrl,
+            ModelName = settings.ModelName,
+            ApiKeyConfigured = !string.IsNullOrWhiteSpace(settings.ApiKeyProtected),
+            RequestTimeoutSeconds = settings.RequestTimeoutSeconds,
+            MaxOutputTokens = settings.MaxOutputTokens,
+            Temperature = settings.Temperature,
+            ToolCallingEnabled = settings.ToolCallingEnabled,
+            GlobalSystemPrompt = settings.GlobalSystemPrompt,
+            UpdatedAtUtc = settings.UpdatedAtUtc,
+            UpdatedByUserId = settings.UpdatedByUserId
+        };
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationAutoBackupBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationAutoBackupBackgroundService.cs
@@ -147,6 +147,7 @@ public sealed class ConfigurationAutoBackupBackgroundService : BackgroundService
             ConfigurationBackupSections.SecuritySettings,
             ConfigurationBackupSections.NotificationSettings,
             ConfigurationBackupSections.UserNotificationSettings,
+            ConfigurationBackupSections.AiAssistantSettings,
             ConfigurationBackupSections.NetworkDiagrams
         };
 

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentValidator.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupDocumentValidator.cs
@@ -46,6 +46,7 @@ public sealed class ConfigurationBackupDocumentValidator : IConfigurationBackupD
             || document.Sections.SecuritySettings is not null
             || document.Sections.NotificationSettings is not null
             || document.Sections.UserNotificationSettings is not null
+            || document.Sections.AiAssistantSettings is not null
             || document.Sections.Identity is not null
             || document.Sections.NetworkDiagrams is not null;
 

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupModels.cs
@@ -15,6 +15,7 @@ public static class ConfigurationBackupSections
     public const string SecuritySettings = "security_settings";
     public const string NotificationSettings = "notification_settings";
     public const string UserNotificationSettings = "user_notification_settings";
+    public const string AiAssistantSettings = "ai_assistant_settings";
     public const string Identity = "identity";
     public const string NetworkDiagrams = "network_diagrams";
 
@@ -28,6 +29,7 @@ public static class ConfigurationBackupSections
         SecuritySettings,
         NotificationSettings,
         UserNotificationSettings,
+        AiAssistantSettings,
         Identity,
         NetworkDiagrams
     ];
@@ -161,6 +163,9 @@ public sealed class ConfigurationBackupSectionData
     [JsonPropertyName("user_notification_settings")]
     public IReadOnlyList<BackupUserNotificationSettingsRecord>? UserNotificationSettings { get; init; }
 
+    [JsonPropertyName("ai_assistant_settings")]
+    public BackupAiAssistantSettingsRecord? AiAssistantSettings { get; init; }
+
     [JsonPropertyName("identity")]
     public BackupIdentitySection? Identity { get; init; }
 
@@ -289,6 +294,28 @@ public sealed class BackupNotificationSettingsRecord
     public bool SmtpNotifyEndpointRecovered { get; init; }
     public bool SmtpNotifyAgentOffline { get; init; }
     public bool SmtpNotifyAgentOnline { get; init; }
+    public DateTimeOffset UpdatedAtUtc { get; init; }
+    public string? UpdatedByUserId { get; init; }
+}
+
+
+public sealed class BackupAiAssistantSettingsRecord
+{
+    public bool AssistantEnabled { get; init; }
+    public bool WebChatEnabled { get; init; }
+    public bool TelegramChatEnabled { get; init; }
+    public bool MemoryEnabled { get; init; }
+    public bool DebugLoggingEnabled { get; init; }
+    public string ProviderDisplayName { get; init; } = "Local Ollama";
+    public string ProviderType { get; init; } = "OpenAICompatible";
+    public string BaseUrl { get; init; } = "http://localhost:11434/v1";
+    public string ModelName { get; init; } = string.Empty;
+    public string? ApiKeyProtected { get; init; }
+    public int RequestTimeoutSeconds { get; init; }
+    public int MaxOutputTokens { get; init; }
+    public double Temperature { get; init; }
+    public bool ToolCallingEnabled { get; init; }
+    public string GlobalSystemPrompt { get; init; } = string.Empty;
     public DateTimeOffset UpdatedAtUtc { get; init; }
     public string? UpdatedByUserId { get; init; }
 }
@@ -550,6 +577,7 @@ public sealed class ConfigurationBackupSectionCounts
     public int SecuritySettings { get; init; }
     public int NotificationSettings { get; init; }
     public int UserNotificationSettings { get; init; }
+    public int AiAssistantSettings { get; init; }
     public int IdentityUsers { get; init; }
     public int IdentityRoles { get; init; }
     public int IdentityUserRoles { get; init; }

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationBackupService.cs
@@ -104,6 +104,9 @@ public sealed class ConfigurationBackupService : IConfigurationBackupService
             UserNotificationSettings = selectedSections.Contains(ConfigurationBackupSections.UserNotificationSettings, StringComparer.Ordinal)
                 ? await LoadUserNotificationSettingsAsync(cancellationToken)
                 : null,
+            AiAssistantSettings = selectedSections.Contains(ConfigurationBackupSections.AiAssistantSettings, StringComparer.Ordinal)
+                ? await LoadAiAssistantSettingsAsync(cancellationToken)
+                : null,
             Identity = selectedSections.Contains(ConfigurationBackupSections.Identity, StringComparer.Ordinal)
                 ? await LoadIdentityAsync(cancellationToken)
                 : null,
@@ -483,6 +486,39 @@ public sealed class ConfigurationBackupService : IConfigurationBackupService
             SmtpNotifyEndpointRecovered = settings.SmtpNotifyEndpointRecovered,
             SmtpNotifyAgentOffline = settings.SmtpNotifyAgentOffline,
             SmtpNotifyAgentOnline = settings.SmtpNotifyAgentOnline,
+            UpdatedAtUtc = settings.UpdatedAtUtc,
+            UpdatedByUserId = settings.UpdatedByUserId
+        };
+    }
+
+
+    private async Task<BackupAiAssistantSettingsRecord?> LoadAiAssistantSettingsAsync(CancellationToken cancellationToken)
+    {
+        var settings = await _dbContext.AiAssistantSettings
+            .AsNoTracking()
+            .SingleOrDefaultAsync(x => x.AiAssistantSettingsId == AiAssistantSettings.SingletonId, cancellationToken);
+        if (settings is null)
+        {
+            return null;
+        }
+
+        return new BackupAiAssistantSettingsRecord
+        {
+            AssistantEnabled = settings.AssistantEnabled,
+            WebChatEnabled = settings.WebChatEnabled,
+            TelegramChatEnabled = settings.TelegramChatEnabled,
+            MemoryEnabled = settings.MemoryEnabled,
+            DebugLoggingEnabled = settings.DebugLoggingEnabled,
+            ProviderDisplayName = settings.ProviderDisplayName,
+            ProviderType = settings.ProviderType,
+            BaseUrl = settings.BaseUrl,
+            ModelName = settings.ModelName,
+            ApiKeyProtected = settings.ApiKeyProtected,
+            RequestTimeoutSeconds = settings.RequestTimeoutSeconds,
+            MaxOutputTokens = settings.MaxOutputTokens,
+            Temperature = settings.Temperature,
+            ToolCallingEnabled = settings.ToolCallingEnabled,
+            GlobalSystemPrompt = settings.GlobalSystemPrompt,
             UpdatedAtUtc = settings.UpdatedAtUtc,
             UpdatedByUserId = settings.UpdatedByUserId
         };

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestorePreviewService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestorePreviewService.cs
@@ -56,6 +56,7 @@ public sealed class ConfigurationRestorePreviewService : IConfigurationRestorePr
                 Assignments = document.Sections.Assignments?.Count ?? 0,
                 SecuritySettings = document.Sections.SecuritySettings is null ? 0 : 1,
                 NotificationSettings = document.Sections.NotificationSettings is null ? 0 : 1,
+                AiAssistantSettings = document.Sections.AiAssistantSettings is null ? 0 : 1,
                 UserNotificationSettings = document.Sections.UserNotificationSettings?.Count ?? 0,
                 IdentityUsers = document.Sections.Identity?.Users.Count ?? 0,
                 IdentityRoles = document.Sections.Identity?.Roles.Count ?? 0,
@@ -202,6 +203,10 @@ public sealed class ConfigurationRestorePreviewService : IConfigurationRestorePr
         if (document.Sections.UserNotificationSettings is not null)
         {
             yield return ConfigurationBackupSections.UserNotificationSettings;
+        }
+        if (document.Sections.AiAssistantSettings is not null)
+        {
+            yield return ConfigurationBackupSections.AiAssistantSettings;
         }
 
         if (document.Sections.Identity is not null)

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs
@@ -132,6 +132,13 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
             sectionResults.Add(section);
         }
 
+        if (selectedSections.Contains(ConfigurationBackupSections.AiAssistantSettings, StringComparer.Ordinal))
+        {
+            var section = await RestoreAiAssistantSettingsAsync(backup, cancellationToken);
+            section.DeletedCount = GetDeletedCount(deletedCounts, section.Section);
+            sectionResults.Add(section);
+        }
+
         if (selectedSections.Contains(ConfigurationBackupSections.Identity, StringComparer.Ordinal))
         {
             var section = await RestoreIdentityAsync(backup, cancellationToken);
@@ -321,6 +328,7 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
                 ConfigurationBackupSections.SecuritySettings => backup.Sections.SecuritySettings is not null,
                 ConfigurationBackupSections.NotificationSettings => backup.Sections.NotificationSettings is not null,
                 ConfigurationBackupSections.UserNotificationSettings => backup.Sections.UserNotificationSettings is not null,
+                ConfigurationBackupSections.AiAssistantSettings => backup.Sections.AiAssistantSettings is not null,
                 ConfigurationBackupSections.Identity => backup.Sections.Identity is not null,
                 ConfigurationBackupSections.NetworkDiagrams => backup.Sections.NetworkDiagrams is not null,
                 _ => false
@@ -822,6 +830,53 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
             result.UpdatedCount,
             result.SkippedCount,
             result.ErrorCount);
+        return result;
+    }
+
+
+    private async Task<RestoreSectionResult> RestoreAiAssistantSettingsAsync(ConfigurationBackupDocument backup, CancellationToken cancellationToken)
+    {
+        var result = new RestoreSectionResult { Section = ConfigurationBackupSections.AiAssistantSettings };
+        var source = backup.Sections.AiAssistantSettings;
+        if (source is null)
+        {
+            result.SkippedCount++;
+            result.Warnings.Add("Backup does not include AI assistant settings.");
+            return result;
+        }
+
+        var target = await _dbContext.AiAssistantSettings
+            .SingleOrDefaultAsync(x => x.AiAssistantSettingsId == AiAssistantSettings.SingletonId, cancellationToken);
+        if (target is null)
+        {
+            target = new AiAssistantSettings { AiAssistantSettingsId = AiAssistantSettings.SingletonId };
+            _dbContext.AiAssistantSettings.Add(target);
+            result.InsertedCount++;
+        }
+        else
+        {
+            result.UpdatedCount++;
+        }
+
+        target.AssistantEnabled = source.AssistantEnabled;
+        target.WebChatEnabled = source.WebChatEnabled;
+        target.TelegramChatEnabled = source.TelegramChatEnabled;
+        target.MemoryEnabled = source.MemoryEnabled;
+        target.DebugLoggingEnabled = source.DebugLoggingEnabled;
+        target.ProviderDisplayName = string.IsNullOrWhiteSpace(source.ProviderDisplayName) ? "Local Ollama" : source.ProviderDisplayName;
+        target.ProviderType = source.ProviderType == AiAssistantSettings.OpenAICompatibleProviderType ? source.ProviderType : AiAssistantSettings.OpenAICompatibleProviderType;
+        target.BaseUrl = source.BaseUrl ?? string.Empty;
+        target.ModelName = source.ModelName ?? string.Empty;
+        target.ApiKeyProtected = source.ApiKeyProtected;
+        target.RequestTimeoutSeconds = source.RequestTimeoutSeconds <= 0 ? 60 : source.RequestTimeoutSeconds;
+        target.MaxOutputTokens = source.MaxOutputTokens <= 0 ? 2048 : source.MaxOutputTokens;
+        target.Temperature = source.Temperature;
+        target.ToolCallingEnabled = source.ToolCallingEnabled;
+        target.GlobalSystemPrompt = source.GlobalSystemPrompt ?? string.Empty;
+        target.UpdatedAtUtc = source.UpdatedAtUtc == default ? DateTimeOffset.UtcNow : source.UpdatedAtUtc;
+        target.UpdatedByUserId = source.UpdatedByUserId;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
         return result;
     }
 

--- a/src/WebApp/PingMonitor.Web/Services/IAiAssistantSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/IAiAssistantSettingsService.cs
@@ -1,0 +1,7 @@
+namespace PingMonitor.Web.Services;
+
+public interface IAiAssistantSettingsService
+{
+    Task<AiAssistantSettingsDto> GetCurrentAsync(CancellationToken cancellationToken);
+    Task<AiAssistantSettingsDto> UpdateAsync(UpdateAiAssistantSettingsCommand command, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -42,6 +42,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "SecuritySettings",
         "SecurityIpBlocks",
         "NotificationSettings",
+        "AiAssistantSettings",
         "UserNotificationSettings",
         "PendingTelegramLinks",
         "TelegramAccounts",
@@ -231,6 +232,28 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "UpdatedAtUtc",
         "UpdatedByUserId"
     ];
+
+    private static readonly string[] RequiredAiAssistantSettingsColumns =
+    [
+        "AiAssistantSettingsId",
+        "AssistantEnabled",
+        "WebChatEnabled",
+        "TelegramChatEnabled",
+        "MemoryEnabled",
+        "DebugLoggingEnabled",
+        "ProviderDisplayName",
+        "ProviderType",
+        "BaseUrl",
+        "ModelName",
+        "ApiKeyProtected",
+        "RequestTimeoutSeconds",
+        "MaxOutputTokens",
+        "Temperature",
+        "ToolCallingEnabled",
+        "GlobalSystemPrompt",
+        "UpdatedAtUtc",
+        "UpdatedByUserId"
+    ];
     private static readonly string[] RequiredUserNotificationSettingsColumns =
     [
         "UserId",
@@ -389,6 +412,14 @@ internal sealed class StartupSchemaService : IStartupSchemaService
             status.Diagnostics.Add($"NotificationSettings table is missing required columns: {string.Join(", ", missingNotificationSettingsColumns)}.");
             return status;
         }
+        var missingAiAssistantSettingsColumns = await GetMissingColumnsAsync(connection, "AiAssistantSettings", RequiredAiAssistantSettingsColumns, cancellationToken);
+        if (missingAiAssistantSettingsColumns.Length > 0)
+        {
+            var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
+            status.Diagnostics.Add($"AiAssistantSettings table is missing required columns: {string.Join(", ", missingAiAssistantSettingsColumns)}.");
+            return status;
+        }
+
         var missingUserNotificationSettingsColumns = await GetMissingUserNotificationSettingsColumnsAsync(connection, cancellationToken);
         if (missingUserNotificationSettingsColumns.Length > 0)
         {
@@ -665,6 +696,30 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 `UpdatedAtUtc` datetime(6) NOT NULL,
                 `UpdatedByUserId` varchar(255) NULL,
                 PRIMARY KEY (`NotificationSettingsId`)
+            );
+            """;
+
+        const string createAiAssistantSettingsSql = """
+            CREATE TABLE IF NOT EXISTS `AiAssistantSettings` (
+                `AiAssistantSettingsId` int NOT NULL,
+                `AssistantEnabled` tinyint(1) NOT NULL DEFAULT 0,
+                `WebChatEnabled` tinyint(1) NOT NULL DEFAULT 0,
+                `TelegramChatEnabled` tinyint(1) NOT NULL DEFAULT 0,
+                `MemoryEnabled` tinyint(1) NOT NULL DEFAULT 0,
+                `DebugLoggingEnabled` tinyint(1) NOT NULL DEFAULT 0,
+                `ProviderDisplayName` varchar(128) NOT NULL DEFAULT 'Local Ollama',
+                `ProviderType` varchar(64) NOT NULL DEFAULT 'OpenAICompatible',
+                `BaseUrl` varchar(2048) NOT NULL DEFAULT 'http://localhost:11434/v1',
+                `ModelName` varchar(255) NOT NULL DEFAULT '',
+                `ApiKeyProtected` varchar(4096) NULL,
+                `RequestTimeoutSeconds` int NOT NULL DEFAULT 60,
+                `MaxOutputTokens` int NOT NULL DEFAULT 2048,
+                `Temperature` double NOT NULL DEFAULT 0.2,
+                `ToolCallingEnabled` tinyint(1) NOT NULL DEFAULT 1,
+                `GlobalSystemPrompt` varchar(20000) NOT NULL,
+                `UpdatedAtUtc` datetime(6) NOT NULL,
+                `UpdatedByUserId` varchar(255) NULL,
+                PRIMARY KEY (`AiAssistantSettingsId`)
             );
             """;
         const string createUserNotificationSettingsSql = """
@@ -1009,6 +1064,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await dbContext.Database.ExecuteSqlRawAsync(createSecuritySettingsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createSecurityIpBlocksSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createNotificationSettingsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createAiAssistantSettingsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createUserNotificationSettingsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createPendingTelegramLinksSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createTelegramAccountsSql, cancellationToken);

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -716,7 +716,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 `MaxOutputTokens` int NOT NULL DEFAULT 2048,
                 `Temperature` double NOT NULL DEFAULT 0.2,
                 `ToolCallingEnabled` tinyint(1) NOT NULL DEFAULT 1,
-                `GlobalSystemPrompt` varchar(20000) NOT NULL,
+                `GlobalSystemPrompt` longtext NOT NULL,
                 `UpdatedAtUtc` datetime(6) NOT NULL,
                 `UpdatedByUserId` varchar(255) NULL,
                 PRIMARY KEY (`AiAssistantSettingsId`)
@@ -1084,6 +1084,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await EnsureSecuritySettingsColumnsAsync(dbContext, cancellationToken);
         await EnsureApplicationSettingsColumnsAsync(dbContext, cancellationToken);
         await EnsureNotificationSettingsColumnsAsync(dbContext, cancellationToken);
+        await EnsureAiAssistantSettingsSchemaAsync(dbContext, cancellationToken);
         await EnsureUserNotificationSettingsColumnsAsync(dbContext, cancellationToken);
         await EnsureAssignmentMetrics24hColumnsAsync(dbContext, cancellationToken);
         await EnsureAgentColumnsAsync(dbContext, cancellationToken);
@@ -2226,6 +2227,26 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         }
     }
 
+
+    private static async Task EnsureAiAssistantSettingsSchemaAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
+    {
+        await using var connection = dbContext.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        if (!await IsColumnLongTextAsync(connection, "AiAssistantSettings", "GlobalSystemPrompt", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `AiAssistantSettings`
+                MODIFY COLUMN `GlobalSystemPrompt` longtext NOT NULL;
+                """,
+                cancellationToken);
+        }
+    }
+
     private static async Task EnsureUserNotificationSettingsColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
     {
         await using var connection = dbContext.Database.GetDbConnection();
@@ -2474,6 +2495,30 @@ internal sealed class StartupSchemaService : IStartupSchemaService
 
         var value = await command.ExecuteScalarAsync(cancellationToken);
         return value is string dataType && string.Equals(dataType, "double", StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    private static async Task<bool> IsColumnLongTextAsync(System.Data.Common.DbConnection connection, string tableName, string columnName, CancellationToken cancellationToken)
+    {
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = @tableName
+              AND column_name = @columnName
+            LIMIT 1;
+            """;
+        AddParameter(command, "@tableName", tableName);
+        AddParameter(command, "@columnName", columnName);
+
+        var value = await command.ExecuteScalarAsync(cancellationToken);
+        return value is string dataType && string.Equals(dataType, "longtext", StringComparison.OrdinalIgnoreCase);
     }
 
     private static async Task<bool> HasCheckResultsColumnAsync(System.Data.Common.DbConnection connection, string columnName, CancellationToken cancellationToken)

--- a/src/WebApp/PingMonitor.Web/Services/UpdateAiAssistantSettingsCommand.cs
+++ b/src/WebApp/PingMonitor.Web/Services/UpdateAiAssistantSettingsCommand.cs
@@ -1,0 +1,22 @@
+namespace PingMonitor.Web.Services;
+
+public sealed class UpdateAiAssistantSettingsCommand
+{
+    public bool AssistantEnabled { get; set; }
+    public bool WebChatEnabled { get; set; }
+    public bool TelegramChatEnabled { get; set; }
+    public bool MemoryEnabled { get; set; }
+    public bool DebugLoggingEnabled { get; set; }
+    public string? ProviderDisplayName { get; set; }
+    public string? ProviderType { get; set; }
+    public string? BaseUrl { get; set; }
+    public string? ModelName { get; set; }
+    public string? ApiKey { get; set; }
+    public bool ClearApiKey { get; set; }
+    public int RequestTimeoutSeconds { get; set; }
+    public int MaxOutputTokens { get; set; }
+    public double Temperature { get; set; }
+    public bool ToolCallingEnabled { get; set; }
+    public string? GlobalSystemPrompt { get; set; }
+    public string? UpdatedByUserId { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/AiAssistantSettingsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/AiAssistantSettingsPageViewModel.cs
@@ -1,0 +1,56 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PingMonitor.Web.ViewModels.Admin;
+
+public sealed class AiAssistantSettingsPageViewModel
+{
+    [Display(Name = "AI assistant enabled")]
+    public bool AssistantEnabled { get; set; }
+    [Display(Name = "In-app web chat enabled")]
+    public bool WebChatEnabled { get; set; }
+    [Display(Name = "Telegram AI chat enabled")]
+    public bool TelegramChatEnabled { get; set; }
+    [Display(Name = "AI memory enabled")]
+    public bool MemoryEnabled { get; set; }
+    [Display(Name = "AI debug logging enabled")]
+    public bool DebugLoggingEnabled { get; set; }
+
+    [Display(Name = "Provider display name")]
+    [StringLength(128)]
+    public string ProviderDisplayName { get; set; } = "Local Ollama";
+    [Display(Name = "Provider type")]
+    [StringLength(64)]
+    public string ProviderType { get; set; } = "OpenAICompatible";
+    [Display(Name = "Base URL")]
+    [StringLength(2048)]
+    public string BaseUrl { get; set; } = "http://localhost:11434/v1";
+    [Display(Name = "Model name")]
+    [StringLength(255)]
+    public string ModelName { get; set; } = string.Empty;
+    [Display(Name = "API key secret")]
+    [StringLength(4096)]
+    public string? ApiKey { get; set; }
+    [Display(Name = "Clear saved API key")]
+    public bool ClearApiKey { get; set; }
+    public bool ApiKeyConfigured { get; set; }
+
+    [Display(Name = "Request timeout seconds")]
+    [Range(1, 300)]
+    public int RequestTimeoutSeconds { get; set; } = 60;
+    [Display(Name = "Max output tokens")]
+    [Range(64, 32768)]
+    public int MaxOutputTokens { get; set; } = 2048;
+    [Display(Name = "Temperature")]
+    [Range(0, 2)]
+    public double Temperature { get; set; } = 0.2;
+    [Display(Name = "Tool calling enabled")]
+    public bool ToolCallingEnabled { get; set; } = true;
+
+    [Display(Name = "Global assistant prompt / custom instructions")]
+    [StringLength(20000)]
+    public string GlobalSystemPrompt { get; set; } = string.Empty;
+
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+    public string? UpdatedByUserId { get; set; }
+    public bool Saved { get; set; }
+}

--- a/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Admin/Index.cshtml
@@ -41,6 +41,7 @@
                 <a class="button-secondary" href="/admin/default-endpoint-values">Default endpoint values</a>
                 <a class="button-secondary" href="/admin/application-updater">Application updater</a>
                 <a class="button-secondary" href="/admin/notification-infrastructure-settings">Notification infrastructure settings</a>
+                <a class="button-secondary" href="/admin/ai-assistant-settings">AI assistant settings</a>
             </div>
         </section>
 

--- a/src/WebApp/PingMonitor.Web/Views/AdminAiAssistantSettings/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminAiAssistantSettings/Index.cshtml
@@ -1,0 +1,109 @@
+@model PingMonitor.Web.ViewModels.Admin.AiAssistantSettingsPageViewModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    @await Html.PartialAsync("_ThemeHead")
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AI assistant settings</title>
+    <style>
+        :root { color-scheme: light; --bg:#f3f6f8; --card:#ffffff; --text:#102a43; --muted:#52606d; --border:#d9e2ec; --accent:#0f62fe; --success:#137333; --warning-bg:#fff7ed; --warning-border:#fed7aa; --error-bg:#fee4e2; --error-text:#b42318; }
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 860px; margin: 0 auto; padding: 1rem; }
+        .stack { display: grid; gap: 1rem; }
+        .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
+        .grid { display: grid; gap: .85rem; }
+        .button-row { display: flex; gap: .75rem; flex-wrap: wrap; }
+        .button, .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 48px; padding: .8rem 1rem; border-radius: 10px; font-weight: 600; text-decoration: none; }
+        .button { border: 0; color: #fff; background: var(--accent); cursor: pointer; }
+        .button-secondary { border: 1px solid var(--border); color: var(--text); background: white; }
+        label { font-weight: 700; display: block; margin-bottom: .25rem; }
+        input, select, textarea { width: 100%; min-height: 48px; border: 1px solid var(--border); border-radius: 10px; padding: .75rem; font: inherit; }
+        textarea { min-height: 220px; resize: vertical; }
+        .checkbox-row { display: flex; align-items: center; min-height: 48px; gap: .6rem; }
+        input[type="checkbox"] { width: auto; min-height: 0; transform: scale(1.2); }
+        .field-help, .muted { color: var(--muted); }
+        .field-help { font-size: .9rem; margin: .25rem 0 0; }
+        .saved { border: 1px solid #c2f0c2; background: #ebffee; color: var(--success); border-radius: 10px; padding: .8rem; }
+        .errors { border: 1px solid #fda29b; background: var(--error-bg); color: var(--error-text); border-radius: 10px; padding: .8rem; }
+        .warning { border: 1px solid var(--warning-border); background: var(--warning-bg); border-radius: 10px; padding: .8rem; }
+        .validation { color: var(--error-text); font-size: .9rem; }
+        @@media (min-width: 720px) { .two { grid-template-columns: 1fr 1fr; } }
+    </style>
+</head>
+<body>
+@await Html.PartialAsync("_AuthenticatedNav")
+<main>
+    <form method="post" action="/admin/ai-assistant-settings" class="stack">
+        @Html.AntiForgeryToken()
+        <section class="card">
+            <h1>AI assistant settings</h1>
+            <p class="muted">Configure the future AI Operations Assistant. This slice only stores configuration; it does not enable chat, provider calls, Telegram AI routing, tools, memories, diagnostics, or runtime assistant behaviour.</p>
+            <div class="button-row">
+                <a class="button-secondary" href="/admin">Back to admin settings</a>
+            </div>
+        </section>
+
+        @if (Model.Saved) { <div class="saved" role="status">AI assistant settings saved successfully.</div> }
+        @if (!ViewData.ModelState.IsValid) { <div class="errors" asp-validation-summary="All"></div> }
+
+        <section class="card grid">
+            <h2>Feature enablement</h2>
+            <div class="checkbox-row"><input asp-for="AssistantEnabled" type="checkbox" /><input name="AssistantEnabled" type="hidden" value="false" /><label asp-for="AssistantEnabled"></label></div>
+            <div class="checkbox-row"><input asp-for="WebChatEnabled" type="checkbox" /><input name="WebChatEnabled" type="hidden" value="false" /><label asp-for="WebChatEnabled"></label></div>
+            <div class="checkbox-row"><input asp-for="TelegramChatEnabled" type="checkbox" /><input name="TelegramChatEnabled" type="hidden" value="false" /><label asp-for="TelegramChatEnabled"></label></div>
+            <div class="checkbox-row"><input asp-for="MemoryEnabled" type="checkbox" /><input name="MemoryEnabled" type="hidden" value="false" /><label asp-for="MemoryEnabled"></label></div>
+            <div class="checkbox-row"><input asp-for="DebugLoggingEnabled" type="checkbox" /><input name="DebugLoggingEnabled" type="hidden" value="false" /><label asp-for="DebugLoggingEnabled"></label></div>
+            <p class="field-help">Enabling these flags records operator intent only. Chat surfaces and runtime execution are implemented in later slices.</p>
+        </section>
+
+        <section class="card grid">
+            <h2>Provider/API configuration</h2>
+            <div class="grid two">
+                <div><label asp-for="ProviderDisplayName"></label><input asp-for="ProviderDisplayName" /><span class="validation" asp-validation-for="ProviderDisplayName"></span></div>
+                <div><label asp-for="ProviderType"></label><select asp-for="ProviderType"><option value="OpenAICompatible">OpenAI-compatible</option></select><span class="validation" asp-validation-for="ProviderType"></span></div>
+                <div><label asp-for="BaseUrl"></label><input asp-for="BaseUrl" inputmode="url" /><p class="field-help">For example: local Ollama <code>http://localhost:11434/v1</code> or a hosted OpenAI-compatible endpoint.</p><span class="validation" asp-validation-for="BaseUrl"></span></div>
+                <div><label asp-for="ModelName"></label><input asp-for="ModelName" /><span class="validation" asp-validation-for="ModelName"></span></div>
+            </div>
+            <div>
+                <label asp-for="ApiKey"></label>
+                <input asp-for="ApiKey" type="password" autocomplete="new-password" value="" />
+                <p class="field-help">Saved key configured: <strong>@(Model.ApiKeyConfigured ? "Yes" : "No")</strong>. Leave blank to keep the saved key. API key is optional for local providers.</p>
+            </div>
+            <div class="checkbox-row"><input asp-for="ClearApiKey" type="checkbox" /><input name="ClearApiKey" type="hidden" value="false" /><label asp-for="ClearApiKey"></label></div>
+        </section>
+
+        <section class="card grid">
+            <h2>Model behaviour</h2>
+            <div class="grid two">
+                <div><label asp-for="RequestTimeoutSeconds"></label><input asp-for="RequestTimeoutSeconds" type="number" min="1" max="300" /><span class="validation" asp-validation-for="RequestTimeoutSeconds"></span></div>
+                <div><label asp-for="MaxOutputTokens"></label><input asp-for="MaxOutputTokens" type="number" min="64" max="32768" /><span class="validation" asp-validation-for="MaxOutputTokens"></span></div>
+                <div><label asp-for="Temperature"></label><input asp-for="Temperature" type="number" min="0" max="2" step="0.1" /><span class="validation" asp-validation-for="Temperature"></span></div>
+                <div class="checkbox-row"><input asp-for="ToolCallingEnabled" type="checkbox" /><input name="ToolCallingEnabled" type="hidden" value="false" /><label asp-for="ToolCallingEnabled"></label></div>
+            </div>
+        </section>
+
+        <section class="card grid">
+            <h2>Admin global prompt</h2>
+            <textarea asp-for="GlobalSystemPrompt" maxlength="20000"></textarea>
+            <p class="field-help">Use this for site-specific guidance only. Admin instructions cannot override read-only mode, permissions, application safety rules, or tool-result truthfulness.</p>
+            <span class="validation" asp-validation-for="GlobalSystemPrompt"></span>
+        </section>
+
+        <section class="card warning">
+            <h2>Safety notes</h2>
+            <ul>
+                <li>The assistant is planned as read-only and must not modify monitoring configuration, agents, dependencies, alerts, or diagram data.</li>
+                <li>These settings only configure the future assistant; enabling flags here does not make chat available until later runtime slices are implemented.</li>
+                <li>The built-in non-editable safety prompt will be added in the runtime layer and takes precedence over the admin prompt.</li>
+                <li>Diagram/topology answers must remain based on saved documentation only, not live link-state.</li>
+            </ul>
+            <p class="muted">Last updated: @await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.UpdatedAtUtc)</p>
+        </section>
+
+        <div class="button-row"><button class="button" type="submit">Save AI assistant settings</button><a class="button-secondary" href="/admin">Cancel</a></div>
+    </form>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 20,
+    "RequiredSchemaVersion": 21,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 19,
+    "RequiredSchemaVersion": 20,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 19,
+    "RequiredSchemaVersion": 20,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 20,
+    "RequiredSchemaVersion": 21,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
### Motivation

- Introduce the first V0.2.x AI Assistant configuration slice so operators can centrally manage admin-only AI settings before any runtime/chat/provider behaviour is implemented.  
- Provide a dedicated, single-row settings model to avoid polluting `ApplicationSettings` and to make secrets and prompts explicit and auditable.  
- Ensure Startup Gate and schema/versioning rules are followed so the application will not start without the new schema present.  
- Trace this work to planning issue: Fixes #551.

### Description

- Adds a new singleton EF entity `AiAssistantSettings` with provider, model, feature flags, protected API-key storage, model-behaviour fields, admin global prompt, and audit fields, and registers a `DbSet<AiAssistantSettings>` and EF column constraints in `PingMonitorDbContext` (new file: `src/WebApp/PingMonitor.Web/Models/AiAssistantSettings.cs`; DbContext changes in `src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs`).
- Implements a service and API surface using `IAiAssistantSettingsService`, `AiAssistantSettingsService`, `AiAssistantSettingsDto`, and `UpdateAiAssistantSettingsCommand` to encapsulate DB access, secret protection (DPAPI fallback), and DTO shaping (`src/WebApp/PingMonitor.Web/Services/*`).
- Adds an admin-only controller and Razor UI for `/admin/ai-assistant-settings` with mobile-friendly layout, server-side validation, anti-forgery protection, and a link from the main Admin page (`src/WebApp/PingMonitor.Web/Controllers/AdminAiAssistantSettingsController.cs`, `src/WebApp/PingMonitor.Web/Views/AdminAiAssistantSettings/Index.cshtml`, and admin Index update).
- Updates Startup Gate to require and create the new `AiAssistantSettings` table and column set and bumps the required schema version from `19` to `20` (changes in `src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs`, `src/WebApp/PingMonitor.Web/Options/StartupGateOptions.cs`, and `appsettings*.json`).
- Integrates AI settings into configuration backup/restore flows by adding `ai_assistant_settings` to backup sections, serialization, preview, validation, restore execution, and automatic backup defaults (`src/WebApp/PingMonitor.Web/Services/Backups/*`).
- Adds a strongly-typed view model and server-side validation rules: provider must be `OpenAICompatible`, Base URL must be absolute http/https if supplied (required when assistant enabled), Model required when enabled, bounded ranges for timeout, max tokens, temperature, and a 20k-char limit on the global prompt (`src/WebApp/PingMonitor.Web/ViewModels/Admin/AiAssistantSettingsPageViewModel.cs`, controller validation).  
- No AI runtime behaviour implemented: there are no provider HTTP clients, chat handlers, tool runtimes, Telegram routing, memories, diagnostics, or assistant runtime logic in this change.

### Testing

- Built the solution and ran unit tests: `dotnet build src/WebApp/PingMonitor.WebApp.slnx` and `dotnet test` were executed in CI/dev environment and completed successfully.  
- Unit test additions/updates: `src/WebApp/PingMonitor.Web.Tests/AiAssistantSettingsTests.cs` (covers admin-only authorization, page access, save behaviour, validation, API-key non-echo semantics, and defaults) and a small update to `StartupSchemaServiceTests` to reflect schema bump; test run passed (all tests passed).  
- Verified runtime compilation after adding the Razor view and fixed template issues during build; the test run reported all tests passing (165 passed in the test run observed).  
- Backup/restore integration paths exercised via unit-level preview/serialize code paths (no live DB integration performed during tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f2e0289dc832aaa7a2294396370ef)