### PR TITLE
Fix AI assistant prompt schema for MySQL

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AiAssistantSettingsTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiAssistantSettingsTests.cs
@@ -116,6 +116,7 @@ public sealed class AiAssistantSettingsTests
         Assert.Contains("AiAssistantSettings", source);
         Assert.Contains("ApiKeyProtected", source);
         Assert.Contains("GlobalSystemPrompt", source);
+        Assert.Contains("`GlobalSystemPrompt` longtext NOT NULL", source);
     }
 
     private sealed class FakeAiAssistantSettingsService : IAiAssistantSettingsService

--- a/src/WebApp/PingMonitor.Web.Tests/StartupSchemaServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/StartupSchemaServiceTests.cs
@@ -60,7 +60,7 @@ public sealed class StartupSchemaServiceTests
 
         Assert.Contains("\"NetworkDiagramAreas\"", source);
         Assert.Contains("\"NetworkDiagramLinkVlans\"", source);
-        Assert.Equal(20, appRequiredSchemaVersion);
+        Assert.Equal(21, appRequiredSchemaVersion);
         Assert.Contains("AiAssistantSettings", source);
         Assert.Contains("RequiredAiAssistantSettingsColumns", source);
         Assert.Equal(appRequiredSchemaVersion, developmentRequiredSchemaVersion);

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -346,7 +346,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         aiAssistantSettings.Property(x => x.MaxOutputTokens).IsRequired();
         aiAssistantSettings.Property(x => x.Temperature).IsRequired();
         aiAssistantSettings.Property(x => x.ToolCallingEnabled).IsRequired();
-        aiAssistantSettings.Property(x => x.GlobalSystemPrompt).HasMaxLength(20000).IsRequired();
+        aiAssistantSettings.Property(x => x.GlobalSystemPrompt).HasColumnType("longtext").IsRequired();
         aiAssistantSettings.Property(x => x.UpdatedAtUtc).IsRequired();
         aiAssistantSettings.Property(x => x.UpdatedByUserId).HasMaxLength(255);
 

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -716,7 +716,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 `MaxOutputTokens` int NOT NULL DEFAULT 2048,
                 `Temperature` double NOT NULL DEFAULT 0.2,
                 `ToolCallingEnabled` tinyint(1) NOT NULL DEFAULT 1,
-                `GlobalSystemPrompt` varchar(20000) NOT NULL,
+                `GlobalSystemPrompt` longtext NOT NULL,
                 `UpdatedAtUtc` datetime(6) NOT NULL,
                 `UpdatedByUserId` varchar(255) NULL,
                 PRIMARY KEY (`AiAssistantSettingsId`)
@@ -1084,6 +1084,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await EnsureSecuritySettingsColumnsAsync(dbContext, cancellationToken);
         await EnsureApplicationSettingsColumnsAsync(dbContext, cancellationToken);
         await EnsureNotificationSettingsColumnsAsync(dbContext, cancellationToken);
+        await EnsureAiAssistantSettingsSchemaAsync(dbContext, cancellationToken);
         await EnsureUserNotificationSettingsColumnsAsync(dbContext, cancellationToken);
         await EnsureAssignmentMetrics24hColumnsAsync(dbContext, cancellationToken);
         await EnsureAgentColumnsAsync(dbContext, cancellationToken);
@@ -2226,6 +2227,26 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         }
     }
 
+
+    private static async Task EnsureAiAssistantSettingsSchemaAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
+    {
+        await using var connection = dbContext.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        if (!await IsColumnLongTextAsync(connection, "AiAssistantSettings", "GlobalSystemPrompt", cancellationToken))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(
+                """
+                ALTER TABLE `AiAssistantSettings`
+                MODIFY COLUMN `GlobalSystemPrompt` longtext NOT NULL;
+                """,
+                cancellationToken);
+        }
+    }
+
     private static async Task EnsureUserNotificationSettingsColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)
     {
         await using var connection = dbContext.Database.GetDbConnection();
@@ -2474,6 +2495,30 @@ internal sealed class StartupSchemaService : IStartupSchemaService
 
         var value = await command.ExecuteScalarAsync(cancellationToken);
         return value is string dataType && string.Equals(dataType, "double", StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    private static async Task<bool> IsColumnLongTextAsync(System.Data.Common.DbConnection connection, string tableName, string columnName, CancellationToken cancellationToken)
+    {
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = @tableName
+              AND column_name = @columnName
+            LIMIT 1;
+            """;
+        AddParameter(command, "@tableName", tableName);
+        AddParameter(command, "@columnName", columnName);
+
+        var value = await command.ExecuteScalarAsync(cancellationToken);
+        return value is string dataType && string.Equals(dataType, "longtext", StringComparison.OrdinalIgnoreCase);
     }
 
     private static async Task<bool> HasCheckResultsColumnAsync(System.Data.Common.DbConnection connection, string columnName, CancellationToken cancellationToken)

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 20,
+    "RequiredSchemaVersion": 21,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 20,
+    "RequiredSchemaVersion": 21,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
### Motivation

- MySQL rejects the current `varchar(20000)` declaration for `AiAssistantSettings.GlobalSystemPrompt`, causing startup-gate schema apply failures with "Column length too big" errors.
- The startup gate must be able to both create the correct schema for new installs and repair existing databases to the supported MySQL-compatible column type.

### Description

- Change startup-gate table creation so `AiAssistantSettings.GlobalSystemPrompt` is declared as `longtext` instead of `varchar(20000)` in `StartupSchemaService`.
- Add `EnsureAiAssistantSettingsSchemaAsync` which detects non-`longtext` prompt columns and runs `ALTER TABLE ... MODIFY COLUMN ... longtext NOT NULL` to repair existing schemas at startup-gate time.
- Update EF model mapping to use `HasColumnType("longtext")` for `AiAssistantSettings.GlobalSystemPrompt` in `PingMonitorDbContext`.
- Bump `StartupGate.RequiredSchemaVersion` from `20` to `21` in both `appsettings.json` and `appsettings.Development.json`, and update unit tests to assert the new metadata and the `longtext` declaration.

### Testing

- Ran the unit test suite with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and all tests passed (`Passed: 165, Failed: 0`).
- Ran `git diff --check` and basic repository checks to ensure no whitespace or diff issues were introduced, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f3294150c832a9da89c31d9c2e409)