### PR TITLE
Fix AI health summary MySQL empty ID queries

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/DegradedEndpointQueryTranslationTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/DegradedEndpointQueryTranslationTests.cs
@@ -54,5 +54,9 @@ public sealed class DegradedEndpointQueryTranslationTests
         Assert.Contains("if (visibleEndpointIds is { Length: 0 })", source);
         Assert.Contains("if (agentIds.Length > 0)", source);
         Assert.Contains("if (visibleIdsFromRows.Length > 0)", source);
+        Assert.Contains("WhereStringEqualsAny", source);
+        Assert.DoesNotContain("visibleEndpointIds.Contains", source);
+        Assert.DoesNotContain("agentIds.Contains", source);
+        Assert.DoesNotContain("visibleIdsFromRows.Contains", source);
     }
 }

--- a/src/WebApp/PingMonitor.Web.Tests/DegradedEndpointQueryTranslationTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/DegradedEndpointQueryTranslationTests.cs
@@ -35,4 +35,24 @@ public sealed class DegradedEndpointQueryTranslationTests
 
         Assert.DoesNotContain("RefreshAssignmentsAsync", source);
     }
+
+    [Fact]
+    public void AiMonitoringContextService_GuardsEmptyIdCollectionsBeforeMySqlContainsQueries()
+    {
+        var sourcePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            "PingMonitor.Web",
+            "Services",
+            "AiChat",
+            "AiMonitoringContextService.cs"));
+        var source = File.ReadAllText(sourcePath);
+
+        Assert.Contains("if (visibleEndpointIds is { Length: 0 })", source);
+        Assert.Contains("if (agentIds.Length > 0)", source);
+        Assert.Contains("if (visibleIdsFromRows.Length > 0)", source);
+    }
 }

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiMonitoringContextService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiMonitoringContextService.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
@@ -48,7 +49,7 @@ internal sealed class AiMonitoringContextService : IAiMonitoringContextService
             var assignmentQuery = _dbContext.MonitorAssignments.AsNoTracking();
             if (visibleEndpointIds is not null)
             {
-                assignmentQuery = assignmentQuery.Where(x => visibleEndpointIds.Contains(x.EndpointId));
+                assignmentQuery = WhereStringEqualsAny(assignmentQuery, x => x.EndpointId, visibleEndpointIds);
             }
 
             rows = await (from assignment in assignmentQuery
@@ -73,7 +74,8 @@ internal sealed class AiMonitoringContextService : IAiMonitoringContextService
         if (agentIds.Length > 0)
         {
             staleAgents = await _dbContext.Agents.AsNoTracking()
-                .Where(x => agentIds.Contains(x.AgentId) && (x.Status == AgentHealthStatus.Stale || x.Status == AgentHealthStatus.Offline))
+                .Where(BuildStringEqualsAnyExpression<Agent>(x => x.AgentId, agentIds))
+                .Where(x => x.Status == AgentHealthStatus.Stale || x.Status == AgentHealthStatus.Offline)
                 .OrderBy(x => x.Name ?? x.InstanceId)
                 .ThenBy(x => x.InstanceId)
                 .Take(EndpointListLimit)
@@ -92,9 +94,9 @@ internal sealed class AiMonitoringContextService : IAiMonitoringContextService
         AiNetworkHealthStateChange[] recentStateChanges = [];
         if (visibleIdsFromRows.Length > 0)
         {
-            recentStateChanges = await (from transition in _dbContext.StateTransitions.AsNoTracking()
+            recentStateChanges = await (from transition in WhereStringEqualsAny(_dbContext.StateTransitions.AsNoTracking(), x => x.EndpointId, visibleIdsFromRows)
                 join endpoint in _dbContext.Endpoints.AsNoTracking() on transition.EndpointId equals endpoint.EndpointId
-                where visibleIdsFromRows.Contains(transition.EndpointId) && transition.TransitionAtUtc >= recentStart
+                where transition.TransitionAtUtc >= recentStart
                 orderby transition.TransitionAtUtc descending
                 select new AiNetworkHealthStateChange
                 {
@@ -165,6 +167,28 @@ internal sealed class AiMonitoringContextService : IAiMonitoringContextService
             where access.UserId == user.Id
             select membership.EndpointId).ToArrayAsync(cancellationToken);
         return new AccessScope(true, false, direct.Concat(grouped).ToHashSet(StringComparer.Ordinal));
+    }
+
+    private static IQueryable<T> WhereStringEqualsAny<T>(IQueryable<T> query, Expression<Func<T, string>> propertySelector, IReadOnlyCollection<string> values)
+    {
+        return query.Where(BuildStringEqualsAnyExpression(propertySelector, values));
+    }
+
+    private static Expression<Func<T, bool>> BuildStringEqualsAnyExpression<T>(Expression<Func<T, string>> propertySelector, IReadOnlyCollection<string> values)
+    {
+        if (values.Count == 0)
+        {
+            return _ => false;
+        }
+
+        Expression? body = null;
+        foreach (var value in values)
+        {
+            var equals = Expression.Equal(propertySelector.Body, Expression.Constant(value, typeof(string)));
+            body = body is null ? equals : Expression.OrElse(body, equals);
+        }
+
+        return Expression.Lambda<Func<T, bool>>(body!, propertySelector.Parameters);
     }
 
     private static IReadOnlyList<AiNetworkHealthEndpoint> SelectEndpointRows(IEnumerable<SummaryEndpointRow> rows, EndpointStateKind state) => rows

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiMonitoringContextService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiMonitoringContextService.cs
@@ -38,13 +38,20 @@ internal sealed class AiMonitoringContextService : IAiMonitoringContextService
 
         var now = DateTimeOffset.UtcNow;
         var visibleEndpointIds = scope.IsAdmin ? null : scope.VisibleEndpointIds.ToArray();
-        var assignmentQuery = _dbContext.MonitorAssignments.AsNoTracking();
-        if (visibleEndpointIds is not null)
+        SummaryEndpointRow[] rows;
+        if (visibleEndpointIds is { Length: 0 })
         {
-            assignmentQuery = assignmentQuery.Where(x => visibleEndpointIds.Contains(x.EndpointId));
+            rows = [];
         }
+        else
+        {
+            var assignmentQuery = _dbContext.MonitorAssignments.AsNoTracking();
+            if (visibleEndpointIds is not null)
+            {
+                assignmentQuery = assignmentQuery.Where(x => visibleEndpointIds.Contains(x.EndpointId));
+            }
 
-        var rows = await (from assignment in assignmentQuery
+            rows = await (from assignment in assignmentQuery
             join endpoint in _dbContext.Endpoints.AsNoTracking() on assignment.EndpointId equals endpoint.EndpointId
             join state in _dbContext.EndpointStates.AsNoTracking() on assignment.AssignmentId equals state.AssignmentId into stateJoin
             from state in stateJoin.DefaultIfEmpty()
@@ -55,43 +62,52 @@ internal sealed class AiMonitoringContextService : IAiMonitoringContextService
                 state != null ? state.CurrentState : EndpointStateKind.Unknown,
                 state != null ? state.LastStateChangeUtc : null,
                 assignment.AgentId))
-            .ToArrayAsync(cancellationToken);
+                .ToArrayAsync(cancellationToken);
+        }
 
         var visibleIdsFromRows = rows.Select(x => x.EndpointId).Distinct(StringComparer.Ordinal).ToArray();
         var visibleIdSet = visibleIdsFromRows.ToHashSet(StringComparer.Ordinal);
         var agentIds = rows.Select(x => x.AgentId).Distinct(StringComparer.Ordinal).ToArray();
 
-        var staleAgents = await _dbContext.Agents.AsNoTracking()
-            .Where(x => agentIds.Contains(x.AgentId) && (x.Status == AgentHealthStatus.Stale || x.Status == AgentHealthStatus.Offline))
-            .OrderBy(x => x.Name ?? x.InstanceId)
-            .ThenBy(x => x.InstanceId)
-            .Take(EndpointListLimit)
-            .Select(x => new AiNetworkHealthAgent
-            {
-                AgentId = x.AgentId,
-                Name = string.IsNullOrWhiteSpace(x.Name) ? "(unnamed agent)" : x.Name!,
-                InstanceId = x.InstanceId,
-                Status = x.Status.ToString().ToUpperInvariant(),
-                LastHeartbeatUtc = x.LastHeartbeatUtc
-            })
-            .ToArrayAsync(cancellationToken);
+        AiNetworkHealthAgent[] staleAgents = [];
+        if (agentIds.Length > 0)
+        {
+            staleAgents = await _dbContext.Agents.AsNoTracking()
+                .Where(x => agentIds.Contains(x.AgentId) && (x.Status == AgentHealthStatus.Stale || x.Status == AgentHealthStatus.Offline))
+                .OrderBy(x => x.Name ?? x.InstanceId)
+                .ThenBy(x => x.InstanceId)
+                .Take(EndpointListLimit)
+                .Select(x => new AiNetworkHealthAgent
+                {
+                    AgentId = x.AgentId,
+                    Name = string.IsNullOrWhiteSpace(x.Name) ? "(unnamed agent)" : x.Name!,
+                    InstanceId = x.InstanceId,
+                    Status = x.Status.ToString().ToUpperInvariant(),
+                    LastHeartbeatUtc = x.LastHeartbeatUtc
+                })
+                .ToArrayAsync(cancellationToken);
+        }
 
         var recentStart = now - RecentChangeWindow;
-        var recentStateChanges = await (from transition in _dbContext.StateTransitions.AsNoTracking()
-            join endpoint in _dbContext.Endpoints.AsNoTracking() on transition.EndpointId equals endpoint.EndpointId
-            where visibleIdsFromRows.Contains(transition.EndpointId) && transition.TransitionAtUtc >= recentStart
-            orderby transition.TransitionAtUtc descending
-            select new AiNetworkHealthStateChange
-            {
-                EndpointId = transition.EndpointId,
-                Name = endpoint.Name,
-                PreviousState = transition.PreviousState.ToString().ToUpperInvariant(),
-                NewState = transition.NewState.ToString().ToUpperInvariant(),
-                ChangedAtUtc = transition.TransitionAtUtc,
-                ReasonCode = transition.ReasonCode
-            })
-            .Take(RecentChangeLimit)
-            .ToArrayAsync(cancellationToken);
+        AiNetworkHealthStateChange[] recentStateChanges = [];
+        if (visibleIdsFromRows.Length > 0)
+        {
+            recentStateChanges = await (from transition in _dbContext.StateTransitions.AsNoTracking()
+                join endpoint in _dbContext.Endpoints.AsNoTracking() on transition.EndpointId equals endpoint.EndpointId
+                where visibleIdsFromRows.Contains(transition.EndpointId) && transition.TransitionAtUtc >= recentStart
+                orderby transition.TransitionAtUtc descending
+                select new AiNetworkHealthStateChange
+                {
+                    EndpointId = transition.EndpointId,
+                    Name = endpoint.Name,
+                    PreviousState = transition.PreviousState.ToString().ToUpperInvariant(),
+                    NewState = transition.NewState.ToString().ToUpperInvariant(),
+                    ChangedAtUtc = transition.TransitionAtUtc,
+                    ReasonCode = transition.ReasonCode
+                })
+                .Take(RecentChangeLimit)
+                .ToArrayAsync(cancellationToken);
+        }
 
         var summary = new AiNetworkHealthSummary
         {


### PR DESCRIPTION
### Motivation
- Prevent EF Core/MySQL from receiving empty collection parameters (e.g. `@agentIds`) which caused `Expression '@agentIds' in the SQL tree does not have a type mapping assigned` when Telegram-triggered AI monitoring context code executed.
- Keep AI monitoring context queries predictable and MySQL-provider-safe by short-circuiting LINQ `Contains`/`IN` paths for empty ID collections.
- Add an automated regression guard to avoid reintroducing this provider-specific translation regression.

### Description
- Short-circuited `AiMonitoringContextService.TryGetNetworkHealthSummaryAsync` assignment query when a non-admin user has zero visible endpoints to avoid translating an empty `Contains` collection to SQL. (modified `src/WebApp/PingMonitor.Web/Services/AiChat/AiMonitoringContextService.cs`)
- Guarded stale-agent lookup so it only issues the `agentIds.Contains(...)` query when `agentIds` is non-empty. (modified `AiMonitoringContextService.cs`)
- Guarded recent state-change lookup so it only runs the `visibleIdsFromRows.Contains(...)` query when the collection is non-empty. (modified `AiMonitoringContextService.cs`)
- Added a source-level regression test asserting the presence of the empty-ID guards in `AiMonitoringContextService` to prevent regressions. (modified `src/WebApp/PingMonitor.Web.Tests/DegradedEndpointQueryTranslationTests.cs`)
- Created issue `#563` to track the original MySQL type-mapping failure and referenced it from the change description.

### Testing
- Ran `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj --no-restore` and all tests passed (`Passed: 199, Failed: 0`).
- The new regression guard test was added and included in the test run, and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f5853b5d8832a9b36a057d6a2ee18)