### PR TITLE
Tidy AI Assistant settings page

### DIFF
--- a/src/WebApp/PingMonitor.Web.Tests/AiAssistantSettingsPageViewTests.cs
+++ b/src/WebApp/PingMonitor.Web.Tests/AiAssistantSettingsPageViewTests.cs
@@ -1,0 +1,121 @@
+using Xunit;
+
+namespace PingMonitor.Web.Tests;
+
+public sealed class AiAssistantSettingsPageViewTests
+{
+    [Fact]
+    public void AdminAiAssistantSettingsView_GroupsSettingsIntoReadableSections()
+    {
+        var view = ReadWebFile("Views", "AdminAiAssistantSettings", "Index.cshtml");
+
+        AssertInOrder(view,
+            "Feature enablement",
+            "Provider and model",
+            "Tool calling and context limits",
+            "Admin global prompt",
+            "Safety notes");
+
+        foreach (var heading in new[]
+                 {
+                     "Provider connection",
+                     "Model behaviour",
+                     "General tool execution",
+                     "Endpoint and metrics tools",
+                     "Historic state transition tools",
+                     "Diagram tools",
+                     "Dependency tools",
+                     "Memory tools",
+                     "Runtime tools"
+                 })
+        {
+            Assert.Contains(heading, view);
+        }
+
+        Assert.Contains("class=\"grid two\"", view);
+        Assert.Contains("@@media (min-width: 720px)", view);
+        Assert.Contains("sub-card", view);
+    }
+
+    [Fact]
+    public void AdminAiAssistantSettingsView_PlacesProviderTestWithProviderSettings()
+    {
+        var view = ReadWebFile("Views", "AdminAiAssistantSettings", "Index.cshtml");
+
+        var providerSection = view.IndexOf("<h2>Provider and model</h2>", StringComparison.Ordinal);
+        var toolSection = view.IndexOf("<h2>Tool calling and context limits</h2>", StringComparison.Ordinal);
+        var testHeading = view.IndexOf("Test AI provider connection", StringComparison.Ordinal);
+        var testButton = view.IndexOf("Test saved provider settings", StringComparison.Ordinal);
+
+        Assert.True(providerSection >= 0);
+        Assert.True(toolSection > providerSection);
+        Assert.InRange(testHeading, providerSection, toolSection);
+        Assert.InRange(testButton, providerSection, toolSection);
+        Assert.Contains("Save changes before testing updated provider settings.", view);
+        Assert.Contains("This does not send monitoring data, endpoint data, diagrams, dependencies, memories, or secrets.", view);
+    }
+
+    [Fact]
+    public void AdminAiAssistantSettingsView_KeepsAllSettingsBoundAndApiKeyHidden()
+    {
+        var view = ReadWebFile("Views", "AdminAiAssistantSettings", "Index.cshtml");
+
+        foreach (var property in new[]
+                 {
+                     "AssistantEnabled", "WebChatEnabled", "TelegramChatEnabled", "MemoryEnabled", "DebugLoggingEnabled",
+                     "ProviderDisplayName", "ProviderType", "BaseUrl", "ApiKey", "ClearApiKey", "ModelName",
+                     "RequestTimeoutSeconds", "MaxOutputTokens", "Temperature", "ToolCallingEnabled",
+                     "MaxToolRounds", "MaxToolCallsPerRound", "MaxTotalToolResultCharacters", "MaxSingleToolResultCharacters",
+                     "MaxEndpointSearchResults", "MaxEndpointMetricsSampleTailPoints", "MaxEndpointTransitionItems", "MaxEndpointFailureClusters",
+                     "DefaultEndpointMetricsWindow", "MaximumEndpointMetricsWindow", "MaxStateTransitionSearchResults", "MaxStateTransitionLookbackDays", "MaxStateTransitionEndpointDetails",
+                     "MaxDiagramListResults", "MaxDiagramNodeSearchResults", "MaxDiagramConnectionResults", "MaxFullDiagramNodesReturned", "MaxFullDiagramLinksReturned", "MaxDiagramToolResultCharacters", "MaxDiagramItemMetadataCharacters",
+                     "MaxDependencyEndpointsReturned", "MaxDependencyPathsReturned", "MaxDependencyTraversalDepth", "MaxTopDependedOnEndpoints",
+                     "MaxMemorySearchResults", "MaxMemoryContentCharacters", "MaxRuntimeLargestTablesReturned", "GlobalSystemPrompt"
+                 })
+        {
+            Assert.Contains($"asp-for=\"{property}\"", view);
+        }
+
+        Assert.Contains("type=\"password\"", view);
+        Assert.Contains("value=\"\"", view);
+        Assert.Contains("Leave blank to keep the saved key. The saved key must never be displayed.", view);
+    }
+
+    [Fact]
+    public void AdminAiAssistantSettingsView_AddsHelpTextForKeySafetyAndLimitSettings()
+    {
+        var view = ReadWebFile("Views", "AdminAiAssistantSettings", "Index.cshtml");
+
+        foreach (var text in new[]
+                 {
+                     "Master switch for AI assistant features.",
+                     "Friendly name shown in the admin UI.",
+                     "Maximum number of tool-call cycles",
+                     "Maximum endpoints returned when the assistant searches",
+                     "Maximum bulk state transitions returned",
+                     "Maximum dependency paths returned",
+                     "Memories should not contain live monitoring truth.",
+                     "Provider/API secrets are protected and must not be logged or displayed."
+                 })
+        {
+            Assert.Contains(text, view);
+        }
+    }
+
+    private static void AssertInOrder(string source, params string[] expected)
+    {
+        var previous = -1;
+        foreach (var item in expected)
+        {
+            var index = source.IndexOf(item, StringComparison.Ordinal);
+            Assert.True(index > previous, $"Expected '{item}' after index {previous}, but found {index}.");
+            previous = index;
+        }
+    }
+
+    private static string ReadWebFile(params string[] path)
+    {
+        var fullPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "PingMonitor.Web", Path.Combine(path));
+        return File.ReadAllText(fullPath);
+    }
+}

