### PR TITLE
Add user-specific AI memories

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
@@ -6,6 +6,7 @@ using PingMonitor.Web.Models;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.AiChat;
 using PingMonitor.Web.Services.AiProviders;
+using PingMonitor.Web.Services.AiMemory;
 using PingMonitor.Web.Services.AiTools;
 using PingMonitor.Web.ViewModels.AiAssistant;
 using Xunit;
@@ -318,7 +319,7 @@ public sealed class AiAssistantChatTests
     {
         var settingsService = new FakeAiAssistantSettingsService(settings);
         var chat = new AiChatService(settingsService, provider, new FakeAiToolRegistry(), NullLogger<AiChatService>.Instance);
-        return new AiAssistantController(settingsService, chat);
+        return new AiAssistantController(settingsService, chat, new FakeAiUserMemoryService());
     }
 
     private static AiAssistantSettingsDto EnabledSettings(bool assistantEnabled = true, bool webChatEnabled = true, string globalPrompt = "") => new()
@@ -354,6 +355,15 @@ public sealed class AiAssistantChatTests
             ToolCallingEnabled = _settings.ToolCallingEnabled
         });
         public Task<AiAssistantSettingsDto> UpdateAsync(UpdateAiAssistantSettingsCommand command, CancellationToken cancellationToken) => throw new NotSupportedException();
+    }
+
+    private sealed class FakeAiUserMemoryService : IAiUserMemoryService
+    {
+        public Task<AiUserMemoryMutationResult> CreateAsync(CreateAiUserMemoryCommand command, CancellationToken cancellationToken) => Task.FromResult(new AiUserMemoryMutationResult(false, "not implemented", null));
+        public Task<IReadOnlyList<AiUserMemoryDto>> SearchAsync(SearchAiUserMemoriesQuery query, CancellationToken cancellationToken) => Task.FromResult((IReadOnlyList<AiUserMemoryDto>)Array.Empty<AiUserMemoryDto>());
+        public Task<IReadOnlyList<AiUserMemoryDto>> ListAsync(string userId, CancellationToken cancellationToken) => Task.FromResult((IReadOnlyList<AiUserMemoryDto>)Array.Empty<AiUserMemoryDto>());
+        public Task<AiUserMemoryMutationResult> DeleteAsync(DeleteAiUserMemoryCommand command, CancellationToken cancellationToken) => Task.FromResult(new AiUserMemoryMutationResult(false, "not implemented", null));
+        public string? ResolveUserId(System.Security.Claims.ClaimsPrincipal? principal, string? applicationUserId) => applicationUserId;
     }
 
     private sealed class FakeAiProviderClient : IAiProviderClient

--- a/src/WebApp/PingMonitor.Web.Tests/AiUserMemorySliceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiUserMemorySliceTests.cs
@@ -1,0 +1,51 @@
+using PingMonitor.Web.Services.AiChat;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class AiUserMemorySliceTests
+{
+    [Fact]
+    public void BuiltInPromptIncludesExplicitUserMemoryRules()
+    {
+        Assert.Contains("Only create a memory when the user clearly asks", AiChatService.BuiltInSystemPrompt);
+        Assert.Contains("Memories are user-specific", AiChatService.BuiltInSystemPrompt);
+        Assert.Contains("Live Ping Monitor tool data overrides memory", AiChatService.BuiltInSystemPrompt);
+        Assert.Contains("Do not store current endpoint state", AiChatService.BuiltInSystemPrompt);
+        Assert.Contains("delete_user_memory", AiChatService.BuiltInSystemPrompt);
+    }
+
+    [Fact]
+    public void MemoryServiceSourceContainsValidationAndIsolationGuards()
+    {
+        var source = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "PingMonitor.Web", "Services", "AiMemory", "AiUserMemoryService.cs"));
+        Assert.Contains("Memory creation requires an explicit user request", source);
+        Assert.Contains("remember that", source);
+        Assert.Contains("password|api", source);
+        Assert.Contains("currently down", source);
+        Assert.Contains("x.UserId == query.UserId", source);
+        Assert.Contains("x.UserId == command.UserId", source);
+        Assert.Contains("DeletedAtUtc", source);
+    }
+
+    [Fact]
+    public void MemoryToolsDeclareBoundedUserSpecificFunctionsWithoutSecrets()
+    {
+        var source = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "PingMonitor.Web", "Services", "AiTools", "UserMemoryAiTools.cs"));
+        Assert.Contains("search_user_memories", source);
+        Assert.Contains("remember_user_memory", source);
+        Assert.Contains("delete_user_memory", source);
+        Assert.Contains("AI memory is disabled", source);
+        Assert.Contains("maxLength", source);
+        Assert.DoesNotContain("runtime-secret", source, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void StartupGateDeclaresAiUserMemoriesSchema()
+    {
+        var source = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "PingMonitor.Web", "Services", "StartupGate", "StartupSchemaService.cs"));
+        Assert.Contains("AiUserMemories", source);
+        Assert.Contains("RequiredAiUserMemoryColumns", source);
+        Assert.Contains("CREATE TABLE IF NOT EXISTS `AiUserMemories`", source);
+    }
+}

--- a/src/WebApp/PingMonitor.Web.Tests/StartupSchemaServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/StartupSchemaServiceTests.cs
@@ -60,7 +60,7 @@ public sealed class StartupSchemaServiceTests
 
         Assert.Contains("\"NetworkDiagramAreas\"", source);
         Assert.Contains("\"NetworkDiagramLinkVlans\"", source);
-        Assert.Equal(22, appRequiredSchemaVersion);
+        Assert.Equal(23, appRequiredSchemaVersion);
         Assert.Contains("AiAssistantSettings", source);
         Assert.Contains("RequiredAiAssistantSettingsColumns", source);
         Assert.Equal(appRequiredSchemaVersion, developmentRequiredSchemaVersion);

