### PR TITLE
AI Assistant: web chat session history and safe Markdown rendering

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
 using PingMonitor.Web.Controllers;
@@ -110,7 +111,7 @@ public sealed class AiAssistantChatTests
         Assert.Contains(firstModel.Messages, x => x.Role == "assistant" && x.Content == "Hello human");
 
         provider.Result = new AiProviderChatResult { Succeeded = true, ResponseText = "I remember you said Hello", Model = "llama" };
-        await controller.Send(new AiAssistantPageViewModel { Message = "What did I say?", HistoryJson = firstModel.HistoryJson }, CancellationToken.None);
+        await controller.Send(new AiAssistantPageViewModel { Message = "What did I say?" }, CancellationToken.None);
 
         Assert.Contains(provider.LastRequest!.Messages, x => x.Role == "user" && x.Content == "Hello");
         Assert.Contains(provider.LastRequest.Messages, x => x.Role == "assistant" && x.Content == "Hello human");
@@ -124,6 +125,61 @@ public sealed class AiAssistantChatTests
         var result = Assert.IsType<ViewResult>(await controller.Send(new AiAssistantPageViewModel { Message = "hello" }, CancellationToken.None));
         var model = Assert.IsType<AiAssistantPageViewModel>(result.Model);
         Assert.Contains("AI provider did not return", model.ErrorMessage);
+    }
+
+
+    [Fact]
+    public async Task IndexLoadsRetainedMessagesFromSessionAndClearRemovesThem()
+    {
+        var provider = new FakeAiProviderClient { Result = new AiProviderChatResult { Succeeded = true, ResponseText = "First reply", Model = "llama" } };
+        var controller = CreateController(provider, EnabledSettings());
+
+        var sendResult = Assert.IsType<ViewResult>(await controller.Send(new AiAssistantPageViewModel { Message = "First question" }, CancellationToken.None));
+        var sendModel = Assert.IsType<AiAssistantPageViewModel>(sendResult.Model);
+        Assert.Equal(2, sendModel.Messages.Count);
+
+        var indexResult = Assert.IsType<ViewResult>(await controller.Index(CancellationToken.None));
+        var indexModel = Assert.IsType<AiAssistantPageViewModel>(indexResult.Model);
+        Assert.Contains(indexModel.Messages, x => x.Role == "user" && x.Content == "First question");
+        Assert.Contains(indexModel.Messages, x => x.Role == "assistant" && x.Content == "First reply");
+
+        var clearResult = Assert.IsType<ViewResult>(await controller.Clear(CancellationToken.None));
+        var clearModel = Assert.IsType<AiAssistantPageViewModel>(clearResult.Model);
+        Assert.Empty(clearModel.Messages);
+
+        var afterClearResult = Assert.IsType<ViewResult>(await controller.Index(CancellationToken.None));
+        var afterClearModel = Assert.IsType<AiAssistantPageViewModel>(afterClearResult.Model);
+        Assert.Empty(afterClearModel.Messages);
+    }
+
+    [Fact]
+    public void ContextHistoryExcludesVisibleErrorMessages()
+    {
+        var history = AiAssistantController.BoundContextHistory([
+            new AiChatMessageDto { Role = "user", Content = "hello" },
+            new AiChatMessageDto { Role = "error", Content = "provider failed" },
+            new AiChatMessageDto { Role = "assistant", Content = "hi" }
+        ]);
+
+        Assert.DoesNotContain(history, x => x.Role == "error");
+        Assert.Equal(2, history.Count);
+    }
+
+    [Fact]
+    public void AssistantMarkdownIsRenderedAndUnsafeHtmlIsSanitized()
+    {
+        var renderer = new AiMarkdownRenderer();
+
+        var html = renderer.RenderAssistantMessage("### Heading\n\n**bold text**\n\n- item\n\n```bash\necho ok\n```\n\n<script>alert(1)</script><a href=\"javascript:alert(1)\" onclick=\"alert(2)\">bad</a> [safe](https://example.com)");
+
+        Assert.Contains("<h3", html);
+        Assert.Contains("<strong>bold text</strong>", html);
+        Assert.Contains("<ul>", html);
+        Assert.Contains("<pre><code", html);
+        Assert.DoesNotContain("<script", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("onclick", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("javascript:", html, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("rel=\"noopener noreferrer\"", html);
     }
 
     [Fact]
@@ -157,7 +213,7 @@ public sealed class AiAssistantChatTests
         var controller = CreateController(provider, EnabledSettings());
         var result = Assert.IsType<ViewResult>(await controller.Send(new AiAssistantPageViewModel { Message = "hello" }, CancellationToken.None));
         var model = Assert.IsType<AiAssistantPageViewModel>(result.Model);
-        Assert.DoesNotContain("runtime-secret", model.HistoryJson ?? string.Empty);
+        Assert.DoesNotContain("runtime-secret", string.Join("\n", model.Messages.Select(x => x.Content)));
         Assert.DoesNotContain(provider.LastRequest!.Messages, x => x.Content!.Contains("runtime-secret", StringComparison.Ordinal));
     }
 
@@ -319,7 +375,9 @@ public sealed class AiAssistantChatTests
     {
         var settingsService = new FakeAiAssistantSettingsService(settings);
         var chat = new AiChatService(settingsService, provider, new FakeAiToolRegistry(), NullLogger<AiChatService>.Instance);
-        return new AiAssistantController(settingsService, chat, new FakeAiUserMemoryService());
+        var controller = new AiAssistantController(settingsService, chat, new FakeAiUserMemoryService());
+        controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { Session = new FakeSession() } };
+        return controller;
     }
 
     private static AiAssistantSettingsDto EnabledSettings(bool assistantEnabled = true, bool webChatEnabled = true, string globalPrompt = "") => new()
@@ -379,6 +437,31 @@ public sealed class AiAssistantChatTests
             return Task.FromResult(Results.Count > 0 ? Results.Dequeue() : Result);
         }
     }
