### PR TITLE
Fix buffered result shutdown flush cancellation

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/BufferedResultFlushBackgroundServiceTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/BufferedResultFlushBackgroundServiceTests.cs
@@ -1,0 +1,166 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using PingMonitor.Web.Options;
+using PingMonitor.Web.Services.BufferedResults;
+using PingMonitor.Web.Services.StartupGate;
+using PingMonitor.Web.Services.State;
+
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class BufferedResultFlushBackgroundServiceTests
+{
+    [Fact]
+    public async Task StopAsync_WhenHostShutdownTokenIsCanceled_UsesIndependentFlushToken()
+    {
+        var buffer = new FakeBufferedResultIngestionService([
+            new BufferedCheckResult
+            {
+                CheckResultId = "result-1",
+                AssignmentId = "assignment-1",
+                CheckedAtUtc = DateTimeOffset.Parse("2026-06-17T00:00:00Z"),
+                ReceivedAtUtc = DateTimeOffset.Parse("2026-06-17T00:00:01Z"),
+                BatchId = "batch-1",
+                Success = true
+            }
+        ]);
+        var service = new TestBufferedResultFlushBackgroundService(
+            buffer,
+            new OperationalStartupGateRuntimeState(),
+            new ResultBufferOptions
+            {
+                ResultBufferMaxBatchSize = 500,
+                ResultBufferFlushIntervalSeconds = 60,
+                ResultBufferShutdownFlushTimeoutSeconds = 30
+            });
+
+        await service.StartAsync(CancellationToken.None);
+        using var canceledShutdown = new CancellationTokenSource();
+        await canceledShutdown.CancelAsync();
+
+        await service.StopAsync(canceledShutdown.Token);
+
+        Assert.Equal(1, service.PersistCallCount);
+        Assert.False(service.LastPersistCancellationTokenWasCanceled);
+        Assert.Equal(1, buffer.LastFlushPersistedCount);
+    }
+
+    [Fact]
+    public void CreateShutdownFlushCancellationTokenSource_EnforcesPositiveTimeout()
+    {
+        using var tokenSource = BufferedResultFlushBackgroundService.CreateShutdownFlushCancellationTokenSource(0);
+
+        Assert.False(tokenSource.IsCancellationRequested);
+    }
+
+    private sealed class TestBufferedResultFlushBackgroundService : BufferedResultFlushBackgroundService
+    {
+        public TestBufferedResultFlushBackgroundService(
+            IBufferedResultIngestionService buffer,
+            IStartupGateRuntimeState startupGateRuntimeState,
+            ResultBufferOptions options)
+            : base(
+                new ServiceCollection().BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
+                buffer,
+                new FakeAssignmentProcessingQueue(),
+                startupGateRuntimeState,
+                Microsoft.Extensions.Options.Options.Create(options),
+                NullLogger<BufferedResultFlushBackgroundService>.Instance)
+        {
+        }
+
+        public int PersistCallCount { get; private set; }
+        public bool LastPersistCancellationTokenWasCanceled { get; private set; }
+
+        protected override Task<FlushResult> PersistAndEnqueueAssignmentsAsync(IReadOnlyList<BufferedCheckResult> batch, CancellationToken cancellationToken)
+        {
+            PersistCallCount++;
+            LastPersistCancellationTokenWasCanceled = cancellationToken.IsCancellationRequested;
+            return Task.FromResult(new FlushResult(batch.Count, 1, 1, DateTimeOffset.Parse("2026-06-17T00:00:02Z")));
+        }
+    }
+
+    private sealed class FakeBufferedResultIngestionService : IBufferedResultIngestionService
+    {
+        private readonly Queue<BufferedCheckResult> _items;
+
+        public FakeBufferedResultIngestionService(IEnumerable<BufferedCheckResult> items)
+        {
+            _items = new Queue<BufferedCheckResult>(items);
+        }
+
+        public int LastFlushPersistedCount { get; private set; }
+
+        public void Enqueue(IReadOnlyCollection<BufferedCheckResult> results)
+        {
+            foreach (var result in results)
+            {
+                _items.Enqueue(result);
+            }
+        }
+
+        public bool HasPendingItems() => _items.Count > 0;
+
+        public bool HasPendingFullBatch() => _items.Count >= 500;
+
+        public IReadOnlyList<BufferedCheckResult> DequeueBatch(int maxBatchSize)
+        {
+            var results = new List<BufferedCheckResult>();
+            while (_items.Count > 0 && results.Count < maxBatchSize)
+            {
+                results.Add(_items.Dequeue());
+            }
+
+            return results;
+        }
+
+        public BufferedResultBufferSnapshot GetSnapshot() => new(
+            _items.Count,
+            0,
+            0,
+            0,
+            0,
+            0,
+            null,
+            0,
+            0,
+            null,
+            0,
+            0,
+            null);
+
+        public Task<bool> WaitForSignalAsync(TimeSpan timeout, CancellationToken cancellationToken) => Task.Delay(timeout, cancellationToken).ContinueWith(_ => false, CancellationToken.None);
+
+        public void RecordFlushOutcome(
+            int attemptedCount,
+            int persistedCount,
+            DateTimeOffset completedAtUtc,
+            Exception? error,
+            long persistDurationMs,
+            int enqueuedAssignmentCount,
+            DateTimeOffset? lastAssignmentsEnqueuedAtUtc)
+        {
+            LastFlushPersistedCount = persistedCount;
+        }
+    }
+
+    private sealed class FakeAssignmentProcessingQueue : IAssignmentProcessingQueue
+    {
+        public AssignmentProcessingQueueEnqueueResult EnqueueAssignments(IReadOnlyCollection<string> assignmentIds) => new(assignmentIds.Count, 0);
+        public IReadOnlyList<string> DequeueBatch(int maxBatchSize) => [];
+        public bool HasPendingItems() => false;
+        public Task<bool> WaitForSignalAsync(TimeSpan timeout, CancellationToken cancellationToken) => Task.FromResult(false);
+        public void RecordProcessedCount(int processedCount, DateTimeOffset processedAtUtc) { }
+        public void RecordFailure(Exception exception, DateTimeOffset failedAtUtc) { }
+        public AssignmentProcessingQueueSnapshot GetSnapshot() => new(0, 0, 0, 0, 0, 0, 0, null, null, null, null, null);
+    }
+
+    private sealed class OperationalStartupGateRuntimeState : IStartupGateRuntimeState
+    {
+        public StartupMode CurrentMode => StartupMode.Normal;
+        public bool IsOperationalMode => true;
+        public void Update(StartupGateStatus status) { }
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Options/ResultBufferOptions.cs
+++ b/src/WebApp/PingMonitor.Web/Options/ResultBufferOptions.cs
@@ -8,4 +8,5 @@ public sealed class ResultBufferOptions
     public int ResultBufferMaxBatchSize { get; set; } = 500;
     public int ResultBufferFlushIntervalSeconds { get; set; } = 60;
     public int ResultBufferMaxQueueSize { get; set; } = 5000;
+    public int ResultBufferShutdownFlushTimeoutSeconds { get; set; } = 30;
 }

--- a/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultFlushBackgroundService.cs
+++ b/src/WebApp/PingMonitor.Web/Services/BufferedResults/BufferedResultFlushBackgroundService.cs
@@ -9,7 +9,7 @@ using PingMonitor.Web.Services.StartupGate;
 
 namespace PingMonitor.Web.Services.BufferedResults;
 
-internal sealed class BufferedResultFlushBackgroundService : BackgroundService
+internal class BufferedResultFlushBackgroundService : BackgroundService
 {
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IBufferedResultIngestionService _buffer;
@@ -81,27 +81,37 @@ internal sealed class BufferedResultFlushBackgroundService : BackgroundService
 
     public override async Task StopAsync(CancellationToken cancellationToken)
     {
+        await base.StopAsync(CancellationToken.None);
+
         if (!_startupGateRuntimeState.IsOperationalMode)
         {
             _logger.LogInformation("Startup Gate is active during shutdown. Skipping buffered result flush drain.");
-            await base.StopAsync(cancellationToken);
             return;
         }
 
-        _logger.LogInformation("Application shutdown requested. Attempting best-effort flush of buffered raw check results.");
+        using var shutdownFlushCancellation = CreateShutdownFlushCancellationTokenSource(_options.ResultBufferShutdownFlushTimeoutSeconds);
+        _logger.LogInformation(
+            "Application shutdown requested. Attempting best-effort flush of buffered raw check results with a {TimeoutSeconds}-second flush timeout.",
+            _options.ResultBufferShutdownFlushTimeoutSeconds);
+
         try
         {
-            await FlushAvailableBatchesAsync(flushAllPending: true, cancellationToken);
+            await FlushAvailableBatchesAsync(flushAllPending: true, shutdownFlushCancellation.Token);
+        }
+        catch (OperationCanceledException ex) when (shutdownFlushCancellation.IsCancellationRequested)
+        {
+            _logger.LogError(
+                ex,
+                "Best-effort shutdown flush timed out after {TimeoutSeconds} seconds for buffered raw check results.",
+                _options.ResultBufferShutdownFlushTimeoutSeconds);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Best-effort shutdown flush failed for buffered raw check results.");
         }
-
-        await base.StopAsync(cancellationToken);
     }
 
-    private async Task FlushAvailableBatchesAsync(bool flushAllPending, CancellationToken cancellationToken)
+    internal async Task FlushAvailableBatchesAsync(bool flushAllPending, CancellationToken cancellationToken)
     {
         while (_buffer.HasPendingItems())
         {
@@ -143,7 +153,13 @@ internal sealed class BufferedResultFlushBackgroundService : BackgroundService
         }
     }
 
-    private async Task<FlushResult> PersistAndEnqueueAssignmentsAsync(IReadOnlyList<BufferedCheckResult> batch, CancellationToken cancellationToken)
+    internal static CancellationTokenSource CreateShutdownFlushCancellationTokenSource(int timeoutSeconds)
+    {
+        var boundedTimeoutSeconds = Math.Max(1, timeoutSeconds);
+        return new CancellationTokenSource(TimeSpan.FromSeconds(boundedTimeoutSeconds));
+    }
+
+    protected virtual async Task<FlushResult> PersistAndEnqueueAssignmentsAsync(IReadOnlyList<BufferedCheckResult> batch, CancellationToken cancellationToken)
     {
         using var scope = _scopeFactory.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<PingMonitorDbContext>();
@@ -192,5 +208,5 @@ internal sealed class BufferedResultFlushBackgroundService : BackgroundService
             AssignmentEnqueuedCount: enqueueResult.EnqueuedCount,
             LastAssignmentsEnqueuedAtUtc: enqueueResult.EnqueuedCount > 0 ? enqueueTimeUtc : null);
     }
-    private sealed record FlushResult(int PersistedCount, long PersistDurationMs, int AssignmentEnqueuedCount, DateTimeOffset? LastAssignmentsEnqueuedAtUtc);
+    protected internal sealed record FlushResult(int PersistedCount, long PersistDurationMs, int AssignmentEnqueuedCount, DateTimeOffset? LastAssignmentsEnqueuedAtUtc);
 }

