### PR TITLE
Connect Telegram bot to AI Assistant chat

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
@@ -43,6 +43,37 @@ public sealed class AiAssistantChatTests
         Assert.Null(provider.LastRequest);
     }
 
+
+    [Fact]
+    public async Task TelegramChatDisabledDoesNotCallProviderForTelegramSource()
+    {
+        var provider = new FakeAiProviderClient();
+        var settings = EnabledSettings();
+        settings.TelegramChatEnabled = false;
+        var chat = new AiChatService(new FakeAiAssistantSettingsService(settings), provider, NullLogger<AiChatService>.Instance);
+
+        var response = await chat.SendAsync(new AiChatRequest { Source = AiChatSource.Telegram, UserMessage = "hello" }, CancellationToken.None);
+
+        Assert.False(response.Succeeded);
+        Assert.Contains("Telegram AI chat is disabled", response.ErrorMessage);
+        Assert.Null(provider.LastRequest);
+    }
+
+    [Fact]
+    public async Task TelegramChatSourceUsesSharedSafetyPromptAndProviderPath()
+    {
+        var provider = new FakeAiProviderClient { Result = new AiProviderChatResult { Succeeded = true, ResponseText = "I am chat-only.", Model = "llama" } };
+        var settings = EnabledSettings(webChatEnabled: false);
+        settings.TelegramChatEnabled = true;
+        var chat = new AiChatService(new FakeAiAssistantSettingsService(settings), provider, NullLogger<AiChatService>.Instance);
+
+        var response = await chat.SendAsync(new AiChatRequest { Source = AiChatSource.Telegram, UserMessage = "How is my network looking today?" }, CancellationToken.None);
+
+        Assert.True(response.Succeeded);
+        Assert.Contains(provider.LastRequest!.Messages, x => x.Role == "system" && x.Content.Contains("live monitoring data", StringComparison.Ordinal));
+        Assert.Contains(provider.LastRequest.Messages, x => x.Role == "system" && x.Content.Contains("CheckResults", StringComparison.Ordinal));
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
@@ -149,7 +180,8 @@ public sealed class AiAssistantChatTests
         RequestTimeoutSeconds = 180,
         MaxOutputTokens = 2048,
         Temperature = 0.2,
-        GlobalSystemPrompt = globalPrompt
+        GlobalSystemPrompt = globalPrompt,
+        TelegramChatEnabled = true
     };
 
     private sealed class FakeAiAssistantSettingsService : IAiAssistantSettingsService
@@ -181,5 +213,39 @@ public sealed class AiAssistantChatTests
             LastRequest = request;
             return Task.FromResult(Result);
         }
