### PR TITLE
Fix AI diagram endpoint lookup MySQL translation

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AiNetworkDiagramSliceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiNetworkDiagramSliceTests.cs
@@ -54,6 +54,9 @@ public sealed class AiNetworkDiagramSliceTests
         Assert.Contains("MaxConnections = 50", source);
         Assert.Contains("MaxFullNodes = 120", source);
         Assert.Contains("visibleEndpointIds", source);
+        Assert.Contains("ApplyEndpointFilter(DbContext.Endpoints.AsNoTracking(), ids)", source);
+        Assert.Contains("Expression.OrElse", source);
+        Assert.DoesNotContain("ids.Contains(x.EndpointId)", source);
         Assert.Contains("visibleNodeIds.Contains(l.SourceNodeId) && visibleNodeIds.Contains(l.TargetNodeId)", source);
         Assert.Contains("SafeMetadata", source);
         Assert.Contains("Truncate", source);

--- a/src/WebApp/PingMonitor.Web/Services/AiTools/NetworkDiagramAiTools.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiTools/NetworkDiagramAiTools.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.Identity;
@@ -71,8 +72,27 @@ internal abstract class NetworkDiagramAiToolBase : IAiTool
         var ids = endpointIds.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct(StringComparer.Ordinal).Cast<string>().ToArray();
         if (visibleEndpointIds is not null) ids = ids.Where(id => visibleEndpointIds.Contains(id, StringComparer.Ordinal)).ToArray();
         if (ids.Length == 0) return new Dictionary<string, EndpointBrief>(StringComparer.Ordinal);
-        var rows = await DbContext.Endpoints.AsNoTracking().Where(x => ids.Contains(x.EndpointId)).Select(x => new EndpointBrief(x.EndpointId, x.Name, x.Target)).ToArrayAsync(cancellationToken);
+        var rows = await ApplyEndpointFilter(DbContext.Endpoints.AsNoTracking(), ids).Select(x => new EndpointBrief(x.EndpointId, x.Name, x.Target)).ToArrayAsync(cancellationToken);
         return rows.ToDictionary(x => x.EndpointId, StringComparer.Ordinal);
+    }
+
+    private static IQueryable<Models.Endpoint> ApplyEndpointFilter(IQueryable<Models.Endpoint> endpoints, IReadOnlyCollection<string> endpointIds)
+    {
+        if (endpointIds.Count == 0)
+        {
+            return endpoints.Where(static _ => false);
+        }
+
+        var parameter = Expression.Parameter(typeof(Models.Endpoint), "endpoint");
+        var endpointId = Expression.Property(parameter, nameof(Models.Endpoint.EndpointId));
+        Expression? predicate = null;
+        foreach (var id in endpointIds)
+        {
+            var equals = Expression.Equal(endpointId, Expression.Constant(id));
+            predicate = predicate is null ? equals : Expression.OrElse(predicate, equals);
+        }
+
+        return endpoints.Where(Expression.Lambda<Func<Models.Endpoint, bool>>(predicate!, parameter));
     }
 
     protected static object NodePayload(NetworkDiagramNode n, IReadOnlyDictionary<string, EndpointBrief> endpoints, IReadOnlyList<NetworkDiagramArea> areas) => new


### PR DESCRIPTION
### Motivation

- A runtime error occurred when the AI assistant requested diagram data due to EF producing an untyped SQL parameter from `ids.Contains(x.EndpointId)`, causing MySQL provider type-mapping failures.  
- The change aims to make the endpoint lookup LINQ query provider-safe for MySQL translation following the repository's MySQL-first validation guidance.  
- Add a source-level regression guard to prevent reintroducing the unsafe `Contains` usage on endpoint ID arrays.

### Description

- Replaced the unsafe array `Contains` query in `NetworkDiagramAiToolBase.LoadEndpointBriefsAsync` with a provider-safe `ApplyEndpointFilter` helper that builds an explicit equality predicate joined with `Expression.OrElse`.  
- Added `ApplyEndpointFilter` and imported `System.Linq.Expressions`, and updated `LoadEndpointBriefsAsync` to call `ApplyEndpointFilter` in `src/WebApp/PingMonitor.Web/Services/AiTools/NetworkDiagramAiTools.cs`.  
- Added assertions to `src/WebApp/PingMonitor.Web.Tests/AiNetworkDiagramSliceTests.cs` to assert the presence of the `ApplyEndpointFilter` usage and to assert `ids.Contains(x.EndpointId)` is not present as a regression barrier.  
- Touched query path: `NetworkDiagramAiToolBase.LoadEndpointBriefsAsync` (used by `search_diagram_nodes`, `get_network_diagram`, and `find_diagram_connections`).

### Testing

- Ran unit tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and all tests passed (`Passed: 210, Failed: 0`).  
- Built the web solution with `dotnet build src/WebApp/PingMonitor.WebApp.slnx` and the build succeeded with no errors.  
- The added test assertions validate the exact regression class (unsafe `Contains` over endpoint ID arrays) and passed as part of the test run.

Refs #578

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31b5f6db4c832a90fbaf9b6031ef5f)