--- a/src/WebApp/PingMonitor.Web/Views/AdminAiAssistantSettings/Index.cshtml
+++ b/src/WebApp/PingMonitor.Web/Views/AdminAiAssistantSettings/Index.cshtml
@@ -14,6 +14,14 @@
         .stack { display: grid; gap: 1rem; }
         .card { background: var(--card); border-radius: 14px; box-shadow: 0 1px 2px rgba(16,24,40,.08); padding: 1rem; }
         .grid { display: grid; gap: .85rem; }
+        .section-header { display: grid; gap: .25rem; }
+        .section-header h2, .section-header h3 { margin-bottom: 0; }
+        .sub-card { border: 1px solid var(--border); border-radius: 12px; padding: 1rem; background: color-mix(in srgb, var(--card) 94%, var(--bg)); }
+        .sub-card h3 { margin-top: 0; }
+        .field { display: grid; gap: .25rem; align-content: start; }
+        .option { align-items: flex-start; border: 1px solid var(--border); border-radius: 12px; padding: .75rem; }
+        .option label { margin-bottom: .15rem; }
+        .option-text { display: grid; gap: .15rem; }
         .button-row { display: flex; gap: .75rem; flex-wrap: wrap; }
         .button, .button-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 48px; padding: .8rem 1rem; border-radius: 10px; font-weight: 600; text-decoration: none; }
         .button { border: 0; color: #fff; background: var(--accent); cursor: pointer; }
@@ -28,6 +36,7 @@
         .saved { border: 1px solid var(--success-border); background: var(--success-bg); color: var(--success); border-radius: 10px; padding: .8rem; }
         .errors { border: 1px solid #fda29b; background: var(--error-bg); color: var(--error-text); border-radius: 10px; padding: .8rem; }
         .warning { border: 1px solid var(--warning-border); background: var(--warning-bg); border-radius: 10px; padding: .8rem; }
+        .sticky-actions { position: sticky; bottom: 0; background: var(--bg); padding: .75rem 0 0; }
         .validation { color: var(--error-text); font-size: .9rem; }
         @@media (min-width: 720px) { .two { grid-template-columns: 1fr 1fr; } }
     </style>
@@ -49,119 +58,158 @@
         @if (!ViewData.ModelState.IsValid) { <div class="errors" asp-validation-summary="All"></div> }
 
         <section class="card grid">
-            <h2>Feature enablement</h2>
-            <div class="checkbox-row"><input asp-for="AssistantEnabled" type="checkbox" /><input name="AssistantEnabled" type="hidden" value="false" /><label asp-for="AssistantEnabled"></label></div>
-            <div class="checkbox-row"><input asp-for="WebChatEnabled" type="checkbox" /><input name="WebChatEnabled" type="hidden" value="false" /><label asp-for="WebChatEnabled"></label></div>
-            <div class="checkbox-row"><input asp-for="TelegramChatEnabled" type="checkbox" /><input name="TelegramChatEnabled" type="hidden" value="false" /><label asp-for="TelegramChatEnabled"></label></div>
-            <div class="checkbox-row"><input asp-for="MemoryEnabled" type="checkbox" /><input name="MemoryEnabled" type="hidden" value="false" /><label asp-for="MemoryEnabled"></label></div>
-            <div class="checkbox-row"><input asp-for="DebugLoggingEnabled" type="checkbox" /><input name="DebugLoggingEnabled" type="hidden" value="false" /><label asp-for="DebugLoggingEnabled"></label></div>
-            <p class="field-help">Enabling these flags records operator intent only. Chat surfaces and runtime execution are implemented in later slices.</p>
-        </section>
-
-        <section class="card grid">
-            <h2>Provider/API configuration</h2>
-            <div class="grid two">
-                <div><label asp-for="ProviderDisplayName"></label><input asp-for="ProviderDisplayName" /><span class="validation" asp-validation-for="ProviderDisplayName"></span></div>
-                <div><label asp-for="ProviderType"></label><select asp-for="ProviderType"><option value="OpenAICompatible">OpenAI-compatible</option></select><span class="validation" asp-validation-for="ProviderType"></span></div>
-                <div><label asp-for="BaseUrl"></label><input asp-for="BaseUrl" inputmode="url" /><p class="field-help">For example: local Ollama <code>http://localhost:11434/v1</code> or a hosted OpenAI-compatible endpoint.</p><span class="validation" asp-validation-for="BaseUrl"></span></div>
-                <div><label asp-for="ModelName"></label><input asp-for="ModelName" /><span class="validation" asp-validation-for="ModelName"></span></div>
+            <div class="section-header">
+                <h2>Feature enablement</h2>
+                <p class="muted">Control which AI assistant surfaces and diagnostics are allowed to run.</p>
             </div>
-            <div>
-                <label asp-for="ApiKey"></label>
-                <input asp-for="ApiKey" type="password" autocomplete="new-password" value="" />
-                <p class="field-help">Saved key configured: <strong>@(Model.ApiKeyConfigured ? "Yes" : "No")</strong>. Leave blank to keep the saved key. API key is optional for local providers.</p>
-            </div>
-            <div class="checkbox-row"><input asp-for="ClearApiKey" type="checkbox" /><input name="ClearApiKey" type="hidden" value="false" /><label asp-for="ClearApiKey"></label></div>
-        </section>
-
-        <section class="card grid">
-            <h2>Model behaviour</h2>
             <div class="grid two">
-                <div><label asp-for="RequestTimeoutSeconds"></label><input asp-for="RequestTimeoutSeconds" type="number" min="1" max="600" /><p class="field-help">Default: 180 seconds. Maximum: 600 seconds.</p><span class="validation" asp-validation-for="RequestTimeoutSeconds"></span></div>
-                <div><label asp-for="MaxOutputTokens"></label><input asp-for="MaxOutputTokens" type="number" min="64" max="32768" /><span class="validation" asp-validation-for="MaxOutputTokens"></span></div>
-                <div><label asp-for="Temperature"></label><input asp-for="Temperature" type="number" min="0" max="2" step="0.1" /><span class="validation" asp-validation-for="Temperature"></span></div>
-                <div class="checkbox-row"><input asp-for="ToolCallingEnabled" type="checkbox" /><input name="ToolCallingEnabled" type="hidden" value="false" /><label asp-for="ToolCallingEnabled"></label></div>
-            </div>
-        </section>
-
-
-        <section class="card grid">
-            <h2>Tool/context limits</h2>
-            <p class="field-help">These limits control how much context AI tools may return to the model. Higher values can improve rich reports but increase token usage, latency, and the chance of oversized responses. Lower values reduce token usage and are better for smaller local models.</p>
-            <p class="field-help"><strong>Recommended defaults:</strong> 3 tool rounds, 5 tool calls per round, 24,000 total tool-result characters, and 12,000 characters per single tool result. Setting maximum tool rounds to 0 safely disables tool execution for AI requests even when tool calling is enabled.</p>
-            <h3>General tool loop limits</h3>
-            <div class="grid two">
-                <div><label asp-for="MaxToolRounds"></label><input asp-for="MaxToolRounds" type="number" min="0" max="10" /><span class="validation" asp-validation-for="MaxToolRounds"></span></div>
-                <div><label asp-for="MaxToolCallsPerRound"></label><input asp-for="MaxToolCallsPerRound" type="number" min="0" max="20" /><span class="validation" asp-validation-for="MaxToolCallsPerRound"></span></div>
-                <div><label asp-for="MaxTotalToolResultCharacters"></label><input asp-for="MaxTotalToolResultCharacters" type="number" min="1000" max="200000" /><span class="validation" asp-validation-for="MaxTotalToolResultCharacters"></span></div>
-                <div><label asp-for="MaxSingleToolResultCharacters"></label><input asp-for="MaxSingleToolResultCharacters" type="number" min="1000" max="100000" /><span class="validation" asp-validation-for="MaxSingleToolResultCharacters"></span></div>
-            </div>
-            <h3>Endpoint/metrics tool limits</h3>
-            <div class="grid two">
-                <div><label asp-for="MaxEndpointSearchResults"></label><input asp-for="MaxEndpointSearchResults" type="number" /><span class="validation" asp-validation-for="MaxEndpointSearchResults"></span></div>
-                <div><label asp-for="MaxEndpointMetricsSampleTailPoints"></label><input asp-for="MaxEndpointMetricsSampleTailPoints" type="number" /><span class="validation" asp-validation-for="MaxEndpointMetricsSampleTailPoints"></span></div>
-                <div><label asp-for="MaxEndpointTransitionItems"></label><input asp-for="MaxEndpointTransitionItems" type="number" /><span class="validation" asp-validation-for="MaxEndpointTransitionItems"></span></div>
-                <div><label asp-for="MaxEndpointFailureClusters"></label><input asp-for="MaxEndpointFailureClusters" type="number" /><span class="validation" asp-validation-for="MaxEndpointFailureClusters"></span></div>
-                <div><label asp-for="MaxStateTransitionSearchResults"></label><input asp-for="MaxStateTransitionSearchResults" type="number" /><span class="validation" asp-validation-for="MaxStateTransitionSearchResults"></span></div>
-                <div><label asp-for="MaxStateTransitionLookbackDays"></label><input asp-for="MaxStateTransitionLookbackDays" type="number" /><span class="validation" asp-validation-for="MaxStateTransitionLookbackDays"></span></div>
-                <div><label asp-for="MaxStateTransitionEndpointDetails"></label><input asp-for="MaxStateTransitionEndpointDetails" type="number" /><span class="validation" asp-validation-for="MaxStateTransitionEndpointDetails"></span></div>
-                <div><label asp-for="DefaultEndpointMetricsWindow"></label><select asp-for="DefaultEndpointMetricsWindow"><option>1h</option><option>6h</option><option>24h</option><option>7d</option></select><span class="validation" asp-validation-for="DefaultEndpointMetricsWindow"></span></div>
-                <div><label asp-for="MaximumEndpointMetricsWindow"></label><select asp-for="MaximumEndpointMetricsWindow"><option>1h</option><option>6h</option><option>24h</option><option>7d</option></select><span class="validation" asp-validation-for="MaximumEndpointMetricsWindow"></span></div>
-            </div>
-            <h3>Diagram/runtime/memory limits</h3>
-            <div class="grid two">
-                <div><label asp-for="MaxDiagramListResults"></label><input asp-for="MaxDiagramListResults" type="number" /></div>
-                <div><label asp-for="MaxDiagramNodeSearchResults"></label><input asp-for="MaxDiagramNodeSearchResults" type="number" /></div>
-                <div><label asp-for="MaxDiagramConnectionResults"></label><input asp-for="MaxDiagramConnectionResults" type="number" /></div>
-                <div><label asp-for="MaxFullDiagramNodesReturned"></label><input asp-for="MaxFullDiagramNodesReturned" type="number" /></div>
-                <div><label asp-for="MaxFullDiagramLinksReturned"></label><input asp-for="MaxFullDiagramLinksReturned" type="number" /></div>
-                <div><label asp-for="MaxDiagramToolResultCharacters"></label><input asp-for="MaxDiagramToolResultCharacters" type="number" /></div>
-                <div><label asp-for="MaxDiagramItemMetadataCharacters"></label><input asp-for="MaxDiagramItemMetadataCharacters" type="number" /></div>
-                <div><label asp-for="MaxMemorySearchResults"></label><input asp-for="MaxMemorySearchResults" type="number" /></div>
-                <div><label asp-for="MaxMemoryContentCharacters"></label><input asp-for="MaxMemoryContentCharacters" type="number" /></div>
-                <div><label asp-for="MaxRuntimeLargestTablesReturned"></label><input asp-for="MaxRuntimeLargestTablesReturned" type="number" /></div>
-                <div><label asp-for="MaxDependencyEndpointsReturned"></label><input asp-for="MaxDependencyEndpointsReturned" type="number" /></div>
-                <div><label asp-for="MaxDependencyPathsReturned"></label><input asp-for="MaxDependencyPathsReturned" type="number" /></div>
-                <div><label asp-for="MaxDependencyTraversalDepth"></label><input asp-for="MaxDependencyTraversalDepth" type="number" /></div>
-                <div><label asp-for="MaxTopDependedOnEndpoints"></label><input asp-for="MaxTopDependedOnEndpoints" type="number" /></div>
+                <div class="checkbox-row option"><input asp-for="AssistantEnabled" type="checkbox" /><input name="AssistantEnabled" type="hidden" value="false" /><div class="option-text"><label asp-for="AssistantEnabled"></label><p class="field-help">Master switch for AI assistant features. If disabled, AI chat, scheduled AI reports, and event-triggered AI reports should not run.</p></div></div>
+                <div class="checkbox-row option"><input asp-for="WebChatEnabled" type="checkbox" /><input name="WebChatEnabled" type="hidden" value="false" /><div class="option-text"><label asp-for="WebChatEnabled"></label><p class="field-help">Allows logged-in users to use the AI Assistant page in the web app.</p></div></div>
+                <div class="checkbox-row option"><input asp-for="TelegramChatEnabled" type="checkbox" /><input name="TelegramChatEnabled" type="hidden" value="false" /><div class="option-text"><label asp-for="TelegramChatEnabled"></label><p class="field-help">Allows linked Telegram users to chat with the AI assistant through Telegram.</p></div></div>
+                <div class="checkbox-row option"><input asp-for="MemoryEnabled" type="checkbox" /><input name="MemoryEnabled" type="hidden" value="false" /><div class="option-text"><label asp-for="MemoryEnabled"></label><p class="field-help">Allows user-specific AI memories. Memories are not live monitoring state and are not shared between users.</p></div></div>
+                <div class="checkbox-row option"><input asp-for="DebugLoggingEnabled" type="checkbox" /><input name="DebugLoggingEnabled" type="hidden" value="false" /><div class="option-text"><label asp-for="DebugLoggingEnabled"></label><p class="field-help">Records AI request/tool/debug information for troubleshooting. This may increase log volume.</p></div></div>
             </div>
         </section>
 
         <section class="card grid">
-            <h2>Admin global prompt</h2>
-            <textarea asp-for="GlobalSystemPrompt" maxlength="20000"></textarea>
-            <p class="field-help">Use this for site-specific guidance only. Admin instructions cannot override read-only mode, permissions, application safety rules, or tool-result truthfulness.</p>
-            <span class="validation" asp-validation-for="GlobalSystemPrompt"></span>
-        </section>
-
-        <section class="card grid">
-            <h2>Test AI provider connection</h2>
-            <p class="field-help">Save changes before testing. This sends a small test prompt to the configured OpenAI-compatible endpoint and does not send monitoring data, endpoint data, tools, prompt history, memories, or secrets.</p>
-            @if (Model.TestResult is not null)
-            {
-                <div class="@(Model.TestResult.Succeeded ? "saved" : "errors")" role="status">
-                    <strong>@(Model.TestResult.Succeeded ? "AI provider connection succeeded." : "AI provider connection failed.")</strong>
-                    <div>Elapsed: @Model.TestResult.ElapsedMilliseconds ms</div>
-                    @if (Model.TestResult.StatusCode.HasValue) { <div>HTTP status: @Model.TestResult.StatusCode.Value</div> }
-                    @if (Model.TestResult.Succeeded) { <div>Returned text: <code>@Model.TestResult.ResponseText</code></div> }
-                    else { <div>Error: @Model.TestResult.ErrorMessage</div> }
+            <div class="section-header">
+                <h2>Provider and model</h2>
+                <p class="muted">Configure the saved provider connection, model request settings, and connection test in one place.</p>
+            </div>
+            <div class="sub-card grid">
+                <h3>Provider connection</h3>
+                <div class="grid two">
+                    <div class="field"><label asp-for="ProviderDisplayName"></label><input asp-for="ProviderDisplayName" /><p class="field-help">Friendly name shown in the admin UI. This does not affect the provider API.</p><span class="validation" asp-validation-for="ProviderDisplayName"></span></div>
+                    <div class="field"><label asp-for="ProviderType"></label><select asp-for="ProviderType"><option value="OpenAICompatible">OpenAI-compatible</option></select><p class="field-help">The API format used by the configured model provider. OpenAI-compatible is used for Ollama/OpenAI-compatible chat completion APIs.</p><span class="validation" asp-validation-for="ProviderType"></span></div>
+                    <div class="field"><label asp-for="BaseUrl"></label><input asp-for="BaseUrl" inputmode="url" /><p class="field-help">Base URL for the provider API. For local Ollama this is usually <code>http://localhost:11434/v1</code>. For Ollama cloud through a local Ollama client, keep the existing project behaviour.</p><span class="validation" asp-validation-for="BaseUrl"></span></div>
+                    <div class="field"><label asp-for="ApiKey"></label><input asp-for="ApiKey" type="password" autocomplete="new-password" value="" /><p class="field-help">Optional provider API key. Leave blank to keep the saved key. The saved key must never be displayed. Saved key configured: <strong>@(Model.ApiKeyConfigured ? "Yes" : "No")</strong>.</p><span class="validation" asp-validation-for="ApiKey"></span></div>
                 </div>
-            }
-            <div class="button-row"><button class="button-secondary" type="submit" formaction="/admin/ai-assistant-settings/test" formmethod="post">Test saved provider settings</button></div>
+                <div class="checkbox-row option"><input asp-for="ClearApiKey" type="checkbox" /><input name="ClearApiKey" type="hidden" value="false" /><div class="option-text"><label asp-for="ClearApiKey"></label><p class="field-help">Removes the saved provider API key on save.</p></div></div>
+                <div class="sub-card grid">
+                    <h3>Test AI provider connection</h3>
+                    <p class="field-help">Sends a small test request to the configured provider. This does not send monitoring data, endpoint data, diagrams, dependencies, memories, or secrets.</p>
+                    <p class="field-help"><strong>Save changes before testing updated provider settings.</strong></p>
+                    @if (Model.TestResult is not null)
+                    {
+                        <div class="@(Model.TestResult.Succeeded ? "saved" : "errors")" role="status">
+                            <strong>@(Model.TestResult.Succeeded ? "AI provider connection succeeded." : "AI provider connection failed.")</strong>
+                            <div>Elapsed: @Model.TestResult.ElapsedMilliseconds ms</div>
+                            @if (Model.TestResult.StatusCode.HasValue) { <div>HTTP status: @Model.TestResult.StatusCode.Value</div> }
+                            @if (Model.TestResult.Succeeded) { <div>Returned text: <code>@Model.TestResult.ResponseText</code></div> }
+                            else { <div>Error: @Model.TestResult.ErrorMessage</div> }
+                        </div>
+                    }
+                    <div class="button-row"><button class="button-secondary" type="submit" formaction="/admin/ai-assistant-settings/test" formmethod="post">Test saved provider settings</button></div>
+                </div>
+            </div>
+            <div class="sub-card grid">
+                <h3>Model behaviour</h3>
+                <div class="grid two">
+                    <div class="field"><label asp-for="ModelName"></label><input asp-for="ModelName" /><p class="field-help">Model identifier sent to the provider, for example <code>gpt-oss:120b-cloud</code>.</p><span class="validation" asp-validation-for="ModelName"></span></div>
+                    <div class="field"><label asp-for="RequestTimeoutSeconds"></label><input asp-for="RequestTimeoutSeconds" type="number" min="1" max="600" /><p class="field-help">Maximum time the web app will wait for an AI provider response before timing out. Larger cloud models may need higher values.</p><span class="validation" asp-validation-for="RequestTimeoutSeconds"></span></div>
+                    <div class="field"><label asp-for="MaxOutputTokens"></label><input asp-for="MaxOutputTokens" type="number" min="64" max="32768" /><p class="field-help">Maximum number of tokens the model may generate in its final response. This does not control how much tool context is retrieved.</p><span class="validation" asp-validation-for="MaxOutputTokens"></span></div>
+                    <div class="field"><label asp-for="Temperature"></label><input asp-for="Temperature" type="number" min="0" max="2" step="0.1" /><p class="field-help">Controls response randomness. Lower values are more consistent and usually better for operational diagnostics.</p><span class="validation" asp-validation-for="Temperature"></span></div>
+                    <div class="checkbox-row option"><input asp-for="ToolCallingEnabled" type="checkbox" /><input name="ToolCallingEnabled" type="hidden" value="false" /><div class="option-text"><label asp-for="ToolCallingEnabled"></label><p class="field-help">Allows the model to request approved internal read-only tools. If disabled, the assistant can only answer from the prompt and conversation context.</p></div></div>
+                </div>
+            </div>
+        </section>
+
+        <section class="card grid">
+            <div class="section-header">
+                <h2>Tool calling and context limits</h2>
+                <p class="muted">Bound read-only tool execution and the amount of context tools may return to the model.</p>
+            </div>
+            <p class="field-help"><strong>Recommended defaults:</strong> 3 tool rounds, 5 tool calls per round, 24,000 total tool-result characters, and 12,000 characters per single tool result. Setting maximum tool rounds to 0 safely disables tool execution for AI requests even when tool calling is enabled.</p>
+            <div class="sub-card grid">
+                <h3>General tool execution</h3>
+                <p class="field-help">Maximum number of tool-call cycles the assistant may run before it must answer. Higher values allow more complex investigations but increase latency and token usage.</p>
+                <div class="grid two">
+                    <div class="field"><label asp-for="MaxToolRounds"></label><input asp-for="MaxToolRounds" type="number" min="0" max="10" /><p class="field-help">Maximum number of tool-call cycles the assistant may run before it must answer. Higher values allow more complex investigations but increase latency and token usage.</p><span class="validation" asp-validation-for="MaxToolRounds"></span></div>
+                    <div class="field"><label asp-for="MaxToolCallsPerRound"></label><input asp-for="MaxToolCallsPerRound" type="number" min="0" max="20" /><p class="field-help">Maximum number of tools the model may request in one tool-call cycle.</p><span class="validation" asp-validation-for="MaxToolCallsPerRound"></span></div>
+                    <div class="field"><label asp-for="MaxTotalToolResultCharacters"></label><input asp-for="MaxTotalToolResultCharacters" type="number" min="1000" max="200000" /><p class="field-help">Overall character budget for all tool results in one AI request. Higher values allow richer context but increase token usage and the chance of oversized requests.</p><span class="validation" asp-validation-for="MaxTotalToolResultCharacters"></span></div>
+                    <div class="field"><label asp-for="MaxSingleToolResultCharacters"></label><input asp-for="MaxSingleToolResultCharacters" type="number" min="1000" max="100000" /><p class="field-help">Maximum characters one tool call may return. Prevents one large diagram/history result from consuming the entire context budget.</p><span class="validation" asp-validation-for="MaxSingleToolResultCharacters"></span></div>
+                </div>
+            </div>
+            <div class="sub-card grid">
+                <h3>Endpoint and metrics tools</h3>
+                <p class="field-help">Limits for endpoint search, recent metrics, and endpoint-focused history tools.</p>
+                <div class="grid two">
+                    <div class="field"><label asp-for="MaxEndpointSearchResults"></label><input asp-for="MaxEndpointSearchResults" type="number"  /><p class="field-help">Maximum endpoints returned when the assistant searches by endpoint name, target, group, or agent.</p><span class="validation" asp-validation-for="MaxEndpointSearchResults"></span></div>
+                    <div class="field"><label asp-for="MaxEndpointMetricsSampleTailPoints"></label><input asp-for="MaxEndpointMetricsSampleTailPoints" type="number"  /><p class="field-help">Maximum recent check samples returned for endpoint metrics questions. Higher values improve detailed RTT/packet-loss analysis but use more context.</p><span class="validation" asp-validation-for="MaxEndpointMetricsSampleTailPoints"></span></div>
+                    <div class="field"><label asp-for="MaxEndpointTransitionItems"></label><input asp-for="MaxEndpointTransitionItems" type="number"  /><p class="field-help">Maximum endpoint state transitions returned by endpoint-focused metrics/history tools.</p><span class="validation" asp-validation-for="MaxEndpointTransitionItems"></span></div>
+                    <div class="field"><label asp-for="MaxEndpointFailureClusters"></label><input asp-for="MaxEndpointFailureClusters" type="number"  /><p class="field-help">Maximum grouped failure periods returned when summarising endpoint instability.</p><span class="validation" asp-validation-for="MaxEndpointFailureClusters"></span></div>
+                    <div class="field"><label asp-for="DefaultEndpointMetricsWindow"></label><select asp-for="DefaultEndpointMetricsWindow"><option>1h</option><option>6h</option><option>24h</option><option>7d</option></select><p class="field-help">Default time window used when the user asks for endpoint metrics without specifying a period.</p><span class="validation" asp-validation-for="DefaultEndpointMetricsWindow"></span></div>
+                    <div class="field"><label asp-for="MaximumEndpointMetricsWindow"></label><select asp-for="MaximumEndpointMetricsWindow"><option>1h</option><option>6h</option><option>24h</option><option>7d</option></select><p class="field-help">Largest time window endpoint metrics tools may query.</p><span class="validation" asp-validation-for="MaximumEndpointMetricsWindow"></span></div>
+                </div>
+            </div>
+            <div class="sub-card grid">
+                <h3>Historic state transition tools</h3>
+                <div class="grid two">
+                    <div class="field"><label asp-for="MaxStateTransitionSearchResults"></label><input asp-for="MaxStateTransitionSearchResults" type="number" /><p class="field-help">Maximum bulk state transitions returned for period-level timeline questions such as &quot;what changed last night?&quot;</p><span class="validation" asp-validation-for="MaxStateTransitionSearchResults"></span></div>
+                    <div class="field"><label asp-for="MaxStateTransitionLookbackDays"></label><input asp-for="MaxStateTransitionLookbackDays" type="number" /><p class="field-help">Largest historic period the assistant may query for state transitions.</p><span class="validation" asp-validation-for="MaxStateTransitionLookbackDays"></span></div>
+                    <div class="field"><label asp-for="MaxStateTransitionEndpointDetails"></label><input asp-for="MaxStateTransitionEndpointDetails" type="number" /><p class="field-help">Maximum endpoint details included with state transition results.</p><span class="validation" asp-validation-for="MaxStateTransitionEndpointDetails"></span></div>
+                </div>
+            </div>
+            <div class="sub-card grid">
+                <h3>Diagram tools</h3>
+                <div class="grid two">
+                    <div class="field"><label asp-for="MaxDiagramListResults"></label><input asp-for="MaxDiagramListResults" type="number" /><p class="field-help">Maximum saved diagrams returned when listing diagrams.</p><span class="validation" asp-validation-for="MaxDiagramListResults"></span></div>
+                    <div class="field"><label asp-for="MaxDiagramNodeSearchResults"></label><input asp-for="MaxDiagramNodeSearchResults" type="number" /><p class="field-help">Maximum diagram nodes returned when the assistant searches for devices/nodes.</p><span class="validation" asp-validation-for="MaxDiagramNodeSearchResults"></span></div>
+                    <div class="field"><label asp-for="MaxDiagramConnectionResults"></label><input asp-for="MaxDiagramConnectionResults" type="number" /><p class="field-help">Maximum diagram links returned by connection/path lookup tools.</p><span class="validation" asp-validation-for="MaxDiagramConnectionResults"></span></div>
+                    <div class="field"><label asp-for="MaxFullDiagramNodesReturned"></label><input asp-for="MaxFullDiagramNodesReturned" type="number" /><p class="field-help">Maximum nodes returned when the assistant loads a full diagram.</p><span class="validation" asp-validation-for="MaxFullDiagramNodesReturned"></span></div>
+                    <div class="field"><label asp-for="MaxFullDiagramLinksReturned"></label><input asp-for="MaxFullDiagramLinksReturned" type="number" /><p class="field-help">Maximum links returned when the assistant loads a full diagram.</p><span class="validation" asp-validation-for="MaxFullDiagramLinksReturned"></span></div>
+                    <div class="field"><label asp-for="MaxDiagramToolResultCharacters"></label><input asp-for="MaxDiagramToolResultCharacters" type="number" /><p class="field-help">Character budget for diagram tool results.</p><span class="validation" asp-validation-for="MaxDiagramToolResultCharacters"></span></div>
+                    <div class="field"><label asp-for="MaxDiagramItemMetadataCharacters"></label><input asp-for="MaxDiagramItemMetadataCharacters" type="number" /><p class="field-help">Maximum note/metadata text returned per diagram node or link.</p><span class="validation" asp-validation-for="MaxDiagramItemMetadataCharacters"></span></div>
+                </div>
+            </div>
+            <div class="sub-card grid">
+                <h3>Dependency tools</h3>
+                <div class="grid two">
+                    <div class="field"><label asp-for="MaxDependencyEndpointsReturned"></label><input asp-for="MaxDependencyEndpointsReturned" type="number" /><p class="field-help">Maximum endpoints returned by dependency lookup and impact tools.</p><span class="validation" asp-validation-for="MaxDependencyEndpointsReturned"></span></div>
+                    <div class="field"><label asp-for="MaxDependencyPathsReturned"></label><input asp-for="MaxDependencyPathsReturned" type="number" /><p class="field-help">Maximum dependency paths returned when walking upstream/downstream relationships.</p><span class="validation" asp-validation-for="MaxDependencyPathsReturned"></span></div>
+                    <div class="field"><label asp-for="MaxDependencyTraversalDepth"></label><input asp-for="MaxDependencyTraversalDepth" type="number" /><p class="field-help">Maximum recursive depth for dependency tree traversal. Prevents excessive graph walks.</p><span class="validation" asp-validation-for="MaxDependencyTraversalDepth"></span></div>
+                    <div class="field"><label asp-for="MaxTopDependedOnEndpoints"></label><input asp-for="MaxTopDependedOnEndpoints" type="number" /><p class="field-help">Maximum entries returned in dependency summary rankings.</p><span class="validation" asp-validation-for="MaxTopDependedOnEndpoints"></span></div>
+                </div>
+            </div>
+            <div class="sub-card grid">
+                <h3>Memory tools</h3>
+                <div class="grid two">
+                    <div class="field"><label asp-for="MaxMemorySearchResults"></label><input asp-for="MaxMemorySearchResults" type="number" /><p class="field-help">Maximum user-specific memories returned to the model in one memory search.</p><span class="validation" asp-validation-for="MaxMemorySearchResults"></span></div>
+                    <div class="field"><label asp-for="MaxMemoryContentCharacters"></label><input asp-for="MaxMemoryContentCharacters" type="number" /><p class="field-help">Maximum total memory text returned to the model. Memories should not contain live monitoring truth.</p><span class="validation" asp-validation-for="MaxMemoryContentCharacters"></span></div>
+                </div>
+            </div>
+            <div class="sub-card grid">
+                <h3>Runtime tools</h3>
+                <div class="grid two">
+                    <div class="field"><label asp-for="MaxRuntimeLargestTablesReturned"></label><input asp-for="MaxRuntimeLargestTablesReturned" type="number" /><p class="field-help">Maximum database/runtime table-size entries returned by runtime diagnostic tools.</p><span class="validation" asp-validation-for="MaxRuntimeLargestTablesReturned"></span></div>
+                </div>
+            </div>
+        </section>
+
+        <section class="card grid">
+            <div class="section-header">
+                <h2>Admin global prompt</h2>
+                <p class="muted">Site-specific instructions appended to the built-in AI safety and behaviour prompt. Use this for local terminology, preferred diagnostic style, and operational guidance. Admin prompt text cannot override read-only mode, permissions, safety rules, or tool restrictions.</p>
+            </div>
+            <textarea asp-for="GlobalSystemPrompt" maxlength="20000"></textarea>
+            <p class="field-help">This is a useful place for temporary stress-test rules before they are folded into the built-in prompt later.</p>
+            <span class="validation" asp-validation-for="GlobalSystemPrompt"></span>
         </section>
 
         <section class="card warning">
             <h2>Safety notes</h2>
             <ul>
-                <li>The assistant is planned as read-only and must not modify monitoring configuration, agents, dependencies, alerts, or diagram data.</li>
-                <li>These settings only configure the future assistant; enabling flags here does not make chat available until later runtime slices are implemented.</li>
-                <li>The built-in non-editable safety prompt will be added in the runtime layer and takes precedence over the admin prompt.</li>
-                <li>Diagram/topology answers must remain based on saved documentation only, not live link-state.</li>
+                <li>AI tools are read-only except explicit user-memory management.</li>
+                <li>The assistant cannot edit endpoints, agents, dependencies, diagrams, alerts, settings, schedules, or event tasks.</li>
+                <li>Tool results are permission-filtered using the current web user, linked Telegram user, or task owner.</li>
+                <li>Diagram data is saved documentation, not live link state.</li>
+                <li>Dependency data is monitoring configuration, not physical topology.</li>
+                <li>Provider/API secrets are protected and must not be logged or displayed.</li>
             </ul>
             <p class="muted">Last updated: @await DisplayTimeFormatter.FormatForCurrentUserAsync(Model.UpdatedAtUtc)</p>
         </section>
 
-        <div class="button-row"><button class="button" type="submit">Save AI assistant settings</button><a class="button-secondary" href="/admin">Cancel</a></div>
+        <div class="button-row sticky-actions"><button class="button" type="submit">Save AI assistant settings</button><a class="button-secondary" href="/admin">Cancel</a></div>
     </form>
 </main>
 </body>


### PR DESCRIPTION
### Motivation

- The AI Assistant settings page had become a long, dense vertical list that was hard to scan and understand, and the provider test action was misplaced near the bottom of the page. 
- The change was driven as a UI/UX cleanup to group related settings, add concise per-field help text, and improve readability without changing runtime behaviour or storage. 
- A tracking issue was created to capture the work as requested: Issue #614 "Tidy and reorganise AI Assistant settings page".

### Description

- Reorganized the admin view `src/WebApp/PingMonitor.Web/Views/AdminAiAssistantSettings/Index.cshtml` into clear top-level cards: Feature enablement, Provider and model (with provider test), Tool calling and context limits (split into sub-cards), Admin global prompt, and Safety notes, and added new CSS helpers (`.section-header`, `.sub-card`, `.field`, `.option`, `.option-text`, `.sticky-actions`) to improve layout and readability. 
- Moved the existing provider test UI into the Provider and model section (keeps the same `/admin/ai-assistant-settings/test` POST action) and added explicit help text for the test and other provider fields (API key handling remains hidden and unchanged). 
- Split the large tool/context limits area into sub-cards for General tool execution, Endpoint/metrics, Historic state transitions, Diagram, Dependency, Memory, and Runtime tools, and added per-field help text while preserving all `asp-for` bindings and validation spans. 
- Added a new view-level test `src/WebApp/PingMonitor.Web.Tests/AiAssistantSettingsPageViewTests.cs` that asserts the new grouping/order, presence of sub-section headings, provider test placement, retained bindings, hidden API key input, responsive two-column classes, and key help/safety text.

### Testing

- Built the web solution using the required SDK after installing .NET SDK `10.0.104` into `/tmp/dotnet10` to satisfy `global.json`, and `dotnet build src/WebApp/PingMonitor.WebApp.slnx` completed successfully with 0 warnings and 0 errors. 
- Ran unit tests with `dotnet test` for the web tests and the test project `PingMonitor.Web.Tests`, and the test run passed (PingMonitor.Web.Tests: Passed 261, Failed 0, Skipped 0). 
- The added view-level tests executed as part of the test run and passed, and the change was implemented without modifying validation rules, storage format, schema version, provider test behaviour, or AI/tool runtime behaviour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a356eaa7d38832a9594efca3e2c27e8)