+    }
+}
+
+public sealed class TelegramAiConversationStoreTests
+{
+    [Fact]
+    public void TelegramConversationHistoryIsBoundedToLastTenTurns()
+    {
+        using var memoryCache = new Microsoft.Extensions.Caching.Memory.MemoryCache(new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
+        var store = new PingMonitor.Web.Services.Telegram.TelegramAiConversationStore(memoryCache);
+
+        for (var i = 0; i < 12; i++)
+        {
+            store.AddTurn("chat-1", "user-1", $"user {i}", $"assistant {i}");
+        }
+
+        var history = store.GetHistory("chat-1", "user-1");
+        Assert.Equal(20, history.Count);
+        Assert.Equal("user 2", history[0].Content);
+        Assert.Equal("assistant 11", history[^1].Content);
+    }
+
+    [Fact]
+    public void ClearOnlyRemovesMatchingTelegramChatAndUserHistory()
+    {
+        using var memoryCache = new Microsoft.Extensions.Caching.Memory.MemoryCache(new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
+        var store = new PingMonitor.Web.Services.Telegram.TelegramAiConversationStore(memoryCache);
+        store.AddTurn("chat-1", "user-1", "hello", "hi");
+        store.AddTurn("chat-1", "user-2", "other", "there");
+
+        store.Clear("chat-1", "user-1");
+
+        Assert.Empty(store.GetHistory("chat-1", "user-1"));
+        Assert.NotEmpty(store.GetHistory("chat-1", "user-2"));
     }
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -201,7 +201,9 @@ builder.Services.AddScoped<IAgentProvisioningService, AgentProvisioningService>(
 builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsService>();
 builder.Services.AddScoped<IAiAssistantSettingsService, AiAssistantSettingsService>();
 builder.Services.AddScoped<IAiProviderClient, OpenAiCompatibleProviderClient>();
+builder.Services.AddMemoryCache();
 builder.Services.AddScoped<IAiChatService, AiChatService>();
+builder.Services.AddSingleton<ITelegramAiConversationStore, TelegramAiConversationStore>();
 builder.Services.AddSingleton<IApplicationMetadataProvider, ApplicationMetadataProvider>();
 builder.Services.AddHttpClient(nameof(OpenAiCompatibleProviderClient));
 builder.Services.AddHttpClient(nameof(GitHubReleaseLookupService));

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatModels.cs
@@ -1,7 +1,14 @@
 namespace PingMonitor.Web.Services.AiChat;
 
+public enum AiChatSource
+{
+    Web = 0,
+    Telegram = 1
+}
+
 public sealed class AiChatRequest
 {
+    public AiChatSource Source { get; set; } = AiChatSource.Web;
     public IList<AiChatMessageDto> ConversationHistory { get; set; } = new List<AiChatMessageDto>();
     public string UserMessage { get; set; } = string.Empty;
 }
@@ -11,6 +18,7 @@ public sealed class AiChatResponse
     public bool Succeeded { get; set; }
     public bool AssistantEnabled { get; set; }
     public bool WebChatEnabled { get; set; }
+    public bool TelegramChatEnabled { get; set; }
     public string? AssistantMessage { get; set; }
     public string? ErrorMessage { get; set; }
     public string? ProviderName { get; set; }

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs
@@ -34,12 +34,17 @@ You may answer general questions and help explain what future Ping Monitor AI fe
         var settings = await _settingsService.GetCurrentAsync(cancellationToken);
         if (!settings.AssistantEnabled)
         {
-            return new AiChatResponse { AssistantEnabled = false, WebChatEnabled = settings.WebChatEnabled, ErrorMessage = "AI assistant is disabled. An administrator can enable it from Admin > AI Assistant settings." };
+            return new AiChatResponse { AssistantEnabled = false, WebChatEnabled = settings.WebChatEnabled, TelegramChatEnabled = settings.TelegramChatEnabled, ErrorMessage = "AI assistant is disabled. An administrator can enable it from Admin > AI Assistant settings." };
         }
 
-        if (!settings.WebChatEnabled)
+        if (request.Source == AiChatSource.Web && !settings.WebChatEnabled)
         {
-            return new AiChatResponse { AssistantEnabled = true, WebChatEnabled = false, ErrorMessage = "AI web chat is disabled. An administrator can enable it from Admin > AI Assistant settings." };
+            return new AiChatResponse { AssistantEnabled = true, WebChatEnabled = false, TelegramChatEnabled = settings.TelegramChatEnabled, ErrorMessage = "AI web chat is disabled. An administrator can enable it from Admin > AI Assistant settings." };
+        }
+
+        if (request.Source == AiChatSource.Telegram && !settings.TelegramChatEnabled)
+        {
+            return new AiChatResponse { AssistantEnabled = true, WebChatEnabled = settings.WebChatEnabled, TelegramChatEnabled = false, ErrorMessage = "Telegram AI chat is disabled. An administrator can enable it from AI Assistant settings." };
         }
 
         var runtime = await _settingsService.GetProviderRuntimeSettingsAsync(cancellationToken);
@@ -74,10 +79,10 @@ You may answer general questions and help explain what future Ping Monitor AI fe
         if (!result.Succeeded || string.IsNullOrWhiteSpace(result.ResponseText))
         {
             _logger.LogWarning("AI web chat provider call failed. Provider={ProviderName} Model={ModelName} StatusCode={StatusCode}", runtime.ProviderDisplayName, runtime.ModelName, result.StatusCode);
-            return new AiChatResponse { AssistantEnabled = true, WebChatEnabled = true, ProviderName = runtime.ProviderDisplayName, ModelName = runtime.ModelName, ErrorMessage = "The AI provider did not return a response. Check the AI Assistant settings and the local Ollama/OpenAI-compatible endpoint." };
+            return new AiChatResponse { AssistantEnabled = true, WebChatEnabled = settings.WebChatEnabled, TelegramChatEnabled = settings.TelegramChatEnabled, ProviderName = runtime.ProviderDisplayName, ModelName = runtime.ModelName, ErrorMessage = "The AI provider did not return a response. Check the AI Assistant settings and the local Ollama/OpenAI-compatible endpoint." };
         }
 
-        return new AiChatResponse { Succeeded = true, AssistantEnabled = true, WebChatEnabled = true, ProviderName = runtime.ProviderDisplayName, ModelName = result.Model ?? runtime.ModelName, AssistantMessage = result.ResponseText.Trim() };
+        return new AiChatResponse { Succeeded = true, AssistantEnabled = true, WebChatEnabled = settings.WebChatEnabled, TelegramChatEnabled = settings.TelegramChatEnabled, ProviderName = runtime.ProviderDisplayName, ModelName = result.Model ?? runtime.ModelName, AssistantMessage = result.ResponseText.Trim() };
     }
 
     internal static IList<AiProviderChatMessage> BuildMessages(string? adminGlobalPrompt, IEnumerable<AiChatMessageDto> history, string latestUserMessage)
@@ -98,7 +103,7 @@ You may answer general questions and help explain what future Ping Monitor AI fe
         return messages;
     }
 
-    private static AiChatResponse ConfigurationError(AiAssistantSettingsDto settings, string message) => new() { AssistantEnabled = settings.AssistantEnabled, WebChatEnabled = settings.WebChatEnabled, ErrorMessage = message };
+    private static AiChatResponse ConfigurationError(AiAssistantSettingsDto settings, string message) => new() { AssistantEnabled = settings.AssistantEnabled, WebChatEnabled = settings.WebChatEnabled, TelegramChatEnabled = settings.TelegramChatEnabled, ErrorMessage = message };
     private static string Truncate(string value, int max) => value.Length <= max ? value : value[..max];
     private static void TrimToPromptLimit(List<AiProviderChatMessage> messages)
     {

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/ITelegramAiConversationStore.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/ITelegramAiConversationStore.cs
@@ -1,0 +1,10 @@
+using PingMonitor.Web.Services.AiChat;
+
+namespace PingMonitor.Web.Services.Telegram;
+
+public interface ITelegramAiConversationStore
+{
+    IReadOnlyList<AiChatMessageDto> GetHistory(string chatId, string userId);
+    void AddTurn(string chatId, string userId, string userMessage, string assistantMessage);
+    void Clear(string chatId, string userId);
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramAiConversationStore.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramAiConversationStore.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.Caching.Memory;
+using PingMonitor.Web.Services.AiChat;
+
+namespace PingMonitor.Web.Services.Telegram;
+
+public sealed class TelegramAiConversationStore : ITelegramAiConversationStore
+{
+    public const int MaxTurns = 10;
+    public const int MaxMessageCharacters = 4000;
+    public const int MaxHistoryCharacters = 20000;
+    private static readonly TimeSpan SlidingTtl = TimeSpan.FromHours(6);
+    private readonly IMemoryCache _cache;
+
+    public TelegramAiConversationStore(IMemoryCache cache) => _cache = cache;
+
+    public IReadOnlyList<AiChatMessageDto> GetHistory(string chatId, string userId)
+    {
+        return _cache.TryGetValue(Key(chatId, userId), out List<AiChatMessageDto>? history) && history is not null
+            ? history.Select(x => new AiChatMessageDto { Role = x.Role, Content = x.Content }).ToList()
+            : [];
+    }
+
+    public void AddTurn(string chatId, string userId, string userMessage, string assistantMessage)
+    {
+        var history = GetHistory(chatId, userId).ToList();
+        history.Add(new AiChatMessageDto { Role = "user", Content = Truncate(userMessage.Trim(), MaxMessageCharacters) });
+        history.Add(new AiChatMessageDto { Role = "assistant", Content = Truncate(assistantMessage.Trim(), MaxMessageCharacters) });
+
+        history = history.TakeLast(MaxTurns * 2).ToList();
+        while (history.Sum(x => x.Content.Length) > MaxHistoryCharacters && history.Count > 2)
+        {
+            history.RemoveAt(0);
+        }
+
+        _cache.Set(Key(chatId, userId), history, new MemoryCacheEntryOptions { SlidingExpiration = SlidingTtl });
+    }
+
+    public void Clear(string chatId, string userId) => _cache.Remove(Key(chatId, userId));
+
+    private static string Key(string chatId, string userId) => $"telegram-ai:{chatId}:{userId}";
+    private static string Truncate(string value, int max) => value.Length <= max ? value : value[..max];
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessor.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessor.cs
@@ -1,60 +1,173 @@
 using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Services.AiChat;
 
 namespace PingMonitor.Web.Services.Telegram;
 
 internal sealed partial class TelegramMessageProcessor : ITelegramMessageProcessor
 {
+    private const int TelegramMessageLimit = 4096;
+    private const int MaxInboundAiMessageCharacters = 4000;
+    private const string UnlinkedMessage = "Your Telegram account is not linked to a Ping Monitor user yet.";
     private readonly ITelegramLinkService _telegramLinkService;
+    private readonly INotificationSettingsService _notificationSettingsService;
+    private readonly IAiAssistantSettingsService _aiSettingsService;
+    private readonly IAiChatService _aiChatService;
+    private readonly ITelegramAiConversationStore _conversationStore;
+    private readonly PingMonitorDbContext _dbContext;
 
-    public TelegramMessageProcessor(ITelegramLinkService telegramLinkService)
+    public TelegramMessageProcessor(
+        ITelegramLinkService telegramLinkService,
+        INotificationSettingsService notificationSettingsService,
+        IAiAssistantSettingsService aiSettingsService,
+        IAiChatService aiChatService,
+        ITelegramAiConversationStore conversationStore,
+        PingMonitorDbContext dbContext)
     {
         _telegramLinkService = telegramLinkService;
+        _notificationSettingsService = notificationSettingsService;
+        _aiSettingsService = aiSettingsService;
+        _aiChatService = aiChatService;
+        _conversationStore = conversationStore;
+        _dbContext = dbContext;
     }
 
     public async Task<TelegramMessageProcessingResult> ProcessAsync(TelegramInboundMessage inboundMessage, CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(inboundMessage.Text))
+        var text = inboundMessage.Text.Trim();
+        if (string.IsNullOrWhiteSpace(text))
         {
-            return new TelegramMessageProcessingResult
-            {
-                Status = TelegramMessageProcessingStatus.Ignored,
-                Handled = false,
-                Success = true,
-                Message = "No text content.",
-                ShouldReply = false
-            };
+            return Ignored("No text content.");
         }
 
-        var match = CodeRegex().Match(inboundMessage.Text.Trim());
-        if (!match.Success)
+        var codeMatch = CodeRegex().Match(text);
+        if (codeMatch.Success)
         {
-            return new TelegramMessageProcessingResult
-            {
-                Status = TelegramMessageProcessingStatus.Ignored,
-                Handled = false,
-                Success = true,
-                Message = "Unsupported message content.",
-                ShouldReply = false
-            };
+            return await ConsumeLinkCodeAsync(inboundMessage, codeMatch.Groups[1].Value, cancellationToken);
         }
 
-        var result = await _telegramLinkService.ConsumeCodeAsync(
-            match.Groups[1].Value,
-            inboundMessage.ChatId,
-            inboundMessage.ChatType,
-            inboundMessage.Username,
-            inboundMessage.DisplayName,
-            cancellationToken);
-
-        return new TelegramMessageProcessingResult
+        if (IsKnownCommand(text))
         {
-            Status = MapStatus(result.Status),
-            Handled = true,
-            Success = result.Success,
-            Message = result.Message,
-            ShouldReply = true,
-            ReplyText = GetReplyText(result.Status)
-        };
+            if (IsClearAiCommand(text))
+            {
+                return await ClearAiAsync(inboundMessage, cancellationToken);
+            }
+
+            return Ignored("Known Telegram command is handled by existing command routing.");
+        }
+
+        if (!string.Equals(inboundMessage.ChatType, "private", StringComparison.OrdinalIgnoreCase))
+        {
+            return Ignored("AI chat is only available in private Telegram chats.");
+        }
+
+        var channel = await _notificationSettingsService.GetTelegramChannelAsync(cancellationToken);
+        if (!channel.TelegramEnabled)
+        {
+            return Reply(TelegramMessageProcessingStatus.Ignored, "Telegram bot notifications are disabled. An administrator can enable Telegram infrastructure from notification settings.");
+        }
+
+        var aiSettings = await _aiSettingsService.GetCurrentAsync(cancellationToken);
+        if (!aiSettings.AssistantEnabled)
+        {
+            return Reply(TelegramMessageProcessingStatus.Ignored, "AI assistant is disabled. An administrator can enable it from AI Assistant settings.");
+        }
+
+        if (!aiSettings.TelegramChatEnabled)
+        {
+            return Reply(TelegramMessageProcessingStatus.Ignored, "Telegram AI chat is disabled. An administrator can enable it from AI Assistant settings.");
+        }
+
+        var account = await FindLinkedAccountAsync(inboundMessage.ChatId, cancellationToken);
+        if (account is null)
+        {
+            return Reply(TelegramMessageProcessingStatus.Ignored, UnlinkedMessage);
+        }
+
+        var userMessage = text.Length <= MaxInboundAiMessageCharacters ? text : text[..MaxInboundAiMessageCharacters];
+        var response = await _aiChatService.SendAsync(new AiChatRequest
+        {
+            Source = AiChatSource.Telegram,
+            UserMessage = userMessage,
+            ConversationHistory = _conversationStore.GetHistory(inboundMessage.ChatId, account.UserId).ToList()
+        }, cancellationToken);
+
+        if (!response.Succeeded || string.IsNullOrWhiteSpace(response.AssistantMessage))
+        {
+            return Reply(TelegramMessageProcessingStatus.Ignored, ToTelegramSafeError(response.ErrorMessage));
+        }
+
+        var replyText = FitTelegramMessage(response.AssistantMessage.Trim());
+        _conversationStore.AddTurn(inboundMessage.ChatId, account.UserId, userMessage, replyText);
+        return Reply(TelegramMessageProcessingStatus.Ignored, replyText);
+    }
+
+    private async Task<TelegramMessageProcessingResult> ConsumeLinkCodeAsync(TelegramInboundMessage inboundMessage, string code, CancellationToken cancellationToken)
+    {
+        var result = await _telegramLinkService.ConsumeCodeAsync(code, inboundMessage.ChatId, inboundMessage.ChatType, inboundMessage.Username, inboundMessage.DisplayName, cancellationToken);
+        return new TelegramMessageProcessingResult { Status = MapStatus(result.Status), Handled = true, Success = result.Success, Message = result.Message, ShouldReply = true, ReplyText = GetReplyText(result.Status) };
+    }
+
+    private async Task<TelegramMessageProcessingResult> ClearAiAsync(TelegramInboundMessage inboundMessage, CancellationToken cancellationToken)
+    {
+        if (!string.Equals(inboundMessage.ChatType, "private", StringComparison.OrdinalIgnoreCase))
+        {
+            return Ignored("AI clear command is only available in private Telegram chats.");
+        }
+
+        var account = await FindLinkedAccountAsync(inboundMessage.ChatId, cancellationToken);
+        if (account is null)
+        {
+            return Reply(TelegramMessageProcessingStatus.Ignored, UnlinkedMessage);
+        }
+
+        _conversationStore.Clear(inboundMessage.ChatId, account.UserId);
+        return Reply(TelegramMessageProcessingStatus.Ignored, "AI conversation context cleared.");
+    }
+
+    private Task<LinkedTelegramAccount?> FindLinkedAccountAsync(string chatId, CancellationToken cancellationToken)
+        => _dbContext.TelegramAccounts.AsNoTracking()
+            .Where(x => x.ChatId == chatId && x.Verified && x.IsActive)
+            .Select(x => new LinkedTelegramAccount(x.UserId))
+            .SingleOrDefaultAsync(cancellationToken);
+
+    private static bool IsKnownCommand(string text)
+    {
+        var command = text.Split(' ', 2)[0].Split('@', 2)[0];
+        return command.Equals("/start", StringComparison.OrdinalIgnoreCase)
+            || command.Equals("/help", StringComparison.OrdinalIgnoreCase)
+            || IsClearAiCommand(command);
+    }
+
+    private static bool IsClearAiCommand(string text)
+    {
+        var command = text.Split(' ', 2)[0].Split('@', 2)[0];
+        return command.Equals("/clearai", StringComparison.OrdinalIgnoreCase) || command.Equals("/clear_ai", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static TelegramMessageProcessingResult Ignored(string message) => new() { Status = TelegramMessageProcessingStatus.Ignored, Handled = false, Success = true, Message = message, ShouldReply = false };
+    private static TelegramMessageProcessingResult Reply(TelegramMessageProcessingStatus status, string text) => new() { Status = status, Handled = true, Success = true, Message = "Telegram message processed.", ShouldReply = true, ReplyText = text };
+
+    private static string ToTelegramSafeError(string? errorMessage)
+    {
+        if (string.IsNullOrWhiteSpace(errorMessage))
+        {
+            return "The AI assistant could not respond right now. Please try again later.";
+        }
+
+        if (errorMessage.Contains("disabled", StringComparison.OrdinalIgnoreCase) || errorMessage.Contains("configuration", StringComparison.OrdinalIgnoreCase))
+        {
+            return errorMessage;
+        }
+
+        return "The AI assistant could not respond right now. Please try again later.";
+    }
+
+    private static string FitTelegramMessage(string value)
+    {
+        const string note = "\n\n[Response truncated for Telegram.]";
+        return value.Length <= TelegramMessageLimit ? value : value[..(TelegramMessageLimit - note.Length)] + note;
     }
 
     private static TelegramMessageProcessingStatus MapStatus(TelegramLinkConsumeStatus status)
@@ -78,6 +191,8 @@ internal sealed partial class TelegramMessageProcessor : ITelegramMessageProcess
             TelegramLinkConsumeStatus.UnsupportedChatType => "⚠️ Verification must be completed in a private chat with this bot.",
             _ => string.Empty
         };
+
+    private sealed record LinkedTelegramAccount(string UserId);
 
     [GeneratedRegex("^(\\d{8})$")]
     private static partial Regex CodeRegex();


### PR DESCRIPTION
### Motivation

- Enable linked Telegram users to ask natural-language questions to the existing AI Assistant using the same shared chat service and built-in safety prompt. 
- Keep the Telegram bot as a transport adapter that does not change AI orchestration, security, or monitoring semantics. 
- Preserve existing Telegram verification/linking and command flows while gating AI access behind feature flags and linked accounts. 
- Provide a short-lived, bounded conversation context for Telegram to support follow-ups without adding persistent storage or AI memory.

### Description

- Added `AiChatSource` and extended `AiChatRequest`/`AiChatResponse` so the shared `AiChatService` can handle Telegram-origin requests while reusing the same provider/prompt path and built-in safety prompt. (src/WebApp/PingMonitor.Web/Services/AiChat/AiChatModels.cs, src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs)
- Implemented a Telegram adapter path in the message processor that runs existing verification-code handling and known-command routing first, then routes unknown private-chat messages to the AI service when allowed. Group/supergroup/channel messages are not routed to AI. (src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessor.cs)
- Added an in-memory, bounded Telegram conversation store implemented with `IMemoryCache` keyed by Telegram chat ID + application user ID, retaining up to 10 turns (user+assistant), per-message truncation, a 6-hour sliding TTL, and total-history character bounds; added `/clearai` and `/clear_ai` to clear only the linked chat/user context. (src/WebApp/PingMonitor.Web/Services/Telegram/ITelegramAiConversationStore.cs, src/WebApp/PingMonitor.Web/Services/Telegram/TelegramAiConversationStore.cs)
- Registered `IMemoryCache` and the Telegram AI conversation store in DI and updated the Telegram message processor to enforce feature flags and linked-user lookup through verified `TelegramAccounts`. (src/WebApp/PingMonitor.Web/Program.cs, src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessor.cs)

Files changed (key):
- src/WebApp/PingMonitor.Web/Services/AiChat/AiChatModels.cs
- src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs
- src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessor.cs
- src/WebApp/PingMonitor.Web/Services/Telegram/ITelegramAiConversationStore.cs
- src/WebApp/PingMonitor.Web/Services/Telegram/TelegramAiConversationStore.cs
- src/WebApp/PingMonitor.Web/Program.cs
- src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs (added Telegram-related unit tests)

Security and scope notes:
- The AI path respects: global Telegram infrastructure enabled, AI assistant enabled, Telegram AI chat enabled, valid provider configuration, and linked Telegram account requirement, and never exposes provider secrets or stack traces in replies.
- Replies are plain text and truncated safely for Telegram message limits; provider/tool debug data is not included.
- No monitoring tools, endpoint metrics, CheckResults access, diagram lookup, AI memory, prompt history, persistent AI audit/chat logs, group-chat AI mode, or write-capable AI behavior were implemented.

### Testing

- Created GitHub issue: #559 "Connect AI Assistant chat to Telegram bot".
- Unit tests added/updated to cover: Telegram-source feature gating, shared safety prompt usage, bounded Telegram conversation history, and scoped clear-history behavior. (src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs)
- Automated build and tests executed successfully in this environment: `dotnet build` and `dotnet test` for the solution and tests completed with all tests passing.
- Test summary: solution build succeeded and unit test run passed (all tests green during the run performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f4eca2438832aa8c6591cd4b8ced1)