+
+    private sealed class FakeSession : ISession
+    {
+        private readonly Dictionary<string, byte[]> _values = new();
+        public IEnumerable<string> Keys => _values.Keys;
+        public string Id { get; } = Guid.NewGuid().ToString("N");
+        public bool IsAvailable => true;
+        public void Clear() => _values.Clear();
+        public Task CommitAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task LoadAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public void Remove(string key) => _values.Remove(key);
+        public void Set(string key, byte[] value) => _values[key] = value;
+        public bool TryGetValue(string key, out byte[] value)
+        {
+            if (_values.TryGetValue(key, out var stored))
+            {
+                value = stored;
+                return true;
+            }
+
+            value = [];
+            return false;
+        }
+    }
+
     private sealed class FakeAiToolRegistry : IAiToolRegistry
     {
         public List<AiToolCall> Calls { get; } = new();

--- a/src/WebApp/PingMonitor.Web/Controllers/AiAssistantController.cs
+++ b/src/WebApp/PingMonitor.Web/Controllers/AiAssistantController.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using PingMonitor.Web.Services;
 using PingMonitor.Web.Services.AiChat;
@@ -15,6 +16,7 @@ public sealed class AiAssistantController : Controller
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private const int MaxStoredMessages = 20;
+    private const string WebChatSessionKey = "AiAssistant.WebChat.History";
 
     private readonly IAiAssistantSettingsService _settingsService;
     private readonly IAiChatService _chatService;
@@ -34,10 +36,10 @@ public sealed class AiAssistantController : Controller
         var model = new AiAssistantPageViewModel
         {
             AssistantEnabled = settings.AssistantEnabled,
-            WebChatEnabled = settings.WebChatEnabled
+            WebChatEnabled = settings.WebChatEnabled,
+            Messages = ReadSessionHistory()
         };
         ApplyDisabledMessage(model);
-        model.HistoryJson = SerializeHistory(model.Messages);
         return View("Index", model);
     }
 