--- a/src/WebApp/PingMonitor.Web/appsettings.Development.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.Development.json
@@ -51,6 +51,7 @@
     "ResultBufferEnabled": true,
     "ResultBufferMaxBatchSize": 500,
     "ResultBufferFlushIntervalSeconds": 60,
-    "ResultBufferMaxQueueSize": 5000
+    "ResultBufferMaxQueueSize": 5000,
+    "ResultBufferShutdownFlushTimeoutSeconds": 30
   }
 }

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -52,7 +52,8 @@
     "ResultBufferEnabled": true,
     "ResultBufferMaxBatchSize": 500,
     "ResultBufferFlushIntervalSeconds": 60,
-    "ResultBufferMaxQueueSize": 5000
+    "ResultBufferMaxQueueSize": 5000,
+    "ResultBufferShutdownFlushTimeoutSeconds": 30
   },
   "DatabaseMaintenance": {
     "BackupStoragePath": "App_Data/DbBackups",


### PR DESCRIPTION
### Motivation
- Buffered raw-result flushes could be canceled during IIS/host shutdown because the host-provided shutdown token was passed into EF/MySQL persistence, causing TaskCanceledException and potential loss of buffered telemetry.  
- Ensure a best-effort shutdown drain is attempted without being immediately canceled by the host shutdown token, while preserving Startup Gate rules that block DB access during gate mode.  

### Description
- Stop the background loop before performing the shutdown drain and use an independent bounded shutdown flush token instead of the host shutdown token to avoid immediate cancellation during persistence.  
- Add configurable `ResultBufferShutdownFlushTimeoutSeconds` (default 30s) in `ResultBufferOptions` and add the setting to `appsettings.json` and `appsettings.Development.json`.  
- Introduce `CreateShutdownFlushCancellationTokenSource` and switch the flush path to accept the independent token; make persistence and flush helper methods testable by relaxing visibility (`protected virtual` / `internal`).  
- Add a regression unit test `BufferedResultFlushBackgroundServiceTests` that reproduces a canceled host shutdown token and verifies the flush path receives a non-canceled bounded token.  

### Testing
- Ran the focused test for the new behavior: `PATH=/tmp/dotnet10:$PATH dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj --filter BufferedResultFlushBackgroundServiceTests` which passed.  
- Ran the full web test suite: `PATH=/tmp/dotnet10:$PATH dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj` which completed successfully (all tests passed).  
- Performed `git diff --check` to validate whitespace/format issues and committed the changes; no automated checks failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32ed488370832ab3391e95c7f87198)