### PR TITLE
Add AI Assistant read-only network health summary context

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using PingMonitor.Web.Controllers;
 using PingMonitor.Web.Models;
@@ -50,7 +51,7 @@ public sealed class AiAssistantChatTests
         var provider = new FakeAiProviderClient();
         var settings = EnabledSettings();
         settings.TelegramChatEnabled = false;
-        var chat = new AiChatService(new FakeAiAssistantSettingsService(settings), provider, NullLogger<AiChatService>.Instance);
+        var chat = new AiChatService(new FakeAiAssistantSettingsService(settings), provider, new FakeAiMonitoringContextService(), new HttpContextAccessor(), NullLogger<AiChatService>.Instance);
 
         var response = await chat.SendAsync(new AiChatRequest { Source = AiChatSource.Telegram, UserMessage = "hello" }, CancellationToken.None);
 
@@ -65,13 +66,80 @@ public sealed class AiAssistantChatTests
         var provider = new FakeAiProviderClient { Result = new AiProviderChatResult { Succeeded = true, ResponseText = "I am chat-only.", Model = "llama" } };
         var settings = EnabledSettings(webChatEnabled: false);
         settings.TelegramChatEnabled = true;
-        var chat = new AiChatService(new FakeAiAssistantSettingsService(settings), provider, NullLogger<AiChatService>.Instance);
+        var chat = new AiChatService(new FakeAiAssistantSettingsService(settings), provider, new FakeAiMonitoringContextService(), new HttpContextAccessor(), NullLogger<AiChatService>.Instance);
 
         var response = await chat.SendAsync(new AiChatRequest { Source = AiChatSource.Telegram, UserMessage = "How is my network looking today?" }, CancellationToken.None);
 
         Assert.True(response.Succeeded);
-        Assert.Contains(provider.LastRequest!.Messages, x => x.Role == "system" && x.Content.Contains("live monitoring data", StringComparison.Ordinal));
+        Assert.Contains(provider.LastRequest!.Messages, x => x.Role == "system" && x.Content.Contains("read-only network health summary", StringComparison.Ordinal));
         Assert.Contains(provider.LastRequest.Messages, x => x.Role == "system" && x.Content.Contains("CheckResults", StringComparison.Ordinal));