@@ -45,13 +47,12 @@ public sealed class AiAssistantController : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Send([FromForm] AiAssistantPageViewModel model, CancellationToken cancellationToken)
     {
-        model.Messages = ParseHistory(model.HistoryJson);
+        model.Messages = ReadSessionHistory();
 
         if (string.IsNullOrWhiteSpace(model.Message))
         {
             await PopulateFlagsAsync(model, cancellationToken);
             model.ErrorMessage = "Enter a message before sending.";
-            model.HistoryJson = SerializeHistory(model.Messages);
             return View("Index", model);
         }
 
@@ -59,12 +60,12 @@ public sealed class AiAssistantController : Controller
         {
             await PopulateFlagsAsync(model, cancellationToken);
             model.ErrorMessage = "Message must be 4000 characters or fewer.";
-            model.HistoryJson = SerializeHistory(model.Messages);
             return View("Index", model);
         }
 
         var userMessage = model.Message.Trim();
-        var response = await _chatService.SendAsync(new AiChatRequest { Source = AiChatSource.Web, ConversationHistory = model.Messages, UserMessage = userMessage, Principal = User }, cancellationToken);
+        var contextHistory = BoundContextHistory(model.Messages);
+        var response = await _chatService.SendAsync(new AiChatRequest { Source = AiChatSource.Web, ConversationHistory = contextHistory, UserMessage = userMessage, Principal = User }, cancellationToken);
         model.AssistantEnabled = response.AssistantEnabled;
         model.WebChatEnabled = response.WebChatEnabled;
         model.Message = string.Empty;
@@ -74,14 +75,18 @@ public sealed class AiAssistantController : Controller
             model.Messages.Add(new AiChatMessageDto { Role = "user", Content = userMessage });
             model.Messages.Add(new AiChatMessageDto { Role = "assistant", Content = response.AssistantMessage });
             model.Messages = BoundHistory(model.Messages);
+            WriteSessionHistory(model.Messages);
             model.StatusMessage = "AI assistant response received.";
         }
         else
         {
             model.ErrorMessage = response.ErrorMessage ?? "The AI provider did not return a response. Check the AI Assistant settings and the local Ollama/OpenAI-compatible endpoint.";
+            model.Messages.Add(new AiChatMessageDto { Role = "user", Content = userMessage });
+            model.Messages.Add(new AiChatMessageDto { Role = "error", Content = model.ErrorMessage });
+            model.Messages = BoundHistory(model.Messages);
+            WriteSessionHistory(model.Messages);
         }
 
-        model.HistoryJson = SerializeHistory(model.Messages);
         return View("Index", model);
     }
 
@@ -116,14 +121,14 @@ public sealed class AiAssistantController : Controller
     public async Task<IActionResult> Clear(CancellationToken cancellationToken)
     {
         var settings = await _settingsService.GetCurrentAsync(cancellationToken);
+        ClearSessionHistory();
         var model = new AiAssistantPageViewModel { AssistantEnabled = settings.AssistantEnabled, WebChatEnabled = settings.WebChatEnabled, StatusMessage = "Conversation cleared." };
         ApplyDisabledMessage(model);
-        model.HistoryJson = SerializeHistory(model.Messages);
         return View("Index", model);
     }
 
     internal static IList<AiChatMessageDto> BoundHistory(IEnumerable<AiChatMessageDto> messages) => messages
-        .Where(x => x.Role is "user" or "assistant" && !string.IsNullOrWhiteSpace(x.Content))
+        .Where(x => (x.Role is "user" or "assistant" or "error") && !string.IsNullOrWhiteSpace(x.Content))
         .Select(x => new AiChatMessageDto { Role = x.Role, Content = x.Content.Length <= AiAssistantPageViewModel.MaxUserMessageLength ? x.Content : x.Content[..AiAssistantPageViewModel.MaxUserMessageLength] })
         .TakeLast(MaxStoredMessages)
         .ToList();
@@ -136,14 +141,22 @@ public sealed class AiAssistantController : Controller
         ApplyDisabledMessage(model);
     }
 
-    private static IList<AiChatMessageDto> ParseHistory(string? json)
+    internal static IList<AiChatMessageDto> BoundContextHistory(IEnumerable<AiChatMessageDto> messages) => BoundHistory(messages)
+        .Where(x => x.Role is "user" or "assistant")
+        .ToList();
+
+    private IList<AiChatMessageDto> ReadSessionHistory()
     {
+        var json = HttpContext.Session.GetString(WebChatSessionKey);
         if (string.IsNullOrWhiteSpace(json)) return new List<AiChatMessageDto>();
         try { return BoundHistory(JsonSerializer.Deserialize<List<AiChatMessageDto>>(json, JsonOptions) ?? []); }
         catch (JsonException) { return new List<AiChatMessageDto>(); }
     }
 