--- a/src/WebApp/PingMonitor.Web/Controllers/AiAssistantController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AiAssistantController.cs
@@ -1,8 +1,10 @@
+using System.Security.Claims;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.AiChat;
+using PingMonitor.Web.Services.AiMemory;
 using PingMonitor.Web.ViewModels.AiAssistant;
 
 namespace PingMonitor.Web.Controllers;
@@ -16,11 +18,13 @@ public sealed class AiAssistantController : Controller
 
     private readonly IAiAssistantSettingsService _settingsService;
     private readonly IAiChatService _chatService;
+    private readonly IAiUserMemoryService _memoryService;
 
-    public AiAssistantController(IAiAssistantSettingsService settingsService, IAiChatService chatService)
+    public AiAssistantController(IAiAssistantSettingsService settingsService, IAiChatService chatService, IAiUserMemoryService memoryService)
     {
         _settingsService = settingsService;
         _chatService = chatService;
+        _memoryService = memoryService;
     }
 
     [HttpGet("")]
@@ -79,6 +83,32 @@ public sealed class AiAssistantController : Controller
 
         model.HistoryJson = SerializeHistory(model.Messages);
         return View("Index", model);
+    }
+
+
+    [HttpGet("memories")]
+    public async Task<IActionResult> Memories(CancellationToken cancellationToken)
+    {
+        var settings = await _settingsService.GetCurrentAsync(cancellationToken);
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
+        var model = new AiMemoriesPageViewModel
+        {
+            AssistantEnabled = settings.AssistantEnabled,
+            MemoryEnabled = settings.MemoryEnabled,
+            Memories = settings.MemoryEnabled && !string.IsNullOrWhiteSpace(userId) ? await _memoryService.ListAsync(userId, cancellationToken) : []
+        };
+        if (!settings.MemoryEnabled) model.ErrorMessage = "AI memory is disabled. An administrator can enable it from Admin > AI Assistant settings.";
+        return View("Memories", model);
+    }
+
+    [HttpPost("memories/delete")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteMemory([FromForm] string memoryId, CancellationToken cancellationToken)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
+        var result = await _memoryService.DeleteAsync(new DeleteAiUserMemoryCommand(userId, memoryId), cancellationToken);
+        TempData[result.Succeeded ? "StatusMessage" : "ErrorMessage"] = result.Succeeded ? "AI memory deleted." : result.ErrorMessage;
+        return RedirectToAction(nameof(Memories));
     }
 
     [HttpPost("clear")]

--- a/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
+++ b/src/WebApp/PingMonitor.Web/Data/PingMonitorDbContext.cs
@@ -40,6 +40,7 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
     public DbSet<SecurityIpBlock> SecurityIpBlocks => Set<SecurityIpBlock>();
     public DbSet<NotificationSettings> NotificationSettings => Set<NotificationSettings>();
     public DbSet<AiAssistantSettings> AiAssistantSettings => Set<AiAssistantSettings>();
+    public DbSet<AiUserMemory> AiUserMemories => Set<AiUserMemory>();
     public DbSet<UserNotificationSettings> UserNotificationSettings => Set<UserNotificationSettings>();
     public DbSet<PendingTelegramLink> PendingTelegramLinks => Set<PendingTelegramLink>();
     public DbSet<TelegramAccount> TelegramAccounts => Set<TelegramAccount>();
@@ -388,6 +389,24 @@ public sealed class PingMonitorDbContext : IdentityDbContext<ApplicationUser, Ap
         notificationSettings.Property(x => x.SmtpNotifyAgentOnline).IsRequired();
         notificationSettings.Property(x => x.UpdatedAtUtc).IsRequired();
         notificationSettings.Property(x => x.UpdatedByUserId).HasMaxLength(255);
+
+
+        var aiUserMemory = modelBuilder.Entity<AiUserMemory>();
+        aiUserMemory.ToTable("AiUserMemories");
+        aiUserMemory.HasKey(x => x.AiUserMemoryId);
+        aiUserMemory.Property(x => x.AiUserMemoryId).HasMaxLength(AiUserMemory.MemoryIdMaxLength);
+        aiUserMemory.Property(x => x.UserId).HasMaxLength(AiUserMemory.UserIdMaxLength).IsRequired();
+        aiUserMemory.Property(x => x.MemoryType).HasConversion<string>().HasMaxLength(AiUserMemory.MemoryTypeMaxLength).IsRequired();
+        aiUserMemory.Property(x => x.Content).HasMaxLength(AiUserMemory.ContentMaxLength).IsRequired();
+        aiUserMemory.Property(x => x.NormalizedContent).HasMaxLength(AiUserMemory.NormalizedContentMaxLength).IsRequired();
+        aiUserMemory.Property(x => x.Source).HasMaxLength(AiUserMemory.SourceMaxLength).IsRequired();
+        aiUserMemory.Property(x => x.CreatedAtUtc).IsRequired();
+        aiUserMemory.Property(x => x.UpdatedAtUtc).IsRequired();
+        aiUserMemory.Property(x => x.UseCount).IsRequired();
+        aiUserMemory.Property(x => x.Enabled).HasDefaultValue(true);
+        aiUserMemory.Property(x => x.CreatedFromConversationSource).HasMaxLength(AiUserMemory.SourceMaxLength);
+        aiUserMemory.HasIndex(x => new { x.UserId, x.Enabled, x.DeletedAtUtc });
+        aiUserMemory.HasIndex(x => new { x.UserId, x.NormalizedContent });
 
         var userNotificationSettings = modelBuilder.Entity<UserNotificationSettings>();
         userNotificationSettings.ToTable("UserNotificationSettings");

