### PR TITLE
Fix AI health summary agent query translation

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
@@ -157,6 +157,15 @@ public sealed class AiAssistantChatTests
     }
 
 
+
+    [Fact]
+    public void NetworkHealthSummaryTool_DoesNotUseMySqlUnsafeAgentIdArrayContainsQuery()
+    {
+        var source = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "PingMonitor.Web", "Services", "AiTools", "NetworkHealthSummaryAiTool.cs"));
+
+        Assert.DoesNotContain("agentIds.Contains(x.AgentId)", source);
+    }
+
     [Fact]
     public async Task ToolCallingExecutesToolAndReturnsFinalAnswer()
     {

--- a/src/WebApp/PingMonitor.Web/Services/AiTools/NetworkHealthSummaryAiTool.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiTools/NetworkHealthSummaryAiTool.cs
@@ -71,13 +71,16 @@ internal sealed class NetworkHealthSummaryAiTool : IAiTool
             select new SummaryRow(endpoint.EndpointId, endpoint.Name, assignment.AssignmentId, agent.AgentId, agent.InstanceId, agent.Name, state != null ? state.CurrentState : EndpointStateKind.Unknown, state != null ? state.LastCheckUtc : null, state != null ? state.LastStateChangeUtc : null))
             .ToArrayAsync(cancellationToken);
 
-        var agentIds = rows.Select(x => x.AgentId).Distinct().ToArray();
-        var agents = await _dbContext.Agents.AsNoTracking()
-            .Where(x => agentIds.Contains(x.AgentId) && (x.Status == AgentHealthStatus.Offline || x.Status == AgentHealthStatus.Stale))
+        var visibleAgentIds = rows.Select(x => x.AgentId).Distinct(StringComparer.Ordinal).ToHashSet(StringComparer.Ordinal);
+        var unhealthyAgents = await _dbContext.Agents.AsNoTracking()
+            .Where(x => x.Status == AgentHealthStatus.Offline || x.Status == AgentHealthStatus.Stale)
             .OrderBy(x => x.InstanceId)
             .Select(x => new { x.AgentId, x.InstanceId, x.Name, x.Status, x.LastHeartbeatUtc, x.LastSeenUtc })
-            .Take(MaxListedItemsPerState)
             .ToArrayAsync(cancellationToken);
+        var agents = unhealthyAgents
+            .Where(x => visibleAgentIds.Contains(x.AgentId))
+            .Take(MaxListedItemsPerState)
+            .ToArray();
 
         var result = new
         {


### PR DESCRIPTION
### Motivation
- Production requests to `/ai-assistant/send` threw `RelationalTypeMappingPostprocessor` errors caused by an EF query that translated an `agentIds.Contains(x.AgentId)` array predicate into a provider-unsafe MySQL parameter expression. 
- The change avoids returning a runtime exception and prevents that unsafe provider-specific `IN`/array containment pattern from being emitted by EF.

### Description
- Rewrote the unhealthy-agent lookup in `NetworkHealthSummaryAiTool.ExecuteAsync` to first materialize assignment/agent summary rows and then perform the visible-agent intersection in memory instead of using `agentIds.Contains(x.AgentId)` inside the EF query (file: `src/WebApp/PingMonitor.Web/Services/AiTools/NetworkHealthSummaryAiTool.cs`).
- Kept the database query provider-safe by filtering only on `Status` server-side and then intersecting with visible agent IDs in memory, preserving ordering and the `Take(MaxListedItemsPerState)` cap.
- Added a regression guard test `NetworkHealthSummaryTool_DoesNotUseMySqlUnsafeAgentIdArrayContainsQuery` to `AiAssistantChatTests` that fails if the exact unsafe `agentIds.Contains(x.AgentId)` pattern is reintroduced (file: `src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs`).
- No database schema or metadata changes were made and the required schema version is unchanged.

### Testing
- Ran targeted tests with `PATH=/tmp/dotnet10:$PATH dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj --filter "AiAssistantChatTests|TelegramAiConversationStoreTests"` which passed (21 tests passed).
- Ran the full test suite with `PATH=/tmp/dotnet10:$PATH dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` which also passed (198 tests passed).
- The change was validated to remove the unsafe EF array `Contains` usage and prevent the MySQL type-mapping error from reoccurring.

Fixes #573

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a317cb3f5c8832a872fba77389b2629)