### PR TITLE
AI Assistant: increase request timeout to 180/600s and fix top-nav layout

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
@@ -146,7 +146,7 @@ public sealed class AiAssistantChatTests
         ProviderDisplayName = "Local Ollama",
         BaseUrl = "http://localhost:11434/v1",
         ModelName = "llama",
-        RequestTimeoutSeconds = 60,
+        RequestTimeoutSeconds = 180,
         MaxOutputTokens = 2048,
         Temperature = 0.2,
         GlobalSystemPrompt = globalPrompt

--- a/src/WebApp/PingMonitor.Web.Tests/AiAssistantSettingsTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiAssistantSettingsTests.cs
@@ -42,7 +42,7 @@ public sealed class AiAssistantSettingsTests
             ProviderType = AiAssistantSettings.OpenAICompatibleProviderType,
             ProviderDisplayName = "Ops AI",
             ApiKey = "secret",
-            RequestTimeoutSeconds = 60,
+            RequestTimeoutSeconds = 600,
             MaxOutputTokens = 2048,
             Temperature = 0.2,
             ToolCallingEnabled = true
@@ -52,6 +52,7 @@ public sealed class AiAssistantSettingsTests
         Assert.True(model.Saved);
         Assert.Null(model.ApiKey);
         Assert.Equal("secret", service.LastCommand?.ApiKey);
+        Assert.Equal(600, service.LastCommand?.RequestTimeoutSeconds);
     }
 
     [Theory]
@@ -59,6 +60,7 @@ public sealed class AiAssistantSettingsTests
     [InlineData(true, "ftp://example.test", "model", 60, 2048, 0.2)]
     [InlineData(true, "https://example.test/v1", "", 60, 2048, 0.2)]
     [InlineData(true, "https://example.test/v1", "model", 0, 2048, 0.2)]
+    [InlineData(true, "https://example.test/v1", "model", 601, 2048, 0.2)]
     [InlineData(true, "https://example.test/v1", "model", 60, 63, 0.2)]
     [InlineData(true, "https://example.test/v1", "model", 60, 2048, 2.1)]
     public async Task InvalidSettingsAreRejected(bool enabled, string baseUrl, string modelName, int timeout, int tokens, double temperature)
@@ -66,7 +68,7 @@ public sealed class AiAssistantSettingsTests
         var service = new FakeAiAssistantSettingsService(new AiAssistantSettingsDto());
         var controller = new AdminAiAssistantSettingsController(service, new FakeAiProviderClient());
         controller.ModelState.Clear();
-        if (timeout is < 1 or > 300) controller.ModelState.AddModelError(nameof(AiAssistantSettingsPageViewModel.RequestTimeoutSeconds), "range");
+        if (timeout is < 1 or > 600) controller.ModelState.AddModelError(nameof(AiAssistantSettingsPageViewModel.RequestTimeoutSeconds), "range");
         if (tokens is < 64 or > 32768) controller.ModelState.AddModelError(nameof(AiAssistantSettingsPageViewModel.MaxOutputTokens), "range");
         if (temperature is < 0 or > 2) controller.ModelState.AddModelError(nameof(AiAssistantSettingsPageViewModel.Temperature), "range");
 
@@ -127,7 +129,7 @@ public sealed class AiAssistantSettingsTests
             BaseUrl = "http://localhost:11434/v1",
             ModelName = "llama",
             MaxOutputTokens = 2048,
-            RequestTimeoutSeconds = 60,
+            RequestTimeoutSeconds = 180,
             Temperature = 0.2
         }), provider);
 
@@ -138,6 +140,7 @@ public sealed class AiAssistantSettingsTests
         Assert.Equal("Ping Monitor AI test OK", model.TestResult.ResponseText);
         Assert.Null(model.ApiKey);
         Assert.Equal("runtime-secret", provider.LastRequest!.ApiKey);
+        Assert.Equal(180, provider.LastRequest.TimeoutSeconds);
         Assert.Equal(256, provider.LastRequest.MaxOutputTokens);
     }
 
@@ -160,7 +163,7 @@ public sealed class AiAssistantSettingsTests
         Assert.Equal("Local Ollama", settings.ProviderDisplayName);
         Assert.Equal("OpenAICompatible", settings.ProviderType);
         Assert.Equal("http://localhost:11434/v1", settings.BaseUrl);
-        Assert.Equal(60, settings.RequestTimeoutSeconds);
+        Assert.Equal(180, settings.RequestTimeoutSeconds);
         Assert.Equal(2048, settings.MaxOutputTokens);
         Assert.Equal(0.2, settings.Temperature);
         Assert.True(settings.ToolCallingEnabled);

