### PR TITLE
Prepare V0.2.1 preview release (AI Assistant preview)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ Agents collect facts. The server decides meaning.
 
 ## Key Features
 
+### AI Assistant preview (V0.2.1)
+
+- Admin AI Assistant settings for OpenAI-compatible providers, including local Ollama-compatible endpoints.
+- In-app AI chat and Telegram AI chat share the same conversation service and tool execution path.
+- Read-only AI tools can summarize network health, endpoint metrics, RTT/jitter/uptime/check history, Network Diagrams, dependencies, and runtime/application information.
+- User-specific AI memories can be explicitly created or deleted by the user; other AI tools remain read-only.
+- GUI-only scheduled and event-triggered AI tasks can deliver Telegram reports for configured users.
+- Web chat Markdown is sanitized before rendering, and Telegram Markdown is converted through a safe formatting path.
+
+Preview caveats: AI Assistant is a preview feature, AI output should be treated as an assistant summary rather than an authoritative replacement for stored monitoring data, and no AI remediation or monitoring configuration write actions are provided.
+
 ### Endpoint Monitoring
 
 - ICMP ping checks

--- a/docs/ai-assistant-v0.2-implementation-plan.md
+++ b/docs/ai-assistant-v0.2-implementation-plan.md
@@ -659,12 +659,11 @@ According to the saved Home diagram, AP1 is connected to Switch 1 on port Gi1/0/
 - Add audit/debug logging.
 - No Telegram AI path until web chat is proven.
 
-### V0.2.1-preview - Telegram AI transport
+### V0.2.1-preview - AI Assistant preview release baseline
 
-- Route Telegram natural-language messages to AI conversation service.
-- Reuse same tools and prompt stack as web chat.
-- Add Telegram-specific answer formatting and error handling.
-- Ensure linked-user permission enforcement.
+V0.2.1-preview now collects the implemented AI Assistant slices for preview testing rather than only Telegram transport. The current preview baseline includes shared web/Telegram AI chat, OpenAI-compatible/Ollama provider configuration and testing, read-only monitoring/metrics/diagram/dependency/runtime tools, user-specific memories, safe Markdown rendering, GUI-only scheduled AI Telegram reports, GUI-only event-triggered AI Telegram reports, and admin-configurable tool/context limits.
+
+Preview caveats remain: AI output is an assistant summary, AI tools are read-only except explicit user-memory create/delete, and no AI remediation or monitoring-configuration write actions are included.
 
 ### V0.2.2-preview - Diagnostic packs and check-result insight
 

--- a/docs/config-backup-and-restore.md
+++ b/docs/config-backup-and-restore.md
@@ -30,6 +30,7 @@ The following entities are included in configuration backups:
 - User notification settings
 - Endpoint metadata (tags, attributes if applicable)
 - Network diagrams, including diagram canvas/viewport settings, nodes, visual links, link media/speed/LACP metadata, and link VLAN metadata
+- AI Assistant provider/settings/tool-limit configuration (`ai_assistant_settings`)
 
 ---
 
@@ -51,6 +52,9 @@ The following are **never included**:
 - Logs
 - Performance metrics
 - Any transient or runtime-only state
+- AI user memories (`AiUserMemories`) because they are user-owned assistant context rather than portable configuration
+- Scheduled AI task rows (`AiScheduledTasks`) because they are user-owned operational schedules
+- Event-triggered AI task definitions and run history (`AiEventTriggeredTasks`, `AiEventTriggeredTaskRuns`) because they are user-owned operational automation/reporting state
 
 ---
 
@@ -95,6 +99,7 @@ Example:
     "security_settings": {...},
     "notification_settings": {...},
     "user_notification_settings": [...],
