### PR TITLE
Add AI endpoint diagnostics and bounded CheckResults context

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
@@ -59,7 +59,7 @@ public sealed class AiAssistantChatTests
         var settings = EnabledSettings();
         settings.TelegramChatEnabled = false;
         var monitoring = new FakeAiMonitoringContextService();
-        var chat = new AiChatService(new FakeAiAssistantSettingsService(settings), provider, monitoring, NullLogger<AiChatService>.Instance);
+        var chat = new AiChatService(new FakeAiAssistantSettingsService(settings), provider, monitoring, new FakeAiEndpointLookupService(), new FakeAiEndpointDiagnosticsService(), NullLogger<AiChatService>.Instance);
 
         var response = await chat.SendAsync(new AiChatRequest { Source = AiChatSource.Telegram, UserMessage = "hello" }, CancellationToken.None);
 
@@ -76,7 +76,7 @@ public sealed class AiAssistantChatTests
         var settings = EnabledSettings(webChatEnabled: false);
         settings.TelegramChatEnabled = true;
         var monitoring = new FakeAiMonitoringContextService();
-        var chat = new AiChatService(new FakeAiAssistantSettingsService(settings), provider, monitoring, NullLogger<AiChatService>.Instance);
+        var chat = new AiChatService(new FakeAiAssistantSettingsService(settings), provider, monitoring, new FakeAiEndpointLookupService(), new FakeAiEndpointDiagnosticsService(), NullLogger<AiChatService>.Instance);
 
         var response = await chat.SendAsync(new AiChatRequest { Source = AiChatSource.Telegram, User = User(), UserMessage = "How is my network looking today?" }, CancellationToken.None);
 
@@ -112,7 +112,7 @@ public sealed class AiAssistantChatTests
         {
             Result = AiMonitoringContextResult.Unavailable("database unavailable")
         };
-        var chat = new AiChatService(new FakeAiAssistantSettingsService(EnabledSettings()), provider, monitoring, NullLogger<AiChatService>.Instance);
+        var chat = new AiChatService(new FakeAiAssistantSettingsService(EnabledSettings()), provider, monitoring, new FakeAiEndpointLookupService(), new FakeAiEndpointDiagnosticsService(), NullLogger<AiChatService>.Instance);
 
         var response = await chat.SendAsync(new AiChatRequest { User = User(), UserMessage = "How is my network looking today?" }, CancellationToken.None);
 