--- a/src/WebApp/PingMonitor.Web.Tests/OpenAiCompatibleProviderClientTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/OpenAiCompatibleProviderClientTests.cs
@@ -80,7 +80,7 @@ public sealed class OpenAiCompatibleProviderClientTests
         BaseUrl = baseUrl,
         ModelName = "llama",
         ApiKey = "secret",
-        TimeoutSeconds = 60,
+        TimeoutSeconds = 180,
         Temperature = 0.2,
         MaxOutputTokens = 256,
         Messages = { new AiProviderChatMessage { Role = "system", Content = "sys" }, new AiProviderChatMessage { Role = "user", Content = "user" } }

--- a/src/WebApp/PingMonitor.Web.Tests/StartupSchemaServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/StartupSchemaServiceTests.cs
@@ -60,7 +60,7 @@ public sealed class StartupSchemaServiceTests
 
         Assert.Contains("\"NetworkDiagramAreas\"", source);
         Assert.Contains("\"NetworkDiagramLinkVlans\"", source);
-        Assert.Equal(21, appRequiredSchemaVersion);
+        Assert.Equal(22, appRequiredSchemaVersion);
         Assert.Contains("AiAssistantSettings", source);
         Assert.Contains("RequiredAiAssistantSettingsColumns", source);
         Assert.Equal(appRequiredSchemaVersion, developmentRequiredSchemaVersion);

--- a/src/WebApp/PingMonitor.Web/Controllers/AdminAiAssistantSettingsController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AdminAiAssistantSettingsController.cs
@@ -140,6 +140,11 @@ public sealed class AdminAiAssistantSettingsController : Controller
         {
             ModelState.AddModelError(nameof(model.BaseUrl), "Base URL must be an absolute http or https URL.");
         }
+
+        if (model.RequestTimeoutSeconds is < 1 or > 600)
+        {
+            ModelState.AddModelError(nameof(model.RequestTimeoutSeconds), "Request timeout seconds must be between 1 and 600.");
+        }
     }
 
     private static AiAssistantSettingsPageViewModel ToViewModel(AiAssistantSettingsDto settings, bool saved)

--- a/src/WebApp/PingMonitor.Web/Models/AiAssistantSettings.cs
+++ b/src/WebApp/PingMonitor.Web/Models/AiAssistantSettings.cs
@@ -16,7 +16,7 @@ public sealed class AiAssistantSettings
     public string BaseUrl { get; set; } = "http://localhost:11434/v1";
     public string ModelName { get; set; } = string.Empty;
     public string? ApiKeyProtected { get; set; }
-    public int RequestTimeoutSeconds { get; set; } = 60;
+    public int RequestTimeoutSeconds { get; set; } = 180;
     public int MaxOutputTokens { get; set; } = 2048;
     public double Temperature { get; set; } = 0.2;
     public bool ToolCallingEnabled { get; set; } = true;

--- a/src/WebApp/PingMonitor.Web/Services/AiAssistantSettingsDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiAssistantSettingsDto.cs
@@ -12,7 +12,7 @@ public sealed class AiAssistantSettingsDto
     public string BaseUrl { get; set; } = "http://localhost:11434/v1";
     public string ModelName { get; set; } = string.Empty;
     public bool ApiKeyConfigured { get; set; }
-    public int RequestTimeoutSeconds { get; set; } = 60;
+    public int RequestTimeoutSeconds { get; set; } = 180;
     public int MaxOutputTokens { get; set; } = 2048;
     public double Temperature { get; set; } = 0.2;
     public bool ToolCallingEnabled { get; set; } = true;

--- a/src/WebApp/PingMonitor.Web/Services/AiAssistantSettingsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiAssistantSettingsService.cs
@@ -106,7 +106,7 @@ internal sealed class AiAssistantSettingsService : IAiAssistantSettingsService
             ProviderType = AiAssistantSettings.OpenAICompatibleProviderType,
             BaseUrl = "http://localhost:11434/v1",
             ModelName = string.Empty,
-            RequestTimeoutSeconds = 60,
+            RequestTimeoutSeconds = 180,
             MaxOutputTokens = 2048,
             Temperature = 0.2,
             ToolCallingEnabled = true,

--- a/src/WebApp/PingMonitor.Web/Services/AiProviderRuntimeSettingsDto.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiProviderRuntimeSettingsDto.cs
@@ -7,7 +7,7 @@ public sealed class AiProviderRuntimeSettingsDto
     public string BaseUrl { get; set; } = "http://localhost:11434/v1";
     public string ModelName { get; set; } = string.Empty;
     public string? ApiKey { get; set; }
