### PR TITLE
Fix AI assistant endpoint search MySQL type-mapping error

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
@@ -181,6 +181,19 @@ public sealed class AiAssistantChatTests
         Assert.Contains("\"7d\"", source);
     }
 
+
+    [Fact]
+    public void SearchEndpointsTool_DoesNotUseMySqlUnsafeEndpointIdArrayContainsQuery()
+    {
+        var source = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "PingMonitor.Web", "Services", "AiTools", "EndpointMetricsAiTools.cs"));
+
+        Assert.Contains("ApplyEndpointFilter(endpoints, visibleEndpointIds)", source);
+        Assert.Contains("ApplyEndpointFilter(_dbContext.MonitorAssignments.AsNoTracking(), endpointIds)", source);
+        Assert.Contains("Expression.OrElse", source);
+        Assert.DoesNotContain("visibleEndpointIds.Contains(x.EndpointId)", source);
+        Assert.DoesNotContain("endpointIds.Contains(assignment.EndpointId)", source);
+    }
+
     [Fact]
     public void NetworkHealthSummaryTool_DoesNotUseMySqlUnsafeAgentIdArrayContainsQuery()
     {

--- a/src/WebApp/PingMonitor.Web/Services/AiTools/EndpointMetricsAiTools.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiTools/EndpointMetricsAiTools.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using System.Security.Claims;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -48,7 +49,7 @@ internal sealed class SearchEndpointsAiTool : IAiTool
         var visibleEndpointIds = await AiToolUserVisibility.GetVisibleEndpointIdsOrNullForAdminAsync(_dbContext, _userManager, user, cancellationToken);
 
         var endpoints = _dbContext.Endpoints.AsNoTracking();
-        if (visibleEndpointIds is not null) endpoints = visibleEndpointIds.Count == 0 ? endpoints.Where(static _ => false) : endpoints.Where(x => visibleEndpointIds.Contains(x.EndpointId));
+        if (visibleEndpointIds is not null) endpoints = ApplyEndpointFilter(endpoints, visibleEndpointIds);
         var lower = query.ToLowerInvariant();
         var candidates = await endpoints
             .Where(x => x.Name.ToLower().Contains(lower) || x.Target.ToLower().Contains(lower))
@@ -60,10 +61,10 @@ internal sealed class SearchEndpointsAiTool : IAiTool
             .OrderByDescending(x => x.Score).ThenBy(x => x.Endpoint.Name).Take(MaxMatches).ToArray();
         var matches = ranked.Select(x => x.Endpoint).ToArray();
         var endpointIds = matches.Select(x => x.EndpointId).ToArray();
-        var states = await (from assignment in _dbContext.MonitorAssignments.AsNoTracking()
+        var assignmentQuery = ApplyEndpointFilter(_dbContext.MonitorAssignments.AsNoTracking(), endpointIds);
+        var states = await (from assignment in assignmentQuery
             join state in _dbContext.EndpointStates.AsNoTracking() on assignment.AssignmentId equals state.AssignmentId into sj
             from state in sj.DefaultIfEmpty()
-            where endpointIds.Contains(assignment.EndpointId)
             select new { assignment.EndpointId, State = state != null ? state.CurrentState : EndpointStateKind.Unknown }).ToArrayAsync(cancellationToken);
         var stateByEndpoint = states.GroupBy(x => x.EndpointId).ToDictionary(x => x.Key, x => x.First().State, StringComparer.Ordinal);
 
@@ -77,6 +78,44 @@ internal sealed class SearchEndpointsAiTool : IAiTool
             message = matches.Length == 0 ? "No visible endpoint matched the query." : null
         };
         return JsonResult(result, Definition.MaxResultCharacters);
+    }
+
+    private static IQueryable<Models.Endpoint> ApplyEndpointFilter(IQueryable<Models.Endpoint> endpoints, IReadOnlyCollection<string> endpointIds)
+    {
+        if (endpointIds.Count == 0)
+        {
+            return endpoints.Where(static _ => false);
+        }
+
+        var parameter = Expression.Parameter(typeof(Models.Endpoint), "endpoint");
+        var endpointId = Expression.Property(parameter, nameof(Models.Endpoint.EndpointId));
+        Expression? predicate = null;
+        foreach (var id in endpointIds)
+        {
+            var equals = Expression.Equal(endpointId, Expression.Constant(id));
+            predicate = predicate is null ? equals : Expression.OrElse(predicate, equals);
+        }
+
+        return endpoints.Where(Expression.Lambda<Func<Models.Endpoint, bool>>(predicate!, parameter));
+    }
+
+    private static IQueryable<MonitorAssignment> ApplyEndpointFilter(IQueryable<MonitorAssignment> assignments, IReadOnlyCollection<string> endpointIds)
+    {
+        if (endpointIds.Count == 0)
+        {
+            return assignments.Where(static _ => false);
+        }
+
+        var parameter = Expression.Parameter(typeof(MonitorAssignment), "assignment");
+        var endpointId = Expression.Property(parameter, nameof(MonitorAssignment.EndpointId));
+        Expression? predicate = null;
+        foreach (var id in endpointIds)
+        {
+            var equals = Expression.Equal(endpointId, Expression.Constant(id));
+            predicate = predicate is null ? equals : Expression.OrElse(predicate, equals);
+        }
+
+        return assignments.Where(Expression.Lambda<Func<MonitorAssignment, bool>>(predicate!, parameter));
     }
 
     private static int Score(string name, string target, string query) => string.Equals(name, query, StringComparison.OrdinalIgnoreCase) || string.Equals(target, query, StringComparison.OrdinalIgnoreCase) ? 100 : (name.StartsWith(query, StringComparison.OrdinalIgnoreCase) || target.StartsWith(query, StringComparison.OrdinalIgnoreCase) ? 80 : 50);


### PR DESCRIPTION
### Motivation
- The AI assistant endpoint search could produce a MySQL EF Core type-mapping error for the generated `@endpointIds` SQL parameter when LINQ used `Contains` with a string array, which caused a runtime `InvalidOperationException` during `/ai-assistant/send` handling.
- The change replaces array-`Contains` query shapes with provider-safe scalar equality predicates to ensure deterministic server-side translation against MySQL.
- An attempt to open a tracking issue from this environment failed due to unavailable GitHub authentication, so no issue number is attached to this PR.

### Description
- Replaced visibility and assignment filters in `SearchEndpointsAiTool.ExecuteAsync` to use explicit `ApplyEndpointFilter(...)` helpers that build `Expression.OrElse` equality predicates instead of `endpointIds.Contains(...)` or `visibleEndpointIds.Contains(...)` patterns. (see `src/WebApp/PingMonitor.Web/Services/AiTools/EndpointMetricsAiTools.cs`).
- Added two helper methods `ApplyEndpointFilter` for `Endpoint` and `MonitorAssignment` queryables that compose OR predicates via `System.Linq.Expressions` to avoid array-parameter mapping.
- Added a regression guard test `SearchEndpointsTool_DoesNotUseMySqlUnsafeEndpointIdArrayContainsQuery` to `src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs` asserting the unsafe `Contains` shapes are not present in the source.
- Minor using/import addition for `System.Linq.Expressions` and committed changes under the message "Fix AI endpoint search MySQL filter".

### Testing
- Ran the unit test suite with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and all automated tests passed (`Passed: 202, Failed: 0`).
- The change is covered by an automated regression guard in `PingMonitor.Web.Tests` that verifies the LINQ query shape was updated to the safe helper usage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a319238bbf4832a9cb2a1b347fd4e39)