### PR TITLE
Fix AI dependency MySQL filters

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiAssistantChatTests.cs
@@ -255,6 +255,22 @@ public sealed class AiAssistantChatTests
     }
 
     [Fact]
+    public void DependencyAiTools_DoNotUseMySqlUnsafeEndpointIdArrayContainsQueries()
+    {
+        var source = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "PingMonitor.Web", "Services", "AiTools", "DependencyAiTools.cs"));
+
+        Assert.Contains("ApplyEndpointFilter(endpointQuery, visibleIds)", source);
+        Assert.Contains("var visibleAssignments = ApplyEndpointFilter(DbContext.MonitorAssignments.AsNoTracking(), endpointIds)", source);
+        Assert.Contains("ApplyDependencyParentFilter(DbContext.EndpointDependencies.AsNoTracking(), endpointIds)", source);
+        Assert.Contains("ApplyDependencyEndpointFilter(", source);
+        Assert.Contains("Expression.OrElse", source);
+        Assert.DoesNotContain("visibleIds.Contains(x.EndpointId)", source);
+        Assert.DoesNotContain("endpointIds.Contains(assignment.EndpointId)", source);
+        Assert.DoesNotContain("endpointIds.Contains(x.EndpointId)", source);
+        Assert.DoesNotContain("endpointIds.Contains(x.DependsOnEndpointId)", source);
+    }
+
+    [Fact]
     public void SearchEndpointsTool_DoesNotUseMySqlUnsafeEndpointIdArrayContainsQuery()
     {
         var source = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "PingMonitor.Web", "Services", "AiTools", "EndpointMetricsAiTools.cs"));

--- a/src/WebApp/PingMonitor.Web/Services/AiTools/DependencyAiTools.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiTools/DependencyAiTools.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.Identity;
@@ -38,21 +39,88 @@ internal abstract class DependencyAiToolBase : IAiTool
         if (user is null) return (false, new Dictionary<string, EndpointInfo>(), [], Error("unauthorized", "No application user was available for tool execution."));
         var visibleIds = await AiToolUserVisibility.GetVisibleEndpointIdsOrNullForAdminAsync(DbContext, UserManager, user, cancellationToken);
         var endpointQuery = DbContext.Endpoints.AsNoTracking();
-        if (visibleIds is not null) endpointQuery = endpointQuery.Where(x => visibleIds.Contains(x.EndpointId));
+        if (visibleIds is not null) endpointQuery = ApplyEndpointFilter(endpointQuery, visibleIds);
         var endpoints = await endpointQuery.Select(x => new EndpointInfo(x.EndpointId, x.Name, x.Target, x.Enabled, "UNKNOWN")).ToArrayAsync(cancellationToken);
         var endpointIds = endpoints.Select(x => x.EndpointId).ToArray();