-    public int RequestTimeoutSeconds { get; set; } = 60;
+    public int RequestTimeoutSeconds { get; set; } = 180;
     public int MaxOutputTokens { get; set; } = 2048;
     public double Temperature { get; set; } = 0.2;
     public bool ToolCallingEnabled { get; set; } = true;

--- a/src/WebApp/PingMonitor.Web/Services/AiProviders/AiProviderModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiProviders/AiProviderModels.cs
@@ -6,7 +6,7 @@ public sealed class AiProviderChatRequest
     public string BaseUrl { get; set; } = string.Empty;
     public string ModelName { get; set; } = string.Empty;
     public string? ApiKey { get; set; }
-    public int TimeoutSeconds { get; set; } = 60;
+    public int TimeoutSeconds { get; set; } = 180;
     public double Temperature { get; set; } = 0.2;
     public int MaxOutputTokens { get; set; } = 256;
     public IList<AiProviderChatMessage> Messages { get; set; } = new List<AiProviderChatMessage>();

--- a/src/WebApp/PingMonitor.Web/Services/AiProviders/OpenAiCompatibleProviderClient.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiProviders/OpenAiCompatibleProviderClient.cs
@@ -37,7 +37,7 @@ internal sealed class OpenAiCompatibleProviderClient : IAiProviderClient
         if (request.Messages.Count == 0) return Fail(result, sw, "At least one message is required.");
 
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeoutCts.CancelAfter(TimeSpan.FromSeconds(Math.Clamp(request.TimeoutSeconds, 1, 300)));
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(Math.Clamp(request.TimeoutSeconds, 1, 600)));
 
         try
         {

--- a/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Backups/ConfigurationRestoreService.cs
@@ -868,7 +868,7 @@ public sealed class ConfigurationRestoreService : IConfigurationRestoreService
         target.BaseUrl = source.BaseUrl ?? string.Empty;
         target.ModelName = source.ModelName ?? string.Empty;
         target.ApiKeyProtected = source.ApiKeyProtected;
-        target.RequestTimeoutSeconds = source.RequestTimeoutSeconds <= 0 ? 60 : source.RequestTimeoutSeconds;
+        target.RequestTimeoutSeconds = source.RequestTimeoutSeconds <= 0 ? 180 : source.RequestTimeoutSeconds;
         target.MaxOutputTokens = source.MaxOutputTokens <= 0 ? 2048 : source.MaxOutputTokens;
         target.Temperature = source.Temperature;
         target.ToolCallingEnabled = source.ToolCallingEnabled;

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -712,7 +712,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 `BaseUrl` varchar(2048) NOT NULL DEFAULT 'http://localhost:11434/v1',
                 `ModelName` varchar(255) NOT NULL DEFAULT '',
                 `ApiKeyProtected` varchar(4096) NULL,
-                `RequestTimeoutSeconds` int NOT NULL DEFAULT 60,
+                `RequestTimeoutSeconds` int NOT NULL DEFAULT 180,
                 `MaxOutputTokens` int NOT NULL DEFAULT 2048,
                 `Temperature` double NOT NULL DEFAULT 0.2,
                 `ToolCallingEnabled` tinyint(1) NOT NULL DEFAULT 1,
@@ -2245,6 +2245,13 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 """,
                 cancellationToken);
         }
+
+        await dbContext.Database.ExecuteSqlRawAsync(
+            """
+            ALTER TABLE `AiAssistantSettings`
+            MODIFY COLUMN `RequestTimeoutSeconds` int NOT NULL DEFAULT 180;
+            """,
+            cancellationToken);
     }
 
     private static async Task EnsureUserNotificationSettingsColumnsAsync(PingMonitorDbContext dbContext, CancellationToken cancellationToken)

--- a/src/WebApp/PingMonitor.Web/ViewModels/Admin/AiAssistantSettingsPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/Admin/AiAssistantSettingsPageViewModel.cs
@@ -35,8 +35,8 @@ public sealed class AiAssistantSettingsPageViewModel
     public bool ApiKeyConfigured { get; set; }
 
     [Display(Name = "Request timeout seconds")]
-    [Range(1, 300)]
-    public int RequestTimeoutSeconds { get; set; } = 60;
+    [Range(1, 600)]
+    public int RequestTimeoutSeconds { get; set; } = 180;
     [Display(Name = "Max output tokens")]
     [Range(64, 32768)]
     public int MaxOutputTokens { get; set; } = 2048;

--- a/src/WebApp/PingMonitor.Web/Views/AdminAiAssistantSettings/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminAiAssistantSettings/Index.cshtml
@@ -77,7 +77,7 @@
         <section class="card grid">
             <h2>Model behaviour</h2>
             <div class="grid two">
-                <div><label asp-for="RequestTimeoutSeconds"></label><input asp-for="RequestTimeoutSeconds" type="number" min="1" max="300" /><span class="validation" asp-validation-for="RequestTimeoutSeconds"></span></div>
+                <div><label asp-for="RequestTimeoutSeconds"></label><input asp-for="RequestTimeoutSeconds" type="number" min="1" max="600" /><p class="field-help">Default: 180 seconds. Maximum: 600 seconds.</p><span class="validation" asp-validation-for="RequestTimeoutSeconds"></span></div>
                 <div><label asp-for="MaxOutputTokens"></label><input asp-for="MaxOutputTokens" type="number" min="64" max="32768" /><span class="validation" asp-validation-for="MaxOutputTokens"></span></div>
                 <div><label asp-for="Temperature"></label><input asp-for="Temperature" type="number" min="0" max="2" step="0.1" /><span class="validation" asp-validation-for="Temperature"></span></div>
                 <div class="checkbox-row"><input asp-for="ToolCallingEnabled" type="checkbox" /><input name="ToolCallingEnabled" type="hidden" value="false" /><label asp-for="ToolCallingEnabled"></label></div>

--- a/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/Shared/_AuthenticatedNav.cshtml
@@ -137,6 +137,8 @@
         border: 1px solid var(--border);
         background: var(--surface-1);
         min-width: 110px;
+        width: auto;
+        flex: 0 0 auto;
         justify-content: center;
         font-weight: 700;
     }

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 21,
+    "RequiredSchemaVersion": 22,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 21,
+    "RequiredSchemaVersion": 22,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
### Motivation

- The AI Assistant web chat and admin settings need a higher default and maximum request timeout for real-world provider latencies and long-running model responses.
- A recent nav change caused the AI Assistant link to stretch and disrupt the top navigation layout, so it must be constrained to match other shortcuts.
- Changing the database default for the AI timeout requires a Startup Gate/schema metadata alignment per platform rules.

### Description

- Raised AI provider request default from `60` to `180` seconds across settings, DTOs, service defaults, provider runtime DTOs, provider request models, backup/restore fallback, and tests so newly created settings use the new default while existing stored values are preserved. (e.g. `AiAssistantSettings`, `AiAssistantSettingsService`, `AiAssistantSettingsDto`, `AiProviderRuntimeSettingsDto`, `AiProviderModels`).
- Increased maximum allowed timeout from `300` to `600` seconds in the admin view model validation and UI (`[Range(1,600)]`, Razor input `max="600"` and help text) and added explicit controller-side validation to reject >600 values. (e.g. `AiAssistantSettingsPageViewModel`, admin controller, Razor view).
- Extended provider client hard clamp to use `Math.Clamp(..., 1, 600)` so runtime calls honor the new maximum and updated default `TimeoutSeconds` for provider request model. (e.g. `OpenAiCompatibleProviderClient`, `AiProviderChatRequest`).
- Fixed top navigation regression by preventing nav shortcuts from flex-growing: set `width: auto; flex: 0 0 auto;` for `.site-nav-shortcut` so the AI Assistant link sizes like other shortcuts and does not consume remaining horizontal space. (e.g. `_AuthenticatedNav.cshtml`).
- Because the DB column default for `AiAssistantSettings.RequestTimeoutSeconds` was changed, added an idempotent Startup Gate schema action to update the column default and bumped the required schema version from `21` to `22` so release metadata remains aligned; this does not overwrite existing saved values. (e.g. `StartupSchemaService`, `appsettings.json`, `appsettings.Development.json`, `StartupSchemaService` ALTER TABLE). 

### Testing

- Ran project build and tests: `dotnet build` succeeded for `PingMonitor.Web`, and the unit test suite `PingMonitor.Web.Tests` passed (187 passed, 0 failed). The test commands used were `PATH=/tmp/dotnet10:$PATH dotnet build src/WebApp/PingMonitor.WebApp.slnx` and `PATH=/tmp/dotnet10:$PATH dotnet test ...`.
- Updated/added automated tests to assert the new defaults and limits and provider behavior: tests confirm default timeout is `180` for new settings, `600` is accepted, `601` is rejected, the provider test path forwards the configured timeout, and the startup-schema metadata is aligned; these tests passed as part of the test run.
- No runtime LINQ/EF query translation changes were made to monitoring/state runtime paths, and no tests touching database migrations were removed; the Startup Gate change is an idempotent ALTER to a column default and is covered by the startup/schema tests that were updated to reflect the bumped required schema version.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f486a8008832a8d1e5efb48526f43)