### PR TITLE
Add read-only get_application_runtime_info AI tool

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AiRuntimeInfoSliceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiRuntimeInfoSliceTests.cs
@@ -1,0 +1,98 @@
+using PingMonitor.Web.Services.AiChat;
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class AiRuntimeInfoSliceTests
+{
+    [Fact]
+    public void RuntimeInfoTool_IsRegisteredOnSharedAiToolPath()
+    {
+        var programSource = ReadWebSource("Program.cs");
+
+        Assert.Contains("IAiRuntimeInfoService, AiRuntimeInfoService", programSource);
+        Assert.Contains("IAiTool, AiRuntimeInfoTool", programSource);
+    }
+
+    [Fact]
+    public void RuntimeInfoTool_DefinitionUsesExpectedNameDescriptionAndSchema()
+    {
+        var source = ReadWebSource("Services", "AiTools", "AiRuntimeInfoTool.cs");
+
+        Assert.Contains("get_application_runtime_info", source);
+        Assert.Contains("read-only Ping Monitor runtime and build information", source);
+        Assert.Contains("includeDatabase", source);
+        Assert.Contains("includeEnvironment", source);
+        Assert.Contains("includeBuild", source);
+        Assert.Contains("additionalProperties", source);
+        Assert.Contains("false", source);
+    }
+
+    [Fact]
+    public void RuntimeInfoService_RedactsNonAdminOperationalDetails()
+    {
+        var source = ReadWebSource("Services", "AiTools", "AiRuntimeInfoService.cs");
+
+        Assert.Contains("if (!request.IsAdmin)", source);
+        Assert.Contains("DetailLevel = \"Minimal\"", source);
+        Assert.Contains("detailed runtime", source, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("admin-only", source, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("connection strings", source, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("API keys", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ConnectionString", source, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RuntimeInfoService_AdminResultIncludesSafeRuntimeStartupAndDatabaseFields()
+    {
+        var source = ReadWebSource("Services", "AiTools", "AiRuntimeInfoService.cs");
+
+        Assert.Contains("RuntimeInformation.FrameworkDescription", source);
+        Assert.Contains("RuntimeInformation.OSDescription", source);
+        Assert.Contains("ProcessArchitecture", source);
+        Assert.Contains("RequiredSchemaVersion", source);
+        Assert.Contains("CurrentSchemaVersion", source);
+        Assert.Contains("SchemaCompatible", source);
+        Assert.Contains("Provider = snapshot.ProviderName", source);
+        Assert.Contains("DatabaseName = snapshot.DatabaseName", source);
+        Assert.Contains("Take(10)", source);
+        Assert.Contains("Database size information is not available", source);
+    }
+
+    [Fact]
+    public void RuntimeInfoService_DoesNotAccessDatabaseWhileStartupGateIsActive()
+    {
+        var source = ReadWebSource("Services", "AiTools", "AiRuntimeInfoService.cs");
+
+        Assert.Contains("!_startupGateRuntimeState.IsOperationalMode", source);
+        Assert.Contains("Startup Gate is active", source);
+    }
+
+    [Fact]
+    public void BuiltInPromptMentionsRuntimeInfoToolAndSecretRestrictions()
+    {
+        Assert.Contains("get_application_runtime_info", AiChatService.BuiltInSystemPrompt);
+        Assert.Contains("Do not guess version, schema, database size, or build status", AiChatService.BuiltInSystemPrompt);
+        Assert.Contains("connection strings", AiChatService.BuiltInSystemPrompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("API keys", AiChatService.BuiltInSystemPrompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("admin-only", AiChatService.BuiltInSystemPrompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ToolArgumentDefaultsAreTrueAndRejectUnsupportedArguments()
+    {
+        var source = ReadWebSource("Services", "AiTools", "AiRuntimeInfoTool.cs");
+
+        Assert.Contains("includeDatabase = true", source);
+        Assert.Contains("includeEnvironment = true", source);
+        Assert.Contains("includeBuild = true", source);
+        Assert.Contains("Unsupported argument", source);
+        Assert.Contains("must be a boolean", source);
+    }
+
+    private static string ReadWebSource(params string[] parts)
+    {
+        var path = Path.Combine(new[] { AppContext.BaseDirectory, "..", "..", "..", "..", "PingMonitor.Web" }.Concat(parts).ToArray());
+        return File.ReadAllText(path);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -203,8 +203,10 @@ builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsServi
 builder.Services.AddScoped<IAiAssistantSettingsService, AiAssistantSettingsService>();
 builder.Services.AddScoped<PingMonitor.Web.Services.AiMemory.IAiUserMemoryService, PingMonitor.Web.Services.AiMemory.AiUserMemoryService>();
 builder.Services.AddScoped<IAiProviderClient, OpenAiCompatibleProviderClient>();
+builder.Services.AddScoped<IAiRuntimeInfoService, AiRuntimeInfoService>();
 builder.Services.AddMemoryCache();
 builder.Services.AddScoped<IAiTool, NetworkHealthSummaryAiTool>();
+builder.Services.AddScoped<IAiTool, AiRuntimeInfoTool>();
 builder.Services.AddScoped<IAiTool, SearchEndpointsAiTool>();
 builder.Services.AddScoped<IAiTool, EndpointMetricsSummaryAiTool>();
 builder.Services.AddScoped<IAiTool, ListNetworkDiagramsAiTool>();

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs
@@ -13,8 +13,12 @@ You are the Ping Monitor AI assistant.
 You are read-only.
 
 You have access to approved read-only Ping Monitor tools.
-Use tools when you need current monitoring state, endpoint state counts, down/unknown/suppressed endpoints, endpoint metrics, agent health, or saved Network Diagram documentation.
+Use tools when you need current monitoring state, endpoint state counts, down/unknown/suppressed endpoints, endpoint metrics, agent health, saved Network Diagram documentation, or current application runtime/build metadata.
 Use `get_network_health_summary` for broad network status questions.
+Use `get_application_runtime_info` for questions about the Ping Monitor app version, build, schema version, database size, runtime environment, startup gate, update/build status, or deployment/runtime details.
+Do not guess version, schema, database size, or build status. Use the tool when available.
+Do not expose or request secrets, connection strings, credentials, API keys, protected settings, filesystem paths, or host details that the tool does not provide.
+If runtime info is redacted because the user is not an admin, say that detailed runtime information is admin-only.
 Use Network Diagram tools for questions about saved topology documentation, device connections, switch ports, link labels, link media, link speed, LAG/LACP, VLANs, diagram areas, or diagram notes.
 Network Diagram data is saved documentation only. It is not live switch port state, not SNMP discovery, and not authoritative live topology.
 When answering from diagram tools, clearly say "According to the saved diagram..." or equivalent.

--- a/src/WebApp/PingMonitor.Web/Services/AiTools/AiRuntimeInfoService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiTools/AiRuntimeInfoService.cs
@@ -1,0 +1,259 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Options;
+using PingMonitor.Web.Options;
+using PingMonitor.Web.Services.ApplicationMetadata;
+using PingMonitor.Web.Services.DatabaseStatus;
+using PingMonitor.Web.Services.StartupGate;
+
+namespace PingMonitor.Web.Services.AiTools;
+
+public interface IAiRuntimeInfoService
+{
+    Task<AiRuntimeInfoDto> GetRuntimeInfoAsync(AiRuntimeInfoRequest request, CancellationToken cancellationToken);
+}
+
+public sealed class AiRuntimeInfoRequest
+{
+    public bool IsAdmin { get; init; }
+    public bool IncludeDatabase { get; init; } = true;
+    public bool IncludeEnvironment { get; init; } = true;
+    public bool IncludeBuild { get; init; } = true;
+}
+
+public sealed class AiRuntimeInfoDto
+{
+    public DateTimeOffset GeneratedAtUtc { get; init; }
+    public string DataSource { get; init; } = "application_runtime_info";
+    public bool PermissionFiltered { get; init; }
+    public string DetailLevel { get; init; } = "Minimal";
+    public AiApplicationRuntimeInfo Application { get; init; } = new();
+    public AiRuntimeEnvironmentInfo? Runtime { get; init; }
+    public AiStartupGateInfo? StartupGate { get; init; }
+    public AiDatabaseRuntimeInfo? Database { get; init; }
+    public IReadOnlyList<string> Limitations { get; init; } = Array.Empty<string>();
+}
+
+public sealed class AiApplicationRuntimeInfo
+{
+    public string Name { get; init; } = "Ping Monitor";
+    public string? Version { get; init; }
+    public string? AssemblyVersion { get; init; }
+    public string? InformationalVersion { get; init; }
+    public string? FileVersion { get; init; }
+    public string? CommitSha { get; init; }
+    public string? Branch { get; init; }
+    public string? BuildTimestampUtc { get; init; }
+}
+
+public sealed class AiRuntimeEnvironmentInfo
+{
+    public string? Environment { get; init; }
+    public string DotNetVersion { get; init; } = string.Empty;
+    public string OSDescription { get; init; } = string.Empty;
+    public string ProcessArchitecture { get; init; } = string.Empty;
+    public DateTimeOffset ProcessStartedAtUtc { get; init; }
+    public long UptimeSeconds { get; init; }
+    public DateTimeOffset CurrentServerTimeUtc { get; init; }
+    public DateTimeOffset CurrentServerLocalTime { get; init; }
+    public bool? IsIisInProcess { get; init; }
+}
+
+public sealed class AiStartupGateInfo
+{
+    public string Mode { get; init; } = string.Empty;
+    public int RequiredSchemaVersion { get; init; }
+    public int? CurrentSchemaVersion { get; init; }
+    public bool? SchemaCompatible { get; init; }
+    public bool ReadOnlyMode { get; init; }
+}
+
+public sealed class AiDatabaseRuntimeInfo
+{
+    public bool Available { get; init; } = true;
+    public string? Reason { get; init; }
+    public string? Provider { get; init; }
+    public string? DatabaseName { get; init; }
+    public long? SizeBytes { get; init; }
+    public long? DataSizeBytes { get; init; }
+    public long? IndexSizeBytes { get; init; }
+    public int? TableCount { get; init; }
+    public IReadOnlyList<AiDatabaseTableRuntimeInfo> LargestTables { get; init; } = Array.Empty<AiDatabaseTableRuntimeInfo>();
+}
+
+public sealed class AiDatabaseTableRuntimeInfo
+{
+    public string TableName { get; init; } = string.Empty;
+    public long SizeBytes { get; init; }
+    public long RowCountEstimate { get; init; }
+}
+
+internal sealed class AiRuntimeInfoService : IAiRuntimeInfoService
+{
+    private readonly IApplicationMetadataProvider _metadataProvider;
+    private readonly IWebHostEnvironment _environment;
+    private readonly IStartupGateRuntimeState _startupGateRuntimeState;
+    private readonly IStartupSchemaService _startupSchemaService;
+    private readonly IDatabaseStatusQueryService _databaseStatusQueryService;
+    private readonly IOptions<StartupGateOptions> _startupGateOptions;
+    private readonly ILogger<AiRuntimeInfoService> _logger;
+
+    public AiRuntimeInfoService(
+        IApplicationMetadataProvider metadataProvider,
+        IWebHostEnvironment environment,
+        IStartupGateRuntimeState startupGateRuntimeState,
+        IStartupSchemaService startupSchemaService,
+        IDatabaseStatusQueryService databaseStatusQueryService,
+        IOptions<StartupGateOptions> startupGateOptions,
+        ILogger<AiRuntimeInfoService> logger)
+    {
+        _metadataProvider = metadataProvider;
+        _environment = environment;
+        _startupGateRuntimeState = startupGateRuntimeState;
+        _startupSchemaService = startupSchemaService;
+        _databaseStatusQueryService = databaseStatusQueryService;
+        _startupGateOptions = startupGateOptions;
+        _logger = logger;
+    }
+
+    public async Task<AiRuntimeInfoDto> GetRuntimeInfoAsync(AiRuntimeInfoRequest request, CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var application = BuildApplicationInfo(request.IncludeBuild);
+        if (!request.IsAdmin)
+        {
+            return new AiRuntimeInfoDto
+            {
+                GeneratedAtUtc = now,
+                PermissionFiltered = true,
+                DetailLevel = "Minimal",
+                Application = new AiApplicationRuntimeInfo { Name = application.Name, Version = application.Version },
+                Limitations = new[] { "Detailed runtime, environment, database, startup gate, schema, and build metadata is admin-only.", "Secrets, connection strings, credentials, API keys, protected settings, filesystem paths, and host details are not exposed." }
+            };
+        }
+
+        var startupGate = await BuildStartupGateInfoAsync(cancellationToken);
+        return new AiRuntimeInfoDto
+        {
+            GeneratedAtUtc = now,
+            PermissionFiltered = false,
+            DetailLevel = "Admin",
+            Application = application,
+            Runtime = request.IncludeEnvironment ? BuildRuntimeInfo(now) : null,
+            StartupGate = startupGate,
+            Database = request.IncludeDatabase ? await BuildDatabaseInfoAsync(cancellationToken) : null,
+            Limitations = new[] { "Database sizes and row counts are approximate where reported by the database provider.", "Secrets, connection strings, credentials, API keys, protected settings, filesystem paths, hostnames, ports, usernames, and runtime command access are not exposed." }
+        };
+    }
+
+    private AiApplicationRuntimeInfo BuildApplicationInfo(bool includeBuild)
+    {
+        var metadata = _metadataProvider.GetSnapshot();
+        var assembly = Assembly.GetEntryAssembly() ?? typeof(AiRuntimeInfoService).Assembly;
+        if (!includeBuild) return new AiApplicationRuntimeInfo { Name = Safe(metadata.ApplicationName, "Ping Monitor"), Version = metadata.Version };
+        var info = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        return new AiApplicationRuntimeInfo
+        {
+            Name = Safe(metadata.ApplicationName, "Ping Monitor"),
+            Version = metadata.Version,
+            AssemblyVersion = assembly.GetName().Version?.ToString(),
+            InformationalVersion = info,
+            FileVersion = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version,
+            CommitSha = TryParseSourceRevision(info),
+            Branch = null,
+            BuildTimestampUtc = null
+        };
+    }
+
+    private AiRuntimeEnvironmentInfo BuildRuntimeInfo(DateTimeOffset now)
+    {
+        var process = Process.GetCurrentProcess();
+        var started = new DateTimeOffset(process.StartTime.ToUniversalTime(), TimeSpan.Zero);
+        return new AiRuntimeEnvironmentInfo
+        {
+            Environment = _environment.EnvironmentName,
+            DotNetVersion = RuntimeInformation.FrameworkDescription,
+            OSDescription = RuntimeInformation.OSDescription,
+            ProcessArchitecture = RuntimeInformation.ProcessArchitecture.ToString(),
+            ProcessStartedAtUtc = started,
+            UptimeSeconds = Math.Max(0, (long)(now - started).TotalSeconds),
+            CurrentServerTimeUtc = now,
+            CurrentServerLocalTime = DateTimeOffset.Now,
+            IsIisInProcess = string.Equals(Environment.GetEnvironmentVariable("ASPNETCORE_HOSTINGSTARTUPASSEMBLIES"), "Microsoft.AspNetCore.Server.IIS", StringComparison.OrdinalIgnoreCase) ? true : null
+        };
+    }
+
+    private async Task<AiStartupGateInfo> BuildStartupGateInfoAsync(CancellationToken cancellationToken)
+    {
+        int? current = null;
+        bool? compatible = null;
+        if (_startupGateRuntimeState.IsOperationalMode)
+        {
+            try
+            {
+                var schema = await _startupSchemaService.GetStatusAsync(cancellationToken);
+                current = schema.CurrentSchemaVersion;
+                compatible = schema.State == StartupGateSchemaState.Compatible;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "AI runtime info could not read startup schema status.");
+            }
+        }
+
+        return new AiStartupGateInfo
+        {
+            Mode = _startupGateRuntimeState.CurrentMode.ToString(),
+            RequiredSchemaVersion = _startupGateOptions.Value.RequiredSchemaVersion,
+            CurrentSchemaVersion = current,
+            SchemaCompatible = compatible,
+            ReadOnlyMode = !_startupGateRuntimeState.IsOperationalMode
+        };
+    }
+
+    private async Task<AiDatabaseRuntimeInfo> BuildDatabaseInfoAsync(CancellationToken cancellationToken)
+    {
+        if (!_startupGateRuntimeState.IsOperationalMode)
+        {
+            return new AiDatabaseRuntimeInfo { Available = false, Reason = "Database runtime information is not available while Startup Gate is active." };
+        }
+
+        try
+        {
+            var snapshot = await _databaseStatusQueryService.GetSnapshotAsync(cancellationToken);
+            var largestTables = snapshot.Tables
+                .OrderByDescending(x => x.DataBytes + x.IndexBytes)
+                .ThenBy(x => x.TableName, StringComparer.Ordinal)
+                .Take(10)
+                .Select(x => new AiDatabaseTableRuntimeInfo { TableName = x.TableName, SizeBytes = x.DataBytes + x.IndexBytes, RowCountEstimate = x.ApproximateRowCount })
+                .ToArray();
+
+            return new AiDatabaseRuntimeInfo
+            {
+                Provider = snapshot.ProviderName,
+                DatabaseName = snapshot.DatabaseName,
+                SizeBytes = snapshot.TotalDataBytes + snapshot.TotalIndexBytes,
+                DataSizeBytes = snapshot.TotalDataBytes,
+                IndexSizeBytes = snapshot.TotalIndexBytes,
+                TableCount = snapshot.TableCount,
+                LargestTables = largestTables
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "AI runtime info could not read database size metadata.");
+            return new AiDatabaseRuntimeInfo { Available = false, Reason = "Database size information is not available from the current provider." };
+        }
+    }
+
+    private static string Safe(string? value, string fallback) => string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+    private static string? TryParseSourceRevision(string? informationalVersion)
+    {
+        if (string.IsNullOrWhiteSpace(informationalVersion)) return null;
+        var plus = informationalVersion.LastIndexOf('+');
+        if (plus < 0 || plus == informationalVersion.Length - 1) return null;
+        var candidate = informationalVersion[(plus + 1)..].Trim();
+        return candidate.Length is >= 7 and <= 64 && candidate.All(Uri.IsHexDigit) ? candidate : null;
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Services/AiTools/AiRuntimeInfoTool.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiTools/AiRuntimeInfoTool.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.Identity;
+using PingMonitor.Web.Models.Identity;
+using PingMonitor.Web.Services.Identity;
+
+namespace PingMonitor.Web.Services.AiTools;
+
+internal sealed class AiRuntimeInfoTool : IAiTool
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly IAiRuntimeInfoService _runtimeInfoService;
+    private readonly UserManager<ApplicationUser> _userManager;
+
+    public AiRuntimeInfoTool(IAiRuntimeInfoService runtimeInfoService, UserManager<ApplicationUser> userManager)
+    {
+        _runtimeInfoService = runtimeInfoService;
+        _userManager = userManager;
+    }
+
+    public AiToolDefinition Definition { get; } = new()
+    {
+        Name = "get_application_runtime_info",
+        Description = "Get read-only Ping Monitor runtime and build information for the current application instance, including app version, assembly version, schema version, database provider/size where allowed, runtime environment, startup gate status, and build/update metadata where available. Use this for questions about the running app instance, versioning, database size, schema/build status, and deployment/runtime health.",
+        MaxResultCharacters = 16000,
+        Parameters = new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject
+            {
+                ["includeDatabase"] = new JsonObject { ["type"] = "boolean", ["description"] = "Whether to include database provider, schema, and approximate database size when the current user is allowed to see it." },
+                ["includeEnvironment"] = new JsonObject { ["type"] = "boolean", ["description"] = "Whether to include safe runtime environment details when the current user is allowed to see them." },
+                ["includeBuild"] = new JsonObject { ["type"] = "boolean", ["description"] = "Whether to include safe build/version/release metadata when available." }
+            },
+            ["required"] = new JsonArray(),
+            ["additionalProperties"] = false
+        }
+    };
+
+    public async Task<AiToolExecutionResult> ExecuteAsync(AiToolCall call, CancellationToken cancellationToken)
+    {
+        if (!TryReadArguments(call.ArgumentsJson, out var includeDatabase, out var includeEnvironment, out var includeBuild, out var error)) return error!;
+
+        var user = await AiToolUserVisibility.ResolveUserAsync(call, _userManager, cancellationToken);
+        if (user is null) return Error("unauthorized", "No application user was available for tool execution.");
+
+        var isAdmin = await _userManager.IsInRoleAsync(user, ApplicationRoles.Admin);
+        var result = await _runtimeInfoService.GetRuntimeInfoAsync(new AiRuntimeInfoRequest { IsAdmin = isAdmin, IncludeDatabase = includeDatabase, IncludeEnvironment = includeEnvironment, IncludeBuild = includeBuild }, cancellationToken);
+        var json = JsonSerializer.Serialize(result, JsonOptions);
+        return new AiToolExecutionResult { Succeeded = true, ContentJson = json.Length <= Definition.MaxResultCharacters ? json : json[..Definition.MaxResultCharacters] };
+    }
+
+    private static bool TryReadArguments(string json, out bool includeDatabase, out bool includeEnvironment, out bool includeBuild, out AiToolExecutionResult? error)
+    {
+        includeDatabase = true;
+        includeEnvironment = true;
+        includeBuild = true;
+        error = null;
+        try
+        {
+            using var doc = JsonDocument.Parse(string.IsNullOrWhiteSpace(json) ? "{}" : json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) { error = Error("invalid_arguments", "Arguments must be a JSON object."); return false; }
+            foreach (var prop in doc.RootElement.EnumerateObject())
+            {
+                if (prop.Name is not ("includeDatabase" or "includeEnvironment" or "includeBuild")) { error = Error("invalid_arguments", "Unsupported argument."); return false; }
+                if (prop.Value.ValueKind is not JsonValueKind.True and not JsonValueKind.False) { error = Error("invalid_arguments", $"{prop.Name} must be a boolean."); return false; }
+                if (prop.Name == "includeDatabase") includeDatabase = prop.Value.GetBoolean();
+                if (prop.Name == "includeEnvironment") includeEnvironment = prop.Value.GetBoolean();
+                if (prop.Name == "includeBuild") includeBuild = prop.Value.GetBoolean();
+            }
+            return true;
+        }
+        catch (JsonException)
+        {
+            error = Error("invalid_arguments", "Arguments must be valid JSON.");
+            return false;
+        }
+    }
+
+    private static AiToolExecutionResult Error(string code, string message) => new() { Succeeded = false, ErrorMessage = message, ContentJson = JsonSerializer.Serialize(new { error = code, message }, JsonOptions) };
+}


### PR DESCRIPTION
### Motivation

- Provide the AI assistant a safe, read-only way to answer operational questions about the running Ping Monitor instance (version, schema, approximate DB size, runtime/build metadata, startup gate status) without exposing secrets or unsafe host details.
- Surface bounded database size and schema/startup-gate information to admins while ensuring non-admin callers only receive a minimal redacted summary.
- Reuse existing safe paths (application metadata, startup gate/schema services, database status query) and obey Startup Gate isolation rules so no DB access occurs while gate is active.

### Description

- Adds a service interface and implementation `IAiRuntimeInfoService` / `AiRuntimeInfoService` and DTOs that collect application, runtime, startup/schema, and database summaries with safe defaults and redaction rules (new file: `src/WebApp/PingMonitor.Web/Services/AiTools/AiRuntimeInfoService.cs`).
- Adds the AI tool `get_application_runtime_info` as `AiRuntimeInfoTool` implementing the shared tool contract, with validated boolean arguments `includeDatabase`, `includeEnvironment`, `includeBuild` (defaults = true) and JSON schema (new file: `src/WebApp/PingMonitor.Web/Services/AiTools/AiRuntimeInfoTool.cs`).
- Registers the service/tool and wires them into the shared AI tool registry and DI container, and updates the built-in system prompt guidance to instruct the model to use the new tool and not to guess sensitive values (changes: `src/WebApp/PingMonitor.Web/Program.cs`, `src/WebApp/PingMonitor.Web/Services/AiChat/AiChatService.cs`).
- Database size metadata is provided via the existing `IDatabaseStatusQueryService` (which queries `information_schema.tables`) and is returned only when Startup Gate is operational; largest tables are bounded to top 10 and values are approximate; results gracefully fall back to an unavailable reason on permission/provider errors.
- Adds source/regression-style tests to validate registration, tool schema/arguments, admin vs non-admin redaction, Startup Gate isolation, and prompt guidance (new test: `src/WebApp/PingMonitor.Web.Tests/AiRuntimeInfoSliceTests.cs`).

### Testing

- Built the solution: `dotnet build src/WebApp/PingMonitor.WebApp.slnx` (succeeded).
- Ran unit tests: `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj --no-build` and full solution tests; test run completed successfully with all tests passing (217 passed, 0 failed in this environment).
- Verified compile and that new tests exercise registration, schema, argument validation, redaction text, Startup Gate DB-access guard, and prompt updates.

Note on issue creation: an attempt to create the required GitHub issue before coding failed due to repository authentication not being available in this environment (API returned 401). Per repository policy, an implementation issue must be created and linked by a maintainer before merging; please create or link the corresponding issue and add the issue reference to this PR before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31b9a28358832aa60f33daf40af0ff)