### PR TITLE
Use compact text summary for AI health prompt (fixes Ollama phi4-mini failure)

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
@@ -77,6 +77,31 @@ public sealed class AiAssistantChatTests
 
 
     [Fact]
+    public void HealthSummaryPromptUsesCompactTextInsteadOfRawJson()
+    {
+        var messages = AiChatService.BuildMessages(null, [], "Is anything down?", new AiMonitoringContextResult
+        {
+            ShouldInclude = true,
+            Succeeded = true,
+            Summary = new AiNetworkHealthSummary
+            {
+                GeneratedAtUtc = DateTimeOffset.Parse("2026-06-15T12:00:00Z"),
+                VisibleEndpointCount = 1,
+                StateCounts = new AiNetworkHealthStateCounts { Down = 1 },
+                DownEndpoints = [new AiNetworkHealthEndpoint { EndpointId = "endpoint-1", Name = "Farm Router WAN", Target = "1.2.3.4", State = "DOWN", LastChangedUtc = DateTimeOffset.Parse("2026-06-15T11:55:00Z") }],
+                StaleAgents = [new AiNetworkHealthAgent { AgentId = "agent-1", Name = "Shed Agent", InstanceId = "shed", Status = "OFFLINE" }],
+                RecentStateChanges = [new AiNetworkHealthStateChange { EndpointId = "endpoint-1", Name = "Farm Router WAN", PreviousState = "UP", NewState = "DOWN", ChangedAtUtc = DateTimeOffset.Parse("2026-06-15T11:55:00Z"), ReasonCode = "failure_threshold_met" }]
+            }
+        });
+
+        var contextPrompt = Assert.Single(messages, x => x.Content.Contains("get_network_health_summary", StringComparison.Ordinal));
+        Assert.Contains("StateCounts: UP=0; DEGRADED=0; DOWN=1; SUPPRESSED=0; UNKNOWN=0", contextPrompt.Content);
+        Assert.Contains("DOWN: Farm Router WAN (1.2.3.4)", contextPrompt.Content);
+        Assert.Contains("OFFLINE: Shed Agent", contextPrompt.Content);
+        Assert.DoesNotContain("{\"", contextPrompt.Content, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task WebChatInjectsHealthSummaryForBroadNetworkStatusQuestion()
     {
         var provider = new FakeAiProviderClient { Result = new AiProviderChatResult { Succeeded = true, ResponseText = "Based on current state, one endpoint is DOWN.", Model = "llama" } };

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Services.AiProviders;
@@ -130,9 +129,66 @@ You do not have database access and must not ask for or produce SQL.
             return "The read-only Ping Monitor tool get_network_health_summary was selected, but the network health summary is unavailable. Tell the user that current monitoring summary data is unavailable; do not invent endpoint, agent, outage, or metric details.";
         }
 
-        var json = JsonSerializer.Serialize(context.Summary, new JsonSerializerOptions(JsonSerializerDefaults.Web));
-        return "Read-only Ping Monitor tool result: get_network_health_summary. Use this structured summary as the source of truth for current endpoint state visible to the user. Do not expose it as raw JSON unless explicitly asked by an administrator. Summary JSON:\n" + json;
+        var summary = context.Summary;
+        var lines = new List<string>
+        {
+            "Read-only Ping Monitor tool result: get_network_health_summary.",
+            "Use this summary as the source of truth for current endpoint state visible to the user.",
+            "Do not invent endpoint, agent, outage, metric, or raw CheckResults details.",
+            $"GeneratedAtUtc: {summary.GeneratedAtUtc:O}",
+            $"DataSource: {summary.DataSource}",
+            $"VisibleEndpointCount: {summary.VisibleEndpointCount}",
+            $"StateCounts: UP={summary.StateCounts.Up}; DEGRADED={summary.StateCounts.Degraded}; DOWN={summary.StateCounts.Down}; SUPPRESSED={summary.StateCounts.Suppressed}; UNKNOWN={summary.StateCounts.Unknown}"
+        };
+
+        AppendEndpointSection(lines, "DownEndpoints", summary.DownEndpoints);
+        AppendEndpointSection(lines, "DegradedEndpoints", summary.DegradedEndpoints);
+        AppendEndpointSection(lines, "UnknownEndpoints", summary.UnknownEndpoints);
+        AppendEndpointSection(lines, "SuppressedEndpoints", summary.SuppressedEndpoints);
+        AppendAgentSection(lines, summary.StaleAgents);
+        AppendStateChangeSection(lines, summary.RecentStateChanges);
+        AppendStringSection(lines, "Limitations", summary.Limitations);
+
+        return string.Join("\n", lines);
     }
+
+    private static void AppendEndpointSection(List<string> lines, string name, IReadOnlyList<AiNetworkHealthEndpoint> endpoints)
+    {
+        lines.Add($"{name}: {(endpoints.Count == 0 ? "none" : endpoints.Count.ToString(System.Globalization.CultureInfo.InvariantCulture))}");
+        foreach (var endpoint in endpoints)
+        {
+            lines.Add($"- {endpoint.State}: {endpoint.Name} ({endpoint.Target}); EndpointId={endpoint.EndpointId}; LastChangedUtc={FormatTimestamp(endpoint.LastChangedUtc)}");
+        }
+    }
+
+    private static void AppendAgentSection(List<string> lines, IReadOnlyList<AiNetworkHealthAgent> agents)
+    {
+        lines.Add($"StaleOrOfflineAgents: {(agents.Count == 0 ? "none" : agents.Count.ToString(System.Globalization.CultureInfo.InvariantCulture))}");
+        foreach (var agent in agents)
+        {
+            lines.Add($"- {agent.Status}: {agent.Name}; InstanceId={agent.InstanceId}; AgentId={agent.AgentId}; LastHeartbeatUtc={FormatTimestamp(agent.LastHeartbeatUtc)}");
+        }
+    }
+
+    private static void AppendStateChangeSection(List<string> lines, IReadOnlyList<AiNetworkHealthStateChange> changes)
+    {
+        lines.Add($"RecentStateChanges: {(changes.Count == 0 ? "none" : changes.Count.ToString(System.Globalization.CultureInfo.InvariantCulture))}");
+        foreach (var change in changes)
+        {
+            lines.Add($"- {change.ChangedAtUtc:O}: {change.Name} ({change.EndpointId}) {change.PreviousState}->{change.NewState}; ReasonCode={change.ReasonCode ?? "none"}");
+        }
+    }
+
+    private static void AppendStringSection(List<string> lines, string name, IReadOnlyList<string> values)
+    {
+        lines.Add($"{name}: {(values.Count == 0 ? "none" : values.Count.ToString(System.Globalization.CultureInfo.InvariantCulture))}");
+        foreach (var value in values)
+        {
+            lines.Add($"- {value}");
+        }
+    }
+
+    private static string FormatTimestamp(DateTimeOffset? timestamp) => timestamp.HasValue ? timestamp.Value.ToString("O") : "unknown";
 
     private static AiChatResponse ConfigurationError(AiAssistantSettingsDto settings, string message) => new() { AssistantEnabled = settings.AssistantEnabled, WebChatEnabled = settings.WebChatEnabled, TelegramChatEnabled = settings.TelegramChatEnabled, ErrorMessage = message };
     private static string Truncate(string value, int max) => value.Length <= max ? value : value[..max];


### PR DESCRIPTION
### Motivation

- The local Ollama provider (`phi4-mini`) was failing when the AI assistant prompt included a raw JSON health summary, so replace the large JSON payload with a compact, line-oriented text summary to improve compatibility and avoid provider/model parsing issues.
- Preserve the existing read-only, source-of-truth safety instructions so the model cannot invent endpoint/agent/state details.
- Add an automated regression to prevent reintroducing raw JSON prompts that can break local models.

### Description

- Replace the JSON-serialized monitoring summary in `AiChatService.BuildMonitoringContextPrompt` with a compact, line-oriented text summary that lists generated timestamp, data source, visible endpoint counts, state counts, endpoint sections, stale/offline agents, recent state changes, and limitations in a simpler format (`src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs`).
- Add helper methods to format sections and timestamps: `AppendEndpointSection`, `AppendAgentSection`, `AppendStateChangeSection`, `AppendStringSection`, and `FormatTimestamp` in `AiChatService` to produce the compact prompt.
- Add a unit test `HealthSummaryPromptUsesCompactTextInsteadOfRawJson` to `AiAssistantChatTests` to assert the compact prompt contains grounded outage/agent details and does not contain raw JSON (`src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs`).
- No LINQ/EF query paths or database schema changes were made and the change keeps existing safety and access checks intact; this PR links the investigation issue with `Fixes #566`.

### Testing

- Ran the web tests with .NET 10: `PATH=/tmp/dotnet10:$PATH DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj --verbosity minimal` and with `--no-restore`; the test run passed with `Passed: 200, Failed: 0, Skipped: 0, Total: 200` and the new regression test passed.
- The test runs used a locally-installed .NET 10 SDK matching the repository `global.json` (10.0.104) to ensure runtime parity and reproducible results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f61f90d74832a9bfda7239bafbe1d)