-        var states = await (from assignment in DbContext.MonitorAssignments.AsNoTracking()
+        var visibleAssignments = ApplyEndpointFilter(DbContext.MonitorAssignments.AsNoTracking(), endpointIds);
+        var states = await (from assignment in visibleAssignments
             join state in DbContext.EndpointStates.AsNoTracking() on assignment.AssignmentId equals state.AssignmentId into sj
             from state in sj.DefaultIfEmpty()
-            where endpointIds.Contains(assignment.EndpointId)
             select new { assignment.EndpointId, State = state != null ? state.CurrentState : EndpointStateKind.Unknown }).ToArrayAsync(cancellationToken);
         var stateByEndpoint = states.GroupBy(x => x.EndpointId).ToDictionary(x => x.Key, x => x.First().State.ToString().ToUpperInvariant(), StringComparer.Ordinal);
         var endpointMap = endpoints.Select(x => x with { CurrentState = stateByEndpoint.GetValueOrDefault(x.EndpointId, "UNKNOWN") }).ToDictionary(x => x.EndpointId, StringComparer.Ordinal);
-        var edges = await DbContext.EndpointDependencies.AsNoTracking()
-            .Where(x => endpointIds.Contains(x.EndpointId) && endpointIds.Contains(x.DependsOnEndpointId))
+        var visibleDependencies = ApplyDependencyEndpointFilter(
+            ApplyDependencyParentFilter(DbContext.EndpointDependencies.AsNoTracking(), endpointIds),
+            endpointIds);
+        var edges = await visibleDependencies
             .Select(x => new Edge(x.EndpointId, x.DependsOnEndpointId))
             .ToArrayAsync(cancellationToken);
         return (true, endpointMap, edges, null);
+    }
+
+
+    private static IQueryable<Models.Endpoint> ApplyEndpointFilter(IQueryable<Models.Endpoint> endpoints, IReadOnlyCollection<string> endpointIds)
+    {
+        if (endpointIds.Count == 0)
+        {
+            return endpoints.Where(static _ => false);
+        }
+
+        var parameter = Expression.Parameter(typeof(Models.Endpoint), "endpoint");
+        var endpointId = Expression.Property(parameter, nameof(Models.Endpoint.EndpointId));
+        var predicate = BuildStringEqualsAnyPredicate(endpointId, endpointIds);
+        return endpoints.Where(Expression.Lambda<Func<Models.Endpoint, bool>>(predicate, parameter));
+    }
+
+    private static IQueryable<MonitorAssignment> ApplyEndpointFilter(IQueryable<MonitorAssignment> assignments, IReadOnlyCollection<string> endpointIds)
+    {
+        if (endpointIds.Count == 0)
+        {
+            return assignments.Where(static _ => false);
+        }
+
+        var parameter = Expression.Parameter(typeof(MonitorAssignment), "assignment");
+        var endpointId = Expression.Property(parameter, nameof(MonitorAssignment.EndpointId));
+        var predicate = BuildStringEqualsAnyPredicate(endpointId, endpointIds);
+        return assignments.Where(Expression.Lambda<Func<MonitorAssignment, bool>>(predicate, parameter));
+    }
+
+    private static IQueryable<EndpointDependency> ApplyDependencyEndpointFilter(IQueryable<EndpointDependency> dependencies, IReadOnlyCollection<string> endpointIds)
+    {
+        if (endpointIds.Count == 0)
+        {
+            return dependencies.Where(static _ => false);
+        }
+
+        var parameter = Expression.Parameter(typeof(EndpointDependency), "dependency");
+        var endpointId = Expression.Property(parameter, nameof(EndpointDependency.EndpointId));
+        var predicate = BuildStringEqualsAnyPredicate(endpointId, endpointIds);
+        return dependencies.Where(Expression.Lambda<Func<EndpointDependency, bool>>(predicate, parameter));
+    }
+
+    private static IQueryable<EndpointDependency> ApplyDependencyParentFilter(IQueryable<EndpointDependency> dependencies, IReadOnlyCollection<string> parentEndpointIds)
+    {
+        if (parentEndpointIds.Count == 0)
+        {
+            return dependencies.Where(static _ => false);
+        }
+
+        var parameter = Expression.Parameter(typeof(EndpointDependency), "dependency");
+        var parentEndpointId = Expression.Property(parameter, nameof(EndpointDependency.DependsOnEndpointId));
+        var predicate = BuildStringEqualsAnyPredicate(parentEndpointId, parentEndpointIds);
+        return dependencies.Where(Expression.Lambda<Func<EndpointDependency, bool>>(predicate, parameter));
+    }
+
+    private static Expression BuildStringEqualsAnyPredicate(MemberExpression member, IReadOnlyCollection<string> values)
+    {
+        Expression? predicate = null;
+        foreach (var value in values)
+        {
+            var equals = Expression.Equal(member, Expression.Constant(value));
+            predicate = predicate is null ? equals : Expression.OrElse(predicate, equals);
+        }
+
+        return predicate!;
     }
 
     protected static (int Depth, bool Clamped) ReadDepth(JsonElement root, AiToolCall call, int defaultDepth)


### PR DESCRIPTION
### Motivation
- Prevent an EF Core MySQL type-mapping failure caused by using collection `Contains` against endpoint ID arrays in AI dependency tool queries, which threw `Expression '@endpointIds' in the SQL tree does not have a type mapping assigned.`
- Ensure dependency-related AI tools use provider-safe query shapes consistent with other code paths so MySQL translations remain deterministic and safe.
- Add a regression barrier so the unsafe array-`Contains` pattern cannot be reintroduced accidentally.

### Description
- Replaced array `Contains` usage in `DependencyAiToolBase.LoadVisibleGraphAsync` with provider-safe filters by applying `ApplyEndpointFilter`, `ApplyDependencyParentFilter`, and `ApplyDependencyEndpointFilter` before executing EF queries. 
- Moved monitor assignment state loading to use `visibleAssignments = ApplyEndpointFilter(...)` instead of `endpointIds.Contains(assignment.EndpointId)` so the query compiles with proper scalar type mappings.
- Added reusable helper methods `ApplyEndpointFilter`, `ApplyDependencyEndpointFilter`, `ApplyDependencyParentFilter`, and `BuildStringEqualsAnyPredicate` to build explicit OR equality predicates over the mapped string columns.
- Added a unit test `DependencyAiTools_DoNotUseMySqlUnsafeEndpointIdArrayContainsQueries` in `AiAssistantChatTests.cs` to detect regressions that reintroduce `visibleIds.Contains(...)` / `endpointIds.Contains(...)` query shapes.
- Linked the change to the tracking issue with `Fixes #605` for traceability.

### Testing
- Ran `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` and all tests passed: `Passed 247, Failed 0`.
- Verified repository diff and linting via `git diff --check` with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32e2ea2d84832a9fdf279f0563ddc6)