+    "ai_assistant_settings": {...},
     "identity": [...],
     "network_diagrams": {
       "diagrams": [...]
@@ -121,6 +126,7 @@ Example:
   - `security_settings`
   - `notification_settings`
   - `user_notification_settings`
+  - `ai_assistant_settings`
   - `identity` (optional and explicit, sensitive)
   - `network_diagrams`
 - Network diagrams are restored as configuration/documentation data only. Diagram restore does not create endpoints, monitor assignments, endpoint dependencies, alerts, or any network-device configuration.

--- a/docs/v0.2.1-preview-release-notes.md
+++ b/docs/v0.2.1-preview-release-notes.md
@@ -1,0 +1,91 @@
+# V0.2.1 Preview
+
+Issue: #610
+
+## Highlights
+
+- AI Assistant preview for web and Telegram users.
+- Ollama/OpenAI-compatible provider configuration and provider testing from the admin UI.
+- Read-only monitoring, metrics, dependency, Network Diagram, runtime, and memory tools.
+- GUI-only scheduled and event-triggered AI reports with Telegram delivery.
+- Admin-configurable AI tool/context limits.
+
+## AI Assistant
+
+V0.2.1-preview promotes the current AI Assistant feature set to preview testing. The assistant includes an admin settings page, OpenAI-compatible/Ollama provider settings, in-app chat, Telegram chat for linked users, a shared AI chat service, and OpenAI-compatible function/tool calling.
+
+AI output is an assistant summary. Stored monitoring data, state transitions, diagrams, dependencies, logs, and settings remain the authoritative data sources.
+
+## AI tools
+
+The preview includes read-only tools for:
+
+- network health and agent health summaries
+- endpoint metrics, RTT, jitter, uptime, and check-history lookups
+- Network Diagram list/search/connection lookup
+- dependency lookup, impact, summary, and suppression explanation
+- runtime/application/schema/update information
+- user-specific memory search
+
+The only AI write actions are explicit user-memory create/delete actions. The AI tool surface does not edit endpoints, agents, alerts, diagrams, dependencies, app settings, scheduled AI tasks, or event-triggered AI tasks.
+
+## Scheduled and event-triggered AI reports
+
+Scheduled AI tasks and event-triggered AI tasks are configured through GUI pages only and deliver reports to Telegram for the owning linked user. Chat cannot create or edit scheduled/event-triggered tasks. Operators should monitor provider usage because scheduled and event-triggered reports can consume local or hosted AI provider resources.
+
+## Network Diagram / dependency AI tools
+
+Network Diagram tools read saved diagram documentation only. They do not infer live switch/router state and do not create monitoring dependencies. Dependency tools read saved monitoring dependency configuration and must preserve the platform distinction between `DOWN`, `SUPPRESSED`, `UP`, and `UNKNOWN`.
+
+## Safety and security
+
+- AI provider API keys and Telegram bot tokens remain protected values and must not be logged.
+- AI tools execute under the authenticated web user, linked Telegram user, or scheduled/event task owner user context.
+- Visibility filtering remains required for non-admin endpoint and diagram access.
+- User memories are user-specific.
+- Runtime information is bounded and must avoid exposing admin-sensitive details to non-admin users.
+- Tool result limits have configured hard bounds.
+- Web Markdown rendering is sanitized, and Telegram Markdown is rendered through a safe/fallback format path.
+
+## Known limitations
+
+- AI Assistant is a preview feature; AI-specific bugs may still be found after release.
+- Local model quality and tool-call reliability depend on the selected model.
+- AI tools are read-only except explicit user-memory management.
+- No remediation, network-control, or monitoring-configuration write actions are available through AI.
+- Scheduled/event-triggered reports can consume provider resources.
+- Tool limits may need tuning for larger or smaller models.
+- Some responses may need prompt/tool tuning after real-world testing.
+
+## Upgrade notes
+
+- Required database schema version: `27`.
+- Publish the release as a pre-release named `V0.2.1 Preview` with tag `V0.2.1` unless Ian chooses otherwise.
+- Do not publish release artifacts unless the strict release build succeeds and the package manifest declares `requiredSchemaVersion: 27`.
+
+## Schema changes
+
+V0.2.1-preview expects schema version `27`. Startup Gate schema checks cover the current AI tables and columns for:
+
+- `AiAssistantSettings` including tool execution limits
+- `AiUserMemories`
+- `AiScheduledTasks`
+- `AiEventTriggeredTasks`
+- `AiEventTriggeredTaskRuns`
+
+Startup Gate must remain responsible for applying schema creation/update paths before normal background services and AI workers run.
+
+## Backup/restore notes
+
+Configuration backup/restore includes AI Assistant provider/settings/tool-limit configuration through the `ai_assistant_settings` section.
+
+The following AI tables are intentionally excluded from configuration backups because they are user-owned operational/history data rather than portable configuration: `AiUserMemories`, `AiScheduledTasks`, `AiEventTriggeredTasks`, and `AiEventTriggeredTaskRuns`. Use database backups for full data preservation.
+
+## Testing
+
+Release validation should include:
+
+- `dotnet build src/WebApp/PingMonitor.WebApp.slnx`
+- `dotnet test src/WebApp/PingMonitor.WebApp.slnx`
+- `pwsh ./scripts/build.ps1 -Version V0.2.1` in a Windows/PowerShell release environment before publishing artifacts
+- functional smoke testing of web chat, Telegram chat, provider test, representative AI tools, scheduled Telegram delivery, event-triggered Telegram delivery, non-admin filtering, and Startup Gate compatible/incompatible schema paths

--- a/src/WebApp/PingMonitor.Web/appsettings.json
+++ b/src/WebApp/PingMonitor.Web/appsettings.json
@@ -70,7 +70,7 @@
     "Attribution": "by ijyates1992",
     "Licence": "Licensed under GNU Affero General Public License v3 (AGPLv3)",
     "RepositoryUrl": "https://github.com/ijyates1992/ping-monitor",
-    "PreviewNote": "Early preview release"
+    "PreviewNote": "V0.2.1 preview release - AI Assistant preview"
   },
   "ApplicationUpdater": {
     "UpdateChecksEnabled": true,


### PR DESCRIPTION
### Motivation

- Prepare the project for the V0.2.1 preview (AI Assistant) release by ensuring version/manifest/schema metadata, release notes, and docs are consistent.  
- Make the AI Assistant preview state visible in user-facing metadata and documentation so operators/testers understand scope and known limitations.  
- Audit backup/restore and Startup Gate schema coverage for the AI tables introduced by the assistant feature set to avoid release-time surprises.

### Description

- Updated visible application preview metadata to reference the V0.2.1 AI Assistant preview and updated user-facing docs: `README.md`, `docs/ai-assistant-v0.2-implementation-plan.md`, and `src/WebApp/PingMonitor.Web/appsettings.json` (preview note).  
- Added comprehensive preview release notes at `docs/v0.2.1-preview-release-notes.md` describing highlights, AI scope, safety/security guidance, upgrade/schema notes (required schema version `27`), backup/restore coverage, and testing guidance.  
- Updated configuration backup/restore docs (`docs/config-backup-and-restore.md`) to include `ai_assistant_settings` in configuration backups and to explicitly document which AI tables are intentionally excluded from config backups (`AiUserMemories`, `AiScheduledTasks`, `AiEventTriggeredTasks`, `AiEventTriggeredTaskRuns`).  
- Clarified the AI implementation plan wording to reflect the current preview baseline (web + Telegram shared AI service, OpenAI-compatible/Ollama provider support, read-only AI tools, safe Markdown handling, GUI-only scheduled/event tasks); no product behavior changes or new AI write/remediation features were introduced.

### Testing

- Ran `dotnet build src/WebApp/PingMonitor.WebApp.slnx` and the build completed successfully.  
- Ran `dotnet test src/WebApp/PingMonitor.WebApp.slnx` and tests completed successfully.  
- Ran the release packaging script `pwsh ./scripts/build.ps1 -Version V0.2.1` as a validation run; packaging completed successfully and produced a release staging folder and zip with an in-package `manifest.json` that declares `requiredSchemaVersion: 27`.  
- Performed grep/scan checks for stale AI wording and schema/backup keywords across `README.md`, `docs`, and `appsettings.json`; the documentation updates removed stale "not connected yet" text and added the expected AI backup/restore and schema guidance.  

Fixes: #610

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32f50f0c20832aa60b19d3ac2564bf)