### PR TITLE
Fix AI log lookup build failure

### DIFF
--- a/src/WebApp/PingMonitor.Web/Services/AiTools/LogLookupAiTools.cs
+++ b/src/WebApp/PingMonitor.Web/Services/AiTools/LogLookupAiTools.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using PingMonitor.Web.Data;
 using PingMonitor.Web.Models;
 using PingMonitor.Web.Models.Identity;
+using PingMonitor.Web.Services.Identity;
 
 namespace PingMonitor.Web.Services.AiTools;
 
@@ -134,9 +135,9 @@ internal abstract class LogLookupAiToolBase(PingMonitorDbContext dbContext, User
     protected static string? ReadString(JsonElement root, string name) => root.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.String ? p.GetString()?.Trim() : null;
     protected static int? ReadInt(JsonElement root, string name) => root.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.Number && p.TryGetInt32(out var value) ? value : null;
 
-    private static LogRow ToRow(DateTimeOffset timestamp, string category, string level, string source, string message, string? details, string? entityType, string? entityId, string correlationId, int maxChars, ref bool redacted)
+    private static LogRow ToRow(DateTimeOffset timestamp, string category, string level, string source, string? message, string? details, string? entityType, string? entityId, string correlationId, int maxChars, ref bool redacted)
     {
-        var sanitizedMessage = Sanitize(Truncate(message, maxChars), ref redacted);
+        var sanitizedMessage = Sanitize(Truncate(message, maxChars), ref redacted) ?? string.Empty;
         var sanitizedDetails = Sanitize(Truncate(details, maxChars), ref redacted);
         return new LogRow(timestamp, category, level, source, sanitizedMessage, entityType, entityId, null, sanitizedDetails, correlationId);
     }


### PR DESCRIPTION
### Motivation
- Resolve a build error where `ApplicationRoles` was not found during AI log lookup validation causing publish to fail with `CS0103`.
- Prevent a potential nullability warning / runtime issue when converting event log messages to `LogRow` by ensuring the message is treated safely.
- This change addresses the CI/publish failure observed when producing a self-contained `win-x64` build (Fixes #616).

### Description
- Added `using PingMonitor.Web.Services.Identity;` so `ApplicationRoles.Admin` resolves in `LogLookupAiTools.cs`.
- Made the `ToRow` helper accept a nullable `message` parameter and ensure the sanitized message value is non-null before constructing `LogRow`.
- No database schema or query semantics were changed and no startup/gating logic was modified.

### Testing
- Reproduced and verified the previous failure mode by running `dotnet publish` with the same release-style properties and confirmed the publish now succeeds. (succeeded)
- Built the web app with `dotnet build src/WebApp/PingMonitor.Web/PingMonitor.Web.csproj --configuration Release` and the build completed with zero warnings/errors. (succeeded)
- Ran unit tests with `dotnet test src/WebApp/PingMonitor.Web.Tests/PingMonitor.Web.Tests.csproj --configuration Release --no-restore` and observed no failing tests. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36a16622f4832abe66310b7e68c531)