-    private static string SerializeHistory(IEnumerable<AiChatMessageDto> messages) => JsonSerializer.Serialize(BoundHistory(messages), JsonOptions);
+    private void WriteSessionHistory(IEnumerable<AiChatMessageDto> messages) =>
+        HttpContext.Session.SetString(WebChatSessionKey, JsonSerializer.Serialize(BoundHistory(messages), JsonOptions));
+
+    private void ClearSessionHistory() => HttpContext.Session.Remove(WebChatSessionKey);
 
     private static void ApplyDisabledMessage(AiAssistantPageViewModel model)
     {

--- a/src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj
+++ b/src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
     <PackageReference Include="Markdig" Version="0.40.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />

--- a/src/WebApp/PingMonitor.Web/Program.cs
+++ b/src/WebApp/PingMonitor.Web/Program.cs
@@ -118,6 +118,14 @@ builder.Services.Configure<ApiBehaviorOptions>(options =>
 });
 
 builder.Services.AddHealthChecks();
+builder.Services.AddDistributedMemoryCache();
+builder.Services.AddSession(options =>
+{
+    options.Cookie.Name = ".PingMonitor.AiAssistant.Session";
+    options.Cookie.HttpOnly = true;
+    options.Cookie.IsEssential = true;
+    options.IdleTimeout = TimeSpan.FromHours(8);
+});
 builder.Services.AddHttpContextAccessor();
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
@@ -218,6 +226,7 @@ builder.Services.AddScoped<IAiTool, RememberUserMemoryAiTool>();
 builder.Services.AddScoped<IAiTool, DeleteUserMemoryAiTool>();
 builder.Services.AddScoped<IAiToolRegistry, AiToolRegistry>();
 builder.Services.AddScoped<IAiChatService, AiChatService>();
+builder.Services.AddSingleton<IAiMarkdownRenderer, AiMarkdownRenderer>();
 builder.Services.AddSingleton<ITelegramAiConversationStore, TelegramAiConversationStore>();
 builder.Services.AddSingleton<IApplicationMetadataProvider, ApplicationMetadataProvider>();
 builder.Services.AddHttpClient(nameof(OpenAiCompatibleProviderClient));