--- a/src/WebApp/PingMonitor.Web/Models/AiUserMemory.cs
+++ b/src/WebApp/PingMonitor.Web/Models/AiUserMemory.cs
@@ -1,0 +1,36 @@
+namespace PingMonitor.Web.Models;
+
+public sealed class AiUserMemory
+{
+    public const int MemoryIdMaxLength = 64;
+    public const int UserIdMaxLength = 255;
+    public const int MemoryTypeMaxLength = 64;
+    public const int ContentMaxLength = 1000;
+    public const int NormalizedContentMaxLength = 1000;
+    public const int SourceMaxLength = 64;
+
+    public string AiUserMemoryId { get; set; } = Guid.NewGuid().ToString("N");
+    public string UserId { get; set; } = string.Empty;
+    public AiUserMemoryType MemoryType { get; set; } = AiUserMemoryType.Other;
+    public string Content { get; set; } = string.Empty;
+    public string NormalizedContent { get; set; } = string.Empty;
+    public string Source { get; set; } = "User";
+    public DateTimeOffset CreatedAtUtc { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset UpdatedAtUtc { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? LastUsedAtUtc { get; set; }
+    public int UseCount { get; set; }
+    public bool Enabled { get; set; } = true;
+    public DateTimeOffset? DeletedAtUtc { get; set; }
+    public string? CreatedFromConversationSource { get; set; }
+}
+
+public enum AiUserMemoryType
+{
+    UserPreference,
+    EndpointAlias,
+    NetworkAlias,
+    LocationAlias,
+    OperationalNote,
+    AssistantInstruction,
+    Other
+}

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -201,11 +201,15 @@ builder.Services.AddScoped<IAgentTemplateVersionProvider, AgentTemplateVersionPr
 builder.Services.AddScoped<IAgentProvisioningService, AgentProvisioningService>();
 builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsService>();
 builder.Services.AddScoped<IAiAssistantSettingsService, AiAssistantSettingsService>();
+builder.Services.AddScoped<PingMonitor.Web.Services.AiMemory.IAiUserMemoryService, PingMonitor.Web.Services.AiMemory.AiUserMemoryService>();
 builder.Services.AddScoped<IAiProviderClient, OpenAiCompatibleProviderClient>();
 builder.Services.AddMemoryCache();
 builder.Services.AddScoped<IAiTool, NetworkHealthSummaryAiTool>();
 builder.Services.AddScoped<IAiTool, SearchEndpointsAiTool>();
 builder.Services.AddScoped<IAiTool, EndpointMetricsSummaryAiTool>();
+builder.Services.AddScoped<IAiTool, SearchUserMemoriesAiTool>();
+builder.Services.AddScoped<IAiTool, RememberUserMemoryAiTool>();
+builder.Services.AddScoped<IAiTool, DeleteUserMemoryAiTool>();
 builder.Services.AddScoped<IAiToolRegistry, AiToolRegistry>();
 builder.Services.AddScoped<IAiChatService, AiChatService>();
 builder.Services.AddSingleton<ITelegramAiConversationStore, TelegramAiConversationStore>();

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs
@@ -36,7 +36,17 @@ When summarizing endpoint metrics:
 - use RTT and jitter only if available
 - say when sample counts are low or data is incomplete
 - mention the applied time window
-Diagram lookup, switch port/VLAN answers, persistent memory, prompt history, persistent audit log, and write actions are not connected yet.
+You have access to user-specific AI memory tools if memory is enabled.
+Use search_user_memories when user wording may depend on aliases, preferences, or prior context.
+Only use remember_user_memory when the user explicitly asks you to remember something.
+Only create a memory when the user clearly asks you to remember something, such as "remember that..." or "from now on...".
+Do not store live monitoring state, current endpoint health, raw metrics, uptime, RTT, packet loss, diagram facts, passwords, API keys, or secrets as memories.
+When in doubt, ask for confirmation before creating a memory.
+Memories are user-specific. Never claim a memory applies to other users.
+Live Ping Monitor tool data overrides memory.
+Do not store current endpoint state, uptime, RTT, packet loss, CheckResults, diagram facts, passwords, API keys, secrets, or temporary incident status as memory.
+If a user asks you to forget/delete a memory, use delete_user_memory when a matching memory exists.
+Diagram lookup, switch port/VLAN answers, prompt history, persistent audit log, and non-memory write actions are not connected yet.
 """;
 
     private readonly IAiAssistantSettingsService _settingsService;
@@ -92,7 +102,7 @@ Diagram lookup, switch port/VLAN answers, persistent memory, prompt history, per
 
         var messages = BuildMessages(settings.GlobalSystemPrompt, request.ConversationHistory, request.UserMessage);
         var toolsEnabled = runtime.ToolCallingEnabled;
-        var toolDefinitions = toolsEnabled ? _toolRegistry.GetDefinitions().Select(x => x.ToProviderDefinition()).ToArray() : [];
+        var toolDefinitions = toolsEnabled ? _toolRegistry.GetDefinitions().Where(x => settings.MemoryEnabled || !x.Name.Contains("user_memor", StringComparison.Ordinal)).Select(x => x.ToProviderDefinition()).ToArray() : [];
         var totalToolResultCharacters = 0;
         AiProviderChatResult result = new();
 
@@ -130,7 +140,7 @@ Diagram lookup, switch port/VLAN answers, persistent memory, prompt history, per
             messages.Add(new AiProviderChatMessage { Role = "assistant", Content = result.ResponseText, ToolCalls = result.ToolCalls.ToList() });
             foreach (var toolCall in result.ToolCalls)
             {
-                var toolResult = await _toolRegistry.ExecuteAsync(new AiToolCall { Name = toolCall.Function.Name, ArgumentsJson = toolCall.Function.Arguments, Principal = request.Principal, ApplicationUserId = request.ApplicationUserId }, cancellationToken);
+                var toolResult = await _toolRegistry.ExecuteAsync(new AiToolCall { Name = toolCall.Function.Name, ArgumentsJson = toolCall.Function.Arguments, Principal = request.Principal, ApplicationUserId = request.ApplicationUserId, CurrentUserMessage = request.UserMessage, ConversationSource = request.Source.ToString() }, cancellationToken);
                 totalToolResultCharacters += toolResult.ContentJson.Length;
                 if (totalToolResultCharacters > MaxTotalToolResultCharacters)
                 {

--- a/src/WebApp/PingMonitor.Web/Services/AiMemory/AiUserMemoryService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiMemory/AiUserMemoryService.cs
@@ -1,0 +1,118 @@
+using System.Security.Claims;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+using PingMonitor.Web.Data;
+using PingMonitor.Web.Models;
+
+namespace PingMonitor.Web.Services.AiMemory;
+
+public sealed record AiUserMemoryDto(string MemoryId, string UserId, string MemoryType, string Content, DateTimeOffset CreatedAtUtc, DateTimeOffset UpdatedAtUtc, DateTimeOffset? LastUsedAtUtc, int UseCount, bool Enabled);
+public sealed record CreateAiUserMemoryCommand(string UserId, string MemoryType, string Content, string? Source, string? ConversationSource, string? CurrentUserMessage);
+public sealed record SearchAiUserMemoriesQuery(string UserId, string? Query, int MaxResults = 10, bool MarkUsed = true);
+public sealed record DeleteAiUserMemoryCommand(string UserId, string MemoryId);
+public sealed record AiUserMemoryMutationResult(bool Succeeded, string? ErrorMessage, AiUserMemoryDto? Memory);
+
+public interface IAiUserMemoryService
+{
+    Task<AiUserMemoryMutationResult> CreateAsync(CreateAiUserMemoryCommand command, CancellationToken cancellationToken);
+    Task<IReadOnlyList<AiUserMemoryDto>> SearchAsync(SearchAiUserMemoriesQuery query, CancellationToken cancellationToken);
+    Task<IReadOnlyList<AiUserMemoryDto>> ListAsync(string userId, CancellationToken cancellationToken);
+    Task<AiUserMemoryMutationResult> DeleteAsync(DeleteAiUserMemoryCommand command, CancellationToken cancellationToken);
+    string? ResolveUserId(ClaimsPrincipal? principal, string? applicationUserId);
+}
+
+internal sealed partial class AiUserMemoryService : IAiUserMemoryService
+{
+    private static readonly string[] ExplicitMemoryPhrases = ["remember that", "remember this", "from now on", "when i say", "call this", "i usually mean"];
+    private static readonly string[] RejectedLiveTruthPhrases = ["currently down", "currently up", "rtt is", "packet loss is", "uptime is", "last check", "today", "right now", "is unhealthy"];
+    private readonly PingMonitorDbContext _dbContext;
+
+    public AiUserMemoryService(PingMonitorDbContext dbContext) => _dbContext = dbContext;
+
+    public string? ResolveUserId(ClaimsPrincipal? principal, string? applicationUserId)
+        => !string.IsNullOrWhiteSpace(applicationUserId) ? applicationUserId : principal?.FindFirstValue(ClaimTypes.NameIdentifier);
+
+    public async Task<AiUserMemoryMutationResult> CreateAsync(CreateAiUserMemoryCommand command, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(command.UserId)) return Fail("A linked Ping Monitor user is required.");
+        if (!HasExplicitMemoryIntent(command.CurrentUserMessage)) return Fail("Memory creation requires an explicit user request.");
+        var content = command.Content.Trim();
+        if (content.Length == 0) return Fail("Memory content is required.");
+        if (content.Length > AiUserMemory.ContentMaxLength) return Fail($"Memory content must be {AiUserMemory.ContentMaxLength} characters or fewer.");
+        if (LooksLikeSecret(content)) return Fail("Memory content appears to contain a secret, password, API key, or token.");
+        if (LooksLikeLiveMonitoringTruth(content)) return Fail("Memory cannot store live monitoring state, current health, raw metrics, uptime, RTT, packet loss, or temporary incident status.");
+        if (LooksLikeRawJson(content)) return Fail("Memory cannot store raw JSON or tool result dumps.");
+
+        var normalized = Normalize(content);
+        var duplicate = await _dbContext.AiUserMemories.AsNoTracking().AnyAsync(x => x.UserId == command.UserId && x.NormalizedContent == normalized && x.Enabled && x.DeletedAtUtc == null, cancellationToken);
+        if (duplicate) return Fail("A near-identical memory already exists.");
+
+        var memory = new AiUserMemory
+        {
+            AiUserMemoryId = Guid.NewGuid().ToString("N"),
+            UserId = command.UserId,
+            MemoryType = Enum.TryParse<AiUserMemoryType>(command.MemoryType, true, out var type) ? type : AiUserMemoryType.Other,
+            Content = content,
+            NormalizedContent = normalized,
+            Source = string.IsNullOrWhiteSpace(command.Source) ? "AiTool" : command.Source.Trim(),
+            CreatedFromConversationSource = command.ConversationSource,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            UpdatedAtUtc = DateTimeOffset.UtcNow,
+            Enabled = true
+        };
+        _dbContext.AiUserMemories.Add(memory);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return new AiUserMemoryMutationResult(true, null, ToDto(memory));
+    }
+
+    public async Task<IReadOnlyList<AiUserMemoryDto>> SearchAsync(SearchAiUserMemoriesQuery query, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(query.UserId)) return [];
+        var q = Normalize(query.Query ?? string.Empty);
+        var memories = await _dbContext.AiUserMemories
+            .Where(x => x.UserId == query.UserId && x.Enabled && x.DeletedAtUtc == null)
+            .Where(x => q == string.Empty || x.NormalizedContent.Contains(q) || x.Content.Contains(query.Query!))
+            .OrderByDescending(x => x.UpdatedAtUtc)
+            .Take(Math.Clamp(query.MaxResults, 1, 10))
+            .ToListAsync(cancellationToken);
+        if (query.MarkUsed && memories.Count > 0)
+        {
+            var now = DateTimeOffset.UtcNow;
+            foreach (var memory in memories) { memory.LastUsedAtUtc = now; memory.UseCount++; }
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+        return memories.Select(ToDto).ToArray();
+    }
+
+    public async Task<IReadOnlyList<AiUserMemoryDto>> ListAsync(string userId, CancellationToken cancellationToken)
+    {
+        var memories = await _dbContext.AiUserMemories.AsNoTracking()
+            .Where(x => x.UserId == userId && x.DeletedAtUtc == null)
+            .OrderByDescending(x => x.CreatedAtUtc)
+            .ToListAsync(cancellationToken);
+        return memories.Select(ToDto).ToArray();
+    }
+
+    public async Task<AiUserMemoryMutationResult> DeleteAsync(DeleteAiUserMemoryCommand command, CancellationToken cancellationToken)
+    {
+        var memory = await _dbContext.AiUserMemories.SingleOrDefaultAsync(x => x.AiUserMemoryId == command.MemoryId && x.UserId == command.UserId && x.DeletedAtUtc == null, cancellationToken);
+        if (memory is null) return Fail("Memory was not found for the current user.");
+        memory.Enabled = false;
+        memory.DeletedAtUtc = DateTimeOffset.UtcNow;
+        memory.UpdatedAtUtc = memory.DeletedAtUtc.Value;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return new AiUserMemoryMutationResult(true, null, ToDto(memory));
+    }
+
+    private static bool HasExplicitMemoryIntent(string? message) => !string.IsNullOrWhiteSpace(message) && ExplicitMemoryPhrases.Any(x => message.Contains(x, StringComparison.OrdinalIgnoreCase));
+    private static bool LooksLikeLiveMonitoringTruth(string content) => RejectedLiveTruthPhrases.Any(x => content.Contains(x, StringComparison.OrdinalIgnoreCase));
+    private static bool LooksLikeSecret(string content) => SecretRegex().IsMatch(content);
+    private static bool LooksLikeRawJson(string content) => content.TrimStart().StartsWith('{') || content.TrimStart().StartsWith('[');
+    private static string Normalize(string value) => Regex.Replace(value.Trim().ToLowerInvariant(), "\\s+", " ");
+    private static AiUserMemoryMutationResult Fail(string message) => new(false, message, null);
+    private static AiUserMemoryDto ToDto(AiUserMemory x) => new(x.AiUserMemoryId, x.UserId, x.MemoryType.ToString(), x.Content, x.CreatedAtUtc, x.UpdatedAtUtc, x.LastUsedAtUtc, x.UseCount, x.Enabled);
+
+    [GeneratedRegex("(?i)(password|api[_ -]?key|secret|token|bearer\\s+[a-z0-9._\\-]{12,}|sk-[a-z0-9]{12,})")]
+    private static partial Regex SecretRegex();
+}

--- a/src/WebApp/PingMonitor.Web/Services/AiTools/AiToolModels.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiTools/AiToolModels.cs
@@ -24,6 +24,8 @@ public sealed class AiToolCall
     public string ArgumentsJson { get; init; } = "{}";
     public ClaimsPrincipal? Principal { get; init; }
     public string? ApplicationUserId { get; init; }
+    public string? CurrentUserMessage { get; init; }
+    public string? ConversationSource { get; init; }
 }
 
 public sealed class AiToolExecutionResult

--- a/src/WebApp/PingMonitor.Web/Services/AiTools/UserMemoryAiTools.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiTools/UserMemoryAiTools.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using PingMonitor.Web.Services.AiMemory;
+
+namespace PingMonitor.Web.Services.AiTools;
+
+internal abstract class UserMemoryAiToolBase
+{
+    protected readonly IAiUserMemoryService MemoryService;
+    protected readonly IAiAssistantSettingsService SettingsService;
+    protected static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    protected UserMemoryAiToolBase(IAiUserMemoryService memoryService, IAiAssistantSettingsService settingsService)
+    {
+        MemoryService = memoryService;
+        SettingsService = settingsService;
+    }
+
+    protected async Task<(bool ok, string? userId, AiToolExecutionResult? result)> ValidateAsync(AiToolCall call, CancellationToken cancellationToken)
+    {
+        var settings = await SettingsService.GetCurrentAsync(cancellationToken);
+        if (!settings.MemoryEnabled)
+        {
+            return (false, null, Error("memory_disabled", "AI memory is disabled."));
+        }
+        var userId = MemoryService.ResolveUserId(call.Principal, call.ApplicationUserId);
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return (false, null, Error("user_required", "A linked Ping Monitor user is required."));
+        }
+        return (true, userId, null);
+    }
+
+    protected static AiToolExecutionResult Ok(object payload) => new() { Succeeded = true, ContentJson = JsonSerializer.Serialize(payload, JsonOptions) };
+    protected static AiToolExecutionResult Error(string code, string message) => new() { Succeeded = false, ErrorMessage = message, ContentJson = JsonSerializer.Serialize(new { error = code, message }, JsonOptions) };
+}
+
+internal sealed class SearchUserMemoriesAiTool : UserMemoryAiToolBase, IAiTool
+{
+    public SearchUserMemoriesAiTool(IAiUserMemoryService memoryService, IAiAssistantSettingsService settingsService) : base(memoryService, settingsService) { }
+    public AiToolDefinition Definition { get; } = new()
+    {
+        Name = "search_user_memories",
+        Description = "Search the current user's AI memories for relevant preferences, aliases, and context. Live Ping Monitor tool data overrides memory.",
+        Parameters = new JsonObject { ["type"] = "object", ["properties"] = new JsonObject { ["query"] = new JsonObject { ["type"] = "string", ["description"] = "Text to search for, such as an alias or preference phrase." } }, ["required"] = new JsonArray("query") }
+    };
+    public async Task<AiToolExecutionResult> ExecuteAsync(AiToolCall call, CancellationToken cancellationToken)
+    {
+        var validation = await ValidateAsync(call, cancellationToken); if (!validation.ok) return validation.result!;
+        var args = JsonSerializer.Deserialize<SearchArgs>(call.ArgumentsJson, JsonOptions) ?? new SearchArgs();
+        var matches = await MemoryService.SearchAsync(new SearchAiUserMemoriesQuery(validation.userId!, args.Query, 10), cancellationToken);
+        return Ok(new { matches = matches.Select(x => new { memoryId = x.MemoryId, memoryType = x.MemoryType, content = x.Content, createdAtUtc = x.CreatedAtUtc, lastUsedAtUtc = x.LastUsedAtUtc }) });
+    }
+    private sealed class SearchArgs { public string? Query { get; set; } }
+}
+
+internal sealed class RememberUserMemoryAiTool : UserMemoryAiToolBase, IAiTool
+{
+    public RememberUserMemoryAiTool(IAiUserMemoryService memoryService, IAiAssistantSettingsService settingsService) : base(memoryService, settingsService) { }
+    public AiToolDefinition Definition { get; } = new()
+    {
+        Name = "remember_user_memory",
+        Description = "Create a user-specific memory only when the current user explicitly asks to remember something. Do not store secrets or live monitoring truth.",
+        Parameters = new JsonObject { ["type"] = "object", ["properties"] = new JsonObject { ["memoryType"] = new JsonObject { ["type"] = "string", ["enum"] = new JsonArray("UserPreference", "EndpointAlias", "NetworkAlias", "LocationAlias", "OperationalNote", "AssistantInstruction", "Other") }, ["content"] = new JsonObject { ["type"] = "string", ["maxLength"] = 1000 } }, ["required"] = new JsonArray("memoryType", "content") }
+    };
+    public async Task<AiToolExecutionResult> ExecuteAsync(AiToolCall call, CancellationToken cancellationToken)
+    {
+        var validation = await ValidateAsync(call, cancellationToken); if (!validation.ok) return validation.result!;
+        var args = JsonSerializer.Deserialize<CreateArgs>(call.ArgumentsJson, JsonOptions) ?? new CreateArgs();
+        var result = await MemoryService.CreateAsync(new CreateAiUserMemoryCommand(validation.userId!, args.MemoryType ?? "Other", args.Content ?? string.Empty, "AiTool", call.ConversationSource, call.CurrentUserMessage), cancellationToken);
+        return result.Succeeded ? Ok(new { memoryId = result.Memory!.MemoryId, memoryType = result.Memory.MemoryType, content = result.Memory.Content }) : Error("memory_rejected", result.ErrorMessage ?? "Memory was rejected.");
+    }
+    private sealed class CreateArgs { public string? MemoryType { get; set; } public string? Content { get; set; } }
+}
+
+internal sealed class DeleteUserMemoryAiTool : UserMemoryAiToolBase, IAiTool
+{
+    public DeleteUserMemoryAiTool(IAiUserMemoryService memoryService, IAiAssistantSettingsService settingsService) : base(memoryService, settingsService) { }
+    public AiToolDefinition Definition { get; } = new()
+    {
+        Name = "delete_user_memory",
+        Description = "Soft-delete one of the current user's own AI memories.",
+        Parameters = new JsonObject { ["type"] = "object", ["properties"] = new JsonObject { ["memoryId"] = new JsonObject { ["type"] = "string" } }, ["required"] = new JsonArray("memoryId") }
+    };
+    public async Task<AiToolExecutionResult> ExecuteAsync(AiToolCall call, CancellationToken cancellationToken)
+    {
+        var validation = await ValidateAsync(call, cancellationToken); if (!validation.ok) return validation.result!;
+        var args = JsonSerializer.Deserialize<DeleteArgs>(call.ArgumentsJson, JsonOptions) ?? new DeleteArgs();
+        var result = await MemoryService.DeleteAsync(new DeleteAiUserMemoryCommand(validation.userId!, args.MemoryId ?? string.Empty), cancellationToken);
+        return result.Succeeded ? Ok(new { deleted = true, memoryId = result.Memory!.MemoryId }) : Error("memory_not_deleted", result.ErrorMessage ?? "Memory was not deleted.");
+    }
+    private sealed class DeleteArgs { public string? MemoryId { get; set; } }
+}

--- a/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/StartupGate/StartupSchemaService.cs
@@ -50,7 +50,8 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "NetworkDiagramAreas",
         "NetworkDiagramNodes",
         "NetworkDiagramLinks",
-        "NetworkDiagramLinkVlans"
+        "NetworkDiagramLinkVlans",
+        "AiUserMemories"
     ];
 
     private static readonly string[] RequiredNetworkDiagramColumns =
@@ -231,6 +232,23 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         "SmtpNotifyAgentOnline",
         "UpdatedAtUtc",
         "UpdatedByUserId"
+    ];
+
+    private static readonly string[] RequiredAiUserMemoryColumns =
+    [
+        "AiUserMemoryId",
+        "UserId",
+        "MemoryType",
+        "Content",
+        "NormalizedContent",
+        "Source",
+        "CreatedAtUtc",
+        "UpdatedAtUtc",
+        "LastUsedAtUtc",
+        "UseCount",
+        "Enabled",
+        "DeletedAtUtc",
+        "CreatedFromConversationSource"
     ];
 
     private static readonly string[] RequiredAiAssistantSettingsColumns =
@@ -417,6 +435,14 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         {
             var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
             status.Diagnostics.Add($"AiAssistantSettings table is missing required columns: {string.Join(", ", missingAiAssistantSettingsColumns)}.");
+            return status;
+        }
+
+        var missingAiUserMemoryColumns = await GetMissingColumnsAsync(connection, "AiUserMemories", RequiredAiUserMemoryColumns, cancellationToken);
+        if (missingAiUserMemoryColumns.Length > 0)
+        {
+            var status = new StartupSchemaStatus { State = StartupGateSchemaState.Incompatible };
+            status.Diagnostics.Add($"AiUserMemories table is missing required columns: {string.Join(", ", missingAiUserMemoryColumns)}.");
             return status;
         }
 
@@ -720,6 +746,26 @@ internal sealed class StartupSchemaService : IStartupSchemaService
                 `UpdatedAtUtc` datetime(6) NOT NULL,
                 `UpdatedByUserId` varchar(255) NULL,
                 PRIMARY KEY (`AiAssistantSettingsId`)
+            );
+            """;
+        const string createAiUserMemoriesSql = """
+            CREATE TABLE IF NOT EXISTS `AiUserMemories` (
+                `AiUserMemoryId` varchar(64) NOT NULL,
+                `UserId` varchar(255) NOT NULL,
+                `MemoryType` varchar(64) NOT NULL,
+                `Content` varchar(1000) NOT NULL,
+                `NormalizedContent` varchar(1000) NOT NULL,
+                `Source` varchar(64) NOT NULL,
+                `CreatedAtUtc` datetime(6) NOT NULL,
+                `UpdatedAtUtc` datetime(6) NOT NULL,
+                `LastUsedAtUtc` datetime(6) NULL,
+                `UseCount` int NOT NULL DEFAULT 0,
+                `Enabled` tinyint(1) NOT NULL DEFAULT 1,
+                `DeletedAtUtc` datetime(6) NULL,
+                `CreatedFromConversationSource` varchar(64) NULL,
+                PRIMARY KEY (`AiUserMemoryId`),
+                KEY `IX_AiUserMemories_UserId_Enabled_DeletedAtUtc` (`UserId`, `Enabled`, `DeletedAtUtc`),
+                KEY `IX_AiUserMemories_UserId_NormalizedContent` (`UserId`, `NormalizedContent`(255))
             );
             """;
         const string createUserNotificationSettingsSql = """
@@ -1065,6 +1111,7 @@ internal sealed class StartupSchemaService : IStartupSchemaService
         await dbContext.Database.ExecuteSqlRawAsync(createSecurityIpBlocksSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createNotificationSettingsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createAiAssistantSettingsSql, cancellationToken);
+        await dbContext.Database.ExecuteSqlRawAsync(createAiUserMemoriesSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createUserNotificationSettingsSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createPendingTelegramLinksSql, cancellationToken);
         await dbContext.Database.ExecuteSqlRawAsync(createTelegramAccountsSql, cancellationToken);

--- a/src/WebApp/PingMonitor.Web/ViewModels/AiAssistant/AiMemoriesPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/AiAssistant/AiMemoriesPageViewModel.cs
@@ -1,0 +1,12 @@
+using PingMonitor.Web.Services.AiMemory;
+
+namespace PingMonitor.Web.ViewModels.AiAssistant;
+
+public sealed class AiMemoriesPageViewModel
+{
+    public bool AssistantEnabled { get; set; }
+    public bool MemoryEnabled { get; set; }
+    public string? StatusMessage { get; set; }
+    public string? ErrorMessage { get; set; }
+    public IReadOnlyList<AiUserMemoryDto> Memories { get; set; } = [];
+}

--- a/src/WebApp/PingMonitor.Web/Views/AiAssistant/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AiAssistant/Index.cshtml
@@ -41,6 +41,7 @@
         <section class="card">
             <h1>AI Assistant</h1>
             <p class="muted">@Model.HelpText</p>
+            <p><a asp-controller="AiAssistant" asp-action="Memories">Manage my AI memories</a></p>
         </section>
 
         @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
@@ -75,7 +76,7 @@
                 <input type="hidden" asp-for="HistoryJson" />
                 <div>
                     <label asp-for="Message"></label>
-                    <textarea asp-for="Message" maxlength="4000" disabled="@(!canSend)" placeholder="Ask a general question. Live monitoring data and tools are not connected yet."></textarea>
+                    <textarea asp-for="Message" maxlength="4000" disabled="@(!canSend)" placeholder="Ask about your monitored network, or say "remember that..." to save a user-specific preference or alias when memory is enabled."></textarea>
                     <span asp-validation-for="Message"></span>
                 </div>
                 <div class="button-row">

--- a/src/WebApp/PingMonitor.Web/Views/AiAssistant/Memories.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AiAssistant/Memories.cshtml
@@ -1,0 +1,60 @@
+@model PingMonitor.Web.ViewModels.AiAssistant.AiMemoriesPageViewModel
+@{
+    ViewData["Title"] = "My AI memories";
+    var status = TempData["StatusMessage"] as string ?? Model.StatusMessage;
+    var error = TempData["ErrorMessage"] as string ?? Model.ErrorMessage;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    @await Html.PartialAsync("_ThemeHead")
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>My AI memories</title>
+    <style>
+        body { margin: 0; font-family: Arial, sans-serif; background: #f3f6f8; color: #102a43; }
+        main { max-width: 920px; margin: 0 auto; padding: 1rem; }
+        .card { background: #fff; border: 1px solid #d9e2ec; border-radius: 14px; padding: 1rem; margin-bottom: 1rem; }
+        .muted { color: #52606d; }
+        .alert { border-radius: 12px; padding: .85rem; margin-bottom: 1rem; }
+        .alert-error { background: #fff3f2; color: #b42318; border: 1px solid #fecdca; }
+        .alert-ok { background: #e7f6ec; color: #137333; border: 1px solid #abefc6; }
+        .memory { display: grid; gap: .35rem; border-top: 1px solid #d9e2ec; padding: 1rem 0; }
+        .button, .button-danger { min-height: 44px; border-radius: 10px; padding: .7rem 1rem; font-weight: 700; }
+        .button { display: inline-block; background: #0f62fe; color: #fff; text-decoration: none; }
+        .button-danger { background: #b42318; color: #fff; border: 0; }
+    </style>
+</head>
+<body>
+@await Html.PartialAsync("_AuthenticatedNav")
+<main>
+    <section class="card">
+        <h1>My AI memories</h1>
+        <p class="muted">User-specific preferences, aliases, and contextual notes used by the AI assistant. Live monitoring tools always override memory.</p>
+        <a class="button" asp-controller="AiAssistant" asp-action="Index">Back to AI Assistant</a>
+    </section>
+    @if (!string.IsNullOrWhiteSpace(error)) { <div class="alert alert-error">@error</div> }
+    @if (!string.IsNullOrWhiteSpace(status)) { <div class="alert alert-ok">@status</div> }
+    <section class="card">
+        @if (!Model.MemoryEnabled) { <p class="muted">AI memory is disabled, so memories cannot be searched, created, or deleted.</p> }
+        else if (Model.Memories.Count == 0) { <p class="muted">No AI memories have been saved for your user.</p> }
+        else
+        {
+            @foreach (var memory in Model.Memories)
+            {
+                <article class="memory">
+                    <strong>@memory.MemoryType</strong>
+                    <div>@memory.Content</div>
+                    <small class="muted">Created @memory.CreatedAtUtc.UtcDateTime.ToString("u") · Last used @(memory.LastUsedAtUtc?.UtcDateTime.ToString("u") ?? "never") · Uses @memory.UseCount</small>
+                    <form asp-controller="AiAssistant" asp-action="DeleteMemory" method="post">
+                        @Html.AntiForgeryToken()
+                        <input type="hidden" name="memoryId" value="@memory.MemoryId" />
+                        <button class="button-danger" type="submit">Delete memory</button>
+                    </form>
+                </article>
+            }
+        }
+    </section>
+</main>
+</body>
+</html>

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate.Development",
-    "RequiredSchemaVersion": 22,
+    "RequiredSchemaVersion": 23,
     "DefaultMySqlPort": 3306
   },
   "Logging": {

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -18,7 +18,7 @@
   },
   "StartupGate": {
     "StorageDirectory": "App_Data/StartupGate",
-    "RequiredSchemaVersion": 22,
+    "RequiredSchemaVersion": 23,
     "DefaultMySqlPort": 3306
   },
   "Logging": {


### PR DESCRIPTION
### Motivation
- Provide user-scoped AI memories so the assistant can remember preferences, aliases, and contextual notes across web chat and Telegram without mixing memory with live monitoring truth. 
- Ensure memories are safe, user-isolated, and feature-gated so they cannot store secrets or transient monitoring state. 
- Maintain startup-gate/schema correctness by adding the new table and bumping required schema version. 
- Expose a simple user UI for managing memories and keep web/Telegram tool paths unified.

### Description
- Added a new DB-backed entity `AiUserMemory` and EF mapping and `DbSet<AiUserMemory>` with schema columns for content, normalized content, source, timestamps, use-count, enabled flag and soft-delete, and added schema creation and startup-gate checks for the `AiUserMemories` table; bumped required schema version to `23` (appsettings). 
- Implemented `IAiUserMemoryService` / `AiUserMemoryService` supporting create/search/list/delete with deterministic guards enforcing ownership, explicit memory intent checks, length bounds, duplicate suppression, secret/raw-json/live-truth rejection, and updating last-used/use-count on search. 
- Added three internal AI tools: `search_user_memories`, `remember_user_memory`, and `delete_user_memory` registered in the existing tool registry and gated by `MemoryEnabled`; the `remember_user_memory` tool requires explicit memory intent (deterministic phrase checks) and runs ownership/validation server-side. 
- Updated AI prompt (built-in system prompt) to describe memory tool usage rules and that live Ping Monitor tool data overrides memory; tool definitions are hidden from the model when memory is disabled; tool execution context now receives the current user message and conversation source. 
- Added a simple authenticated UI at `/ai-assistant/memories` allowing users to view and soft-delete only their own memories and added a link from the AI Assistant page; if memory is disabled the page shows a disabled message. 
- Included memory decisions in backup/restore reasoning: user memories are DB-backed user data and are included by full database backups (not part of config-only backup sections). 

### Testing
- Ran `dotnet build src/WebApp/PingMonitor.WebApp.slnx` and the solution built successfully. (Succeeded) 
- Ran unit tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and `dotnet test src/WebApp/PingMonitor.WebApp.slnx`; test suite passed locally in this environment. (Passed) 
- Added focused source/regression tests asserting prompt changes, memory validation/isolation guards, tool declarations, and Startup Gate schema declarations, and those tests passed. 
- Manual smoke tests (web + Telegram flows with a live DB, AI provider and linked Telegram account) were not executed in this environment because a configured Ping Monitor database, enabled AI provider, and Telegram linkage are required; test commands and a manual checklist are documented for follow-up validation. 

Note: An attempt to create a GitHub issue before implementation failed in this environment because the `gh` CLI and authenticated remote access were not available; the suggested issue title is: "Add user-specific AI memories". Please create/link a matching issue (Fixes/Closes/Refs) before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31961bb31c832aa92bf0fb30a73b41)