### PR TITLE
Add basic in-app AI Assistant web chat

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
@@ -1,0 +1,185 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using PingMonitor.Web.Controllers;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.AiChat;
+using PingMonitor.Web.Services.AiProviders;
+using PingMonitor.Web.ViewModels.AiAssistant;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class AiAssistantChatTests
+{
+    [Fact]
+    public void Controller_RequiresAuthentication()
+    {
+        Assert.Single(typeof(AiAssistantController).GetCustomAttributes(typeof(AuthorizeAttribute), true).Cast<AuthorizeAttribute>());
+    }
+
+    [Fact]
+    public async Task AuthenticatedUserCanAccessPageWhenEnabled()
+    {
+        var controller = CreateController(settings: EnabledSettings());
+        var result = Assert.IsType<ViewResult>(await controller.Index(CancellationToken.None));
+        var model = Assert.IsType<AiAssistantPageViewModel>(result.Model);
+        Assert.True(model.AssistantEnabled);
+        Assert.True(model.WebChatEnabled);
+        Assert.Null(model.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public async Task DisabledFlagsShowMessageAndDoNotCallProvider(bool assistantEnabled, bool webChatEnabled)
+    {
+        var provider = new FakeAiProviderClient();
+        var controller = CreateController(provider, EnabledSettings(assistantEnabled, webChatEnabled));
+        var result = Assert.IsType<ViewResult>(await controller.Send(new AiAssistantPageViewModel { Message = "hello" }, CancellationToken.None));
+        var model = Assert.IsType<AiAssistantPageViewModel>(result.Model);
+        Assert.Contains("disabled", model.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(provider.LastRequest);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task EmptyMessageIsRejected(string message)
+    {
+        var provider = new FakeAiProviderClient();
+        var controller = CreateController(provider, EnabledSettings());
+        var result = Assert.IsType<ViewResult>(await controller.Send(new AiAssistantPageViewModel { Message = message }, CancellationToken.None));
+        var model = Assert.IsType<AiAssistantPageViewModel>(result.Model);
+        Assert.Contains("Enter a message", model.ErrorMessage);
+        Assert.Null(provider.LastRequest);
+    }
+
+    [Fact]
+    public async Task OverlongMessageIsRejected()
+    {
+        var provider = new FakeAiProviderClient();
+        var controller = CreateController(provider, EnabledSettings());
+        var result = Assert.IsType<ViewResult>(await controller.Send(new AiAssistantPageViewModel { Message = new string('x', 4001) }, CancellationToken.None));
+        var model = Assert.IsType<AiAssistantPageViewModel>(result.Model);
+        Assert.Contains("4000", model.ErrorMessage);
+        Assert.Null(provider.LastRequest);
+    }
+
+    [Fact]
+    public async Task SuccessfulProviderResponseIsDisplayedAndHistoryIncludedOnFollowUp()
+    {
+        var provider = new FakeAiProviderClient { Result = new AiProviderChatResult { Succeeded = true, ResponseText = "Hello human", Model = "llama" } };
+        var controller = CreateController(provider, EnabledSettings(globalPrompt: "Use short replies."));
+        var first = Assert.IsType<ViewResult>(await controller.Send(new AiAssistantPageViewModel { Message = "Hello" }, CancellationToken.None));
+        var firstModel = Assert.IsType<AiAssistantPageViewModel>(first.Model);
+        Assert.Contains(firstModel.Messages, x => x.Role == "assistant" && x.Content == "Hello human");
+
+        provider.Result = new AiProviderChatResult { Succeeded = true, ResponseText = "I remember you said Hello", Model = "llama" };
+        await controller.Send(new AiAssistantPageViewModel { Message = "What did I say?", HistoryJson = firstModel.HistoryJson }, CancellationToken.None);
+
+        Assert.Contains(provider.LastRequest!.Messages, x => x.Role == "user" && x.Content == "Hello");
+        Assert.Contains(provider.LastRequest.Messages, x => x.Role == "assistant" && x.Content == "Hello human");
+    }
+
+    [Fact]
+    public async Task ProviderFailureIsDisplayedClearly()
+    {
+        var provider = new FakeAiProviderClient { Result = new AiProviderChatResult { Succeeded = false, ErrorMessage = "boom" } };
+        var controller = CreateController(provider, EnabledSettings());
+        var result = Assert.IsType<ViewResult>(await controller.Send(new AiAssistantPageViewModel { Message = "hello" }, CancellationToken.None));
+        var model = Assert.IsType<AiAssistantPageViewModel>(result.Model);
+        Assert.Contains("AI provider did not return", model.ErrorMessage);
+    }
+
+    [Fact]
+    public void ConversationHistoryIsBounded()
+    {
+        var messages = Enumerable.Range(0, 30).Select(i => new AiChatMessageDto { Role = i % 2 == 0 ? "user" : "assistant", Content = $"m{i}" });
+        var bounded = AiAssistantController.BoundHistory(messages);
+        Assert.Equal(20, bounded.Count);
+        Assert.Equal("m10", bounded[0].Content);
+    }
+
+    [Fact]
+    public void PromptLayeringIncludesSafetyPromptBeforeAdminPrompt()
+    {
+        var messages = AiChatService.BuildMessages("Site guidance", [], "How is my network looking today?");
+        Assert.Contains("do not currently have access to live monitoring data", messages[0].Content);
+        Assert.Contains("CheckResults", messages[0].Content);
+        Assert.Contains("tools", messages[0].Content);
+        Assert.Contains("Admin-configured site instructions", messages[1].Content);
+        Assert.Contains("Site guidance", messages[1].Content);
+    }
+
+    [Fact]
+    public async Task ApiKeyIsNotExposedInRenderedModelOrPrompt()
+    {
+        var provider = new FakeAiProviderClient();
+        var controller = CreateController(provider, EnabledSettings());
+        var result = Assert.IsType<ViewResult>(await controller.Send(new AiAssistantPageViewModel { Message = "hello" }, CancellationToken.None));
+        var model = Assert.IsType<AiAssistantPageViewModel>(result.Model);
+        Assert.DoesNotContain("runtime-secret", model.HistoryJson ?? string.Empty);
+        Assert.DoesNotContain(provider.LastRequest!.Messages, x => x.Content.Contains("runtime-secret", StringComparison.Ordinal));
+    }
+
+    private static AiAssistantController CreateController(AiProviderChatResult? result = null, AiAssistantSettingsDto? settings = null)
+    {
+        var provider = new FakeAiProviderClient();
+        if (result is not null) provider.Result = result;
+        return CreateController(provider, settings ?? EnabledSettings());
+    }
+
+    private static AiAssistantController CreateController(FakeAiProviderClient provider, AiAssistantSettingsDto settings)
+    {
+        var settingsService = new FakeAiAssistantSettingsService(settings);
+        var chat = new AiChatService(settingsService, provider, NullLogger<AiChatService>.Instance);
+        return new AiAssistantController(settingsService, chat);
+    }
+
+    private static AiAssistantSettingsDto EnabledSettings(bool assistantEnabled = true, bool webChatEnabled = true, string globalPrompt = "") => new()
+    {
+        AssistantEnabled = assistantEnabled,
+        WebChatEnabled = webChatEnabled,
+        ProviderType = AiAssistantSettings.OpenAICompatibleProviderType,
+        ProviderDisplayName = "Local Ollama",
+        BaseUrl = "http://localhost:11434/v1",
+        ModelName = "llama",
+        RequestTimeoutSeconds = 60,
+        MaxOutputTokens = 2048,
+        Temperature = 0.2,
+        GlobalSystemPrompt = globalPrompt
+    };
+
+    private sealed class FakeAiAssistantSettingsService : IAiAssistantSettingsService
+    {
+        private readonly AiAssistantSettingsDto _settings;
+        public FakeAiAssistantSettingsService(AiAssistantSettingsDto settings) => _settings = settings;
+        public Task<AiAssistantSettingsDto> GetCurrentAsync(CancellationToken cancellationToken) => Task.FromResult(_settings);
+        public Task<AiProviderRuntimeSettingsDto> GetProviderRuntimeSettingsAsync(CancellationToken cancellationToken) => Task.FromResult(new AiProviderRuntimeSettingsDto
+        {
+            ProviderDisplayName = _settings.ProviderDisplayName,
+            ProviderType = _settings.ProviderType,
+            BaseUrl = _settings.BaseUrl,
+            ModelName = _settings.ModelName,
+            ApiKey = "runtime-secret",
+            RequestTimeoutSeconds = _settings.RequestTimeoutSeconds,
+            MaxOutputTokens = _settings.MaxOutputTokens,
+            Temperature = _settings.Temperature,
+            ToolCallingEnabled = _settings.ToolCallingEnabled
+        });
+        public Task<AiAssistantSettingsDto> UpdateAsync(UpdateAiAssistantSettingsCommand command, CancellationToken cancellationToken) => throw new NotSupportedException();
+    }
+
+    private sealed class FakeAiProviderClient : IAiProviderClient
+    {
+        public AiProviderChatRequest? LastRequest { get; private set; }
+        public AiProviderChatResult Result { get; set; } = new() { Succeeded = true, ResponseText = "assistant response", Model = "llama" };
+        public Task<AiProviderChatResult> SendChatAsync(AiProviderChatRequest request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(Result);
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Controllers/AiAssistantController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AiAssistantController.cs
@@ -1,0 +1,125 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PingMonitor.Web.Services;
+using PingMonitor.Web.Services.AiChat;
+using PingMonitor.Web.ViewModels.AiAssistant;
+
+namespace PingMonitor.Web.Controllers;
+
+[Authorize]
+[Route("ai-assistant")]
+public sealed class AiAssistantController : Controller
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private const int MaxStoredMessages = 20;
+
+    private readonly IAiAssistantSettingsService _settingsService;
+    private readonly IAiChatService _chatService;
+
+    public AiAssistantController(IAiAssistantSettingsService settingsService, IAiChatService chatService)
+    {
+        _settingsService = settingsService;
+        _chatService = chatService;
+    }
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index(CancellationToken cancellationToken)
+    {
+        var settings = await _settingsService.GetCurrentAsync(cancellationToken);
+        var model = new AiAssistantPageViewModel
+        {
+            AssistantEnabled = settings.AssistantEnabled,
+            WebChatEnabled = settings.WebChatEnabled
+        };
+        ApplyDisabledMessage(model);
+        model.HistoryJson = SerializeHistory(model.Messages);
+        return View("Index", model);
+    }
+
+    [HttpPost("send")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Send([FromForm] AiAssistantPageViewModel model, CancellationToken cancellationToken)
+    {
+        model.Messages = ParseHistory(model.HistoryJson);
+
+        if (string.IsNullOrWhiteSpace(model.Message))
+        {
+            await PopulateFlagsAsync(model, cancellationToken);
+            model.ErrorMessage = "Enter a message before sending.";
+            model.HistoryJson = SerializeHistory(model.Messages);
+            return View("Index", model);
+        }
+
+        if (model.Message.Length > AiAssistantPageViewModel.MaxUserMessageLength)
+        {
+            await PopulateFlagsAsync(model, cancellationToken);
+            model.ErrorMessage = "Message must be 4000 characters or fewer.";
+            model.HistoryJson = SerializeHistory(model.Messages);
+            return View("Index", model);
+        }
+
+        var userMessage = model.Message.Trim();
+        var response = await _chatService.SendAsync(new AiChatRequest { ConversationHistory = model.Messages, UserMessage = userMessage }, cancellationToken);
+        model.AssistantEnabled = response.AssistantEnabled;
+        model.WebChatEnabled = response.WebChatEnabled;
+        model.Message = string.Empty;
+
+        if (response.Succeeded && !string.IsNullOrWhiteSpace(response.AssistantMessage))
+        {
+            model.Messages.Add(new AiChatMessageDto { Role = "user", Content = userMessage });
+            model.Messages.Add(new AiChatMessageDto { Role = "assistant", Content = response.AssistantMessage });
+            model.Messages = BoundHistory(model.Messages);
+            model.StatusMessage = "AI assistant response received.";
+        }
+        else
+        {
+            model.ErrorMessage = response.ErrorMessage ?? "The AI provider did not return a response. Check the AI Assistant settings and the local Ollama/OpenAI-compatible endpoint.";
+        }
+
+        model.HistoryJson = SerializeHistory(model.Messages);
+        return View("Index", model);
+    }
+
+    [HttpPost("clear")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Clear(CancellationToken cancellationToken)
+    {
+        var settings = await _settingsService.GetCurrentAsync(cancellationToken);
+        var model = new AiAssistantPageViewModel { AssistantEnabled = settings.AssistantEnabled, WebChatEnabled = settings.WebChatEnabled, StatusMessage = "Conversation cleared." };
+        ApplyDisabledMessage(model);
+        model.HistoryJson = SerializeHistory(model.Messages);
+        return View("Index", model);
+    }
+
+    internal static IList<AiChatMessageDto> BoundHistory(IEnumerable<AiChatMessageDto> messages) => messages
+        .Where(x => x.Role is "user" or "assistant" && !string.IsNullOrWhiteSpace(x.Content))
+        .Select(x => new AiChatMessageDto { Role = x.Role, Content = x.Content.Length <= AiAssistantPageViewModel.MaxUserMessageLength ? x.Content : x.Content[..AiAssistantPageViewModel.MaxUserMessageLength] })
+        .TakeLast(MaxStoredMessages)
+        .ToList();
+
+    private async Task PopulateFlagsAsync(AiAssistantPageViewModel model, CancellationToken cancellationToken)
+    {
+        var settings = await _settingsService.GetCurrentAsync(cancellationToken);
+        model.AssistantEnabled = settings.AssistantEnabled;
+        model.WebChatEnabled = settings.WebChatEnabled;
+        ApplyDisabledMessage(model);
+    }
+
+    private static IList<AiChatMessageDto> ParseHistory(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new List<AiChatMessageDto>();
+        try { return BoundHistory(JsonSerializer.Deserialize<List<AiChatMessageDto>>(json, JsonOptions) ?? []); }
+        catch (JsonException) { return new List<AiChatMessageDto>(); }
+    }
+
+    private static string SerializeHistory(IEnumerable<AiChatMessageDto> messages) => JsonSerializer.Serialize(BoundHistory(messages), JsonOptions);
+
+    private static void ApplyDisabledMessage(AiAssistantPageViewModel model)
+    {
+        if (!model.AssistantEnabled || !model.WebChatEnabled)
+        {
+            model.ErrorMessage ??= "AI web chat is disabled. An administrator can enable it from Admin > AI Assistant settings.";
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -13,6 +13,7 @@ using PingMonitor.Web.Options;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.Agents;
 using PingMonitor.Web.Services.AiProviders;
+using PingMonitor.Web.Services.AiChat;
 using PingMonitor.Web.Services.Backups;
 using PingMonitor.Web.Services.BufferedResults;
 using PingMonitor.Web.Services.Endpoints;
@@ -200,6 +201,7 @@ builder.Services.AddScoped<IAgentProvisioningService, AgentProvisioningService>(
 builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsService>();
 builder.Services.AddScoped<IAiAssistantSettingsService, AiAssistantSettingsService>();
 builder.Services.AddScoped<IAiProviderClient, OpenAiCompatibleProviderClient>();
+builder.Services.AddScoped<IAiChatService, AiChatService>();
 builder.Services.AddSingleton<IApplicationMetadataProvider, ApplicationMetadataProvider>();
 builder.Services.AddHttpClient(nameof(OpenAiCompatibleProviderClient));
 builder.Services.AddHttpClient(nameof(GitHubReleaseLookupService));

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatModels.cs
@@ -1,0 +1,24 @@
+namespace PingMonitor.Web.Services.AiChat;
+
+public sealed class AiChatRequest
+{
+    public IList<AiChatMessageDto> ConversationHistory { get; set; } = new List<AiChatMessageDto>();
+    public string UserMessage { get; set; } = string.Empty;
+}
+
+public sealed class AiChatResponse
+{
+    public bool Succeeded { get; set; }
+    public bool AssistantEnabled { get; set; }
+    public bool WebChatEnabled { get; set; }
+    public string? AssistantMessage { get; set; }
+    public string? ErrorMessage { get; set; }
+    public string? ProviderName { get; set; }
+    public string? ModelName { get; set; }
+}
+
+public sealed class AiChatMessageDto
+{
+    public string Role { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+}

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs
@@ -1,0 +1,110 @@
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.AiProviders;
+
+namespace PingMonitor.Web.Services.AiChat;
+
+internal sealed class AiChatService : IAiChatService
+{
+    public const int MaxHistoryMessages = 20;
+    public const int MaxPromptCharacters = 24000;
+    public const string BuiltInSystemPrompt = """
+You are the Ping Monitor AI assistant.
+
+This is an early chat-only test mode.
+You are read-only.
+You do not currently have access to live monitoring data, endpoint metrics, agents, diagrams, CheckResults, tools, memories, or the database.
+If the user asks about current network state, endpoints, diagrams, outages, ports, VLANs, or metrics, explain that those tools are not connected yet.
+Do not invent network facts.
+You may answer general questions and help explain what future Ping Monitor AI features will be able to do.
+""";
+
+    private readonly IAiAssistantSettingsService _settingsService;
+    private readonly IAiProviderClient _providerClient;
+    private readonly ILogger<AiChatService> _logger;
+
+    public AiChatService(IAiAssistantSettingsService settingsService, IAiProviderClient providerClient, ILogger<AiChatService> logger)
+    {
+        _settingsService = settingsService;
+        _providerClient = providerClient;
+        _logger = logger;
+    }
+
+    public async Task<AiChatResponse> SendAsync(AiChatRequest request, CancellationToken cancellationToken)
+    {
+        var settings = await _settingsService.GetCurrentAsync(cancellationToken);
+        if (!settings.AssistantEnabled)
+        {
+            return new AiChatResponse { AssistantEnabled = false, WebChatEnabled = settings.WebChatEnabled, ErrorMessage = "AI assistant is disabled. An administrator can enable it from Admin > AI Assistant settings." };
+        }
+
+        if (!settings.WebChatEnabled)
+        {
+            return new AiChatResponse { AssistantEnabled = true, WebChatEnabled = false, ErrorMessage = "AI web chat is disabled. An administrator can enable it from Admin > AI Assistant settings." };
+        }
+
+        var runtime = await _settingsService.GetProviderRuntimeSettingsAsync(cancellationToken);
+        if (!string.Equals(runtime.ProviderType, AiAssistantSettings.OpenAICompatibleProviderType, StringComparison.Ordinal))
+        {
+            return ConfigurationError(settings, "AI provider configuration is incomplete. Provider type must be OpenAICompatible.");
+        }
+
+        if (!Uri.TryCreate(runtime.BaseUrl, UriKind.Absolute, out var baseUri) || (baseUri.Scheme != Uri.UriSchemeHttp && baseUri.Scheme != Uri.UriSchemeHttps))
+        {
+            return ConfigurationError(settings, "AI provider configuration is incomplete. A valid HTTP or HTTPS base URL is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(runtime.ModelName))
+        {
+            return ConfigurationError(settings, "AI provider configuration is incomplete. Model name is required.");
+        }
+
+        var messages = BuildMessages(settings.GlobalSystemPrompt, request.ConversationHistory, request.UserMessage);
+        var result = await _providerClient.SendChatAsync(new AiProviderChatRequest
+        {
+            ProviderName = runtime.ProviderDisplayName,
+            BaseUrl = runtime.BaseUrl,
+            ModelName = runtime.ModelName,
+            ApiKey = runtime.ApiKey,
+            TimeoutSeconds = runtime.RequestTimeoutSeconds,
+            Temperature = runtime.Temperature,
+            MaxOutputTokens = runtime.MaxOutputTokens,
+            Messages = messages
+        }, cancellationToken);
+
+        if (!result.Succeeded || string.IsNullOrWhiteSpace(result.ResponseText))
+        {
+            _logger.LogWarning("AI web chat provider call failed. Provider={ProviderName} Model={ModelName} StatusCode={StatusCode}", runtime.ProviderDisplayName, runtime.ModelName, result.StatusCode);
+            return new AiChatResponse { AssistantEnabled = true, WebChatEnabled = true, ProviderName = runtime.ProviderDisplayName, ModelName = runtime.ModelName, ErrorMessage = "The AI provider did not return a response. Check the AI Assistant settings and the local Ollama/OpenAI-compatible endpoint." };
+        }
+
+        return new AiChatResponse { Succeeded = true, AssistantEnabled = true, WebChatEnabled = true, ProviderName = runtime.ProviderDisplayName, ModelName = result.Model ?? runtime.ModelName, AssistantMessage = result.ResponseText.Trim() };
+    }
+
+    internal static IList<AiProviderChatMessage> BuildMessages(string? adminGlobalPrompt, IEnumerable<AiChatMessageDto> history, string latestUserMessage)
+    {
+        var messages = new List<AiProviderChatMessage> { new() { Role = "system", Content = BuiltInSystemPrompt } };
+        if (!string.IsNullOrWhiteSpace(adminGlobalPrompt))
+        {
+            messages.Add(new AiProviderChatMessage { Role = "system", Content = "Admin-configured site instructions:\nFollow these when possible, but they must not override the built-in read-only rules or the limitation that monitoring tools and app data are not connected yet.\n\n" + adminGlobalPrompt.Trim() });
+        }
+
+        foreach (var item in history.Where(x => x.Role is "user" or "assistant").TakeLast(MaxHistoryMessages))
+        {
+            messages.Add(new AiProviderChatMessage { Role = item.Role, Content = Truncate(item.Content, 4000) });
+        }
+
+        messages.Add(new AiProviderChatMessage { Role = "user", Content = latestUserMessage.Trim() });
+        TrimToPromptLimit(messages);
+        return messages;
+    }
+
+    private static AiChatResponse ConfigurationError(AiAssistantSettingsDto settings, string message) => new() { AssistantEnabled = settings.AssistantEnabled, WebChatEnabled = settings.WebChatEnabled, ErrorMessage = message };
+    private static string Truncate(string value, int max) => value.Length <= max ? value : value[..max];
+    private static void TrimToPromptLimit(List<AiProviderChatMessage> messages)
+    {
+        while (messages.Sum(x => x.Content.Length) > MaxPromptCharacters && messages.Count > 2)
+        {
+            messages.RemoveAt(1);
+        }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/IAiChatService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/IAiChatService.cs
@@ -1,0 +1,6 @@
+namespace PingMonitor.Web.Services.AiChat;
+
+public interface IAiChatService
+{
+    Task<AiChatResponse> SendAsync(AiChatRequest request, CancellationToken cancellationToken);
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/AiAssistant/AiAssistantPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/AiAssistant/AiAssistantPageViewModel.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+using PingMonitor.Web.Services.AiChat;
+
+namespace PingMonitor.Web.ViewModels.AiAssistant;
+
+public sealed class AiAssistantPageViewModel
+{
+    public const int MaxUserMessageLength = 4000;
+
+    [Display(Name = "Message")]
+    [StringLength(MaxUserMessageLength, ErrorMessage = "Message must be 4000 characters or fewer.")]
+    public string? Message { get; set; }
+
+    public string? HistoryJson { get; set; }
+    public IList<AiChatMessageDto> Messages { get; set; } = new List<AiChatMessageDto>();
+    public bool AssistantEnabled { get; set; }
+    public bool WebChatEnabled { get; set; }
+    public string? StatusMessage { get; set; }
+    public string? ErrorMessage { get; set; }
+    public string HelpText { get; set; } = "This is the first AI chat test interface. It can talk to the configured model, but monitoring tools, metrics, diagram lookup, Telegram routing, and memory are not connected yet.";
+}

--- a/src/WebApp/PingMonitor.Web/Views/AiAssistant/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AiAssistant/Index.cshtml
@@ -1,0 +1,92 @@
+@model PingMonitor.Web.ViewModels.AiAssistant.AiAssistantPageViewModel
+@{
+    ViewData["Title"] = "AI Assistant";
+    var canSend = Model.AssistantEnabled && Model.WebChatEnabled;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    @await Html.PartialAsync("_ThemeHead")
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AI Assistant</title>
+    <style>
+        :root { color-scheme: light; --bg: #f3f6f8; --card: #ffffff; --text: #102a43; --muted: #52606d; --border: #d9e2ec; --accent: #0f62fe; --danger: #b42318; --ok: #137333; --surface-1: #fff; --surface-2: #eef4ff; }
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background: var(--bg); color: var(--text); }
+        main { max-width: 920px; margin: 0 auto; padding: 1rem; }
+        .stack { display: grid; gap: 1rem; }
+        .card { background: var(--card); border: 1px solid var(--border); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
+        .muted { color: var(--muted); }
+        .alert { border-radius: 12px; padding: .85rem; border: 1px solid var(--border); }
+        .alert-error { background: #fff3f2; color: var(--danger); border-color: #fecdca; }
+        .alert-ok { background: #e7f6ec; color: var(--ok); border-color: #abefc6; }
+        .transcript { display: grid; gap: .75rem; }
+        .message { border: 1px solid var(--border); border-radius: 12px; padding: .85rem; white-space: pre-wrap; overflow-wrap: anywhere; }
+        .message-user { background: #eef4ff; }
+        .message-assistant { background: #fff; }
+        .message-role { display: block; font-weight: 700; margin-bottom: .35rem; }
+        label { display: block; font-weight: 700; margin-bottom: .35rem; }
+        textarea { width: 100%; min-height: 120px; padding: .85rem; border: 1px solid var(--border); border-radius: 10px; font: inherit; resize: vertical; }
+        .button-row { display: flex; flex-wrap: wrap; gap: .75rem; align-items: center; }
+        .button, .button-secondary { min-height: 48px; border-radius: 10px; padding: .8rem 1rem; font-weight: 700; cursor: pointer; }
+        .button { border: 0; background: var(--accent); color: #fff; }
+        .button-secondary { border: 1px solid var(--border); background: #fff; color: var(--text); }
+        .button[disabled] { opacity: .55; cursor: not-allowed; }
+    </style>
+</head>
+<body>
+    @await Html.PartialAsync("_AuthenticatedNav")
+    <main class="stack">
+        <section class="card">
+            <h1>AI Assistant</h1>
+            <p class="muted">@Model.HelpText</p>
+        </section>
+
+        @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
+        {
+            <div class="alert alert-error">@Model.ErrorMessage</div>
+        }
+        @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
+        {
+            <div class="alert alert-ok">@Model.StatusMessage</div>
+        }
+
+        <section class="card transcript" aria-label="Chat transcript">
+            @if (Model.Messages.Count == 0)
+            {
+                <p class="muted">No messages yet. Send a message to start a short-lived browser-session conversation.</p>
+            }
+            else
+            {
+                @foreach (var message in Model.Messages)
+                {
+                    <article class="message @(message.Role == "user" ? "message-user" : "message-assistant")">
+                        <span class="message-role">@(message.Role == "user" ? "You" : "Assistant")</span>
+                        @message.Content
+                    </article>
+                }
+            }
+        </section>
+
+        <section class="card">
+            <form asp-controller="AiAssistant" asp-action="Send" method="post" class="stack">
+                @Html.AntiForgeryToken()
+                <input type="hidden" asp-for="HistoryJson" />
+                <div>
+                    <label asp-for="Message"></label>
+                    <textarea asp-for="Message" maxlength="4000" disabled="@(!canSend)" placeholder="Ask a general question. Live monitoring data and tools are not connected yet."></textarea>
+                    <span asp-validation-for="Message"></span>
+                </div>
+                <div class="button-row">
+                    <button class="button" type="submit" disabled="@(!canSend)">Send</button>
+                </div>
+            </form>
+            <form asp-controller="AiAssistant" asp-action="Clear" method="post" style="margin-top: .75rem;">
+                @Html.AntiForgeryToken()
+                <button class="button-secondary" type="submit">Clear conversation</button>
+            </form>
+        </section>
+    </main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -1,14 +1,18 @@
 @using PingMonitor.Web.Services.Identity
 @inject PingMonitor.Web.Services.IApplicationSettingsService ApplicationSettingsService
+@inject PingMonitor.Web.Services.IAiAssistantSettingsService AiAssistantSettingsService
 @{
     var path = Context?.Request?.Path.Value ?? string.Empty;
     var isAdmin = User.IsInRole(ApplicationRoles.Admin);
     var networkDiagramsEnabled = false;
+    var aiWebChatEnabled = false;
     if (User.Identity?.IsAuthenticated == true)
     {
         var cancellationToken = Context?.RequestAborted ?? CancellationToken.None;
         var applicationSettings = await ApplicationSettingsService.GetCurrentAsync(cancellationToken);
         networkDiagramsEnabled = applicationSettings.NetworkDiagramsEnabled;
+        var aiSettings = await AiAssistantSettingsService.GetCurrentAsync(cancellationToken);
+        aiWebChatEnabled = aiSettings.AssistantEnabled && aiSettings.WebChatEnabled;
     }
 
     static bool IsCurrent(string path, params string[] prefixes)
@@ -29,6 +33,7 @@
     var eventsOpen = IsCurrent(path, "/admin/security");
     var adminOpen = IsCurrent(path, "/admin", "/users", "/settings/notifications");
     var profileOpen = IsCurrent(path, "/profile");
+    var aiOpen = IsCurrent(path, "/ai-assistant");
     var infoOpen = IsCurrent(path, "/about");
 }
 <style>
@@ -270,6 +275,11 @@
                     <a class="site-nav-link" data-current="@IsCurrent(path, "/users")" href="/users">User management</a>
                 </div>
             </details>
+        }
+
+        @if (aiWebChatEnabled)
+        {
+            <a class="site-nav-shortcut" data-current="@aiOpen" href="/ai-assistant">AI Assistant</a>
         }
 
 


### PR DESCRIPTION
### Motivation
- Provide the initial V0.2.x AI Assistant web-chat slice so authenticated users can have a short-lived multi-turn conversation with the configured OpenAI-compatible provider without exposing monitoring data or tools.
- Keep the change small and safe: read-only chat, bounded session history, and strict feature gating to avoid impacting production monitoring behaviour.

### Description
- Adds an authenticated route `/ai-assistant` with GET, `POST /send`, and `POST /clear` actions and an anti-forgery-protected form-based chat UI (Razor view at `src/WebApp/PingMonitor.Web/Views/AiAssistant/Index.cshtml`).
- Introduces `IAiChatService` / `AiChatService` and DTOs (`AiChatRequest`, `AiChatResponse`, `AiChatMessageDto`) to encapsulate prompt building and provider calls; the service uses the existing `IAiProviderClient` for OpenAI-compatible chat completions and validates runtime settings before calling the provider (no tool calling, no app data sent). (Fixes/links issue #555)
- Conversation state is kept short-lived in the browser via a hidden `HistoryJson` form field and bounded on the server: last 20 messages (user/assistant), per-message cap 4000 chars, total prompt cap enforced before provider calls; `HistoryJson` is the only per-session storage (no DB tables added).
- Adds a built-in read-only system prompt (shipped with the app) that forbids inventing monitoring facts and explains the assistant has no access to live monitoring/diagrams/tools, then appends the admin global prompt as subordinate site instructions.
- Enforces feature flags and configuration checks: returns clear disabled/configuration/provider-failure messages when `AssistantEnabled` or `WebChatEnabled` are false, provider type is not `OpenAICompatible`, base URL is invalid, or model name is missing.
- UI and navigation: mobile-readable chat page, Send and Clear controls, and an authenticated nav shortcut shown only when the assistant and web chat flags are enabled (`src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml`).
- Files added/modified (key): `src/WebApp/PingMonitor.Web/Controllers/AiAssistantController.cs`, `src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs`, `src/WebApp/PingMonitor.Web/Services/AiChat/AiChatModels.cs`, `src/WebApp/PingMonitor.Web/Services/AiChat/IAiChatService.cs`, `src/WebApp/PingMonitor.Web/ViewModels/AiAssistant/AiAssistantPageViewModel.cs`, `src/WebApp/PingMonitor.Web/Views/AiAssistant/Index.cshtml`, `src/WebApp/PingMonitor.Web/Program.cs` (DI registration), `src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml`, and unit tests at `src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs`.

### Testing
- Automated build: `PATH=/tmp/dotnet10:$PATH dotnet build src/WebApp/PingMonitor.WebApp.slnx` — succeeded.
- Unit tests: `PATH=/tmp/dotnet10:$PATH dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` — test run passed (all tests green; 186 passed in this environment).
- Added tests (`AiAssistantChatTests`) cover authentication requirement, feature gating (`AssistantEnabled`/`WebChatEnabled`), empty/overlong message validation, successful provider responses and follow-up history inclusion, provider failure handling, conversation bounding, prompt layering (built-in safety before admin prompt), and that runtime API keys are not exposed; tests use fake provider/settings services so they do not require a real Ollama/OpenAI endpoint.
- Manual smoke test steps are documented for local verification (start Ollama, enable assistant & web chat, exercise the UI), but interactive browser smoke was not performed here because the environment is not configured for a running web app with MySQL/Ollama in this session.

No database schema changes, no tool-calling, no metrics/CheckResults/diagram/Telegram/memory/persistent chat history/streaming/autonomous behaviour were implemented in this slice.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f412e3428832aa53180319d3cc641)