@@ -128,14 +128,47 @@ public sealed class AiAssistantChatTests
     {
         var provider = new FakeAiProviderClient();
         var monitoring = new FakeAiMonitoringContextService();
-        var chat = new AiChatService(new FakeAiAssistantSettingsService(EnabledSettings()), provider, monitoring, NullLogger<AiChatService>.Instance);
+        var chat = new AiChatService(new FakeAiAssistantSettingsService(EnabledSettings()), provider, monitoring, new FakeAiEndpointLookupService(), new FakeAiEndpointDiagnosticsService(), NullLogger<AiChatService>.Instance);
 
         await chat.SendAsync(new AiChatRequest { User = User(), UserMessage = "Is WFP WAN RTT higher than its 24h baseline?" }, CancellationToken.None);
 
         Assert.Equal(0, monitoring.CallCount);
         Assert.NotNull(provider.LastRequest);
-        Assert.Contains("baseline comparisons", provider.LastRequest.Messages[0].Content, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Raw CheckResults diagnostics", provider.LastRequest.Messages[0].Content, StringComparison.Ordinal);
+        Assert.Contains("bounded check-result", provider.LastRequest.Messages[0].Content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("unrestricted raw CheckResults export", provider.LastRequest.Messages[0].Content, StringComparison.Ordinal);
+    }
+
+
+
+    [Fact]
+    public async Task WebChatInjectsEndpointDiagnosticsForEndpointQuestion()
+    {
+        var provider = new FakeAiProviderClient { Result = new AiProviderChatResult { Succeeded = true, ResponseText = "WFP WAN is UP.", Model = "llama" } };
+        var lookup = new FakeAiEndpointLookupService { Result = new AiEndpointLookupResult { Succeeded = true, Matches = [new AiEndpointLookupItem { EndpointId = "e-wfp", Name = "WFP WAN", Target = "1.2.3.4", Enabled = true }] } };
+        var diagnostics = new FakeAiEndpointDiagnosticsService();
+        var chat = new AiChatService(new FakeAiAssistantSettingsService(EnabledSettings()), provider, new FakeAiMonitoringContextService(), lookup, diagnostics, NullLogger<AiChatService>.Instance);
+
+        var response = await chat.SendAsync(new AiChatRequest { User = User(), UserMessage = "What is going on with WFP WAN?" }, CancellationToken.None);
+
+        Assert.True(response.Succeeded);
+        Assert.Equal(1, lookup.CallCount);
+        Assert.Equal("24h", diagnostics.RequestedWindow);
+        Assert.Contains(provider.LastRequest!.Messages, x => x.Role == "system" && x.Content.Contains("get_endpoint_diagnostics_pack", StringComparison.Ordinal));
+        Assert.Contains(provider.LastRequest.Messages, x => x.Content.Contains("WFP WAN", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AmbiguousEndpointLookupReturnsClarificationWithoutProviderCall()
+    {
+        var provider = new FakeAiProviderClient();
+        var lookup = new FakeAiEndpointLookupService { Result = new AiEndpointLookupResult { Ambiguous = true, Matches = [new AiEndpointLookupItem { Name = "Kitchen AP", Target = "10.0.0.2" }, new AiEndpointLookupItem { Name = "Kitchen Switch", Target = "10.0.0.3" }] } };
+        var chat = new AiChatService(new FakeAiAssistantSettingsService(EnabledSettings()), provider, new FakeAiMonitoringContextService(), lookup, new FakeAiEndpointDiagnosticsService(), NullLogger<AiChatService>.Instance);
+
+        var response = await chat.SendAsync(new AiChatRequest { User = User(), UserMessage = "Is Kitchen flapping?" }, CancellationToken.None);
+
+        Assert.True(response.Succeeded);
+        Assert.Contains("Which one", response.AssistantMessage);
+        Assert.Null(provider.LastRequest);
     }
 
     [Fact]
@@ -238,10 +271,10 @@ public sealed class AiAssistantChatTests
     public void PromptLayeringIncludesSafetyPromptBeforeAdminPrompt()
     {
         var messages = AiChatService.BuildMessages("Site guidance", [], "How is my network looking today?");
-        Assert.Contains("read-only network health summary", messages[0].Content);
-        Assert.Contains("Raw CheckResults diagnostics", messages[0].Content);
-        Assert.Contains("diagram lookup", messages[0].Content);
-        Assert.Contains("endpoint diagnostic packs", messages[0].Content);
+        Assert.Contains("endpoint diagnostics packs", messages[0].Content);
+        Assert.Contains("bounded check-result summaries", messages[0].Content);
+        Assert.Contains("Diagram lookup", messages[0].Content);
+        Assert.Contains("switch port/VLAN", messages[0].Content);
         Assert.Contains("memory", messages[0].Content);
         Assert.Contains("Do not invent endpoint state", messages[0].Content);
         Assert.Contains("Admin-configured site instructions", messages[1].Content);
@@ -273,7 +306,7 @@ public sealed class AiAssistantChatTests
         FakeAiMonitoringContextService? monitoringContextService = null)
     {
         var settingsService = new FakeAiAssistantSettingsService(settings);
-        var chat = new AiChatService(settingsService, provider, monitoringContextService ?? new FakeAiMonitoringContextService(), NullLogger<AiChatService>.Instance);
+        var chat = new AiChatService(settingsService, provider, monitoringContextService ?? new FakeAiMonitoringContextService(), new FakeAiEndpointLookupService(), new FakeAiEndpointDiagnosticsService(), NullLogger<AiChatService>.Instance);
         return new AiAssistantController(settingsService, chat);
     }
 
@@ -391,6 +424,29 @@ public sealed class AiAssistantChatTests
         {
             CallCount += 1;
             return Task.FromResult(Result);
+        }
+    }
+
+
+
+    private sealed class FakeAiEndpointLookupService : IAiEndpointLookupService
+    {
+        public int CallCount { get; private set; }
+        public AiEndpointLookupResult Result { get; set; } = new() { Succeeded = true, Matches = [new AiEndpointLookupItem { EndpointId = "endpoint-farm-router", Name = "Farm Router WAN", Target = "1.2.3.4", Enabled = true }] };
+        public Task<AiEndpointLookupResult> SearchEndpointsAsync(ClaimsPrincipal user, string userMessage, CancellationToken cancellationToken)
+        {
+            CallCount += 1;
+            return Task.FromResult(Result);
+        }
+    }
+
+    private sealed class FakeAiEndpointDiagnosticsService : IAiEndpointDiagnosticsService
+    {
+        public string? RequestedWindow { get; private set; }
+        public Task<AiEndpointDiagnosticsResult> GetDiagnosticsPackAsync(ClaimsPrincipal user, string endpointId, string requestedWindow, CancellationToken cancellationToken)
+        {
+            RequestedWindow = requestedWindow;
+            return Task.FromResult(new AiEndpointDiagnosticsResult { Succeeded = true, Pack = new AiEndpointDiagnosticsPack { GeneratedAtUtc = DateTimeOffset.Parse("2026-06-15T12:00:00Z"), Endpoint = new AiEndpointLookupItem { EndpointId = endpointId, Name = "WFP WAN", Target = "1.2.3.4", Enabled = true }, CurrentState = new AiEndpointCurrentStateInfo { State = EndpointStateKind.Up }, Checks = new AiEndpointCheckSummary { ReceivedSamples = 1, SuccessfulSamples = 1 }, Uptime = new AiEndpointUptimeSummary { UptimeSeconds = 3600, UptimePercent = 100 } } });
         }
     }
 

--- a/src/WebApp/PingMonitor.Web.Tests/AiEndpointDiagnosticsServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiEndpointDiagnosticsServiceTests.cs
@@ -1,0 +1,114 @@
+using System.Security.Claims;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.AiTools;
+using PingMonitor.Web.Services.Diagnostics;
+using PingMonitor.Web.Services.Identity;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class AiEndpointDiagnosticsServiceTests
+{
+    [Fact]
+    public async Task Lookup_FindsVisibleEndpointByExactNameAndTarget_AndHidesInvisible()
+    {
+        await using var db = CreateDb();
+        Seed(db, "a1", "e1", "Google DNS", "8.8.8.8", EndpointStateKind.Up);
+        Seed(db, "a2", "e2", "Hidden WAN", "192.0.2.1", EndpointStateKind.Down);
+        await db.SaveChangesAsync();
+        var svc = new AiEndpointLookupService(db, new FakeAccess(false, new HashSet<string>(["e1"], StringComparer.Ordinal)), new TestDbActivityScope());
+
+        Assert.Equal("e1", (await svc.SearchEndpointsAsync(User(), "Has Google DNS been down today?", CancellationToken.None)).StrongMatch!.EndpointId);
+        Assert.Equal("e1", (await svc.SearchEndpointsAsync(User(), "What has uptime been like for 8.8.8.8?", CancellationToken.None)).StrongMatch!.EndpointId);
+        Assert.Null((await svc.SearchEndpointsAsync(User(), "What is going on with Hidden WAN?", CancellationToken.None)).StrongMatch);
+    }
+
+    [Fact]
+    public async Task Lookup_ReturnsAmbiguousAndNoMatchResponses()
+    {
+        await using var db = CreateDb();
+        Seed(db, "a1", "e1", "Kitchen Access Point", "10.0.0.2", EndpointStateKind.Up);
+        Seed(db, "a2", "e2", "Kitchen Switch", "10.0.0.3", EndpointStateKind.Up);
+        await db.SaveChangesAsync();
+        var svc = new AiEndpointLookupService(db, new FakeAccess(true), new TestDbActivityScope());
+
+        var ambiguous = await svc.SearchEndpointsAsync(User(), "Is Kitchen flapping?", CancellationToken.None);
+        Assert.True(ambiguous.Ambiguous);
+        Assert.Equal(2, ambiguous.Matches.Count);
+        Assert.Contains("No matching", (await svc.SearchEndpointsAsync(User(), "Is Barn Router flapping?", CancellationToken.None)).Message);
+    }
+
+    [Fact]
+    public async Task Diagnostics_IncludesCurrentStateUptimeCheckSummaryAndBoundedSeries()
+    {
+        await using var db = CreateDb();
+        var now = DateTimeOffset.UtcNow;
+        Seed(db, "a1", "e1", "WFP WAN", "1.2.3.4", EndpointStateKind.Unknown, AgentHealthStatus.Offline);
+        db.AssignmentStateIntervals.AddRange(
+            new AssignmentStateInterval { AssignmentStateIntervalId = "i1", AssignmentId = "a1", State = EndpointStateKind.Up, StartedAtUtc = now.AddHours(-3), EndedAtUtc = now.AddHours(-2), UpdatedAtUtc = now },
+            new AssignmentStateInterval { AssignmentStateIntervalId = "i2", AssignmentId = "a1", State = EndpointStateKind.Unknown, StartedAtUtc = now.AddHours(-2), EndedAtUtc = now.AddHours(-1), UpdatedAtUtc = now },
+            new AssignmentStateInterval { AssignmentStateIntervalId = "i3", AssignmentId = "a1", State = EndpointStateKind.Down, StartedAtUtc = now.AddHours(-1), EndedAtUtc = now.AddMinutes(-30), UpdatedAtUtc = now });
+        db.StateTransitions.AddRange(
+            new StateTransition { TransitionId = "t1", AssignmentId = "a1", AgentId = "agent", EndpointId = "e1", PreviousState = EndpointStateKind.Up, NewState = EndpointStateKind.Down, TransitionAtUtc = now.AddHours(-1) },
+            new StateTransition { TransitionId = "t2", AssignmentId = "a1", AgentId = "agent", EndpointId = "e1", PreviousState = EndpointStateKind.Down, NewState = EndpointStateKind.Up, TransitionAtUtc = now.AddMinutes(-20) });
+        for (var i = 0; i < 150; i++) db.CheckResults.Add(new CheckResult { CheckResultId = $"c{i}", AssignmentId = "a1", CheckedAtUtc = now.AddMinutes(-i), ReceivedAtUtc = now.AddMinutes(-i), Success = i % 10 != 0, RoundTripMs = i, BatchId = "b" });
+        await db.SaveChangesAsync();
+
+        var svc = new AiEndpointDiagnosticsService(db, new FakeAccess(true), new TestDbActivityScope());
+        var result = await svc.GetDiagnosticsPackAsync(User(), "e1", "30d", CancellationToken.None);
+
+        Assert.True(result.Succeeded);
+        var pack = result.Pack!;
+        Assert.Equal(EndpointStateKind.Unknown, pack.CurrentState.State);
+        Assert.Contains("UNKNOWN is not endpoint downtime", pack.CurrentState.UnknownReason);
+        Assert.True(pack.Window.Clamped);
+        Assert.True(pack.Uptime.UnknownSeconds > 0);
+        Assert.True(pack.Uptime.DowntimeSeconds > 0);
+        Assert.NotEqual(pack.Uptime.UnknownSeconds, pack.Uptime.DowntimeSeconds);
+        Assert.Equal(15, pack.Checks.FailedSamples);
+        Assert.True(pack.Rtt.Available);
+        Assert.Equal(120, pack.RecentSampleTail.Count);
+        Assert.Equal(1, pack.Uptime.DownTransitions);
+        Assert.Equal(1, pack.Uptime.RecoveryTransitions);
+    }
+
+    [Fact]
+    public void ResolveWindow_SupportsAndClampsSafeWindows()
+    {
+        var now = DateTimeOffset.Parse("2026-06-15T12:00:00Z");
+        Assert.Equal("1h", AiEndpointDiagnosticsService.ResolveWindow("1h", now).AppliedWindow);
+        Assert.Equal("6h", AiEndpointDiagnosticsService.ResolveWindow("6h", now).AppliedWindow);
+        Assert.Equal("24h", AiEndpointDiagnosticsService.ResolveWindow("today", now).AppliedWindow);
+        Assert.Equal("7d", AiEndpointDiagnosticsService.ResolveWindow("7d", now).AppliedWindow);
+        Assert.True(AiEndpointDiagnosticsService.ResolveWindow("90d", now).Clamped);
+    }
+
+    private static PingMonitorDbContext CreateDb() => new(new DbContextOptionsBuilder<PingMonitorDbContext>().UseInMemoryDatabase(Guid.NewGuid().ToString()).Options);
+    private static ClaimsPrincipal User() => new(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, "user")], "test"));
+    private static void Seed(PingMonitorDbContext db, string assignmentId, string endpointId, string name, string target, EndpointStateKind state, AgentHealthStatus agentStatus = AgentHealthStatus.Online)
+    {
+        var now = DateTimeOffset.UtcNow;
+        if (!db.Agents.Local.Any()) db.Agents.Add(new Agent { AgentId = "agent", InstanceId = "agent-instance", Name = "Agent", Enabled = true, ApiKeyHash = "hash", ApiKeyCreatedAtUtc = now, CreatedAtUtc = now, Status = agentStatus });
+        db.Endpoints.Add(new Endpoint { EndpointId = endpointId, Name = name, Target = target, Enabled = true, CreatedAtUtc = now });
+        db.MonitorAssignments.Add(new MonitorAssignment { AssignmentId = assignmentId, AgentId = "agent", EndpointId = endpointId, Enabled = true, PingIntervalSeconds = 60, RetryIntervalSeconds = 10, TimeoutMs = 1000, FailureThreshold = 3, RecoveryThreshold = 2, CreatedAtUtc = now, UpdatedAtUtc = now });
+        db.EndpointStates.Add(new EndpointState { AssignmentId = assignmentId, AgentId = "agent", EndpointId = endpointId, CurrentState = state, LastStateChangeUtc = now.AddMinutes(-5), LastCheckUtc = now.AddMinutes(-1) });
+    }
+
+    private sealed class FakeAccess : IUserAccessScopeService
+    {
+        private readonly bool _admin; private readonly IReadOnlySet<string> _visible;
+        public FakeAccess(bool admin, IReadOnlySet<string>? visible = null) { _admin = admin; _visible = visible ?? new HashSet<string>(); }
+        public Task<bool> IsAdminAsync(ClaimsPrincipal principal) => Task.FromResult(_admin);
+        public Task<IReadOnlySet<string>> GetVisibleEndpointIdsAsync(ClaimsPrincipal principal, CancellationToken cancellationToken) => Task.FromResult(_visible);
+        public Task<bool> CanAccessAssignmentAsync(ClaimsPrincipal principal, string assignmentId, CancellationToken cancellationToken) => Task.FromResult(_admin);
+    }
+
+    private sealed class TestDbActivityScope : IDbActivityScope
+    {
+        public string CurrentSubsystem => "Test";
+        public IDisposable BeginScope(string subsystem) => new Scope();
+        private sealed class Scope : IDisposable { public void Dispose() { } }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -204,6 +204,8 @@ builder.Services.AddScoped<IAiAssistantSettingsService, AiAssistantSettingsServi
 builder.Services.AddScoped<IAiProviderClient, OpenAiCompatibleProviderClient>();
 builder.Services.AddMemoryCache();
 builder.Services.AddScoped<IAiMonitoringContextService, AiMonitoringContextService>();
+builder.Services.AddScoped<IAiEndpointLookupService, AiEndpointLookupService>();
+builder.Services.AddScoped<IAiEndpointDiagnosticsService, AiEndpointDiagnosticsService>();
 builder.Services.AddScoped<IAiChatService, AiChatService>();
 builder.Services.AddSingleton<ITelegramAiConversationStore, TelegramAiConversationStore>();
 builder.Services.AddSingleton<IApplicationMetadataProvider, ApplicationMetadataProvider>();

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs
@@ -14,17 +14,19 @@ internal sealed class AiChatService : IAiChatService
 You are the Ping Monitor AI assistant.
 
 You are read-only.
-You may be given a read-only network health summary from Ping Monitor.
-Use it as the source of truth for current endpoint and agent state visible to the user.
-Do not invent endpoint state, agents, outages, diagrams, ports, VLANs, metrics, raw CheckResults, or topology.
-If the supplied summary is absent or incomplete, say so.
-Raw CheckResults diagnostics, diagram lookup, endpoint diagnostic packs, baseline comparisons, detailed latency/loss/jitter diagnostics, prompt history, persistent AI audit logs, and memory are not connected yet.
+You may be given read-only Ping Monitor context including network health summaries, endpoint lookup results, endpoint diagnostics packs, bounded uptime/state interval summaries, and bounded check-result summaries or series.
+Use supplied context as the source of truth for current endpoint and agent state visible to the user.
+Do not invent endpoint states, uptime, CheckResults, RTT, packet loss, agents, diagrams, ports, VLANs, outage history, metrics, or topology.
+If endpoint diagnostics context is missing, ambiguous, or incomplete, say so.
+Diagram lookup, switch port/VLAN answers, persistent memory, prompt history, persistent AI audit logs, write actions, formal tool-calling, and unrestricted raw CheckResults export are not connected yet.
 You may summarize and explain only. Do not suggest or perform write actions, remediation, alert acknowledgement, endpoint edits, dependency edits, diagram edits, agent commands, direct SQL, or autonomous actions.
 """;
 
     private readonly IAiAssistantSettingsService _settingsService;
     private readonly IAiProviderClient _providerClient;
     private readonly IAiMonitoringContextService _monitoringContextService;
+    private readonly IAiEndpointLookupService _endpointLookupService;
+    private readonly IAiEndpointDiagnosticsService _endpointDiagnosticsService;
     private readonly ILogger<AiChatService> _logger;
 
     private static readonly JsonSerializerOptions MonitoringSummaryJsonOptions = new(JsonSerializerDefaults.Web)
@@ -37,11 +39,15 @@ You may summarize and explain only. Do not suggest or perform write actions, rem
         IAiAssistantSettingsService settingsService,
         IAiProviderClient providerClient,
         IAiMonitoringContextService monitoringContextService,
+        IAiEndpointLookupService endpointLookupService,
+        IAiEndpointDiagnosticsService endpointDiagnosticsService,
         ILogger<AiChatService> logger)
     {
         _settingsService = settingsService;
         _providerClient = providerClient;
         _monitoringContextService = monitoringContextService;
+        _endpointLookupService = endpointLookupService;
+        _endpointDiagnosticsService = endpointDiagnosticsService;
         _logger = logger;
     }
 
@@ -172,11 +178,44 @@ You may summarize and explain only. Do not suggest or perform write actions, rem
             || normalized.Contains("agent stale", StringComparison.Ordinal);
     }
 
+
+    internal static bool ShouldRequestEndpointDiagnostics(string userMessage)
+    {
+        if (string.IsNullOrWhiteSpace(userMessage)) return false;
+        var normalized = userMessage.Trim().ToLowerInvariant();
+        return normalized.Contains("what is going on with", StringComparison.Ordinal)
+            || normalized.Contains("what's going on with", StringComparison.Ordinal)
+            || normalized.Contains("uptime", StringComparison.Ordinal)
+            || normalized.Contains("down today", StringComparison.Ordinal)
+            || normalized.Contains("been down", StringComparison.Ordinal)
+            || normalized.Contains("flapping", StringComparison.Ordinal)
+            || normalized.Contains("recent check", StringComparison.Ordinal)
+            || normalized.Contains("check pattern", StringComparison.Ordinal)
+            || normalized.Contains("packet loss", StringComparison.Ordinal)
+            || normalized.Contains("latency", StringComparison.Ordinal)
+            || normalized.Contains("rtt", StringComparison.Ordinal)
+            || normalized.Contains("reliable", StringComparison.Ordinal);
+    }
+
+    internal static string RequestedWindowFromMessage(string userMessage)
+    {
+        var normalized = userMessage.ToLowerInvariant();
+        if (normalized.Contains("1h", StringComparison.Ordinal) || normalized.Contains("last hour", StringComparison.Ordinal)) return "1h";
+        if (normalized.Contains("6h", StringComparison.Ordinal) || normalized.Contains("six hours", StringComparison.Ordinal)) return "6h";
+        if (normalized.Contains("7d", StringComparison.Ordinal) || normalized.Contains("week", StringComparison.Ordinal)) return "7d";
+        if (normalized.Contains("today", StringComparison.Ordinal)) return "today";
+        if (normalized.Contains("24h", StringComparison.Ordinal) || normalized.Contains("24 hours", StringComparison.Ordinal)) return "24h";
+        if (normalized.Contains("month", StringComparison.Ordinal) || normalized.Contains("year", StringComparison.Ordinal)) return "30d";
+        return "24h";
+    }
+
     private async Task<MonitoringContextPromptResult> GetMonitoringContextPromptAsync(
         AiChatRequest request,
         CancellationToken cancellationToken)
     {
-        if (!ShouldRequestNetworkHealthSummary(request.UserMessage))
+        var wantsEndpointDiagnostics = ShouldRequestEndpointDiagnostics(request.UserMessage);
+        var wantsNetworkSummary = ShouldRequestNetworkHealthSummary(request.UserMessage);
+        if (!wantsEndpointDiagnostics && !wantsNetworkSummary)
         {
             return MonitoringContextPromptResult.None;
         }
@@ -184,6 +223,34 @@ You may summarize and explain only. Do not suggest or perform write actions, rem
         if (request.User is null)
         {
             return MonitoringContextPromptResult.Unavailable(BuildMonitoringUnavailableMessage());
+        }
+
+        if (wantsEndpointDiagnostics)
+        {
+            var lookup = await _endpointLookupService.SearchEndpointsAsync(request.User, request.UserMessage, cancellationToken);
+            if (lookup.Ambiguous)
+            {
+                var choices = string.Join("\n", lookup.Matches.Select(x => $"- {x.Name} ({x.Target})"));
+                return MonitoringContextPromptResult.Unavailable($"I found multiple visible endpoints that could match. Which one do you mean?\n{choices}");
+            }
+            if (lookup.StrongMatch is null)
+            {
+                return MonitoringContextPromptResult.Unavailable(lookup.Message ?? "No matching visible endpoint was found.");
+            }
+            var diagnostics = await _endpointDiagnosticsService.GetDiagnosticsPackAsync(request.User, lookup.StrongMatch.EndpointId, RequestedWindowFromMessage(request.UserMessage), cancellationToken);
+            if (!diagnostics.Succeeded || diagnostics.Pack is null)
+            {
+                return MonitoringContextPromptResult.Unavailable(diagnostics.ErrorMessage ?? "I couldn't retrieve endpoint diagnostics safely.");
+            }
+            var diagnosticsJson = JsonSerializer.Serialize(diagnostics.Pack, MonitoringSummaryJsonOptions);
+            return MonitoringContextPromptResult.Available($"""
+Read-only Ping Monitor tool result: {AiEndpointDiagnosticsPack.ToolName}
+This structured endpoint diagnostics pack is permission-filtered for the authenticated application user.
+Use it as source of truth. Answer in plain text and do not display the raw JSON.
+CheckResults context is bounded; UNKNOWN is not DOWN; SUPPRESSED is not downtime.
+
+{diagnosticsJson}
+""");
         }
 
         AiMonitoringContextResult contextResult;
@@ -215,7 +282,7 @@ This is current saved monitoring state, not raw packet-level diagnostics.
 
         static string BuildMonitoringUnavailableMessage()
         {
-            return "I couldn't retrieve Ping Monitor's current network health summary, so I don't have enough monitoring data to answer that safely. Raw CheckResults diagnostics, diagram lookup, endpoint diagnostic packs, baseline comparisons, and memory are not connected yet.";
+            return "I couldn't retrieve Ping Monitor's current network health summary, so I don't have enough monitoring data to answer that safely. Endpoint diagnostics are bounded. Diagram lookup, switch port/VLAN answers, memory, write actions, and unrestricted raw CheckResults export are not connected yet.";
         }
     }
 

--- a/src/WebApp/PingMonitor.Web/Services/AiTools/AiEndpointDiagnosticsModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiTools/AiEndpointDiagnosticsModels.cs
@@ -1,0 +1,125 @@
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.AiTools;
+
+public sealed class AiEndpointLookupResult
+{
+    public bool Succeeded { get; init; }
+    public bool Ambiguous { get; init; }
+    public string? Message { get; init; }
+    public IReadOnlyList<AiEndpointLookupItem> Matches { get; init; } = [];
+    public AiEndpointLookupItem? StrongMatch => !Ambiguous && Matches.Count == 1 ? Matches[0] : null;
+}
+
+public sealed class AiEndpointLookupItem
+{
+    public string EndpointId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string Target { get; init; } = string.Empty;
+    public bool Enabled { get; init; }
+}
+
+public sealed class AiEndpointDiagnosticsResult
+{
+    public bool Succeeded { get; init; }
+    public AiEndpointDiagnosticsPack? Pack { get; init; }
+    public string? ErrorMessage { get; init; }
+}
+
+public sealed class AiEndpointDiagnosticsPack
+{
+    public const string ToolName = "get_endpoint_diagnostics_pack";
+    public string CapabilityName { get; init; } = ToolName;
+    public DateTimeOffset GeneratedAtUtc { get; init; }
+    public string DataSource { get; init; } = "endpoint_diagnostics_pack";
+    public bool PermissionFiltered { get; init; } = true;
+    public AiEndpointLookupItem Endpoint { get; init; } = new();
+    public AiEndpointAssignmentInfo? Assignment { get; init; }
+    public AiEndpointCurrentStateInfo CurrentState { get; init; } = new();
+    public AiTimeWindowInfo Window { get; init; } = new();
+    public AiEndpointUptimeSummary Uptime { get; init; } = new();
+    public AiEndpointCheckSummary Checks { get; init; } = new();
+    public AiEndpointRttSummary Rtt { get; init; } = new();
+    public IReadOnlyList<AiEndpointTransitionItem> RecentTransitions { get; init; } = [];
+    public IReadOnlyList<AiEndpointCheckSeriesPoint> RecentSampleTail { get; init; } = [];
+    public IReadOnlyList<string> Limitations { get; init; } =
+    [
+        "This diagnostics pack is bounded and may use bucketed summaries.",
+        "Full raw CheckResults export is not exposed to the AI assistant.",
+        "Diagram lookup, switch port/VLAN answers, AI memory, and write actions are not connected yet."
+    ];
+}
+
+public sealed class AiEndpointAssignmentInfo
+{
+    public string AssignmentId { get; init; } = string.Empty;
+    public string AgentId { get; init; } = string.Empty;
+    public string AgentName { get; init; } = string.Empty;
+    public AgentHealthStatus AgentOnlineState { get; init; }
+}
+
+public sealed class AiEndpointCurrentStateInfo
+{
+    public EndpointStateKind State { get; init; } = EndpointStateKind.Unknown;
+    public DateTimeOffset? LastChangedUtc { get; init; }
+    public DateTimeOffset? LastCheckUtc { get; init; }
+    public string? UnknownReason { get; init; }
+}
+
+public sealed class AiTimeWindowInfo
+{
+    public string RequestedWindow { get; init; } = "24h";
+    public string AppliedWindow { get; init; } = "24h";
+    public bool Clamped { get; init; }
+    public DateTimeOffset FromUtc { get; init; }
+    public DateTimeOffset ToUtc { get; init; }
+}
+
+public sealed class AiEndpointUptimeSummary
+{
+    public long UptimeSeconds { get; init; }
+    public long DowntimeSeconds { get; init; }
+    public long UnknownSeconds { get; init; }
+    public long SuppressedSeconds { get; init; }
+    public double? UptimePercent { get; init; }
+    public int DownTransitions { get; init; }
+    public int RecoveryTransitions { get; init; }
+}
+
+public sealed class AiEndpointCheckSummary
+{
+    public int ReceivedSamples { get; init; }
+    public int SuccessfulSamples { get; init; }
+    public int FailedSamples { get; init; }
+    public int? ExpectedSamples { get; init; }
+    public int? MissingSamplesEstimate { get; init; }
+    public double? PacketLossPercent { get; init; }
+}
+
+public sealed class AiEndpointRttSummary
+{
+    public bool Available { get; init; }
+    public double? MinMs { get; init; }
+    public double? AvgMs { get; init; }
+    public double? MedianMs { get; init; }
+    public double? P95Ms { get; init; }
+    public double? MaxMs { get; init; }
+    public string? Reason { get; init; }
+}
+
+public sealed class AiEndpointTransitionItem
+{
+    public EndpointStateKind PreviousState { get; init; }
+    public EndpointStateKind NewState { get; init; }
+    public DateTimeOffset TransitionAtUtc { get; init; }
+    public string? ReasonCode { get; init; }
+}
+
+public sealed class AiEndpointCheckSeriesPoint
+{
+    public DateTimeOffset CheckedAtUtc { get; init; }
+    public bool Success { get; init; }
+    public double? RttMs { get; init; }
+    public string? ErrorCode { get; init; }
+    public string? ErrorMessage { get; init; }
+}

--- a/src/WebApp/PingMonitor.Web/Services/AiTools/AiEndpointDiagnosticsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiTools/AiEndpointDiagnosticsService.cs
@@ -1,0 +1,172 @@
+using System.Security.Claims;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+using PingMonitor.Web.Services.Diagnostics;
+using PingMonitor.Web.Services.Identity;
+
+namespace PingMonitor.Web.Services.AiTools;
+
+internal sealed class AiEndpointLookupService : IAiEndpointLookupService
+{
+    private const int MaxCandidates = 5;
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly IUserAccessScopeService _access;
+    private readonly IDbActivityScope _dbActivityScope;
+
+    public AiEndpointLookupService(PingMonitorDbContext dbContext, IUserAccessScopeService access, IDbActivityScope dbActivityScope)
+    {
+        _dbContext = dbContext;
+        _access = access;
+        _dbActivityScope = dbActivityScope;
+    }
+
+    public async Task<AiEndpointLookupResult> SearchEndpointsAsync(ClaimsPrincipal user, string userMessage, CancellationToken cancellationToken)
+    {
+        using var scope = _dbActivityScope.BeginScope("Ai.EndpointLookup");
+        var terms = ExtractTerms(userMessage);
+        if (terms.Count == 0) return new AiEndpointLookupResult { Message = "No endpoint reference was found in the question." };
+
+        var query = _dbContext.Endpoints.AsNoTracking();
+        if (!await _access.IsAdminAsync(user))
+        {
+            var visible = (await _access.GetVisibleEndpointIdsAsync(user, cancellationToken)).ToArray();
+            query = query.Where(x => visible.Contains(x.EndpointId));
+        }
+
+        var endpoints = await query.Select(x => new AiEndpointLookupItem { EndpointId = x.EndpointId, Name = x.Name, Target = x.Target, Enabled = x.Enabled }).ToListAsync(cancellationToken);
+        var scored = endpoints.Select(e => (Endpoint: e, Score: Score(e, terms))).Where(x => x.Score > 0).OrderByDescending(x => x.Score).ThenBy(x => x.Endpoint.Name).Take(MaxCandidates).ToList();
+        if (scored.Count == 0) return new AiEndpointLookupResult { Message = "No matching visible endpoint was found." };
+        if (scored.Count == 1 || scored[0].Score >= 100 || scored[0].Score >= scored[1].Score + 30)
+        {
+            return new AiEndpointLookupResult { Succeeded = true, Matches = [scored[0].Endpoint] };
+        }
+
+        return new AiEndpointLookupResult { Ambiguous = true, Message = "Multiple visible endpoints matched. Ask the user to choose one.", Matches = scored.Select(x => x.Endpoint).ToArray() };
+    }
+
+    private static int Score(AiEndpointLookupItem endpoint, IReadOnlyList<string> terms)
+    {
+        var name = endpoint.Name.ToLowerInvariant();
+        var target = endpoint.Target.ToLowerInvariant();
+        var best = 0;
+        foreach (var term in terms)
+        {
+            if (name == term || target == term) best = Math.Max(best, 120);
+            else if (name.Contains(term, StringComparison.Ordinal) || target.Contains(term, StringComparison.Ordinal)) best = Math.Max(best, Math.Min(90, 35 + term.Length * 3));
+            else
+            {
+                var words = term.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                var matched = words.Count(w => name.Contains(w, StringComparison.Ordinal) || target.Contains(w, StringComparison.Ordinal));
+                if (matched > 0) best = Math.Max(best, matched * 15);
+            }
+        }
+        return best;
+    }
+
+    private static IReadOnlyList<string> ExtractTerms(string message)
+    {
+        var normalized = message.ToLowerInvariant();
+        var terms = new List<string>();
+        foreach (var marker in new[] { "with ", "for ", "is ", "has " })
+        {
+            var idx = normalized.IndexOf(marker, StringComparison.Ordinal);
+            if (idx >= 0) terms.Add(Clean(normalized[(idx + marker.Length)..]));
+        }
+        terms.Add(Clean(normalized));
+        return terms.Where(x => x.Length >= 2).Distinct(StringComparer.Ordinal).ToArray();
+    }
+
+    private static string Clean(string value)
+    {
+        foreach (var phrase in new[] { "what is going on", "what's going on", "uptime", "down today", "been down", "flapping", "recent check pattern", "recent checks", "packet loss", "latency", "rtt", "over the last", "last 24 hours", "today", "?" })
+            value = value.Replace(phrase, " ", StringComparison.OrdinalIgnoreCase);
+        return string.Join(' ', value.Split(' ', StringSplitOptions.RemoveEmptyEntries)).Trim();
+    }
+}
+
+internal sealed class AiEndpointDiagnosticsService : IAiEndpointDiagnosticsService
+{
+    private const int MaxSeriesPoints = 120;
+    private readonly PingMonitorDbContext _dbContext;
+    private readonly IUserAccessScopeService _access;
+    private readonly IDbActivityScope _dbActivityScope;
+
+    public AiEndpointDiagnosticsService(PingMonitorDbContext dbContext, IUserAccessScopeService access, IDbActivityScope dbActivityScope)
+    {
+        _dbContext = dbContext;
+        _access = access;
+        _dbActivityScope = dbActivityScope;
+    }
+
+    public async Task<AiEndpointDiagnosticsResult> GetDiagnosticsPackAsync(ClaimsPrincipal user, string endpointId, string requestedWindow, CancellationToken cancellationToken)
+    {
+        using var scope = _dbActivityScope.BeginScope("Ai.EndpointDiagnostics");
+        if (!await _access.IsAdminAsync(user) && !(await _access.GetVisibleEndpointIdsAsync(user, cancellationToken)).Contains(endpointId))
+            return new AiEndpointDiagnosticsResult { ErrorMessage = "No matching visible endpoint was found." };
+
+        var now = DateTimeOffset.UtcNow;
+        var window = ResolveWindow(requestedWindow, now);
+        var row = await (from endpoint in _dbContext.Endpoints.AsNoTracking().Where(x => x.EndpointId == endpointId)
+                         join assignment in _dbContext.MonitorAssignments.AsNoTracking() on endpoint.EndpointId equals assignment.EndpointId
+                         join agent in _dbContext.Agents.AsNoTracking() on assignment.AgentId equals agent.AgentId
+                         join state in _dbContext.EndpointStates.AsNoTracking() on assignment.AssignmentId equals state.AssignmentId into sj
+                         from state in sj.DefaultIfEmpty()
+                         orderby assignment.Enabled descending, assignment.CreatedAtUtc
+                         select new { endpoint, assignment, agent, state }).FirstOrDefaultAsync(cancellationToken);
+        if (row is null) return new AiEndpointDiagnosticsResult { ErrorMessage = "No monitor assignment exists for the visible endpoint." };
+
+        var checks = await _dbContext.CheckResults.AsNoTracking().Where(x => x.AssignmentId == row.assignment.AssignmentId && x.CheckedAtUtc >= window.FromUtc && x.CheckedAtUtc <= window.ToUtc).OrderBy(x => x.CheckedAtUtc).ToListAsync(cancellationToken);
+        var transitions = await _dbContext.StateTransitions.AsNoTracking().Where(x => x.AssignmentId == row.assignment.AssignmentId && x.TransitionAtUtc >= window.FromUtc && x.TransitionAtUtc <= window.ToUtc).OrderBy(x => x.TransitionAtUtc).ToListAsync(cancellationToken);
+        var intervals = await _dbContext.AssignmentStateIntervals.AsNoTracking().Where(x => x.AssignmentId == row.assignment.AssignmentId && x.StartedAtUtc < window.ToUtc && (x.EndedAtUtc == null || x.EndedAtUtc > window.FromUtc)).ToListAsync(cancellationToken);
+
+        var samples = checks.Select(x => (double?)x.RoundTripMs).Where(x => x.HasValue).Select(x => x!.Value).Order().ToArray();
+        var received = checks.Count; var ok = checks.Count(x => x.Success); var failed = received - ok;
+        var expected = row.assignment.PingIntervalSeconds > 0 ? (int)Math.Ceiling((window.ToUtc - window.FromUtc).TotalSeconds / row.assignment.PingIntervalSeconds) : (int?)null;
+        var uptime = BuildUptime(intervals, transitions, window);
+
+        return new AiEndpointDiagnosticsResult { Succeeded = true, Pack = new AiEndpointDiagnosticsPack
+        {
+            GeneratedAtUtc = now,
+            Endpoint = new AiEndpointLookupItem { EndpointId = row.endpoint.EndpointId, Name = row.endpoint.Name, Target = row.endpoint.Target, Enabled = row.endpoint.Enabled },
+            Assignment = new AiEndpointAssignmentInfo { AssignmentId = row.assignment.AssignmentId, AgentId = row.agent.AgentId, AgentName = row.agent.Name ?? row.agent.InstanceId, AgentOnlineState = row.agent.Status },
+            CurrentState = new AiEndpointCurrentStateInfo { State = row.state?.CurrentState ?? EndpointStateKind.Unknown, LastChangedUtc = row.state?.LastStateChangeUtc, LastCheckUtc = row.state?.LastCheckUtc, UnknownReason = row.agent.Status != AgentHealthStatus.Online && (row.state?.CurrentState ?? EndpointStateKind.Unknown) == EndpointStateKind.Unknown ? "Agent is offline or stale; UNKNOWN is not endpoint downtime." : null },
+            Window = window,
+            Uptime = uptime,
+            Checks = new AiEndpointCheckSummary { ReceivedSamples = received, SuccessfulSamples = ok, FailedSamples = failed, ExpectedSamples = expected, MissingSamplesEstimate = expected.HasValue ? Math.Max(0, expected.Value - received) : null, PacketLossPercent = received > 0 ? Math.Round(failed * 100d / received, 2) : null },
+            Rtt = samples.Length == 0 ? new AiEndpointRttSummary { Available = false, Reason = "No RTT samples in the selected bounded window." } : new AiEndpointRttSummary { Available = true, MinMs = samples.First(), MaxMs = samples.Last(), AvgMs = Math.Round(samples.Average(), 2), MedianMs = Percentile(samples, .5), P95Ms = Percentile(samples, .95) },
+            RecentTransitions = transitions.OrderByDescending(x => x.TransitionAtUtc).Take(20).Select(x => new AiEndpointTransitionItem { PreviousState = x.PreviousState, NewState = x.NewState, TransitionAtUtc = x.TransitionAtUtc, ReasonCode = x.ReasonCode }).ToArray(),
+            RecentSampleTail = checks.OrderByDescending(x => x.CheckedAtUtc).Take(MaxSeriesPoints).OrderBy(x => x.CheckedAtUtc).Select(x => new AiEndpointCheckSeriesPoint { CheckedAtUtc = x.CheckedAtUtc, Success = x.Success, RttMs = (double?)x.RoundTripMs, ErrorCode = x.ErrorCode, ErrorMessage = x.ErrorMessage == null ? null : x.ErrorMessage[..Math.Min(160, x.ErrorMessage.Length)] }).ToArray()
+        }};
+    }
+
+    internal static AiTimeWindowInfo ResolveWindow(string requested, DateTimeOffset now)
+    {
+        var r = requested?.Trim().ToLowerInvariant() ?? "24h";
+        var (label, span, clamped) = r switch { "1h" => ("1h", TimeSpan.FromHours(1), false), "6h" => ("6h", TimeSpan.FromHours(6), false), "7d" => ("7d", TimeSpan.FromDays(7), false), "24h" or "today" or "" => ("24h", TimeSpan.FromHours(24), r == "today"), _ => ("7d", TimeSpan.FromDays(7), true) };
+        return new AiTimeWindowInfo { RequestedWindow = string.IsNullOrWhiteSpace(requested) ? "24h" : requested, AppliedWindow = label, Clamped = clamped, FromUtc = now - span, ToUtc = now };
+    }
+
+    private static AiEndpointUptimeSummary BuildUptime(List<AssignmentStateInterval> intervals, List<StateTransition> transitions, AiTimeWindowInfo window)
+    {
+        long up = 0, down = 0, unknown = 0, suppressed = 0;
+        foreach (var i in intervals)
+        {
+            var start = i.StartedAtUtc > window.FromUtc ? i.StartedAtUtc : window.FromUtc;
+            var end = (i.EndedAtUtc ?? window.ToUtc) < window.ToUtc ? (i.EndedAtUtc ?? window.ToUtc) : window.ToUtc;
+            var seconds = Math.Max(0, (long)(end - start).TotalSeconds);
+            if (i.State == EndpointStateKind.Up || i.State == EndpointStateKind.Degraded) up += seconds;
+            else if (i.State == EndpointStateKind.Down) down += seconds;
+            else if (i.State == EndpointStateKind.Suppressed) suppressed += seconds;
+            else unknown += seconds;
+        }
+        var known = up + down;
+        return new AiEndpointUptimeSummary { UptimeSeconds = up, DowntimeSeconds = down, UnknownSeconds = unknown, SuppressedSeconds = suppressed, UptimePercent = known > 0 ? Math.Round(up * 100d / known, 2) : null, DownTransitions = transitions.Count(x => x.NewState == EndpointStateKind.Down), RecoveryTransitions = transitions.Count(x => x.PreviousState == EndpointStateKind.Down && x.NewState != EndpointStateKind.Down) };
+    }
+
+    private static double Percentile(double[] sorted, double p)
+    {
+        var index = (int)Math.Ceiling(sorted.Length * p) - 1;
+        return Math.Round(sorted[Math.Clamp(index, 0, sorted.Length - 1)], 2);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/AiTools/IAiEndpointDiagnosticsService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiTools/IAiEndpointDiagnosticsService.cs
@@ -1,0 +1,13 @@
+using System.Security.Claims;
+
+namespace PingMonitor.Web.Services.AiTools;
+
+public interface IAiEndpointLookupService
+{
+    Task<AiEndpointLookupResult> SearchEndpointsAsync(ClaimsPrincipal user, string userMessage, CancellationToken cancellationToken);
+}
+
+public interface IAiEndpointDiagnosticsService
+{
+    Task<AiEndpointDiagnosticsResult> GetDiagnosticsPackAsync(ClaimsPrincipal user, string endpointId, string requestedWindow, CancellationToken cancellationToken);
+}


### PR DESCRIPTION
### Motivation
- Provide the AI assistant a safe, read-only way to answer endpoint-specific questions without giving models direct DB/SQL access. 
- Keep diagnostics bounded, permission-filtered, and deterministic so web chat and Telegram can share the same path while respecting visibility and platform safety rules. 
- Preserve existing non-goals (no write actions, no diagram/port/VLAN answers, no persistent AI memory or unrestricted raw CheckResults). 

### Description
- Added new AI tools/services: `IAiEndpointLookupService` and `IAiEndpointDiagnosticsService` with models in `AiEndpointDiagnosticsModels.cs`, and implemented `AiEndpointLookupService` + `AiEndpointDiagnosticsService` to produce a bounded diagnostics pack. Files added/modified include `src/WebApp/PingMonitor.Web/Services/AiTools/AiEndpointDiagnosticsModels.cs`, `AiEndpointDiagnosticsService.cs`, `IAiEndpointDiagnosticsService.cs`, `src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs`, and `Program.cs` DI wiring. 
- Endpoint lookup runs under the application user and respects `IUserAccessScopeService` visibility, searching by endpoint name and target/IP and returning a single strong match, an ambiguous candidate list, or a clear no-match message. 
- Diagnostics pack (`get_endpoint_diagnostics_pack`) contains endpoint/assignment/agent info, current state (with `UNKNOWN`/agent-offline reasoning), bounded time window metadata, uptime/state-interval summaries, check counts (received/success/failed/expected/missing estimate), packet-loss %, RTT stats (min/avg/median/p95/max when available), recent transitions, and a bounded recent sample tail. 
- Supported safe windows: `1h`, `6h`, `24h`, `7d` (default `24h`); unsupported/large windows are clamped (applies `7d`), and `today` maps to the bounded 24h fallback. 
- CheckResults access is bounded: summaries + RTT metrics are returned and the recent sample tail is hard-capped at 120 points; no unrestricted raw rows or model-generated SQL are exposed. 
- Integrated diagnostics selection deterministically in `AiChatService` (app-side intent/entity detection) so web chat and Telegram use the same deterministic path and only call the provider after permission-filtered diagnostics are attached. 
- Updated built-in system prompt to explicitly list the new, limited diagnostics context and to restate unsupported capabilities (diagram/ports/VLANs, memory, write actions, unrestricted raw results). 

### Testing
- Added unit tests in `src/WebApp/PingMonitor.Web.Tests` covering: visible/hidden endpoint lookup, target/IP lookup, ambiguous/no-match flows, diagnostics pack contents (current state, uptime intervals, check summary, RTT, bounded series), and window clamping; new test file `AiEndpointDiagnosticsServiceTests.cs` was added. 
- Build and test results in the environment: `dotnet build` and `dotnet test` were run for the web project tests and the full WebApp solution in the workspace using a local .NET 10 SDK; all tests passed. 

Created issue: #569 "AI Assistant endpoint diagnostics and bounded monitoring context".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a301f0cc564832a9125da2b691cd2f5)