+    }
+
+
+    [Fact]
+    public async Task WebChatInjectsHealthSummaryForBroadNetworkStatusQuestion()
+    {
+        var provider = new FakeAiProviderClient { Result = new AiProviderChatResult { Succeeded = true, ResponseText = "Based on current state, one endpoint is DOWN.", Model = "llama" } };
+        var context = new FakeAiMonitoringContextService
+        {
+            Result = new AiMonitoringContextResult
+            {
+                ShouldInclude = true,
+                Succeeded = true,
+                Summary = new AiNetworkHealthSummary
+                {
+                    GeneratedAtUtc = DateTimeOffset.Parse("2026-06-15T12:00:00Z"),
+                    VisibleEndpointCount = 2,
+                    StateCounts = new AiNetworkHealthStateCounts { Up = 1, Down = 1 },
+                    DownEndpoints = [new AiNetworkHealthEndpoint { EndpointId = "visible-down", Name = "Farm Router WAN", Target = "1.2.3.4", State = "DOWN" }]
+                }
+            }
+        };
+        var settings = EnabledSettings();
+        var chat = new AiChatService(new FakeAiAssistantSettingsService(settings), provider, context, new HttpContextAccessor(), NullLogger<AiChatService>.Instance);
+
+        var response = await chat.SendAsync(new AiChatRequest { Source = AiChatSource.Web, UserMessage = "Is anything down?" }, CancellationToken.None);
+
+        Assert.True(response.Succeeded);
+        Assert.Contains(provider.LastRequest!.Messages, x => x.Role == "system" && x.Content.Contains("get_network_health_summary", StringComparison.Ordinal) && x.Content.Contains("Farm Router WAN", StringComparison.Ordinal));
+        Assert.DoesNotContain(provider.LastRequest.Messages, x => x.Content.Contains("runtime-secret", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task TelegramChatUsesSameHealthSummaryInjectionPath()
+    {
+        var provider = new FakeAiProviderClient();
+        var context = new FakeAiMonitoringContextService { Result = new AiMonitoringContextResult { ShouldInclude = true, Succeeded = true, Summary = new AiNetworkHealthSummary { VisibleEndpointCount = 0 } } };
+        var settings = EnabledSettings(webChatEnabled: false);
+        settings.TelegramChatEnabled = true;
+        var chat = new AiChatService(new FakeAiAssistantSettingsService(settings), provider, context, new HttpContextAccessor(), NullLogger<AiChatService>.Instance);
+
+        await chat.SendAsync(new AiChatRequest { Source = AiChatSource.Telegram, UserId = "linked-user", UserMessage = "How is my network looking today?" }, CancellationToken.None);
+
+        Assert.Equal("linked-user", context.LastRequest?.UserId);
+        Assert.Contains(provider.LastRequest!.Messages, x => x.Role == "system" && x.Content.Contains("get_network_health_summary", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task UnavailableHealthSummaryTellsModelNotToInvent()
+    {
+        var provider = new FakeAiProviderClient();
+        var context = new FakeAiMonitoringContextService { Result = new AiMonitoringContextResult { ShouldInclude = true, Succeeded = false, ErrorMessage = "boom" } };
+        var chat = new AiChatService(new FakeAiAssistantSettingsService(EnabledSettings()), provider, context, new HttpContextAccessor(), NullLogger<AiChatService>.Instance);
+
+        await chat.SendAsync(new AiChatRequest { Source = AiChatSource.Web, UserMessage = "Any outages?" }, CancellationToken.None);
+
+        Assert.Contains(provider.LastRequest!.Messages, x => x.Role == "system" && x.Content.Contains("summary is unavailable", StringComparison.Ordinal) && x.Content.Contains("do not invent", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("How is my network looking today?")]
+    [InlineData("Is anything down?")]
+    [InlineData("Any endpoints unknown?")]
+    [InlineData("Are any agents offline?")]
+    public void HealthSummaryIntentDetectionMatchesBroadStatusQuestions(string message)
+    {
+        Assert.True(AiMonitoringContextService.LooksLikeHealthQuestion(message));
     }
 
     [Theory]
@@ -137,9 +205,9 @@ public sealed class AiAssistantChatTests
     public void PromptLayeringIncludesSafetyPromptBeforeAdminPrompt()
     {
         var messages = AiChatService.BuildMessages("Site guidance", [], "How is my network looking today?");
-        Assert.Contains("do not currently have access to live monitoring data", messages[0].Content);
+        Assert.Contains("read-only network health summary", messages[0].Content);
         Assert.Contains("CheckResults", messages[0].Content);
-        Assert.Contains("tools", messages[0].Content);
+        Assert.Contains("diagram lookup", messages[0].Content);
         Assert.Contains("Admin-configured site instructions", messages[1].Content);
         Assert.Contains("Site guidance", messages[1].Content);
     }
@@ -165,7 +233,7 @@ public sealed class AiAssistantChatTests
     private static AiAssistantController CreateController(FakeAiProviderClient provider, AiAssistantSettingsDto settings)
     {
         var settingsService = new FakeAiAssistantSettingsService(settings);
-        var chat = new AiChatService(settingsService, provider, NullLogger<AiChatService>.Instance);
+        var chat = new AiChatService(settingsService, provider, new FakeAiMonitoringContextService(), new HttpContextAccessor(), NullLogger<AiChatService>.Instance);
         return new AiAssistantController(settingsService, chat);
     }
 
@@ -183,6 +251,17 @@ public sealed class AiAssistantChatTests
         GlobalSystemPrompt = globalPrompt,
         TelegramChatEnabled = true
     };
+
+    private sealed class FakeAiMonitoringContextService : IAiMonitoringContextService
+    {
+        public AiMonitoringContextRequest? LastRequest { get; private set; }
+        public AiMonitoringContextResult Result { get; set; } = new() { ShouldInclude = false, Succeeded = true };
+        public Task<AiMonitoringContextResult> TryGetNetworkHealthSummaryAsync(AiMonitoringContextRequest request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(Result);
+        }
+    }
 
     private sealed class FakeAiAssistantSettingsService : IAiAssistantSettingsService
     {

--- a/src/WebApp/PingMonitor.Web.Tests/DegradedEndpointQueryTranslationTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/DegradedEndpointQueryTranslationTests.cs
@@ -54,5 +54,9 @@ public sealed class DegradedEndpointQueryTranslationTests
         Assert.Contains("if (visibleEndpointIds is { Length: 0 })", source);
         Assert.Contains("if (agentIds.Length > 0)", source);
         Assert.Contains("if (visibleIdsFromRows.Length > 0)", source);
+        Assert.Contains("WhereStringEqualsAny", source);
+        Assert.DoesNotContain("visibleEndpointIds.Contains", source);
+        Assert.DoesNotContain("agentIds.Contains", source);
+        Assert.DoesNotContain("visibleIdsFromRows.Contains", source);
     }
 }

--- a/src/WebApp/PingMonitor.Web.Tests/DegradedEndpointQueryTranslationTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/DegradedEndpointQueryTranslationTests.cs
@@ -35,4 +35,24 @@ public sealed class DegradedEndpointQueryTranslationTests
 
         Assert.DoesNotContain("RefreshAssignmentsAsync", source);
     }
+
+    [Fact]
+    public void AiMonitoringContextService_GuardsEmptyIdCollectionsBeforeMySqlContainsQueries()
+    {
+        var sourcePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            "PingMonitor.Web",
+            "Services",
+            "AiChat",
+            "AiMonitoringContextService.cs"));
+        var source = File.ReadAllText(sourcePath);
+
+        Assert.Contains("if (visibleEndpointIds is { Length: 0 })", source);
+        Assert.Contains("if (agentIds.Length > 0)", source);
+        Assert.Contains("if (visibleIdsFromRows.Length > 0)", source);
+    }
 }

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -202,6 +202,7 @@ builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsServi
 builder.Services.AddScoped<IAiAssistantSettingsService, AiAssistantSettingsService>();
 builder.Services.AddScoped<IAiProviderClient, OpenAiCompatibleProviderClient>();
 builder.Services.AddMemoryCache();
+builder.Services.AddScoped<IAiMonitoringContextService, AiMonitoringContextService>();
 builder.Services.AddScoped<IAiChatService, AiChatService>();
 builder.Services.AddSingleton<ITelegramAiConversationStore, TelegramAiConversationStore>();
 builder.Services.AddSingleton<IApplicationMetadataProvider, ApplicationMetadataProvider>();

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatModels.cs
@@ -11,6 +11,7 @@ public sealed class AiChatRequest
     public AiChatSource Source { get; set; } = AiChatSource.Web;
     public IList<AiChatMessageDto> ConversationHistory { get; set; } = new List<AiChatMessageDto>();
     public string UserMessage { get; set; } = string.Empty;
+    public string? UserId { get; set; }
 }
 
 public sealed class AiChatResponse

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Services.AiProviders;
 
@@ -12,20 +14,26 @@ You are the Ping Monitor AI assistant.
 
 This is an early chat-only test mode.
 You are read-only.
-You do not currently have access to live monitoring data, endpoint metrics, agents, diagrams, CheckResults, tools, memories, or the database.
-If the user asks about current network state, endpoints, diagrams, outages, ports, VLANs, or metrics, explain that those tools are not connected yet.
-Do not invent network facts.
-You may answer general questions and help explain what future Ping Monitor AI features will be able to do.
+You may be given a read-only network health summary from Ping Monitor.
+Use it as the source of truth for current endpoint state.
+Do not invent endpoint state, agents, outages, diagrams, ports, VLANs, metrics, or raw CheckResults.
+If the supplied summary is absent or incomplete, say so.
+Raw CheckResults diagnostics, diagram lookup, endpoint diagnostic packs, detailed diagnostics, baselines, latency trends, topology lookup, and memory are not connected yet.
+You do not have database access and must not ask for or produce SQL.
 """;
 
     private readonly IAiAssistantSettingsService _settingsService;
     private readonly IAiProviderClient _providerClient;
+    private readonly IAiMonitoringContextService _monitoringContextService;
+    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ILogger<AiChatService> _logger;
 
-    public AiChatService(IAiAssistantSettingsService settingsService, IAiProviderClient providerClient, ILogger<AiChatService> logger)
+    public AiChatService(IAiAssistantSettingsService settingsService, IAiProviderClient providerClient, IAiMonitoringContextService monitoringContextService, IHttpContextAccessor httpContextAccessor, ILogger<AiChatService> logger)
     {
         _settingsService = settingsService;
         _providerClient = providerClient;
+        _monitoringContextService = monitoringContextService;
+        _httpContextAccessor = httpContextAccessor;
         _logger = logger;
     }
 
@@ -63,7 +71,14 @@ You may answer general questions and help explain what future Ping Monitor AI fe
             return ConfigurationError(settings, "AI provider configuration is incomplete. Model name is required.");
         }
 
-        var messages = BuildMessages(settings.GlobalSystemPrompt, request.ConversationHistory, request.UserMessage);
+        var monitoringContext = await _monitoringContextService.TryGetNetworkHealthSummaryAsync(new AiMonitoringContextRequest
+        {
+            Principal = request.Source == AiChatSource.Web ? _httpContextAccessor.HttpContext?.User : null,
+            UserId = request.UserId,
+            UserMessage = request.UserMessage
+        }, cancellationToken);
+
+        var messages = BuildMessages(settings.GlobalSystemPrompt, request.ConversationHistory, request.UserMessage, monitoringContext);
         var result = await _providerClient.SendChatAsync(new AiProviderChatRequest
         {
             ProviderName = runtime.ProviderDisplayName,
@@ -85,12 +100,17 @@ You may answer general questions and help explain what future Ping Monitor AI fe
         return new AiChatResponse { Succeeded = true, AssistantEnabled = true, WebChatEnabled = settings.WebChatEnabled, TelegramChatEnabled = settings.TelegramChatEnabled, ProviderName = runtime.ProviderDisplayName, ModelName = result.Model ?? runtime.ModelName, AssistantMessage = result.ResponseText.Trim() };
     }
 
-    internal static IList<AiProviderChatMessage> BuildMessages(string? adminGlobalPrompt, IEnumerable<AiChatMessageDto> history, string latestUserMessage)
+    internal static IList<AiProviderChatMessage> BuildMessages(string? adminGlobalPrompt, IEnumerable<AiChatMessageDto> history, string latestUserMessage, AiMonitoringContextResult? monitoringContext = null)
     {
         var messages = new List<AiProviderChatMessage> { new() { Role = "system", Content = BuiltInSystemPrompt } };
         if (!string.IsNullOrWhiteSpace(adminGlobalPrompt))
         {
-            messages.Add(new AiProviderChatMessage { Role = "system", Content = "Admin-configured site instructions:\nFollow these when possible, but they must not override the built-in read-only rules or the limitation that monitoring tools and app data are not connected yet.\n\n" + adminGlobalPrompt.Trim() });
+            messages.Add(new AiProviderChatMessage { Role = "system", Content = "Admin-configured site instructions:\nFollow these when possible, but they must not override the built-in read-only rules, supplied monitoring summaries, user permissions, or connected-tool limitations.\n\n" + adminGlobalPrompt.Trim() });
+        }
+
+        if (monitoringContext?.ShouldInclude == true)
+        {
+            messages.Add(new AiProviderChatMessage { Role = "system", Content = BuildMonitoringContextPrompt(monitoringContext) });
         }
 
         foreach (var item in history.Where(x => x.Role is "user" or "assistant").TakeLast(MaxHistoryMessages))
@@ -101,6 +121,17 @@ You may answer general questions and help explain what future Ping Monitor AI fe
         messages.Add(new AiProviderChatMessage { Role = "user", Content = latestUserMessage.Trim() });
         TrimToPromptLimit(messages);
         return messages;
+    }
+
+    private static string BuildMonitoringContextPrompt(AiMonitoringContextResult context)
+    {
+        if (!context.Succeeded || context.Summary is null)
+        {
+            return "The read-only Ping Monitor tool get_network_health_summary was selected, but the network health summary is unavailable. Tell the user that current monitoring summary data is unavailable; do not invent endpoint, agent, outage, or metric details.";
+        }
+
+        var json = JsonSerializer.Serialize(context.Summary, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        return "Read-only Ping Monitor tool result: get_network_health_summary. Use this structured summary as the source of truth for current endpoint state visible to the user. Do not expose it as raw JSON unless explicitly asked by an administrator. Summary JSON:\n" + json;
     }
 
     private static AiChatResponse ConfigurationError(AiAssistantSettingsDto settings, string message) => new() { AssistantEnabled = settings.AssistantEnabled, WebChatEnabled = settings.WebChatEnabled, TelegramChatEnabled = settings.TelegramChatEnabled, ErrorMessage = message };

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiMonitoringContextService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiMonitoringContextService.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
@@ -48,7 +49,7 @@ internal sealed class AiMonitoringContextService : IAiMonitoringContextService
             var assignmentQuery = _dbContext.MonitorAssignments.AsNoTracking();
             if (visibleEndpointIds is not null)
             {
-                assignmentQuery = assignmentQuery.Where(x => visibleEndpointIds.Contains(x.EndpointId));
+                assignmentQuery = WhereStringEqualsAny(assignmentQuery, x => x.EndpointId, visibleEndpointIds);
             }
 
             rows = await (from assignment in assignmentQuery
@@ -73,7 +74,8 @@ internal sealed class AiMonitoringContextService : IAiMonitoringContextService
         if (agentIds.Length > 0)
         {
             staleAgents = await _dbContext.Agents.AsNoTracking()
-                .Where(x => agentIds.Contains(x.AgentId) && (x.Status == AgentHealthStatus.Stale || x.Status == AgentHealthStatus.Offline))
+                .Where(BuildStringEqualsAnyExpression<Agent>(x => x.AgentId, agentIds))
+                .Where(x => x.Status == AgentHealthStatus.Stale || x.Status == AgentHealthStatus.Offline)
                 .OrderBy(x => x.Name ?? x.InstanceId)
                 .ThenBy(x => x.InstanceId)
                 .Take(EndpointListLimit)
@@ -92,9 +94,9 @@ internal sealed class AiMonitoringContextService : IAiMonitoringContextService
         AiNetworkHealthStateChange[] recentStateChanges = [];
         if (visibleIdsFromRows.Length > 0)
         {
-            recentStateChanges = await (from transition in _dbContext.StateTransitions.AsNoTracking()
+            recentStateChanges = await (from transition in WhereStringEqualsAny(_dbContext.StateTransitions.AsNoTracking(), x => x.EndpointId, visibleIdsFromRows)
                 join endpoint in _dbContext.Endpoints.AsNoTracking() on transition.EndpointId equals endpoint.EndpointId
-                where visibleIdsFromRows.Contains(transition.EndpointId) && transition.TransitionAtUtc >= recentStart
+                where transition.TransitionAtUtc >= recentStart
                 orderby transition.TransitionAtUtc descending
                 select new AiNetworkHealthStateChange
                 {
@@ -165,6 +167,28 @@ internal sealed class AiMonitoringContextService : IAiMonitoringContextService
             where access.UserId == user.Id
             select membership.EndpointId).ToArrayAsync(cancellationToken);
         return new AccessScope(true, false, direct.Concat(grouped).ToHashSet(StringComparer.Ordinal));
+    }
+
+    private static IQueryable<T> WhereStringEqualsAny<T>(IQueryable<T> query, Expression<Func<T, string>> propertySelector, IReadOnlyCollection<string> values)
+    {
+        return query.Where(BuildStringEqualsAnyExpression(propertySelector, values));
+    }
+
+    private static Expression<Func<T, bool>> BuildStringEqualsAnyExpression<T>(Expression<Func<T, string>> propertySelector, IReadOnlyCollection<string> values)
+    {
+        if (values.Count == 0)
+        {
+            return _ => false;
+        }
+
+        Expression? body = null;
+        foreach (var value in values)
+        {
+            var equals = Expression.Equal(propertySelector.Body, Expression.Constant(value, typeof(string)));
+            body = body is null ? equals : Expression.OrElse(body, equals);
+        }
+
+        return Expression.Lambda<Func<T, bool>>(body!, propertySelector.Parameters);
     }
 
     private static IReadOnlyList<AiNetworkHealthEndpoint> SelectEndpointRows(IEnumerable<SummaryEndpointRow> rows, EndpointStateKind state) => rows

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiMonitoringContextService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiMonitoringContextService.cs
@@ -1,0 +1,164 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Models.Identity;
+using PingMonitor.Web.Services.Identity;
+
+namespace PingMonitor.Web.Services.AiChat;
+
+internal sealed class AiMonitoringContextService : IAiMonitoringContextService
+{
+    private const int EndpointListLimit = 10;
+    private const int RecentChangeLimit = 10;
+    private static readonly TimeSpan RecentChangeWindow = TimeSpan.FromHours(1);
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IUserAccessScopeService _userAccessScopeService;
+
+    public AiMonitoringContextService(PingMonitorDbContext dbContext, UserManager<ApplicationUser> userManager, IUserAccessScopeService userAccessScopeService)
+    {
+        _dbContext = dbContext;
+        _userManager = userManager;
+        _userAccessScopeService = userAccessScopeService;
+    }
+
+    public async Task<AiMonitoringContextResult> TryGetNetworkHealthSummaryAsync(AiMonitoringContextRequest request, CancellationToken cancellationToken)
+    {
+        if (!LooksLikeHealthQuestion(request.UserMessage))
+        {
+            return new AiMonitoringContextResult { ShouldInclude = false, Succeeded = true };
+        }
+
+        var scope = await ResolveScopeAsync(request, cancellationToken);
+        if (!scope.Resolved)
+        {
+            return new AiMonitoringContextResult { ShouldInclude = true, Succeeded = false, ErrorMessage = "Network health summary is unavailable because no authenticated application user could be resolved." };
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var visibleEndpointIds = scope.IsAdmin ? null : scope.VisibleEndpointIds.ToArray();
+        var assignmentQuery = _dbContext.MonitorAssignments.AsNoTracking();
+        if (visibleEndpointIds is not null)
+        {
+            assignmentQuery = assignmentQuery.Where(x => visibleEndpointIds.Contains(x.EndpointId));
+        }
+
+        var rows = await (from assignment in assignmentQuery
+            join endpoint in _dbContext.Endpoints.AsNoTracking() on assignment.EndpointId equals endpoint.EndpointId
+            join state in _dbContext.EndpointStates.AsNoTracking() on assignment.AssignmentId equals state.AssignmentId into stateJoin
+            from state in stateJoin.DefaultIfEmpty()
+            select new SummaryEndpointRow(
+                endpoint.EndpointId,
+                endpoint.Name,
+                endpoint.Target,
+                state != null ? state.CurrentState : EndpointStateKind.Unknown,
+                state != null ? state.LastStateChangeUtc : null,
+                assignment.AgentId))
+            .ToArrayAsync(cancellationToken);
+
+        var visibleIdsFromRows = rows.Select(x => x.EndpointId).Distinct(StringComparer.Ordinal).ToArray();
+        var visibleIdSet = visibleIdsFromRows.ToHashSet(StringComparer.Ordinal);
+        var agentIds = rows.Select(x => x.AgentId).Distinct(StringComparer.Ordinal).ToArray();
+
+        var staleAgents = await _dbContext.Agents.AsNoTracking()
+            .Where(x => agentIds.Contains(x.AgentId) && (x.Status == AgentHealthStatus.Stale || x.Status == AgentHealthStatus.Offline))
+            .OrderBy(x => x.Name ?? x.InstanceId)
+            .ThenBy(x => x.InstanceId)
+            .Take(EndpointListLimit)
+            .Select(x => new AiNetworkHealthAgent
+            {
+                AgentId = x.AgentId,
+                Name = string.IsNullOrWhiteSpace(x.Name) ? "(unnamed agent)" : x.Name!,
+                InstanceId = x.InstanceId,
+                Status = x.Status.ToString().ToUpperInvariant(),
+                LastHeartbeatUtc = x.LastHeartbeatUtc
+            })
+            .ToArrayAsync(cancellationToken);
+
+        var recentStart = now - RecentChangeWindow;
+        var recentStateChanges = await (from transition in _dbContext.StateTransitions.AsNoTracking()
+            join endpoint in _dbContext.Endpoints.AsNoTracking() on transition.EndpointId equals endpoint.EndpointId
+            where visibleIdsFromRows.Contains(transition.EndpointId) && transition.TransitionAtUtc >= recentStart
+            orderby transition.TransitionAtUtc descending
+            select new AiNetworkHealthStateChange
+            {
+                EndpointId = transition.EndpointId,
+                Name = endpoint.Name,
+                PreviousState = transition.PreviousState.ToString().ToUpperInvariant(),
+                NewState = transition.NewState.ToString().ToUpperInvariant(),
+                ChangedAtUtc = transition.TransitionAtUtc,
+                ReasonCode = transition.ReasonCode
+            })
+            .Take(RecentChangeLimit)
+            .ToArrayAsync(cancellationToken);
+
+        var summary = new AiNetworkHealthSummary
+        {
+            GeneratedAtUtc = now,
+            VisibleEndpointCount = visibleIdSet.Count,
+            StateCounts = new AiNetworkHealthStateCounts
+            {
+                Up = rows.Count(x => x.State == EndpointStateKind.Up),
+                Degraded = rows.Count(x => x.State == EndpointStateKind.Degraded),
+                Down = rows.Count(x => x.State == EndpointStateKind.Down),
+                Suppressed = rows.Count(x => x.State == EndpointStateKind.Suppressed),
+                Unknown = rows.Count(x => x.State == EndpointStateKind.Unknown)
+            },
+            DownEndpoints = SelectEndpointRows(rows, EndpointStateKind.Down),
+            DegradedEndpoints = SelectEndpointRows(rows, EndpointStateKind.Degraded),
+            UnknownEndpoints = SelectEndpointRows(rows, EndpointStateKind.Unknown),
+            SuppressedEndpoints = SelectEndpointRows(rows, EndpointStateKind.Suppressed),
+            StaleAgents = staleAgents,
+            RecentStateChanges = recentStateChanges,
+            Limitations = [
+                "This summary uses current endpoint state and recent transitions only.",
+                "Raw CheckResults diagnostics, endpoint diagnostic packs, diagram lookup, AI memory, and write actions are not connected in this slice."
+            ]
+        };
+
+        return new AiMonitoringContextResult { ShouldInclude = true, Succeeded = true, Summary = summary };
+    }
+
+    internal static bool LooksLikeHealthQuestion(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message)) return false;
+        var text = message.Trim().ToLowerInvariant();
+        string[] phrases = ["network looking", "anything down", "any outages", "current status", "what is down", "how are things", "endpoints unknown", "anything unknown", "agents offline", "agent offline", "network health", "currently down"];
+        return phrases.Any(text.Contains);
+    }
+
+    private async Task<AccessScope> ResolveScopeAsync(AiMonitoringContextRequest request, CancellationToken cancellationToken)
+    {
+        if (request.Principal is not null)
+        {
+            var isAdmin = await _userAccessScopeService.IsAdminAsync(request.Principal);
+            var visible = isAdmin ? new HashSet<string>(StringComparer.Ordinal) : await _userAccessScopeService.GetVisibleEndpointIdsAsync(request.Principal, cancellationToken);
+            return new AccessScope(true, isAdmin, visible);
+        }
+
+        if (string.IsNullOrWhiteSpace(request.UserId)) return new AccessScope(false, false, new HashSet<string>(StringComparer.Ordinal));
+        var user = await _userManager.FindByIdAsync(request.UserId.Trim());
+        if (user is null) return new AccessScope(false, false, new HashSet<string>(StringComparer.Ordinal));
+        var isUserAdmin = await _userManager.IsInRoleAsync(user, ApplicationRoles.Admin);
+        if (isUserAdmin) return new AccessScope(true, true, new HashSet<string>(StringComparer.Ordinal));
+
+        var direct = await _dbContext.UserEndpointAccesses.AsNoTracking().Where(x => x.UserId == user.Id).Select(x => x.EndpointId).ToArrayAsync(cancellationToken);
+        var grouped = await (from membership in _dbContext.EndpointGroupMemberships.AsNoTracking()
+            join access in _dbContext.UserGroupAccesses.AsNoTracking() on membership.GroupId equals access.GroupId
+            where access.UserId == user.Id
+            select membership.EndpointId).ToArrayAsync(cancellationToken);
+        return new AccessScope(true, false, direct.Concat(grouped).ToHashSet(StringComparer.Ordinal));
+    }
+
+    private static IReadOnlyList<AiNetworkHealthEndpoint> SelectEndpointRows(IEnumerable<SummaryEndpointRow> rows, EndpointStateKind state) => rows
+        .Where(x => x.State == state)
+        .OrderBy(x => x.Name)
+        .ThenBy(x => x.Target)
+        .Take(EndpointListLimit)
+        .Select(x => new AiNetworkHealthEndpoint { EndpointId = x.EndpointId, Name = x.Name, Target = x.Target, State = x.State.ToString().ToUpperInvariant(), LastChangedUtc = x.LastChangedUtc })
+        .ToArray();
+
+    private sealed record SummaryEndpointRow(string EndpointId, string Name, string Target, EndpointStateKind State, DateTimeOffset? LastChangedUtc, string AgentId);
+    private sealed record AccessScope(bool Resolved, bool IsAdmin, IReadOnlySet<string> VisibleEndpointIds);
+}

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiMonitoringContextService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiMonitoringContextService.cs
@@ -38,13 +38,20 @@ internal sealed class AiMonitoringContextService : IAiMonitoringContextService
 
         var now = DateTimeOffset.UtcNow;
         var visibleEndpointIds = scope.IsAdmin ? null : scope.VisibleEndpointIds.ToArray();
-        var assignmentQuery = _dbContext.MonitorAssignments.AsNoTracking();
-        if (visibleEndpointIds is not null)
+        SummaryEndpointRow[] rows;
+        if (visibleEndpointIds is { Length: 0 })
         {
-            assignmentQuery = assignmentQuery.Where(x => visibleEndpointIds.Contains(x.EndpointId));
+            rows = [];
         }
+        else
+        {
+            var assignmentQuery = _dbContext.MonitorAssignments.AsNoTracking();
+            if (visibleEndpointIds is not null)
+            {
+                assignmentQuery = assignmentQuery.Where(x => visibleEndpointIds.Contains(x.EndpointId));
+            }
 
-        var rows = await (from assignment in assignmentQuery
+            rows = await (from assignment in assignmentQuery
             join endpoint in _dbContext.Endpoints.AsNoTracking() on assignment.EndpointId equals endpoint.EndpointId
             join state in _dbContext.EndpointStates.AsNoTracking() on assignment.AssignmentId equals state.AssignmentId into stateJoin
             from state in stateJoin.DefaultIfEmpty()
@@ -55,43 +62,52 @@ internal sealed class AiMonitoringContextService : IAiMonitoringContextService
                 state != null ? state.CurrentState : EndpointStateKind.Unknown,
                 state != null ? state.LastStateChangeUtc : null,
                 assignment.AgentId))
-            .ToArrayAsync(cancellationToken);
+                .ToArrayAsync(cancellationToken);
+        }
 
         var visibleIdsFromRows = rows.Select(x => x.EndpointId).Distinct(StringComparer.Ordinal).ToArray();
         var visibleIdSet = visibleIdsFromRows.ToHashSet(StringComparer.Ordinal);
         var agentIds = rows.Select(x => x.AgentId).Distinct(StringComparer.Ordinal).ToArray();
 
-        var staleAgents = await _dbContext.Agents.AsNoTracking()
-            .Where(x => agentIds.Contains(x.AgentId) && (x.Status == AgentHealthStatus.Stale || x.Status == AgentHealthStatus.Offline))
-            .OrderBy(x => x.Name ?? x.InstanceId)
-            .ThenBy(x => x.InstanceId)
-            .Take(EndpointListLimit)
-            .Select(x => new AiNetworkHealthAgent
-            {
-                AgentId = x.AgentId,
-                Name = string.IsNullOrWhiteSpace(x.Name) ? "(unnamed agent)" : x.Name!,
-                InstanceId = x.InstanceId,
-                Status = x.Status.ToString().ToUpperInvariant(),
-                LastHeartbeatUtc = x.LastHeartbeatUtc
-            })
-            .ToArrayAsync(cancellationToken);
+        AiNetworkHealthAgent[] staleAgents = [];
+        if (agentIds.Length > 0)
+        {
+            staleAgents = await _dbContext.Agents.AsNoTracking()
+                .Where(x => agentIds.Contains(x.AgentId) && (x.Status == AgentHealthStatus.Stale || x.Status == AgentHealthStatus.Offline))
+                .OrderBy(x => x.Name ?? x.InstanceId)
+                .ThenBy(x => x.InstanceId)
+                .Take(EndpointListLimit)
+                .Select(x => new AiNetworkHealthAgent
+                {
+                    AgentId = x.AgentId,
+                    Name = string.IsNullOrWhiteSpace(x.Name) ? "(unnamed agent)" : x.Name!,
+                    InstanceId = x.InstanceId,
+                    Status = x.Status.ToString().ToUpperInvariant(),
+                    LastHeartbeatUtc = x.LastHeartbeatUtc
+                })
+                .ToArrayAsync(cancellationToken);
+        }
 
         var recentStart = now - RecentChangeWindow;
-        var recentStateChanges = await (from transition in _dbContext.StateTransitions.AsNoTracking()
-            join endpoint in _dbContext.Endpoints.AsNoTracking() on transition.EndpointId equals endpoint.EndpointId
-            where visibleIdsFromRows.Contains(transition.EndpointId) && transition.TransitionAtUtc >= recentStart
-            orderby transition.TransitionAtUtc descending
-            select new AiNetworkHealthStateChange
-            {
-                EndpointId = transition.EndpointId,
-                Name = endpoint.Name,
-                PreviousState = transition.PreviousState.ToString().ToUpperInvariant(),
-                NewState = transition.NewState.ToString().ToUpperInvariant(),
-                ChangedAtUtc = transition.TransitionAtUtc,
-                ReasonCode = transition.ReasonCode
-            })
-            .Take(RecentChangeLimit)
-            .ToArrayAsync(cancellationToken);
+        AiNetworkHealthStateChange[] recentStateChanges = [];
+        if (visibleIdsFromRows.Length > 0)
+        {
+            recentStateChanges = await (from transition in _dbContext.StateTransitions.AsNoTracking()
+                join endpoint in _dbContext.Endpoints.AsNoTracking() on transition.EndpointId equals endpoint.EndpointId
+                where visibleIdsFromRows.Contains(transition.EndpointId) && transition.TransitionAtUtc >= recentStart
+                orderby transition.TransitionAtUtc descending
+                select new AiNetworkHealthStateChange
+                {
+                    EndpointId = transition.EndpointId,
+                    Name = endpoint.Name,
+                    PreviousState = transition.PreviousState.ToString().ToUpperInvariant(),
+                    NewState = transition.NewState.ToString().ToUpperInvariant(),
+                    ChangedAtUtc = transition.TransitionAtUtc,
+                    ReasonCode = transition.ReasonCode
+                })
+                .Take(RecentChangeLimit)
+                .ToArrayAsync(cancellationToken);
+        }
 
         var summary = new AiNetworkHealthSummary
         {

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/IAiMonitoringContextService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/IAiMonitoringContextService.cs
@@ -1,0 +1,76 @@
+using System.Security.Claims;
+
+namespace PingMonitor.Web.Services.AiChat;
+
+public interface IAiMonitoringContextService
+{
+    Task<AiMonitoringContextResult> TryGetNetworkHealthSummaryAsync(AiMonitoringContextRequest request, CancellationToken cancellationToken);
+}
+
+public sealed class AiMonitoringContextRequest
+{
+    public ClaimsPrincipal? Principal { get; init; }
+    public string? UserId { get; init; }
+    public string UserMessage { get; init; } = string.Empty;
+}
+
+public sealed class AiMonitoringContextResult
+{
+    public const string ToolName = "get_network_health_summary";
+    public bool ShouldInclude { get; init; }
+    public bool Succeeded { get; init; }
+    public string? ErrorMessage { get; init; }
+    public AiNetworkHealthSummary? Summary { get; init; }
+}
+
+public sealed class AiNetworkHealthSummary
+{
+    public DateTimeOffset GeneratedAtUtc { get; init; }
+    public string DataSource { get; init; } = "current_endpoint_state";
+    public int VisibleEndpointCount { get; init; }
+    public AiNetworkHealthStateCounts StateCounts { get; init; } = new();
+    public IReadOnlyList<AiNetworkHealthEndpoint> DownEndpoints { get; init; } = [];
+    public IReadOnlyList<AiNetworkHealthEndpoint> DegradedEndpoints { get; init; } = [];
+    public IReadOnlyList<AiNetworkHealthEndpoint> UnknownEndpoints { get; init; } = [];
+    public IReadOnlyList<AiNetworkHealthEndpoint> SuppressedEndpoints { get; init; } = [];
+    public IReadOnlyList<AiNetworkHealthAgent> StaleAgents { get; init; } = [];
+    public IReadOnlyList<AiNetworkHealthStateChange> RecentStateChanges { get; init; } = [];
+    public IReadOnlyList<string> Limitations { get; init; } = [];
+}
+
+public sealed class AiNetworkHealthStateCounts
+{
+    public int Up { get; init; }
+    public int Degraded { get; init; }
+    public int Down { get; init; }
+    public int Suppressed { get; init; }
+    public int Unknown { get; init; }
+}
+
+public sealed class AiNetworkHealthEndpoint
+{
+    public string EndpointId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string Target { get; init; } = string.Empty;
+    public string State { get; init; } = string.Empty;
+    public DateTimeOffset? LastChangedUtc { get; init; }
+}
+
+public sealed class AiNetworkHealthAgent
+{
+    public string AgentId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string InstanceId { get; init; } = string.Empty;
+    public string Status { get; init; } = string.Empty;
+    public DateTimeOffset? LastHeartbeatUtc { get; init; }
+}
+
+public sealed class AiNetworkHealthStateChange
+{
+    public string EndpointId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string PreviousState { get; init; } = string.Empty;
+    public string NewState { get; init; } = string.Empty;
+    public DateTimeOffset ChangedAtUtc { get; init; }
+    public string? ReasonCode { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessor.cs
+++ b/src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessor.cs
@@ -90,6 +90,7 @@ internal sealed partial class TelegramMessageProcessor : ITelegramMessageProcess
         {
             Source = AiChatSource.Telegram,
             UserMessage = userMessage,
+            UserId = account.UserId,
             ConversationHistory = _conversationStore.GetHistory(inboundMessage.ChatId, account.UserId).ToList()
         }, cancellationToken);
 

--- a/src/WebApp/PingMonitor.Web/ViewModels/AiAssistant/AiAssistantPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/AiAssistant/AiAssistantPageViewModel.cs
@@ -17,5 +17,5 @@ public sealed class AiAssistantPageViewModel
     public bool WebChatEnabled { get; set; }
     public string? StatusMessage { get; set; }
     public string? ErrorMessage { get; set; }
-    public string HelpText { get; set; } = "This is the first AI chat test interface. It can talk to the configured model, but monitoring tools, metrics, diagram lookup, Telegram routing, and memory are not connected yet.";
+    public string HelpText { get; set; } = "This is the first AI chat test interface. It can talk to the configured model and may use a limited read-only network health summary for broad status questions. Raw diagnostics, diagram lookup, memory, and write actions are not connected yet.";
 }


### PR DESCRIPTION
### Motivation

- Provide the AI Assistant a bounded, read-only monitoring context so it can answer broad network-health questions without direct DB access or raw CheckResults exposure.  
- Introduce this first V0.2.x slice as deterministic context injection (intent detection) to be reliable with local Ollama/OpenAI-compatible setups.  
- Track the work with an explicit issue so platform constraints and schema/versioning guards remain visible; created issue #561 "Add AI Assistant read-only network health summary context".

### Description

- Added a reusable monitoring context abstraction and model (`IAiMonitoringContextService`, `AiMonitoringContextService`, and related DTOs) that returns a compact `get_network_health_summary` structured summary built from current `MonitorAssignments` + `Endpoints` + `EndpointStates`, relevant `Agents`, and bounded recent `StateTransitions` with explicit limitations. (files: `src/WebApp/PingMonitor.Web/Services/AiChat/IAiMonitoringContextService.cs`, `src/WebApp/PingMonitor.Web/Services/AiChat/AiMonitoringContextService.cs`).
- Implemented deterministic intent detection (`AiMonitoringContextService.LooksLikeHealthQuestion`) and injected the monitoring summary as a system message into the existing AI prompt flow rather than enabling model tool-calls in this slice, preserving a clear migration path to tool-calling later. (changes: `src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs`).
- Enforced per-user visibility before any data reaches the model by resolving the web `ClaimsPrincipal` via `IUserAccessScopeService` and by accepting the linked application `UserId` from Telegram, with Telegram passing `UserId` through the shared chat path; registered the new service in DI and updated Telegram message processing to supply `UserId`. (changes: `src/WebApp/PingMonitor.Web/Program.cs`, `src/WebApp/PingMonitor.Web/Services/Telegram/TelegramMessageProcessor.cs`).
- Updated built-in assistant system prompt and the AI Assistant page help text to reflect the new limited read-only capability while explicitly preserving boundaries for raw CheckResults, diagnostics, diagram lookup, memory, SQL, and write actions, and added unit tests covering injection, visibility, intent detection, unavailable-summary handling, and secret leakage. (changes: `src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs`, `src/WebApp/PingMonitor.Web/ViewModels/AiAssistant/AiAssistantPageViewModel.cs`, `src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs`).

### Testing

- Added unit tests exercising the new injection and permission path and ran the test suite with fake provider services; `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` passed with all tests green (198 tests passed).  
- Built the web app with .NET 10 (`PATH=/tmp/dotnet10:$PATH dotnet build src/WebApp/PingMonitor.WebApp.slnx`) using SDK 10.0.104 that was installed in the test environment and the build succeeded.  
- Tests use fake provider/settings/monitoring services and do not require a real Ollama instance, and assertions verify that provider calls include the injected system message and that no secrets (for example the runtime API key) are exposed.  
- Confirmed boundaries: no raw `CheckResults` rows, no endpoint diagnostic packs, no diagram lookup, no AI memory/persistent chat/audit logs, and no write actions or SQL generation were implemented in this slice.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f54752f04832ab86b7fa4c12b4c8a)