### PR TITLE
Fix AI health summary MySQL filter translation

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/DegradedEndpointQueryTranslationTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/DegradedEndpointQueryTranslationTests.cs
@@ -54,5 +54,9 @@ public sealed class DegradedEndpointQueryTranslationTests
         Assert.Contains("if (visibleEndpointIds is { Length: 0 })", source);
         Assert.Contains("if (agentIds.Length > 0)", source);
         Assert.Contains("if (visibleIdsFromRows.Length > 0)", source);
+        Assert.Contains("WhereStringEqualsAny", source);
+        Assert.DoesNotContain("visibleEndpointIds.Contains", source);
+        Assert.DoesNotContain("agentIds.Contains", source);
+        Assert.DoesNotContain("visibleIdsFromRows.Contains", source);
     }
 }

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiMonitoringContextService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiMonitoringContextService.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
@@ -48,7 +49,7 @@ internal sealed class AiMonitoringContextService : IAiMonitoringContextService
             var assignmentQuery = _dbContext.MonitorAssignments.AsNoTracking();
             if (visibleEndpointIds is not null)
             {
-                assignmentQuery = assignmentQuery.Where(x => visibleEndpointIds.Contains(x.EndpointId));
+                assignmentQuery = WhereStringEqualsAny(assignmentQuery, x => x.EndpointId, visibleEndpointIds);
             }
 
             rows = await (from assignment in assignmentQuery
@@ -73,7 +74,8 @@ internal sealed class AiMonitoringContextService : IAiMonitoringContextService
         if (agentIds.Length > 0)
         {
             staleAgents = await _dbContext.Agents.AsNoTracking()
-                .Where(x => agentIds.Contains(x.AgentId) && (x.Status == AgentHealthStatus.Stale || x.Status == AgentHealthStatus.Offline))
+                .Where(BuildStringEqualsAnyExpression<Agent>(x => x.AgentId, agentIds))
+                .Where(x => x.Status == AgentHealthStatus.Stale || x.Status == AgentHealthStatus.Offline)
                 .OrderBy(x => x.Name ?? x.InstanceId)
                 .ThenBy(x => x.InstanceId)
                 .Take(EndpointListLimit)
@@ -92,9 +94,9 @@ internal sealed class AiMonitoringContextService : IAiMonitoringContextService
         AiNetworkHealthStateChange[] recentStateChanges = [];
         if (visibleIdsFromRows.Length > 0)
         {
-            recentStateChanges = await (from transition in _dbContext.StateTransitions.AsNoTracking()
+            recentStateChanges = await (from transition in WhereStringEqualsAny(_dbContext.StateTransitions.AsNoTracking(), x => x.EndpointId, visibleIdsFromRows)
                 join endpoint in _dbContext.Endpoints.AsNoTracking() on transition.EndpointId equals endpoint.EndpointId
-                where visibleIdsFromRows.Contains(transition.EndpointId) && transition.TransitionAtUtc >= recentStart
+                where transition.TransitionAtUtc >= recentStart
                 orderby transition.TransitionAtUtc descending
                 select new AiNetworkHealthStateChange
                 {
@@ -165,6 +167,28 @@ internal sealed class AiMonitoringContextService : IAiMonitoringContextService
             where access.UserId == user.Id
             select membership.EndpointId).ToArrayAsync(cancellationToken);
         return new AccessScope(true, false, direct.Concat(grouped).ToHashSet(StringComparer.Ordinal));
+    }
+
+    private static IQueryable<T> WhereStringEqualsAny<T>(IQueryable<T> query, Expression<Func<T, string>> propertySelector, IReadOnlyCollection<string> values)
+    {
+        return query.Where(BuildStringEqualsAnyExpression(propertySelector, values));
+    }
+
+    private static Expression<Func<T, bool>> BuildStringEqualsAnyExpression<T>(Expression<Func<T, string>> propertySelector, IReadOnlyCollection<string> values)
+    {
+        if (values.Count == 0)
+        {
+            return _ => false;
+        }
+
+        Expression? body = null;
+        foreach (var value in values)
+        {
+            var equals = Expression.Equal(propertySelector.Body, Expression.Constant(value, typeof(string)));
+            body = body is null ? equals : Expression.OrElse(body, equals);
+        }
+
+        return Expression.Lambda<Func<T, bool>>(body!, propertySelector.Parameters);
     }
 
     private static IReadOnlyList<AiNetworkHealthEndpoint> SelectEndpointRows(IEnumerable<SummaryEndpointRow> rows, EndpointStateKind state) => rows


### PR DESCRIPTION
### Motivation
- Prevent a runtime EF Core MySQL translation failure where collection-parameter expressions (e.g. `@agentIds`) lacked type mappings and caused `InvalidOperationException` during Telegram/AI health-summary processing (seen in stack trace at `AiMonitoringContextService.TryGetNetworkHealthSummaryAsync`).
- Ensure AI health-summary queries remain provider-safe and deterministic when targeting MySQL per repository platform constraints.

### Description
- Replaced LINQ `Contains`-on-local-string-array filters with a provider-safe helper that builds explicit string equality predicates (`WhereStringEqualsAny` / `BuildStringEqualsAnyExpression`) inside `AiMonitoringContextService`.
- Applied the helper to the three affected runtime query paths: scoped `MonitorAssignments` visibility filter, `Agents` stale/offline filter, and `StateTransitions` recent-state-change query.
- Preserved and asserted the existing empty-collection guards (`if (visibleEndpointIds is { Length: 0 })`, `if (agentIds.Length > 0)`, `if (visibleIdsFromRows.Length > 0)`) so empty sets are handled without producing provider collection parameters.
- Extended `DegradedEndpointQueryTranslationTests.AiMonitoringContextService_GuardsEmptyIdCollectionsBeforeMySqlContainsQueries` to assert `WhereStringEqualsAny` is present and to assert that prior `*.Contains` patterns are not reintroduced.
- Touched files: `src/WebApp/PingMonitor.Web/Services/AiChat/AiMonitoringContextService.cs`, `src/WebApp/PingMonitor.Web.Tests/DegradedEndpointQueryTranslationTests.cs`.

### Testing
- Linked issue: `Fixes #563`.
- Ran targeted tests: `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj --filter "AiMonitoringContextService_GuardsEmptyIdCollectionsBeforeMySqlContainsQueries|HealthSummaryIntentDetectionMatchesBroadStatusQuestions"` and they passed.
- Ran full test project: `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and all tests passed (199 passed, 0 failed in this environment).
- Notes: Query changes were validated with MySQL-first intent (rewrote to equality predicates to avoid provider collection-parameter translation issues) and no SQLite-only validation was used.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f5c976244832aa82439110eec16d4)