@@ -352,6 +361,7 @@ app.Use(async (context, next) =>
 
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseSession();
 
 app.MapControllers();
 app.MapControllerRoute(

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/AiMarkdownRenderer.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/AiMarkdownRenderer.cs
@@ -1,0 +1,58 @@
+using System.Text.RegularExpressions;
+using Ganss.Xss;
+using Markdig;
+
+namespace PingMonitor.Web.Services.AiChat;
+
+internal sealed partial class AiMarkdownRenderer : IAiMarkdownRenderer
+{
+    private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions()
+        .DisableHtml()
+        .Build();
+
+    private static readonly HtmlSanitizer Sanitizer = CreateSanitizer();
+
+    public string RenderAssistantMessage(string markdown)
+    {
+        if (string.IsNullOrWhiteSpace(markdown)) return string.Empty;
+
+        var html = Markdown.ToHtml(RawHtmlTag().Replace(markdown, string.Empty), Pipeline);
+        var sanitized = Sanitizer.Sanitize(html);
+        return AnchorTag().Replace(sanitized, match =>
+        {
+            var tag = match.Value;
+            if (!tag.Contains(" rel=", StringComparison.OrdinalIgnoreCase))
+            {
+                tag = tag.Insert(tag.Length - 1, " rel=\"noopener noreferrer\"");
+            }
+            return tag;
+        });
+    }
+
+    private static HtmlSanitizer CreateSanitizer()
+    {
+        var sanitizer = new HtmlSanitizer();
+        sanitizer.AllowedTags.Clear();
+        foreach (var tag in new[] { "p", "strong", "em", "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "li", "code", "pre", "blockquote", "a", "br", "hr", "table", "thead", "tbody", "tr", "th", "td" })
+        {
+            sanitizer.AllowedTags.Add(tag);
+        }
+
+        sanitizer.AllowedAttributes.Clear();
+        sanitizer.AllowedAttributes.Add("href");
+        sanitizer.AllowedAttributes.Add("title");
+        sanitizer.AllowedAttributes.Add("rel");
+        sanitizer.AllowedSchemes.Clear();
+        sanitizer.AllowedSchemes.Add("http");
+        sanitizer.AllowedSchemes.Add("https");
+        sanitizer.AllowedSchemes.Add("mailto");
+        return sanitizer;
+    }
+
+    [GeneratedRegex("<a\\s+[^>]*href=", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex AnchorTag();
+
+    [GeneratedRegex("<[^>]+>", RegexOptions.CultureInvariant)]
+    private static partial Regex RawHtmlTag();
+}

--- a/src/WebApp/PingMonitor.Web/Services/AiChat/IAiMarkdownRenderer.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiChat/IAiMarkdownRenderer.cs
@@ -1,0 +1,6 @@
+namespace PingMonitor.Web.Services.AiChat;
+
+public interface IAiMarkdownRenderer
+{
+    string RenderAssistantMessage(string markdown);
+}

--- a/src/WebApp/PingMonitor.Web/ViewModels/AiAssistant/AiAssistantPageViewModel.cs
+++ b/src/WebApp/PingMonitor.Web/ViewModels/AiAssistant/AiAssistantPageViewModel.cs
@@ -11,11 +11,10 @@ public sealed class AiAssistantPageViewModel
     [StringLength(MaxUserMessageLength, ErrorMessage = "Message must be 4000 characters or fewer.")]
     public string? Message { get; set; }
 
-    public string? HistoryJson { get; set; }
     public IList<AiChatMessageDto> Messages { get; set; } = new List<AiChatMessageDto>();
     public bool AssistantEnabled { get; set; }
     public bool WebChatEnabled { get; set; }
     public string? StatusMessage { get; set; }
     public string? ErrorMessage { get; set; }
-    public string HelpText { get; set; } = "This is the first AI chat test interface. It can talk to the configured model, but monitoring tools, metrics, diagram lookup, Telegram routing, and memory are not connected yet.";
+    public string HelpText { get; set; } = "Ask about your monitored network. This web conversation is kept only for the current browser session and is not saved to the database.";
 }

--- a/src/WebApp/PingMonitor.Web/Views/AiAssistant/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AiAssistant/Index.cshtml
@@ -1,4 +1,5 @@
 @model PingMonitor.Web.ViewModels.AiAssistant.AiAssistantPageViewModel
+@inject PingMonitor.Web.Services.AiChat.IAiMarkdownRenderer MarkdownRenderer
 @{
     ViewData["Title"] = "AI Assistant";
     var canSend = Model.AssistantEnabled && Model.WebChatEnabled;
@@ -22,9 +23,17 @@
         .alert-error { background: #fff3f2; color: var(--danger); border-color: #fecdca; }
         .alert-ok { background: #e7f6ec; color: var(--ok); border-color: #abefc6; }
         .transcript { display: grid; gap: .75rem; }
-        .message { border: 1px solid var(--border); border-radius: 12px; padding: .85rem; white-space: pre-wrap; overflow-wrap: anywhere; }
-        .message-user { background: #eef4ff; }
+        .message { border: 1px solid var(--border); border-radius: 12px; padding: .85rem; overflow-wrap: anywhere; }
+        .message-user { background: #eef4ff; white-space: pre-wrap; }
         .message-assistant { background: #fff; }
+        .message-error { background: #fff3f2; color: var(--danger); border-color: #fecdca; white-space: pre-wrap; }
+        .message-markdown > :first-child { margin-top: 0; }
+        .message-markdown > :last-child { margin-bottom: 0; }
+        .message-markdown pre { overflow-x: auto; background: #101828; color: #f8fafc; border-radius: 10px; padding: .85rem; }
+        .message-markdown code { background: rgba(15, 23, 42, .08); border-radius: 4px; padding: .1rem .25rem; }
+        .message-markdown pre code { background: transparent; padding: 0; }
+        .message-markdown blockquote { border-left: 4px solid var(--border); margin-left: 0; padding-left: .85rem; color: var(--muted); }
+        .message-markdown a { color: var(--accent); font-weight: 700; }
         .message-role { display: block; font-weight: 700; margin-bottom: .35rem; }
         label { display: block; font-weight: 700; margin-bottom: .35rem; }
         textarea { width: 100%; min-height: 120px; padding: .85rem; border: 1px solid var(--border); border-radius: 10px; font: inherit; resize: vertical; }
@@ -33,6 +42,10 @@
         .button { border: 0; background: var(--accent); color: #fff; }
         .button-secondary { border: 1px solid var(--border); background: #fff; color: var(--text); }
         .button[disabled] { opacity: .55; cursor: not-allowed; }
+        [data-theme="dark"] .message-user { background: #14213d; }
+        [data-theme="dark"] .message-assistant { background: #111827; }
+        [data-theme="dark"] .message-error { background: #3b1111; color: #fecaca; border-color: #7f1d1d; }
+        [data-theme="dark"] .message-markdown code { background: rgba(248, 250, 252, .12); }
     </style>
 </head>
 <body>
@@ -62,9 +75,18 @@
             {
                 @foreach (var message in Model.Messages)
                 {
-                    <article class="message @(message.Role == "user" ? "message-user" : "message-assistant")">
-                        <span class="message-role">@(message.Role == "user" ? "You" : "Assistant")</span>
-                        @message.Content
+                    var isUser = message.Role == "user";
+                    var isError = message.Role == "error";
+                    <article class="message @(isUser ? "message-user" : isError ? "message-error" : "message-assistant")">
+                        <span class="message-role">@(isUser ? "You" : isError ? "Error" : "Assistant")</span>
+                        @if (message.Role == "assistant")
+                        {
+                            <div class="message-markdown">@Html.Raw(MarkdownRenderer.RenderAssistantMessage(message.Content))</div>
+                        }
+                        else
+                        {
+                            @message.Content
+                        }
                     </article>
                 }
             }
@@ -73,10 +95,9 @@
         <section class="card">
             <form asp-controller="AiAssistant" asp-action="Send" method="post" class="stack">
                 @Html.AntiForgeryToken()
-                <input type="hidden" asp-for="HistoryJson" />
                 <div>
                     <label asp-for="Message"></label>
-                    <textarea asp-for="Message" maxlength="4000" disabled="@(!canSend)" placeholder="Ask about your monitored network, or say "remember that..." to save a user-specific preference or alias when memory is enabled."></textarea>
+                    <textarea asp-for="Message" maxlength="4000" disabled="@(!canSend)" placeholder="Ask about your monitored network, or say &quot;remember that...&quot; to save a user-specific preference or alias when memory is enabled."></textarea>
                     <span asp-validation-for="Message"></span>
                 </div>
                 <div class="button-row">


### PR DESCRIPTION
### Motivation

- Provide an in-app web chat that shows the current session transcript so follow-up questions have context and users can clear the conversation safely. 
- Keep conversation context short-lived and bounded to avoid unbounded growth and to avoid persisting chat to the database. 
- Render assistant replies as safe HTML from Markdown while preventing model-provided HTML/script/event execution or unsafe links.

### Description

- Store web chat transcript server-side in ASP.NET Core Session under key `AiAssistant.WebChat.History` and load/save/clear it from `AiAssistantController`, removing the client-side hidden transcript field. 
- Keep history bounded to the last 20 visible messages and cap individual message length to the existing 4000-character limit, and pass only user/assistant turns (exclude visible error entries) to the AI provider as context. 
- Add `AiMarkdownRenderer` using `Markdig` (Markdown pipeline with HTML disabled) and `HtmlSanitizer` (allow-list tags/attributes/schemes) to render assistant messages safely and normalise links with `rel="noopener noreferrer"`. 
- Update view `Views/AiAssistant/Index.cshtml` to display chronological transcript with distinct styling for user, assistant (rendered Markdown), and error messages; register session and renderer in `Program.cs` and add `HtmlSanitizer` package reference. 

### Testing

- Built and ran the test suite with `dotnet build src/WebApp/PingMonitor.WebApp.slnx` and `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj`, and all tests passed. 
- Added/updated unit tests covering: retained session messages and `Clear` behaviour, context selection excluding visible errors, Markdown rendering and sanitization (script/event/javascript: removed), and bounded history; these tests succeeded in CI-local run. 

Notes: I attempted to create a new GitHub issue for this slice but the environment returned HTTP 401 (requires authentication), so this change references the existing AI web chat work (see issue #555) instead of creating a new issue. No database-backed persistence, cross-device history, Telegram formatting changes, or new AI tools were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31bdce3fb8832aa9a75f89e7689442)